### PR TITLE
process: Fix crash when worker with a running build is disconnected

### DIFF
--- a/master/buildbot/newsfragments/worker-disconnect-props-crash.bugfix
+++ b/master/buildbot/newsfragments/worker-disconnect-props-crash.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash when a worker is disconnected from a running build that uses worker information for some of its properties (:issue:`5745`).

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -37,6 +37,7 @@ class FakeWorker:
     def __init__(self, master):
         self.master = master
         self.conn = fakeprotocol.FakeConnection(self)
+        self.info = properties.Properties()
         self.properties = properties.Properties()
         self.defaultProperties = properties.Properties()
         self.workerid = 383

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -22,8 +22,12 @@ from buildbot.interfaces import IBuildStepFactory
 from buildbot.machine.base import Machine
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
+from buildbot.process.properties import Interpolate
 from buildbot.process.results import CANCELLED
+from buildbot.process.results import RETRY
 from buildbot.test.fake.latent import LatentController
+from buildbot.test.fake.step import BuildStepController
+from buildbot.test.fake.worker import WorkerController
 from buildbot.test.util.integration import RunFakeMasterTestCase
 
 try:
@@ -213,6 +217,37 @@ class Tests(RunFakeMasterTestCase):
 
         # reconfig should succeed
         yield self.reconfig_master(config_dict)
+
+    @defer.inlineCallbacks
+    def test_step_with_worker_build_props_during_worker_disconnect(self):
+        """
+        We need to handle worker disconnection and steps with worker build properties gracefully
+        """
+        controller = WorkerController(self, 'local')
+
+        stepcontroller = BuildStepController()
+
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="builder", workernames=['local'],
+                              properties={'worker': Interpolate("%(worker:numcpus)s")},
+                              factory=BuildFactory([stepcontroller.step])),
+            ],
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+
+        yield self.setup_master(config_dict)
+
+        builder_id = yield self.master.data.updates.findBuilderId('builder')
+        yield self.create_build_request([builder_id])
+
+        yield controller.connect_worker()
+        self.reactor.advance(1)
+        yield controller.disconnect_worker()
+        self.reactor.advance(1)
+        yield self.assertBuildResults(1, RETRY)
 
     @defer.inlineCallbacks
     def test_worker_os_release_info_roundtrip(self):


### PR DESCRIPTION
A worker disconnection will detach the worker from workerforbuilder, so its worker member will become None. If any build was running during the disconnection, it will no longer be able to access the worker information. This will result in a crash as it may be used as a source for build properties which is updated just before the end of the build.

Fixes #5745.

The PR depends on #6052 to land in order for the tests to be stable.
