### PR TITLE
Fix timeouts on master-side shell commands

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -19,7 +19,6 @@ import json
 
 from twisted.internet import defer
 from twisted.internet import reactor
-from twisted.internet import utils
 from twisted.python import log
 
 from buildbot import config
@@ -28,6 +27,7 @@ from buildbot.changes import base
 from buildbot.changes.filter import ChangeFilter
 from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
+from buildbot.util import runprocess
 from buildbot.util.protocol import LineProcessProtocol
 
 
@@ -405,7 +405,11 @@ class GerritChangeSource(GerritChangeSourceBase):
             log.msg("querying gerrit for changed files in change {}/{}: {}".format(change, patchset,
                                                                                    cmd))
 
-        out = yield utils.getProcessOutput(cmd[0], cmd[1:], env=None)
+        rc, out = yield runprocess.run_process(self.master.reactor, cmd, env=None,
+                                               collect_stderr=False)
+        if rc != 0:
+            return ["unknown"]
+
         out = out.splitlines()[0]
         res = json.loads(bytes2unicode(out))
 

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -19,13 +19,13 @@ import stat
 from urllib.parse import quote as urlquote
 
 from twisted.internet import defer
-from twisted.internet import utils
 from twisted.python import log
 
 from buildbot import config
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import private_tempdir
+from buildbot.util import runprocess
 from buildbot.util.git import GitMixin
 from buildbot.util.git import getSshKnownHostsContents
 from buildbot.util.misc import writeLocalFile
@@ -425,9 +425,9 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
 
         full_args += [command] + args
 
-        res = yield utils.getProcessOutputAndValue(self.gitbin,
-            full_args, path=path, env=full_env)
-        (stdout, stderr, code) = res
+        res = yield runprocess.run_process(self.master.reactor, [self.gitbin] + full_args, path,
+                                           env=full_env)
+        (code, stdout, stderr) = res
         stdout = bytes2unicode(stdout, self.encoding)
         stderr = bytes2unicode(stderr, self.encoding)
         if code != 0:

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -17,13 +17,13 @@ import os
 import time
 
 from twisted.internet import defer
-from twisted.internet import utils
 from twisted.python import log
 
 from buildbot import config
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import deferredLocked
+from buildbot.util import runprocess
 from buildbot.util.state import StateMixin
 
 
@@ -118,84 +118,85 @@ class HgPoller(base.PollingChangeSource, StateMixin):
             return workdir
         return os.path.join(self.master.basedir, workdir)
 
+    @defer.inlineCallbacks
     def _getRevDetails(self, rev):
         """Return a deferred for (date, author, files, comments) of given rev.
 
         Deferred will be in error if rev is unknown.
         """
-        args = ['log', '-r', rev, os.linesep.join((
+        command = [
+            self.hgbin, 'log', '-r', rev, os.linesep.join((
             '--template={date|hgdate}',
             '{author}',
             "{files % '{file}" + os.pathsep + "'}",
             '{desc|strip}'))]
+
         # Mercurial fails with status 255 if rev is unknown
-        d = utils.getProcessOutput(self.hgbin, args, path=self._absWorkdir(),
-                                   env=os.environ, errortoo=False)
+        rc, output = yield runprocess.run_process(self.master.reactor,
+                                                  command, workdir=self._absWorkdir(),
+                                                  env=os.environ, collect_stderr=False,
+                                                  stderr_is_error=True)
+        if rc != 0:
+            msg = '{}: got error {} when getting details for revision {}'.format(self, rc, rev)
+            raise Exception(msg)
 
-        @d.addCallback
-        def process(output):
-            # all file names are on one line
-            output = output.decode(self.encoding, "replace")
-            date, author, files, comments = output.split(
-                os.linesep, 3)
+        # all file names are on one line
+        output = output.decode(self.encoding, "replace")
+        date, author, files, comments = output.split(os.linesep, 3)
 
-            if not self.usetimestamps:
-                stamp = None
-            else:
-                try:
-                    stamp = float(date.split()[0])
-                except Exception:
-                    log.msg('hgpoller: caught exception converting output %r '
-                            'to timestamp' % date)
-                    raise
-            return stamp, author.strip(), files.split(os.pathsep)[:-1], comments.strip()
-        return d
+        if not self.usetimestamps:
+            stamp = None
+        else:
+            try:
+                stamp = float(date.split()[0])
+            except Exception:
+                log.msg('hgpoller: caught exception converting output %r '
+                        'to timestamp' % date)
+                raise
+        return stamp, author.strip(), files.split(os.pathsep)[:-1], comments.strip()
 
     def _isRepositoryReady(self):
         """Easy to patch in tests."""
         return os.path.exists(os.path.join(self._absWorkdir(), '.hg'))
 
+    @defer.inlineCallbacks
     def _initRepository(self):
         """Have mercurial init the workdir as a repository (hg init) if needed.
 
         hg init will also create all needed intermediate directories.
         """
         if self._isRepositoryReady():
-            return defer.succeed(None)
+            return
         log.msg('hgpoller: initializing working dir from {}'.format(self.repourl))
-        d = utils.getProcessOutputAndValue(self.hgbin,
-                                           ['init', self._absWorkdir()],
-                                           env=os.environ)
-        d.addCallback(self._convertNonZeroToFailure)
-        d.addErrback(self._stopOnFailure)
-        d.addCallback(lambda _: log.msg(
-            "hgpoller: finished initializing working dir %r" % self.workdir))
-        return d
 
+        rc = yield runprocess.run_process(self.master.reactor,
+                                          [self.hgbin, 'init', self._absWorkdir()],
+                                          env=os.environ, collect_stdout=False,
+                                          collect_stderr=False)
+
+        if rc != 0:
+            self._stopOnFailure()
+            raise EnvironmentError('{}: repository init failed with exit code {}'.format(self, rc))
+
+        log.msg("hgpoller: finished initializing working dir {}".format(self.workdir))
+
+    @defer.inlineCallbacks
     def _getChanges(self):
         self.lastPoll = time.time()
 
-        d = self._initRepository()
-        d.addCallback(lambda _: log.msg("hgpoller: polling hg repo at {}".format(self.repourl)))
+        yield self._initRepository()
+        log.msg("{}: polling hg repo at {}".format(self, self.repourl))
 
-        # get a deferred object that performs the fetch
-        args = ['pull']
+        command = [self.hgbin, 'pull']
         for name in self.branches:
-            args += ['-b', name]
+            command += ['-b', name]
         for name in self.bookmarks:
-            args += ['-B', name]
-        args += [self.repourl]
+            command += ['-B', name]
+        command += [self.repourl]
 
-        # This command always produces data on stderr, but we actually do not
-        # care about the stderr or stdout from this command.
-        # We set errortoo=True to avoid an errback from the deferred.
-        # The callback which will be added to this
-        # deferred will not use the response.
-        d.addCallback(lambda _: utils.getProcessOutput(
-            self.hgbin, args, path=self._absWorkdir(),
-            env=os.environ, errortoo=True))
-
-        return d
+        yield runprocess.run_process(self.master.reactor, command, workdir=self._absWorkdir(),
+                                     env=os.environ, collect_stdout=False,
+                                     collect_stderr=False)
 
     def _getCurrentRev(self, branch='default'):
         """Return a deferred for current numeric rev in state db.
@@ -209,6 +210,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         self.lastRev[branch] = str(rev)
         return self.setState('lastRev', self.lastRev)
 
+    @defer.inlineCallbacks
     def _getHead(self, branch):
         """Return a deferred for branch head revision or None.
 
@@ -217,33 +219,32 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         (if really buildbotting a branch that does not have any changeset
         yet, one shouldn't be surprised to get errors)
         """
-        d = utils.getProcessOutput(self.hgbin,
-                                   ['heads', branch,
-                                       '--template={rev}' + os.linesep],
-                                   path=self._absWorkdir(), env=os.environ, errortoo=False)
 
-        @d.addErrback
-        def no_head_err(exc):
-            log.err("hgpoller: could not find revision %r in repository %r" % (
-                branch, self.repourl))
+        rc, stdout = yield runprocess.run_process(self.master.reactor,
+                                                  [self.hgbin, 'heads', branch,
+                                                   '--template={rev}' + os.linesep],
+                                                  workdir=self._absWorkdir(), env=os.environ,
+                                                  collect_stderr=False, stderr_is_error=True)
 
-        @d.addCallback
-        def results(heads):
-            if not heads:
-                return None
+        if rc != 0:
+            log.err("{}: could not find revision {} in repository {}".format(self, branch,
+                                                                             self.repourl))
+            return None
 
-            if len(heads.split()) > 1:
-                log.err(("hgpoller: caught several heads in branch %r "
-                         "from repository %r. Staying at previous revision"
-                         "You should wait until the situation is normal again "
-                         "due to a merge or directly strip if remote repo "
-                         "gets stripped later.") % (branch, self.repourl))
-                return None
+        if not stdout:
+            return None
 
-            # in case of whole reconstruction, are we sure that we'll get the
-            # same node -> rev assignations ?
-            return heads.strip().decode(self.encoding)
-        return d
+        if len(stdout.split()) > 1:
+            log.err(("{}: caught several heads in branch {} "
+                     "from repository {}. Staying at previous revision"
+                     "You should wait until the situation is normal again "
+                     "due to a merge or directly strip if remote repo "
+                     "gets stripped later.").format(self, branch, self.repourl))
+            return None
+
+        # in case of whole reconstruction, are we sure that we'll get the
+        # same node -> rev assignations ?
+        return stdout.strip().decode(self.encoding)
 
     @defer.inlineCallbacks
     def _processChanges(self, unused_output):
@@ -264,11 +265,18 @@ class HgPoller(base.PollingChangeSource, StateMixin):
 
     @defer.inlineCallbacks
     def _getRevNodeList(self, revset):
-        revListArgs = ['log', '-r', revset, r'--template={rev}:{node}\n']
-        results = yield utils.getProcessOutput(self.hgbin, revListArgs,
-                                               path=self._absWorkdir(), env=os.environ,
-                                               errortoo=False)
-        results = results.decode(self.encoding)
+
+        rc, stdout = yield runprocess.run_process(self.master.reactor,
+                                                  [self.hgbin, 'log', '-r', revset,
+                                                   r'--template={rev}:{node}\n'],
+                                                  workdir=self._absWorkdir(), env=os.environ,
+                                                  collect_stdout=True, collect_stderr=False,
+                                                  stderr_is_error=True)
+
+        if rc != 0:
+            raise EnvironmentError('{}: could not get rev node list: {}'.format(self, rc))
+
+        results = stdout.decode(self.encoding)
 
         revNodeList = [rn.split(':', 1) for rn in results.strip().split()]
         defer.returnValue(revNodeList)
@@ -324,13 +332,6 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         # eat the failure to continue along the deferred chain - we still want
         # to catch up
         return None
-
-    def _convertNonZeroToFailure(self, res):
-        "utility method to handle the result of getProcessOutputAndValue"
-        (stdout, stderr, code) = res
-        if code != 0:
-            raise EnvironmentError('command failed with exit code {}: {}'.format(code, stderr))
-        return (stdout, stderr, code)
 
     def _stopOnFailure(self, f):
         "utility method to stop the service when a failure occurs"

--- a/master/buildbot/newsfragments/master-process-timeout.bugfix
+++ b/master/buildbot/newsfragments/master-process-timeout.bugfix
@@ -1,0 +1,1 @@
+Implemented time out for master-side utility processes (e.g. ``git`` or ``hg``) which could break the respective version control poller potentially indefinitely upon hanging.

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -139,6 +139,8 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.util.queue.UndoableQueue',
             'buildbot.util.raml.RamlLoader',
             'buildbot.util.raml.RamlSpec',
+            'buildbot.util.runprocess.RunProcessPP',
+            'buildbot.util.runprocess.RunProcess',
             'buildbot.util.sautils.InsertFromSelect',
             'buildbot.util.service.AsyncMultiService',
             'buildbot.util.service.AsyncService',

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -25,9 +25,10 @@ from buildbot.changes import gitpoller
 from buildbot.test.fake.private_tempdir import MockPrivateTemporaryDirectory
 from buildbot.test.util import changesource
 from buildbot.test.util import config
-from buildbot.test.util import gpo
 from buildbot.test.util import logging
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.runprocess import ExpectMaster
+from buildbot.test.util.runprocess import MasterRunProcessMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
@@ -35,87 +36,91 @@ from buildbot.util import unicode2bytes
 os.environ['TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'] = 'TRUE'
 
 
-class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
+class TestGitPollerBase(MasterRunProcessMixin,
+                        changesource.ChangeSourceMixin,
+                        logging.LoggingMixin,
+                        TestReactorMixin,
+                        unittest.TestCase):
 
-    """Test GitPoller methods for parsing git output"""
+    REPOURL = 'git@example.com:~foo/baz.git'
+    REPOURL_QUOTED = 'git%40example.com%3A%7Efoo%2Fbaz.git'
 
+    def createPoller(self):
+        # this is overridden in TestGitPollerWithSshPrivateKey
+        return gitpoller.GitPoller(self.REPOURL)
+
+    @defer.inlineCallbacks
     def setUp(self):
-        self.poller = gitpoller.GitPoller('git@example.com:~foo/baz.git')
-        self.setUpGetProcessOutput()
+        self.setUpTestReactor()
+        self.setup_master_run_process()
+        yield self.setUpChangeSource()
+
+        self.poller = self.createPoller()
+        yield self.poller.setServiceParent(self.master)
+
+    def tearDown(self):
+        return self.tearDownChangeSource()
+
+
+class TestGitPoller(TestGitPollerBase):
 
     dummyRevStr = '12345abcde'
 
+    @defer.inlineCallbacks
     def _perform_git_output_test(self, methodToTest, args,
                                  desiredGoodOutput, desiredGoodResult,
                                  emptyRaisesException=True):
 
-        # make this call to self.patch here so that we raise a SkipTest if it
-        # is not supported
-        self.expectCommands(
-            gpo.Expect('git', *args)
-            .path('gitpoller-work'),
+        self.expect_commands(
+            ExpectMaster(['git'] + args)
+            .workdir('gitpoller-work'),
         )
 
-        d = defer.succeed(None)
-
-        @d.addCallback
-        def call_empty(_):
-            # we should get an Exception with empty output from git
-            return methodToTest(self.dummyRevStr)
-
-        def cb_empty(_):
+        # we should get an Exception with empty output from git
+        try:
+            yield methodToTest(self.dummyRevStr)
             if emptyRaisesException:
-                self.fail(
-                    "getProcessOutput should have failed on empty output")
-
-        def eb_empty(f):
+                self.fail("getProcessOutput should have failed on empty output")
+        except Exception as e:
             if not emptyRaisesException:
-                self.fail(
-                    "getProcessOutput should NOT have failed on empty output")
+                import traceback
+                traceback.print_exc()
+                self.fail("getProcessOutput should NOT have failed on empty output: " + repr(e))
 
-        d.addCallbacks(cb_empty, eb_empty)
-        d.addCallback(lambda _: self.assertAllCommandsRan())
+        self.assert_all_commands_ran()
 
         # and the method shouldn't suppress any exceptions
-        self.expectCommands(
-            gpo.Expect('git', *args)
-            .path('gitpoller-work')
+        self.expect_commands(
+            ExpectMaster(['git'] + args)
+            .workdir('gitpoller-work')
             .exit(1),
         )
 
-        @d.addCallback
-        def call_exception(_):
-            return methodToTest(self.dummyRevStr)
-
-        def cb_exception(_):
+        try:
+            yield methodToTest(self.dummyRevStr)
             self.fail("getProcessOutput should have failed on stderr output")
-
-        def eb_exception(f):
+        except Exception:
             pass
-        d.addCallbacks(cb_exception, eb_exception)
-        d.addCallback(lambda _: self.assertAllCommandsRan())
+
+        self.assert_all_commands_ran()
 
         # finally we should get what's expected from good output
-        self.expectCommands(
-            gpo.Expect('git', *args)
-            .path('gitpoller-work')
+        self.expect_commands(
+            ExpectMaster(['git'] + args)
+            .workdir('gitpoller-work')
             .stdout(desiredGoodOutput)
         )
 
-        @d.addCallback
-        def call_desired(_):
-            return methodToTest(self.dummyRevStr)
+        r = yield methodToTest(self.dummyRevStr)
 
-        @d.addCallback
-        def cb_desired(r):
-            self.assertEqual(r, desiredGoodResult)
-            # check types
-            if isinstance(r, str):
-                self.assertIsInstance(r, str)
-            elif isinstance(r, list):
-                [self.assertIsInstance(e, str) for e in r]
-        d.addCallback(lambda _: self.assertAllCommandsRan())
-        return d
+        self.assertEqual(r, desiredGoodResult)
+        # check types
+        if isinstance(r, str):
+            self.assertIsInstance(r, str)
+        elif isinstance(r, list):
+            [self.assertIsInstance(e, str) for e in r]
+
+        self.assert_all_commands_ran()
 
     def test_get_commit_author(self):
         authorStr = 'Sammy Jankis <email@example.com>'
@@ -174,37 +179,6 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
                                                  self.dummyRevStr, '--'],
                                              stampBytes, float(stampStr))
 
-    # _get_changes is tested in TestGitPoller, below
-
-
-class TestGitPollerBase(gpo.GetProcessOutputMixin,
-                        changesource.ChangeSourceMixin,
-                        logging.LoggingMixin,
-                        TestReactorMixin,
-                        unittest.TestCase):
-
-    REPOURL = 'git@example.com:~foo/baz.git'
-    REPOURL_QUOTED = 'git%40example.com%3A%7Efoo%2Fbaz.git'
-
-    def createPoller(self):
-        # this is overridden in TestGitPollerWithSshPrivateKey
-        return gitpoller.GitPoller(self.REPOURL)
-
-    @defer.inlineCallbacks
-    def setUp(self):
-        self.setUpTestReactor()
-        self.setUpGetProcessOutput()
-        yield self.setUpChangeSource()
-
-        self.poller = self.createPoller()
-        yield self.poller.setServiceParent(self.master)
-
-    def tearDown(self):
-        return self.tearDownChangeSource()
-
-
-class TestGitPoller(TestGitPollerBase):
-
     def test_describe(self):
         self.assertSubstring("GitPoller", self.poller.describe())
 
@@ -219,49 +193,49 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_checkGitFeatures_git_not_installed(self):
         self.setUpLogging()
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'Command not found'),
         )
 
         yield self.assertFailure(self.poller._checkGitFeatures(),
                                  EnvironmentError)
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
 
     @defer.inlineCallbacks
     def test_checkGitFeatures_git_bad_version(self):
         self.setUpLogging()
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git ')
         )
 
         yield self.assertFailure(self.poller._checkGitFeatures(),
                                  EnvironmentError)
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
 
     @defer.inlineCallbacks
     def test_poll_initial(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
@@ -272,80 +246,79 @@ class TestGitPoller(TestGitPollerBase):
             })
 
     def test_poll_failInit(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work'])
             .exit(1),
         )
 
         d = self.assertFailure(self.poller.poll(), EnvironmentError)
 
-        d.addCallback(lambda _: self.assertAllCommandsRan())
+        d.addCallback(lambda _: self.assert_all_commands_ran())
         return d
 
     def test_poll_failFetch(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL]),
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .exit(1),
         )
 
         d = self.assertFailure(self.poller.poll(), EnvironmentError)
-        d.addCallback(lambda _: self.assertAllCommandsRan())
+        d.addCallback(lambda _: self.assert_all_commands_ran())
         return d
 
     @defer.inlineCallbacks
     def test_poll_failRevParse(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .exit(1),
         )
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(len(self.flushLoggedErrors()), 1)
         self.assertEqual(self.poller.lastRev, {})
 
     @defer.inlineCallbacks
     def test_poll_failLog(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .exit(1),
         )
 
@@ -355,7 +328,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(len(self.flushLoggedErrors()), 1)
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -363,28 +336,28 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_GitError(self):
         # Raised when git exits with status code 128. See issue 2468
-        self.expectCommands(
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work')
+        self.expect_commands(
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work'])
             .exit(128),
         )
 
         d = self.assertFailure(self.poller._dovccmd('init', ['--bare',
                                                              'gitpoller-work']), gitpoller.GitError)
 
-        d.addCallback(lambda _: self.assertAllCommandsRan())
+        d.addCallback(lambda _: self.assert_all_commands_ran())
         return d
 
     def test_poll_GitError_log(self):
         self.setUpLogging()
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work'])
             .exit(128),
         )
 
         d = self.poller.poll()
-        d.addCallback(lambda _: self.assertAllCommandsRan())
+        d.addCallback(lambda _: self.assert_all_commands_ran())
         self.assertLogged("command.*on repourl.*failed.*exit code 128.*")
         return d
 
@@ -393,29 +366,29 @@ class TestGitPoller(TestGitPollerBase):
         # Test that environment variables get propagated to subprocesses
         # (See #2116)
         self.patch(os, 'environ', {'ENVVAR': 'TRUE'})
-        self.addGetProcessOutputExpectEnv({'ENVVAR': 'TRUE'})
+        self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
 
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'no interesting output'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b''),
         )
 
@@ -424,7 +397,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.master.db.state.assertStateByClass(
             name=bytes2unicode(self.REPOURL), class_name='GitPoller',
             lastRev={
@@ -433,26 +406,26 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_initial(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
                     b'refs/heads/release\n'
                     b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                       '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
         )
 
@@ -460,7 +433,7 @@ class TestGitPoller(TestGitPollerBase):
         self.poller.branches = ['master', 'release', 'not_on_remote']
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
             'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
@@ -468,44 +441,44 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
                     b'refs/heads/release\n'
                     b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                       '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                       '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                       '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
             ])),
@@ -541,7 +514,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
             'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
@@ -600,27 +573,27 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_default(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
 
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b''),
         )
 
@@ -633,7 +606,7 @@ class TestGitPoller(TestGitPollerBase):
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
             'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -642,27 +615,27 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
 
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b''),
         )
 
@@ -698,7 +671,7 @@ class TestGitPoller(TestGitPollerBase):
         self.poller.buildPushesWithNoCommits = True
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
             'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -722,28 +695,28 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true_fast_forward(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
 
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
-                       '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b''),
         )
 
@@ -780,7 +753,7 @@ class TestGitPoller(TestGitPollerBase):
         self.poller.buildPushesWithNoCommits = True
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
             'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -804,27 +777,27 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true_not_tip(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
 
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b''),
         )
 
@@ -860,7 +833,7 @@ class TestGitPoller(TestGitPollerBase):
         self.poller.buildPushesWithNoCommits = True
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
             'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -884,26 +857,25 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_allBranches_single(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect(
-                'git', 'log', '--ignore-missing', '--format=%H',
-                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
@@ -938,7 +910,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'refs/heads/master':
             '4423cdbcbb89c14e50dd5f4152415afd686c5241',
@@ -967,29 +939,29 @@ class TestGitPoller(TestGitPollerBase):
         # Test that environment variables get propagated to subprocesses
         # (See #2116)
         self.patch(os, 'environ', {'ENVVAR': 'TRUE'})
-        self.addGetProcessOutputExpectEnv({'ENVVAR': 'TRUE'})
+        self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
 
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'no interesting output'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b''),
         )
 
@@ -998,52 +970,48 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
         })
 
     @defer.inlineCallbacks
     def test_poll_allBranches_multiple(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
             ])),
-            gpo.Expect(
-                'git', 'fetch', self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect(
-                'git', 'log', '--ignore-missing', '--format=%H',
-                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
-            gpo.Expect(
-                'git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED + '/release')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .workdir('gitpoller-work')
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
-            gpo.Expect(
-                'git', 'log', '--ignore-missing', '--format=%H',
-                '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
+                          '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
 
@@ -1077,7 +1045,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'refs/heads/master':
             '4423cdbcbb89c14e50dd5f4152415afd686c5241',
@@ -1112,30 +1080,28 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_callableFilteredBranches(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
             ])),
-            gpo.Expect(
-                'git', 'fetch', self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect(
-                'git', 'log', '--ignore-missing', '--format=%H',
-                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241']))
@@ -1176,7 +1142,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
 
         # The release branch id should remain unchanged,
         # because it was ignored.
@@ -1207,33 +1173,31 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_branchFilter(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                 b'refs/pull/410/merge',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
                 b'refs/pull/410/head',
             ])),
-            gpo.Expect(
-                'git', 'fetch', self.REPOURL,
-                '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head')
-            .path('gitpoller-work'),
-            gpo.Expect(
-                'git', 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED +
+                          '/refs/pull/410/head'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head'])
+            .workdir('gitpoller-work')
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
-            gpo.Expect(
-                'git', 'log', '--ignore-missing', '--format=%H',
-                '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
+                          '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
 
@@ -1274,7 +1238,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
             'refs/pull/410/head': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
@@ -1295,31 +1259,31 @@ class TestGitPoller(TestGitPollerBase):
         # Test that environment variables get propagated to subprocesses
         # (See #2116)
         self.patch(os, 'environ', {'ENVVAR': 'TRUE'})
-        self.addGetProcessOutputExpectEnv({'ENVVAR': 'TRUE'})
+        self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
 
         # patch out getProcessOutput and getProcessOutputAndValue for the
         # benefit of the _get_changes method
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'no interesting output'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect('git', 'log', '--ignore-missing',
-                       '--format=%H',
-                       '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                       '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                       '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing',
+                          '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -1389,7 +1353,7 @@ class TestGitPoller(TestGitPollerBase):
             'src': 'git',
             'when_timestamp': 1273258009,
         }])
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
 
         self.master.db.state.assertStateByClass(
             name=bytes2unicode(self.REPOURL), class_name='GitPoller',
@@ -1399,26 +1363,25 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_callableCategory(self):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            gpo.Expect(
-                'git', 'log', '--ignore-missing', '--format=%H',
-                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                '--')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
+                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                          '--'])
+            .workdir('gitpoller-work')
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
@@ -1459,7 +1422,7 @@ class TestGitPoller(TestGitPollerBase):
         }
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'refs/heads/master':
             '4423cdbcbb89c14e50dd5f4152415afd686c5241',
@@ -1522,14 +1485,14 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_check_git_features_ssh_1_7(self, write_local_file_mock,
                                         temp_dir_mock):
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
         )
 
         yield self.assertFailure(self.poller._checkGitFeatures(), EnvironmentError)
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
 
         self.assertEqual(len(temp_dir_mock.dirs), 0)
         write_local_file_mock.assert_not_called()
@@ -1541,27 +1504,27 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
         key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git',
-                       '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
-                       'ls-remote', '--refs', self.REPOURL),
-            gpo.Expect('git',
-                       '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
-                       'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
+                          'ls-remote', '--refs', self.REPOURL]),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
+                          'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
@@ -1585,26 +1548,26 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
     def test_poll_initial_2_3(self, write_local_file_mock, temp_dir_mock):
         key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.3.0\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            gpo.Expect('git', 'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .env({'GIT_SSH_COMMAND': 'ssh -o "BatchMode=yes" -i "{0}"'.format(key_path)}),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
@@ -1630,24 +1593,24 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         # make sure we cleanup the private key when fetch fails
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git',
-                       '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
-                       'ls-remote', '--refs', self.REPOURL),
-            gpo.Expect('git',
-                       '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
-                       'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
+                          'ls-remote', '--refs', self.REPOURL]),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
+                          'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .exit(1),
         )
 
         yield self.assertFailure(self.poller.poll(), EnvironmentError)
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
 
         temp_dir_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@')
         self.assertEqual(temp_dir_mock.dirs,
@@ -1673,33 +1636,29 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
         known_hosts_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@',
                                         'ssh-known-hosts')
 
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git',
-                       '-c',
-                       'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
-                       '-o "UserKnownHostsFile={1}"'.format(
-                               key_path, known_hosts_path),
-                       'ls-remote', '--refs', self.REPOURL),
-            gpo.Expect('git',
-                       '-c',
-                       'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
-                       '-o "UserKnownHostsFile={1}"'.format(
-                               key_path, known_hosts_path),
-                       'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
+                          '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
+                          'ls-remote', '--refs', self.REPOURL]),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
+                          '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
+                          'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
@@ -1741,33 +1700,29 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
         known_hosts_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@',
                                         'ssh-known-hosts')
 
-        self.expectCommands(
-            gpo.Expect('git', '--version')
+        self.expect_commands(
+            ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
-            gpo.Expect('git',
-                       '-c',
-                       'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
-                       '-o "UserKnownHostsFile={1}"'.format(
-                               key_path, known_hosts_path),
-                       'ls-remote', '--refs', self.REPOURL),
-            gpo.Expect('git',
-                       '-c',
-                       'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
-                       '-o "UserKnownHostsFile={1}"'.format(
-                               key_path, known_hosts_path),
-                       'fetch', self.REPOURL,
-                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work'),
-            gpo.Expect('git', 'rev-parse',
-                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
-            .path('gitpoller-work')
+            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
+                          '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
+                          'ls-remote', '--refs', self.REPOURL]),
+            ExpectMaster(['git',
+                          '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
+                          '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
+                          'fetch', self.REPOURL,
+                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work'),
+            ExpectMaster(['git', 'rev-parse',
+                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            .workdir('gitpoller-work')
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
         yield self.poller.poll()
 
-        self.assertAllCommandsRan()
+        self.assert_all_commands_ran()
         self.assertEqual(self.poller.lastRev, {
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -1,0 +1,292 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from parameterized import parameterized
+
+import mock
+
+from twisted.internet import defer
+from twisted.python import runtime
+from twisted.trial import unittest
+
+from buildbot.test.util.logging import LoggingMixin
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util.runprocess import RunProcess
+
+# windows returns rc 1, because exit status cannot indicate "signalled";
+# posix returns rc -1 for "signalled"
+FATAL_RC = -1
+EXPECTED_PWD = '/workdir'
+if runtime.platformType == 'win32':
+    FATAL_RC = 1
+    EXPECTED_PWD = 'C:\\workdir'
+
+
+class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
+
+    FAKE_PID = 1234
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.setUpLogging()
+        self.process = None
+        self.reactor.spawnProcess = self.fake_spawn_process
+
+    def fake_spawn_process(self, pp, command, args, env, workdir):
+        self.assertIsNone(self.process)
+        self.pp = pp
+        self.pp.transport = mock.Mock()
+        self.process = mock.Mock()
+        self.process.pid = self.FAKE_PID
+        self.process_spawned_args = (command, args, env, workdir)
+        return self.process
+
+    def run_process(self, command, override_kill_success=True, override_is_dead=True, **kwargs):
+        self.run_process_obj = RunProcess(self.reactor, command, '/workdir', **kwargs)
+        self.run_process_obj.get_os_env = lambda: {'OS_ENV': 'value'}
+        self.run_process_obj.send_signal = mock.Mock(side_effect=lambda sig: override_kill_success)
+        self.run_process_obj.is_dead = mock.Mock(side_effect=lambda: override_is_dead)
+        return self.run_process_obj.start()
+
+    def end_process(self, signal=None, rc=0):
+        reason = mock.Mock()
+        reason.value.signal = signal
+        reason.value.exitCode = rc
+        self.pp.processEnded(reason)
+
+    @defer.inlineCallbacks
+    def test_no_output(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False)
+        self.assertEqual(self.process_spawned_args,
+                         ('cmd', ['cmd'], {'OS_ENV': 'value', 'PWD': EXPECTED_PWD}, '/workdir'))
+
+        self.pp.connectionMade()
+        self.assertFalse(d.called)
+        self.end_process()
+        self.assertTrue(d.called)
+
+        res = yield d
+        self.assertEqual(res, (0, b''))
+
+    @defer.inlineCallbacks
+    def test_env_new_kv(self):
+        d = self.run_process(['cmd'], collect_stdout=False, collect_stderr=False,
+                             env={'custom': 'custom-value'})
+        self.assertEqual(self.process_spawned_args,
+                         ('cmd', ['cmd'], {'OS_ENV': 'value', 'PWD': EXPECTED_PWD,
+                                           'custom': 'custom-value'}, '/workdir'))
+
+        self.pp.connectionMade()
+        self.end_process()
+
+        res = yield d
+        self.assertEqual(res, 0)
+
+    @defer.inlineCallbacks
+    def test_env_overwrite_os_kv(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False,
+                             env={'OS_ENV': 'custom-value'})
+        self.assertEqual(self.process_spawned_args,
+                         ('cmd', ['cmd'], {'OS_ENV': 'custom-value', 'PWD': EXPECTED_PWD},
+                          '/workdir'))
+
+        self.pp.connectionMade()
+        self.end_process()
+
+        res = yield d
+        self.assertEqual(res, (0, b''))
+
+    @defer.inlineCallbacks
+    def test_env_remove_os_kv(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False,
+                             env={'OS_ENV': None})
+        self.assertEqual(self.process_spawned_args,
+                         ('cmd', ['cmd'], {'PWD': EXPECTED_PWD}, '/workdir'))
+
+        self.pp.connectionMade()
+        self.end_process()
+
+        res = yield d
+        self.assertEqual(res, (0, b''))
+
+    @defer.inlineCallbacks
+    def test_collect_nothing(self):
+        d = self.run_process(['cmd'], collect_stdout=False, collect_stderr=False)
+
+        self.pp.connectionMade()
+        self.pp.transport.write.assert_not_called()
+        self.pp.transport.closeStdin.assert_called()
+
+        self.pp.outReceived(b'stdout_data')
+        self.pp.errReceived(b'stderr_data')
+
+        self.assertFalse(d.called)
+        self.end_process()
+        self.assertTrue(d.called)
+
+        res = yield d
+        self.assertEqual(res, 0)
+
+    @defer.inlineCallbacks
+    def test_collect_stdout_no_stderr(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False)
+
+        self.pp.connectionMade()
+        self.pp.transport.write.assert_not_called()
+        self.pp.transport.closeStdin.assert_called()
+
+        self.pp.outReceived(b'stdout_data')
+        self.pp.errReceived(b'stderr_data')
+
+        self.assertFalse(d.called)
+        self.end_process()
+        self.assertTrue(d.called)
+
+        res = yield d
+        self.assertEqual(res, (0, b'stdout_data'))
+
+    @defer.inlineCallbacks
+    def test_collect_stdout_with_stdin(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False,
+                             initial_stdin=b'stdin')
+
+        self.pp.connectionMade()
+        self.pp.transport.write.assert_called_with(b'stdin')
+        self.pp.transport.closeStdin.assert_called()
+
+        self.pp.outReceived(b'stdout_data')
+        self.pp.errReceived(b'stderr_data')
+        self.end_process()
+
+        res = yield d
+        self.assertEqual(res, (0, b'stdout_data'))
+
+    @defer.inlineCallbacks
+    def test_collect_stdout_and_stderr(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=True)
+
+        self.pp.connectionMade()
+        self.pp.transport.write.assert_not_called()
+        self.pp.transport.closeStdin.assert_called()
+
+        self.pp.outReceived(b'stdout_data')
+        self.pp.errReceived(b'stderr_data')
+        self.end_process()
+
+        res = yield d
+        self.assertEqual(res, (0, b'stdout_data', b'stderr_data'))
+
+    @defer.inlineCallbacks
+    def test_process_failed_with_rc(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=True)
+
+        self.pp.connectionMade()
+        self.pp.outReceived(b'stdout_data')
+        self.pp.errReceived(b'stderr_data')
+        self.end_process(rc=1)
+
+        res = yield d
+        self.assertEqual(res, (1, b'stdout_data', b'stderr_data'))
+
+    @defer.inlineCallbacks
+    def test_process_failed_with_signal(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=True)
+
+        self.pp.connectionMade()
+        self.pp.outReceived(b'stdout_data')
+        self.pp.errReceived(b'stderr_data')
+        self.end_process(signal='SIGILL')
+
+        res = yield d
+        self.assertEqual(res, (-1, b'stdout_data', b'stderr_data'))
+
+    @parameterized.expand([
+        ('too_short_time_no_output', 0, 4.9, False, False, False),
+        ('too_short_time_with_output', 0, 4.9, False, True, True),
+        ('timed_out_no_output', 0, 5.1, True, False, False),
+        ('timed_out_with_output', 0, 5.1, True, True, True),
+        ('stdout_prevented_timeout', 1.0, 4.9, False, True, False),
+        ('stderr_prevented_timeout', 1.0, 4.9, False, False, True),
+        ('timed_out_after_extra_output', 1.0, 5.1, True, True, True),
+    ])
+    @defer.inlineCallbacks
+    def test_io_timeout(self, name, wait1, wait2, timed_out, had_stdout, had_stderr):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=True, io_timeout=5)
+
+        self.pp.connectionMade()
+        self.reactor.advance(wait1)
+        if had_stdout:
+            self.pp.outReceived(b'stdout_data')
+        if had_stderr:
+            self.pp.errReceived(b'stderr_data')
+        self.reactor.advance(wait2)
+
+        self.assertFalse(d.called)
+        self.end_process()
+        self.assertTrue(d.called)
+
+        if timed_out:
+            self.run_process_obj.send_signal.assert_called_with('TERM')
+        else:
+            self.run_process_obj.send_signal.assert_not_called()
+
+        res = yield d
+        self.assertEqual(res, (FATAL_RC if timed_out else 0,
+                               b'stdout_data' if had_stdout else b'',
+                               b'stderr_data' if had_stderr else b''))
+
+    @parameterized.expand([
+        ('too_short_time', 4.9, False),
+        ('timed_out', 5.1, True),
+    ])
+    @defer.inlineCallbacks
+    def test_runtime_timeout(self, name, wait, timed_out):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=True, runtime_timeout=5)
+
+        self.pp.connectionMade()
+        self.reactor.advance(wait)
+
+        self.assertFalse(d.called)
+        self.end_process()
+        self.assertTrue(d.called)
+
+        if timed_out:
+            self.run_process_obj.send_signal.assert_called_with('TERM')
+        else:
+            self.run_process_obj.send_signal.assert_not_called()
+
+        res = yield d
+        self.assertEqual(res, (FATAL_RC if timed_out else 0, b'', b''))
+
+    @defer.inlineCallbacks
+    def test_runtime_timeout_failing_to_kill(self):
+        d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=True, runtime_timeout=5,
+                             sigterm_timeout=5, override_is_dead=False)
+
+        self.pp.connectionMade()
+        self.reactor.advance(5.1)
+        self.run_process_obj.send_signal.assert_called_with('TERM')
+        self.reactor.advance(5.1)
+        self.run_process_obj.send_signal.assert_called_with('KILL')
+        self.reactor.advance(5.1)
+
+        self.assertTrue(d.called)
+        self.end_process()
+
+        with self.assertRaises(RuntimeError):
+            yield d
+
+        self.assertLogged("attempted to kill process, but it wouldn't die")

--- a/master/buildbot/test/unit/util/test_test_util_runprocess.py
+++ b/master/buildbot/test/unit/util/test_test_util_runprocess.py
@@ -1,0 +1,254 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import reporter
+from twisted.trial import unittest
+
+from buildbot.test.util.runprocess import ExpectMaster
+from buildbot.test.util.runprocess import MasterRunProcessMixin
+from buildbot.util import runprocess
+
+
+class TestRunprocessMixin(unittest.TestCase):
+
+    def run_test_method(self, method):
+        class TestCase(MasterRunProcessMixin, unittest.TestCase):
+
+            def setUp(self):
+                self.setup_master_run_process()
+
+            def runTest(self):
+                return method(self)
+
+        self.testcase = TestCase()
+        result = reporter.TestResult()
+        self.testcase.run(result)  # This blocks
+        return result
+
+    def assert_test_failure(self, result, expected_failure):
+        self.assertEqual(result.errors, [])
+        self.assertEqual(len(result.failures), 1)
+        self.assertTrue(result.failures[0][1].check(unittest.FailTest))
+        if expected_failure:
+            self.assertSubstring(expected_failure, result.failures[0][1].getErrorMessage())
+
+    def assert_successful(self, result):
+        if not result.wasSuccessful():
+            output = 'expected success'
+            if result.failures:
+                output += ('\ntest failed: {}'.format(result.failures[0][1].getErrorMessage()))
+            if result.errors:
+                output += ('\nerrors: {}'.format([error[1].value for error in result.errors]))
+            raise self.failureException(output)
+
+        self.assertTrue(result.wasSuccessful())
+
+    def test_patch(self):
+        original_run_process = runprocess.run_process
+
+        def method(testcase):
+            testcase.expect_commands()
+            self.assertEqual(runprocess.run_process, testcase.patched_run_process)
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+        self.assertEqual(runprocess.run_process, original_run_process)
+
+    def test_method_chaining(self):
+        expect = ExpectMaster('command')
+        self.assertEqual(expect, expect.exit(0))
+        self.assertEqual(expect, expect.stdout(b"output"))
+        self.assertEqual(expect, expect.stderr(b"error"))
+
+    def test_run_process_one_command_only_rc(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).stdout(b'stdout').stderr(b'stderr'))
+            res = yield runprocess.run_process(None, ["command"],
+                                               collect_stdout=False, collect_stderr=False)
+            self.assertEqual(res, 0)
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_one_command_only_rc_stdout(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).stdout(b'stdout').stderr(b'stderr'))
+            res = yield runprocess.run_process(None, ["command"],
+                                               collect_stdout=True, collect_stderr=False)
+            self.assertEqual(res, (0, b'stdout'))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_one_command_with_rc_stderr(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).stdout(b'stdout').stderr(b'stderr'))
+            res = yield runprocess.run_process(None, ["command"],
+                                               collect_stdout=False, collect_stderr=True)
+            self.assertEqual(res, (0, b'stderr'))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_one_command_with_rc_stdout_stderr(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).stdout(b'stdout').stderr(b'stderr'))
+            res = yield runprocess.run_process(None, ["command"])
+            self.assertEqual(res, (0, b'stdout', b'stderr'))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_expect_two_run_one(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]))
+            testcase.expect_commands(ExpectMaster(["command2"]))
+            res = yield runprocess.run_process(None, ["command"])
+            self.assertEqual(res, (0, b'', b''))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "assert all expected commands were run")
+
+    def test_run_process_wrong_command(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command2"]))
+            yield runprocess.run_process(None, ["command"])
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "unexpected command run")
+        # assert we have a meaningful message
+        self.assert_test_failure(result, "command2")
+
+    def test_run_process_wrong_args(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command", "arg"]))
+            yield runprocess.run_process(None, ["command", "otherarg"])
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "unexpected command run")
+
+    def test_run_process_missing_path(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).workdir("/home"))
+            yield runprocess.run_process(None, ["command"])
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "unexpected command run")
+
+    def test_run_process_wrong_path(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command", "arg"]).workdir("/home"))
+            yield runprocess.run_process(None, ["command"], workdir="/path")
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "unexpected command run")
+
+    def test_run_process_not_current_path(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command", "arg"]))
+            yield runprocess.run_process(None, ["command"], workdir="/path")
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "unexpected command run")
+
+    def test_run_process_error_output(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).stderr(b"some test"))
+            res = yield runprocess.run_process(None, ["command"], collect_stderr=False,
+                                               stderr_is_error=True)
+            self.assertEqual(res, (-1, b''))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_nonzero_exit(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]).exit(1))
+            res = yield runprocess.run_process(None, ["command"])
+            self.assertEqual(res, (1, b'', b''))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_environ_success(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]))
+            testcase.add_run_process_expect_env({'key': 'value'})
+            res = yield runprocess.run_process(None, ["command"], env={'key': 'value'})
+            self.assertEqual(res, (0, b'', b''))
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_successful(result)
+
+    def test_run_process_environ_wrong_value(self):
+
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]))
+            testcase.add_run_process_expect_env({'key': 'value'})
+            yield runprocess.run_process(None, ["command"], env={'key': 'wrongvalue'})
+            testcase.assert_all_commands_ran()
+
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "Expected environment to have key = 'value'")
+
+    def test_run_process_environ_missing(self):
+        @defer.inlineCallbacks
+        def method(testcase):
+            testcase.expect_commands(ExpectMaster(["command"]))
+            testcase.add_run_process_expect_env({'key': 'value'})
+            d = runprocess.run_process(None, ["command"])
+            return d
+        result = self.run_test_method(method)
+        self.assert_test_failure(result, "Expected environment to have key = 'value'")

--- a/master/buildbot/test/util/runprocess.py
+++ b/master/buildbot/test/util/runprocess.py
@@ -1,0 +1,124 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.util import runprocess
+
+
+def _check_env_is_expected(test, expected_env, env):
+    if expected_env is None:
+        return
+
+    env = env or {}
+    for var, value in expected_env.items():
+        test.assertEqual(env.get(var), value,
+                         'Expected environment to have {} = {}'.format(var, repr(value)))
+
+
+class ExpectMaster:
+    _stdout = b""
+    _stderr = b""
+    _exit = 0
+    _workdir = None
+    _env = None
+
+    def __init__(self, command):
+        self._command = command
+
+    def stdout(self, stdout):
+        assert(isinstance(stdout, bytes))
+        self._stdout = stdout
+        return self
+
+    def stderr(self, stderr):
+        assert(isinstance(stderr, bytes))
+        self._stderr = stderr
+        return self
+
+    def exit(self, exit):
+        self._exit = exit
+        return self
+
+    def workdir(self, workdir):
+        self._workdir = workdir
+        return self
+
+    def env(self, env):
+        self._env = env
+        return self
+
+    def check(self, test, command, workdir, env):
+        test.assertDictEqual({'command': command, 'workdir': workdir},
+                             {'command': self._command, 'workdir': self._workdir},
+                             "unexpected command run")
+
+        _check_env_is_expected(test, self._env, env)
+        return (self._exit, self._stdout, self._stderr)
+
+    def __repr__(self):
+        return "<ExpectMaster(command={})>".format(self._command)
+
+
+class MasterRunProcessMixin:
+    long_message = True
+
+    def setup_master_run_process(self):
+        self._master_run_process_patched = False
+        self._expected_master_commands = []
+        self._master_run_process_expect_env = {}
+
+    def assert_all_commands_ran(self):
+        self.assertEqual(self._expected_master_commands, [],
+                         "assert all expected commands were run")
+
+    def patched_run_process(self, reactor, command, workdir=None, env=None,
+                            collect_stdout=True, collect_stderr=True, stderr_is_error=False,
+                            io_timeout=300, runtime_timeout=3600, sigterm_timeout=5,
+                            initial_stdin=None):
+
+        _check_env_is_expected(self, self._master_run_process_expect_env, env)
+
+        if not self._expected_master_commands:
+            self.fail("got command {} when no further commands were expected".format(command))
+
+        expect = self._expected_master_commands.pop(0)
+
+        rc, stdout, stderr = expect.check(self, command, workdir, env)
+
+        if not collect_stderr and stderr_is_error and stderr:
+            rc = -1
+
+        if collect_stdout and collect_stderr:
+            return (rc, stdout, stderr)
+        if collect_stdout:
+            return (rc, stdout)
+        if collect_stderr:
+            return (rc, stderr)
+        return rc
+
+    def _patch_runprocess(self):
+        if not self._master_run_process_patched:
+            self.patch(runprocess, "run_process", self.patched_run_process)
+            self._master_run_process_patched = True
+
+    def add_run_process_expect_env(self, d):
+        self._master_run_process_expect_env.update(d)
+
+    def expect_commands(self, *exp):
+        for e in exp:
+            if not isinstance(e, ExpectMaster):
+                raise Exception('All expectation must be an instance of ExpectMaster')
+
+        self._patch_runprocess()
+        self._expected_master_commands.extend(exp)

--- a/master/buildbot/util/runprocess.py
+++ b/master/buildbot/util/runprocess.py
@@ -1,0 +1,294 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import io
+import os
+import subprocess
+
+from twisted.internet import defer
+from twisted.internet import error
+from twisted.internet import protocol
+from twisted.python import failure
+from twisted.python import log
+from twisted.python import runtime
+
+from buildbot.util import unicode2bytes
+
+
+class RunProcessPP(protocol.ProcessProtocol):
+    def __init__(self, run_process, initial_stdin=None):
+        self.run_process = run_process
+        self.initial_stdin = initial_stdin
+
+    def connectionMade(self):
+        if self.initial_stdin:
+            self.transport.write(self.initial_stdin)
+        self.transport.closeStdin()
+
+    def outReceived(self, data):
+        self.run_process.add_stdout(data)
+
+    def errReceived(self, data):
+        self.run_process.add_stderr(data)
+
+    def processEnded(self, reason):
+        self.run_process.process_ended(reason.value.signal, reason.value.exitCode)
+
+
+class RunProcess:
+
+    TIMEOUT_KILL = 5
+    interrupt_signal = "KILL"
+
+    def __init__(self, reactor, command, workdir=None, env=None,
+                 collect_stdout=True, collect_stderr=True, stderr_is_error=False,
+                 io_timeout=300, runtime_timeout=3600, sigterm_timeout=5, initial_stdin=None):
+
+        self._reactor = reactor
+        self.command = command
+
+        self.workdir = workdir
+        self.process = None
+
+        self.environ = env
+
+        self.initial_stdin = initial_stdin
+
+        self.output_stdout = io.BytesIO() if collect_stdout else None
+        self.output_stderr = io.BytesIO() if collect_stderr else None
+        self.stderr_is_error = stderr_is_error
+
+        self.io_timeout = io_timeout
+        self.io_timer = None
+
+        self.sigterm_timeout = sigterm_timeout
+        self.sigterm_timer = None
+
+        self.runtime_timeout = runtime_timeout
+        self.runtime_timer = None
+
+        self.killed = False
+        self.kill_timer = None
+
+    def __repr__(self):
+        return "<{0} '{1}'>".format(self.__class__.__name__, self.command)
+
+    def get_os_env(self):
+        return os.environ
+
+    def resolve_environment(self, env):
+        os_env = self.get_os_env()
+        if env is None:
+            return os_env.copy()
+
+        new_env = {}
+        for key in os_env:
+            if key not in env or env[key] is not None:
+                new_env[key] = os_env[key]
+        for key, value in env.items():
+            if value is not None:
+                new_env[key] = value
+        return new_env
+
+    def start(self):
+        self.deferred = defer.Deferred()
+        try:
+            self._start_command()
+        except Exception as e:
+            self.deferred.errback(failure.Failure(e))
+        return self.deferred
+
+    def _start_command(self):
+        self.pp = RunProcessPP(self, initial_stdin=self.initial_stdin)
+
+        environ = self.resolve_environment(self.environ)
+
+        # $PWD usually indicates the current directory; spawnProcess may not
+        # update this value, though, so we set it explicitly here.  This causes
+        # weird problems (bug #456) on msys
+        if not environ.get('MACHTYPE', None) == 'i686-pc-msys' and self.workdir is not None:
+            environ['PWD'] = os.path.abspath(self.workdir)
+
+        argv = unicode2bytes(self.command)
+        self.process = self._reactor.spawnProcess(self.pp, argv[0], argv, environ, self.workdir)
+
+        if self.io_timeout:
+            self.io_timer = self._reactor.callLater(self.io_timeout, self.io_timed_out)
+
+        if self.runtime_timeout:
+            self.runtime_timer = self._reactor.callLater(self.runtime_timeout,
+                                                         self.runtime_timed_out)
+
+    def add_stdout(self, data):
+        if self.output_stdout is not None:
+            self.output_stdout.write(data)
+
+        if self.io_timer:
+            self.io_timer.reset(self.io_timeout)
+
+    def add_stderr(self, data):
+        if self.output_stderr is not None:
+            self.output_stderr.write(data)
+        elif self.stderr_is_error:
+            self.kill('command produced stderr which is interpreted as error')
+
+        if self.io_timer:
+            self.io_timer.reset(self.io_timeout)
+
+    def _build_result(self, rc):
+        if self.output_stdout is not None and self.output_stderr is not None:
+            return (rc, self.output_stdout.getvalue(), self.output_stderr.getvalue())
+        if self.output_stdout is not None:
+            return (rc, self.output_stdout.getvalue())
+        if self.output_stderr is not None:
+            return (rc, self.output_stderr.getvalue())
+        return rc
+
+    def process_ended(self, sig, rc):
+        if self.killed and rc == 0:
+            log.msg("process was killed, but exited with status 0; faking a failure")
+
+            # windows returns '1' even for signalled failures, while POSIX returns -1
+            if runtime.platformType == 'win32':
+                rc = 1
+            else:
+                rc = -1
+
+        if sig is not None:
+            rc = -1
+
+        self._cancel_timers()
+        d = self.deferred
+        self.deferred = None
+        if d:
+            d.callback(self._build_result(rc))
+        else:
+            log.err("{}: command finished twice".format(self))
+
+    def failed(self, why):
+        self._cancel_timers()
+        d = self.deferred
+        self.deferred = None
+        if d:
+            d.errback(why)
+        else:
+            log.err("{}: command finished twice".format(self))
+
+    def io_timed_out(self):
+        self.io_timer = None
+        msg = "{}: command timed out: {} seconds without output".format(self, self.io_timeout)
+        self.kill(msg)
+
+    def runtime_timed_out(self):
+        self.runtime_timer = None
+        msg = "{}: command timed out: {} seconds elapsed".format(self, self.runtime_timeout)
+        self.kill(msg)
+
+    def is_dead(self):
+        if self.process.pid is None:
+            return True
+        pid = int(self.process.pid)
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return True
+        return False
+
+    def check_process_was_killed(self):
+
+        self.sigterm_timer = None
+        if not self.is_dead():
+            if not self.send_signal(self.interrupt_signal):
+                log.msg("{}: failed to kill process again".format(self))
+
+        self.cleanup_killed_process()
+
+    def cleanup_killed_process(self):
+        if runtime.platformType == "posix":
+            # we only do this under posix because the win32eventreactor
+            # blocks here until the process has terminated, while closing
+            # stderr. This is weird.
+            self.pp.transport.loseConnection()
+
+        if self.deferred:
+            # finished ought to be called momentarily. Just in case it doesn't,
+            # set a timer which will abandon the command.
+            self.kill_timer = self._reactor.callLater(self.TIMEOUT_KILL, self.kill_timed_out)
+
+    def send_signal(self, interrupt_signal):
+        success = False
+
+        log.msg('{}: killing process using {}'.format(self, interrupt_signal))
+
+        if runtime.platformType == "win32":
+            if interrupt_signal is not None and self.process.pid is not None:
+                if interrupt_signal == "TERM":
+                    # TODO: blocks
+                    subprocess.check_call("TASKKILL /PID {0} /T".format(self.process.pid))
+                    success = True
+                elif interrupt_signal == "KILL":
+                    # TODO: blocks
+                    subprocess.check_call("TASKKILL /F /PID {0} /T".format(self.process.pid))
+                    success = True
+
+        # try signalling the process itself (works on Windows too, sorta)
+        if not success:
+            try:
+                self.process.signalProcess(interrupt_signal)
+                success = True
+            except OSError as e:
+                log.err("{}: from process.signalProcess: {}".format(self, e))
+                # could be no-such-process, because they finished very recently
+            except error.ProcessExitedAlready:
+                log.msg("{}: process exited already - can't kill".format(self))
+
+                # the process has already exited, and likely finished() has
+                # been called already or will be called shortly
+
+        return success
+
+    def kill(self, msg):
+        log.msg('{}: killing process because {}'.format(self, msg))
+        self._cancel_timers()
+
+        self.killed = True
+
+        if self.sigterm_timeout is not None:
+            self.send_signal("TERM")
+            self.sigterm_timer = self._reactor.callLater(self.sigterm_timeout,
+                                                         self.check_process_was_killed)
+        else:
+            if not self.send_signal(self.interrupt_signal):
+                log.msg("{}: failed to kill process".format(self))
+
+            self.cleanup_killed_process()
+
+    def kill_timed_out(self):
+        self.kill_timer = None
+        log.msg("{}: attempted to kill process, but it wouldn't die".format(self))
+
+        self.failed(RuntimeError("SIG{} failed to kill process".format(self.interrupt_signal)))
+
+    def _cancel_timers(self):
+        for name in ('io_timer', 'kill_timer', 'runtime_timer', 'sigterm_timer'):
+            timer = getattr(self, name, None)
+            if timer:
+                timer.cancel()
+                setattr(self, name, None)
+
+
+def run_process(*args, **kwargs):
+    process = RunProcess(*args, **kwargs)
+    return process.start()


### PR DESCRIPTION
This PR adds an reimplementation of Twisted's util.getProcessOutput family of functions with timeout functionality. This prevents a hang of master-side shell function from causing damage to the master itself. An example of hanging master-side shell command is a git pull via ssh during which the target computer is suspended. In practice this may be caused by any network interruption during ssh operations that causes the connection to not being closed or reset appropriately.