### PR TITLE
Worker connection cleanups

### DIFF
--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -16,28 +16,15 @@
 
 from twisted.internet import defer
 
-from buildbot.util import subscription
 from buildbot.worker.protocols import base
 
 
-class FakeTrivialConnection:
+class FakeTrivialConnection(base.Connection):
 
     info = {}
 
     def __init__(self):
-        self._disconnectSubs = subscription.SubscriptionPoint("disconnections from Fake")
-
-    def waitShutdown(self):
-        return defer.succeed(None)
-
-    def notifyOnDisconnect(self, cb):
-        return self._disconnectSubs.subscribe(cb)
-
-    def waitForNotifyDisconnectedDelivered(self):
-        return self._disconnectSubs.waitForDeliveriesToFinish()
-
-    def notifyDisconnected(self):
-        self._disconnectSubs.deliver()
+        super().__init__("Fake")
 
     def loseConnection(self):
         self.notifyDisconnected()

--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -48,8 +48,8 @@ class FakeTrivialConnection:
 
 class FakeConnection(base.Connection):
 
-    def __init__(self, master, worker):
-        super().__init__(master, worker)
+    def __init__(self, worker):
+        super().__init__(worker.workername)
         self._connected = True
         self.remoteCalls = []
         self.builders = {}  # { name : isBusy }

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -93,16 +93,18 @@ class LatentController(SeverWorkerConnectionMixin):
         if self.auto_start_flag and self.state == States.STARTING:
             self.start_instance(True)
 
+    @defer.inlineCallbacks
     def start_instance(self, result):
-        self.do_start_instance(result)
+        yield self.do_start_instance(result)
         d, self._start_deferred = self._start_deferred, None
         d.callback(result)
 
+    @defer.inlineCallbacks
     def do_start_instance(self, result):
         assert self.state == States.STARTING
         self.state = States.STARTED
         if self.auto_connect_worker and result is True:
-            self.connect_worker()
+            yield self.connect_worker()
 
     @defer.inlineCallbacks
     def auto_stop(self, result):
@@ -124,6 +126,7 @@ class LatentController(SeverWorkerConnectionMixin):
         if self.auto_disconnect_worker:
             yield self.disconnect_worker()
 
+    @defer.inlineCallbacks
     def connect_worker(self):
         if self.remote_worker is not None:
             return
@@ -132,7 +135,7 @@ class LatentController(SeverWorkerConnectionMixin):
         workdir = FilePath(self.case.mktemp())
         workdir.createDirectory()
         self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
-        self.remote_worker.setServiceParent(self.worker)
+        yield self.remote_worker.setServiceParent(self.worker)
 
     def disconnect_worker(self):
         super().disconnect_worker()

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -21,6 +21,7 @@ from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SkipTest
 
 from buildbot.test.fake.worker import SeverWorkerConnectionMixin
+from buildbot.test.fake.worker import disconnect_master_side_worker
 from buildbot.worker import AbstractLatentWorker
 
 try:
@@ -142,13 +143,11 @@ class LatentController(SeverWorkerConnectionMixin):
         yield super().disconnect_worker()
         if self.remote_worker is None:
             return
-        self.worker.conn, conn = None, self.worker.conn
+
         self.remote_worker, worker = None, self.remote_worker
 
-        # LocalWorker does actually disconnect, so we must force disconnection
-        # via detached. Note that the worker may have already detached
-        if conn is not None:
-            conn.loseConnection()
+        disconnect_master_side_worker(self.worker)
+
         yield worker.disownServiceParent()
 
     def setup_kind(self, build):

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -137,10 +137,11 @@ class LatentController(SeverWorkerConnectionMixin):
         self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
         yield self.remote_worker.setServiceParent(self.worker)
 
+    @defer.inlineCallbacks
     def disconnect_worker(self):
-        super().disconnect_worker()
+        yield super().disconnect_worker()
         if self.remote_worker is None:
-            return None
+            return
         self.worker.conn, conn = None, self.worker.conn
         self.remote_worker, worker = None, self.remote_worker
 
@@ -148,7 +149,7 @@ class LatentController(SeverWorkerConnectionMixin):
         # via detached. Note that the worker may have already detached
         if conn is not None:
             conn.loseConnection()
-        return worker.disownServiceParent()
+        yield worker.disownServiceParent()
 
     def setup_kind(self, build):
         if build:

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -166,14 +166,15 @@ class WorkerController(SeverWorkerConnectionMixin):
         self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
         yield self.remote_worker.setServiceParent(self.worker)
 
+    @defer.inlineCallbacks
     def disconnect_worker(self):
-        super().disconnect_worker()
+        yield super().disconnect_worker()
         if self.remote_worker is None:
-            return None
+            return
         self.worker.conn, conn = None, self.worker.conn
         # LocalWorker does actually disconnect, so we must force disconnection
         # via detached
         conn.notifyDisconnected()
-        ret = self.remote_worker.disownServiceParent()
+        d = self.remote_worker.disownServiceParent()
         self.remote_worker = None
-        return ret
+        yield d

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -155,6 +155,7 @@ class WorkerController(SeverWorkerConnectionMixin):
         self.worker = worker_class(name, self, **kwargs)
         self.remote_worker = None
 
+    @defer.inlineCallbacks
     def connect_worker(self):
         if self.remote_worker is not None:
             return
@@ -163,7 +164,7 @@ class WorkerController(SeverWorkerConnectionMixin):
         workdir = FilePath(self.case.mktemp())
         workdir.createDirectory()
         self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
-        self.remote_worker.setServiceParent(self.worker)
+        yield self.remote_worker.setServiceParent(self.worker)
 
     def disconnect_worker(self):
         super().disconnect_worker()

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -36,7 +36,7 @@ class FakeWorker:
 
     def __init__(self, master):
         self.master = master
-        self.conn = fakeprotocol.FakeConnection(master, self)
+        self.conn = fakeprotocol.FakeConnection(self)
         self.properties = properties.Properties()
         self.defaultProperties = properties.Properties()
         self.workerid = 383

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -45,7 +45,7 @@ class Tests(RunFakeMasterTestCase):
         yield self.setup_master(config_dict)
         builder_id = yield self.master.data.updates.findBuilderId('testy')
 
-        controller.connect_worker()
+        yield controller.connect_worker()
         controller.sever_connection()
         yield self.create_build_request([builder_id])
 

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -111,7 +111,7 @@ class Tests(RunFakeMasterTestCase):
         # The worker fails to substantiate.
         controller.start_instance(True)
 
-        controller.connect_worker()
+        yield controller.connect_worker()
 
         self.assertEqual(len(started_builds), 1)
         yield controller.auto_stop(True)

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -191,7 +191,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.worker.attached(None)
         self.builder = FakeBuilder(self.master)
         self.build = Build([r])
-        self.build.conn = fakeprotocol.FakeConnection(self.master, self.worker)
+        self.build.conn = fakeprotocol.FakeConnection(self.worker)
 
         self.workerforbuilder = Mock(name='workerforbuilder')
         self.workerforbuilder.worker = self.worker

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -126,7 +126,7 @@ class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
         yield self.workers.setServiceParent(self.master)
         self.master.workers = self.workers
         yield self.wrk.setServiceParent(self.master.workers)
-        self.conn = fakeprotocol.FakeConnection(self.master, self.wrk)
+        self.conn = fakeprotocol.FakeConnection(self.wrk)
         yield self.wrk.attached(self.conn)
 
 
@@ -139,7 +139,7 @@ class FakeWorkerItfc(TestReactorMixin, unittest.TestCase,
         self.wrk = worker.FakeWorker(self.master)
 
     def callAttached(self):
-        self.conn = fakeprotocol.FakeConnection(self.master, self.wrk)
+        self.conn = fakeprotocol.FakeConnection(self.wrk)
         return self.wrk.attached(self.conn)
 
 
@@ -161,7 +161,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         if configured:
             yield worker.setServiceParent(self.workers)
         if attached:
-            worker.conn = fakeprotocol.FakeConnection(self.master, worker)
+            worker.conn = fakeprotocol.FakeConnection(worker)
         return worker
 
     @defer.inlineCallbacks
@@ -512,7 +512,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         ENVIRON = {}
         COMMANDS = {'cmd1': '1', 'cmd2': '1'}
 
-        conn = fakeprotocol.FakeConnection(worker.master, worker)
+        conn = fakeprotocol.FakeConnection(worker)
         conn.info = {
             'admin': 'TheAdmin',
             'host': 'TheHost',
@@ -545,7 +545,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         yield worker.startService()
         yield worker.reconfigServiceWithSibling(worker)
 
-        conn = fakeprotocol.FakeConnection(worker.master, worker)
+        conn = fakeprotocol.FakeConnection(worker)
         conn.info = {}
         yield worker.attached(conn)
 
@@ -565,7 +565,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         worker = yield self.createWorker()
         yield worker.startService()
 
-        conn = fakeprotocol.FakeConnection(worker.master, worker)
+        conn = fakeprotocol.FakeConnection(worker)
         conn.info = {
             'admin': 'TheAdmin',
             'host': 'TheHost',

--- a/master/buildbot/test/unit/worker/test_protocols_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_base.py
@@ -41,9 +41,8 @@ class TestFakeConnection(protocols.ConnectionInterfaceTest,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self)
         self.worker = mock.Mock()
-        self.conn = fakeprotocol.FakeConnection(self.master, self.worker)
+        self.conn = fakeprotocol.FakeConnection(self.worker)
 
 
 class TestConnection(protocols.ConnectionInterfaceTest,
@@ -51,13 +50,8 @@ class TestConnection(protocols.ConnectionInterfaceTest,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self)
         self.worker = mock.Mock()
-        self.conn = base.Connection(self.master, self.worker)
-
-    def test_constructor(self):
-        self.assertEqual(self.conn.master, self.master)
-        self.assertEqual(self.conn.worker, self.worker)
+        self.conn = base.Connection(self.worker.workername)
 
     def test_notify(self):
         cb = mock.Mock()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -436,7 +436,8 @@ class AbstractWorker(service.BuildbotService):
         self.worker_basedir = conn.info.get("basedir", None)
         self.worker_system = conn.info.get("system", None)
 
-        self.conn.notifyOnDisconnect(self.detached)
+        # The _detach_sub member is only ever used from tests.
+        self._detached_sub = self.conn.notifyOnDisconnect(self.detached)
 
         workerinfo = {
             'admin': conn.info.get('admin'),
@@ -486,11 +487,6 @@ class AbstractWorker(service.BuildbotService):
 
     @defer.inlineCallbacks
     def detached(self):
-        # protect against race conditions in conn disconnect path and someone
-        # calling detached directly. At the moment the null worker does that.
-        if self.conn is None:
-            return
-
         conn = self.conn
         self.conn = None
         self._handle_conn_shutdown_notifier(conn)

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -28,7 +28,6 @@ from buildbot.process.properties import Properties
 from buildbot.util import Notifier
 from buildbot.util import bytes2unicode
 from buildbot.util import service
-from buildbot.util.eventual import eventually
 
 
 @implementer(IWorker)
@@ -534,12 +533,7 @@ class AbstractWorker(service.BuildbotService):
     @defer.inlineCallbacks
     def _waitForCompleteShutdownImpl(self, conn):
         if conn:
-            d = defer.Deferred()
-
-            def _disconnected():
-                eventually(d.callback, None)
-            conn.notifyOnDisconnect(_disconnected)
-            yield d
+            yield conn.wait_shutdown_started()
             yield conn.waitShutdown()
         elif self._pending_conn_shutdown_notifier is not None:
             yield self._pending_conn_shutdown_notifier.wait()

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -107,7 +107,8 @@ class WorkerManager(MeasuredBuildbotServiceManager):
             old_conn = self.connections[workerName]
             try:
                 yield misc.cancelAfter(self.PING_TIMEOUT,
-                                       old_conn.remotePrint("master got a duplicate connection"))
+                                       old_conn.remotePrint("master got a duplicate connection"),
+                                       self.master.reactor)
                 # if we get here then old connection is still alive, and new
                 # should be rejected
                 raise RuntimeError("rejecting duplicate worker")

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -13,8 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
+
 from buildbot.util import service
 from buildbot.util import subscription
+from buildbot.util.eventual import eventually
 
 
 class Listener(service.ReconfigurableServiceMixin, service.AsyncMultiService):
@@ -36,7 +39,13 @@ class Connection:
                     v = proxyclass(v)
             newargs[k] = v
         return newargs
+
     # disconnection handling
+
+    def wait_shutdown_started(self):
+        d = defer.Deferred()
+        self.notifyOnDisconnect(lambda: eventually(d.callback, None))
+        return d
 
     def waitShutdown(self):
         return self._disconnectSubs.waitForDeliveriesToFinish()

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -26,10 +26,7 @@ class Listener(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 class Connection:
     proxies = {}
 
-    def __init__(self, master, worker):
-        self.master = master
-        self.worker = worker
-        name = worker.workername
+    def __init__(self, name):
         self._disconnectSubs = subscription.SubscriptionPoint("disconnections from {}".format(name))
 
     # This method replace all Impl args by their Proxy protocol implementation

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -13,8 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
-
 from buildbot.util import service
 from buildbot.util import subscription
 
@@ -41,13 +39,10 @@ class Connection:
     # disconnection handling
 
     def waitShutdown(self):
-        return defer.succeed(None)
+        return self._disconnectSubs.waitForDeliveriesToFinish()
 
     def notifyOnDisconnect(self, cb):
         return self._disconnectSubs.subscribe(cb)
-
-    def waitForNotifyDisconnectedDelivered(self):
-        return self._disconnectSubs.waitForDeliveriesToFinish()
 
     def notifyDisconnected(self):
         self._disconnectSubs.deliver()

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -69,6 +69,10 @@ class Connection(base.Connection):
     proxies = {base.FileWriterImpl: FileWriterProxy,
                base.FileReaderImpl: FileReaderProxy}
 
+    def __init__(self, worker):
+        super().__init__(worker.workername)
+        self.worker = worker
+
     def loseConnection(self):
         self.notifyDisconnected()
 

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -132,7 +132,9 @@ class Connection(base.Connection, pb.Avatar):
     info = None
 
     def __init__(self, master, worker, mind):
-        super().__init__(master, worker)
+        super().__init__(worker.workername)
+        self.master = master
+        self.worker = worker
         self.mind = mind
         self._keepalive_waiter = deferwaiter.DeferWaiter()
         self._keepalive_action_handler = \

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -146,6 +146,7 @@ class Connection(base.Connection, pb.Avatar):
     @defer.inlineCallbacks
     def attached(self, mind):
         self.startKeepaliveTimer()
+        self.notifyOnDisconnect(self._stop_keepalive_timer)
         # pbmanager calls perspective.attached; pass this along to the
         # worker
         yield self.worker.attached(self)
@@ -159,7 +160,7 @@ class Connection(base.Connection, pb.Avatar):
 
     # disconnection handling
     @defer.inlineCallbacks
-    def waitShutdown(self):
+    def _stop_keepalive_timer(self):
         self.stopKeepaliveTimer()
         yield self._keepalive_waiter.wait()
 

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -26,7 +26,6 @@ class LocalWorker(WorkerBase):
     @defer.inlineCallbacks
     def startService(self):
         # importing here to avoid dependency on buildbot master package
-        # requires buildot version >= 0.9.0b5
         from buildbot.worker.protocols.null import Connection
 
         yield WorkerBase.startService(self)

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -36,8 +36,5 @@ class LocalWorker(WorkerBase):
         res = yield master.workers.newConnection(conn, self.name)
         if res:
             yield self.parent.attached(conn)
-
-    @defer.inlineCallbacks
-    def stopService(self):
-        yield self.parent.detached()
-        yield WorkerBase.stopService(self)
+            # detached() will be called automatically on connection disconnection which is
+            # invoked from the master side when the AbstarctWorker.stopService() is called.

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -30,7 +30,7 @@ class LocalWorker(WorkerBase):
 
         yield WorkerBase.startService(self)
         self.workername = self.name
-        conn = Connection(self.parent, self)
+        conn = Connection(self)
         # I don't have a master property, but my parent has.
         master = self.parent.master
         res = yield master.workers.newConnection(conn, self.name)


### PR DESCRIPTION
This PR cleans up worker connection state handling by making clear when the `conn` member is set to `None` during worker disconnection. All duplicate calls to `detached` are now forbidden. Additionally, waiting for complete connection shutdown is streamlined, as all shutdown tasks are registered via `notifyOnDisconnect`. It's now enough to wait for the underlying `SubscriptionPoint` to finish delivering the notifications and at that point worker is completely disconnected with no related work pending.