### PR TITLE
Enable several previously flaky tests

### DIFF
--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -97,24 +97,6 @@ class RunSteps(RunFakeMasterTestCase):
         return builder_id
 
     @defer.inlineCallbacks
-    def do_test_build(self, builder_id):
-
-        # setup waiting for build to finish
-        d_finished = defer.Deferred()
-
-        def on_finished(_, __):
-            if not d_finished.called:
-                d_finished.callback(None)
-        consumer = yield self.master.mq.startConsuming(on_finished, ('builds', None, 'finished'))
-
-        # start the builder
-        yield self.create_build_request([builder_id])
-
-        # and wait for build completion
-        yield d_finished
-        yield consumer.stopConsuming()
-
-    @defer.inlineCallbacks
     def test_step_raising_buildstepfailed_in_start(self):
         builder_id = yield self.create_config_for_step(FailingCustomStep())
 

--- a/master/buildbot/test/unit/scripts/test_start.py
+++ b/master/buildbot/test/unit/scripts/test_start.py
@@ -28,7 +28,6 @@ from twisted.trial import unittest
 from buildbot.scripts import start
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
-from buildbot.test.util.decorators import flaky
 from buildbot.test.util.decorators import skipUnlessPlatformIs
 
 
@@ -118,7 +117,6 @@ class TestStart(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
 
         self.assertEqual(res, (mock.ANY, b'', 0))
 
-    @flaky(bugNumber=2760)
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
     def test_start(self):
@@ -126,8 +124,7 @@ class TestStart(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
             (out, err, rc) = yield self.runStart()
 
             self.assertEqual((rc, err), (0, b''))
-            self.assertSubstring(
-                'buildmaster appears to have (re)started correctly', out)
+            self.assertSubstring(b'buildmaster appears to have (re)started correctly', out)
         finally:
             # wait for the pidfile to go away after the reactor.stop
             # in buildbot.tac takes effect

--- a/master/buildbot/test/unit/worker/test_ec2.py
+++ b/master/buildbot/test/unit/worker/test_ec2.py
@@ -18,7 +18,6 @@ import os
 
 from twisted.trial import unittest
 
-from buildbot.test.util.decorators import flaky
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 
@@ -403,7 +402,6 @@ class TestEC2LatentWorker(unittest.TestCase):
 
         self.assertEqual(image.id, ami.id)
 
-    @flaky(issueNumber=3936)
     @mock_ec2
     def test_get_image_owners(self):
         c, r = self.botoSetup('latent_buildbot_slave')

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -153,6 +153,24 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
         )
         return ret
 
+    @defer.inlineCallbacks
+    def do_test_build(self, builder_id):
+
+        # setup waiting for build to finish
+        d_finished = defer.Deferred()
+
+        def on_finished(_, __):
+            if not d_finished.called:
+                d_finished.callback(None)
+        consumer = yield self.master.mq.startConsuming(on_finished, ('builds', None, 'finished'))
+
+        # start the builder
+        yield self.create_build_request([builder_id])
+
+        # and wait for build completion
+        yield d_finished
+        yield consumer.stopConsuming()
+
 
 class RunMasterBase(unittest.TestCase):
     proto = "null"

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -154,6 +154,11 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
         return ret
 
     @defer.inlineCallbacks
+    def do_test_build_by_name(self, builder_name):
+        builder_id = yield self.master.data.updates.findBuilderId(builder_name)
+        yield self.do_test_build(builder_id)
+
+    @defer.inlineCallbacks
     def do_test_build(self, builder_id):
 
         # setup waiting for build to finish


### PR DESCRIPTION
Fixes #2950, fixes #3936, fixes #2853. The test_custom_service needed more work to make it pass with the new test infrastructure.