### PR TITLE
Fix #5903 - new SecretInVault implementation

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -51,6 +51,7 @@ apimaster
 app
 appdata
 applicative
+approle
 apps
 araujo
 arg
@@ -85,6 +86,7 @@ attrs
 attributeerror
 aug
 auth
+authenticator
 authz
 autocommit
 autoconf
@@ -1486,6 +1488,7 @@ trialargs
 trialmode
 triemstra
 triggerable
+ttl
 tue
 tues
 tuesday

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -657,6 +657,7 @@ html
 http
 httpclientservice
 https
+hvac
 ibuildrequestcontrol
 ibuildrequeststatus
 ibuildsetstatus

--- a/master/buildbot/newsfragments/new-secretinvault-implementation.feature
+++ b/master/buildbot/newsfragments/new-secretinvault-implementation.feature
@@ -1,0 +1,1 @@
+In order to fix several ``HashiCorpVaultSecretProvider`` flaws (see :issue:`5903` for details), new implementation of Vault secret provider ``HvacKvSecretProvider`` was introduced instead.

--- a/master/buildbot/secrets/providers/vault.py
+++ b/master/buildbot/secrets/providers/vault.py
@@ -16,12 +16,12 @@
 vault based providers
 """
 
-
 from twisted.internet import defer
 
 from buildbot import config
 from buildbot.secrets.providers.base import SecretProviderBase
 from buildbot.util import httpclientservice
+from buildbot.warnings import warn_deprecated
 
 
 class HashiCorpVaultSecretProvider(SecretProviderBase):
@@ -33,6 +33,8 @@ class HashiCorpVaultSecretProvider(SecretProviderBase):
 
     def checkConfig(self, vaultServer=None, vaultToken=None, secretsmount=None,
                     apiVersion=1):
+        warn_deprecated("3.4.0", "Use of HashiCorpVaultSecretProvider is deprecated and will be "
+                        "removed in future releases. Use HashiCorpVaultKvSecretProvider instead")
         if not isinstance(vaultServer, str):
             config.error("vaultServer must be a string while it is {}".format(type(vaultServer)))
         if not isinstance(vaultToken, str):

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -1,0 +1,182 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+HVAC based providers
+"""
+
+from twisted.internet import defer
+from twisted.internet import threads
+
+from buildbot import config
+from buildbot.secrets.providers.base import SecretProviderBase
+
+
+class VaultAuthenticator:
+    """
+    base HVAC authenticator class
+    """
+
+    def authenticate(self, client):
+        pass
+
+
+class VaultAuthenticatorToken(VaultAuthenticator):
+    """
+    HVAC authenticator for static token
+    """
+
+    def __init__(self, token):
+        self.token = token
+
+    def authenticate(self, client):
+        client.token = self.token
+
+
+class VaultAuthenticatorApprole(VaultAuthenticator):
+    """
+    HVAC authenticator for Approle login method
+    """
+
+    def __init__(self, roleId, secretId):
+        self.roleId = roleId
+        self.secretId = secretId
+
+    def authenticate(self, client):
+        client.auth.approle.login(role_id=self.roleId, secret_id=self.secretId)
+
+
+class HashiCorpVaultKvSecretProvider(SecretProviderBase):
+    """
+    Basic provider where each secret is stored in Vault KV secret engine.
+    In case more secret engines are going to be supported, each engine should have it's own class.
+    """
+
+    name = 'SecretInVaultKv'
+
+    def checkConfig(self, vault_server=None, authenticator=None, secrets_mount=None,
+                    api_version=2, path_delimiter='|', path_escape='\\'):
+        if not isinstance(vault_server, str):
+            config.error("vault_server must be a string while it is {}".format(type(vault_server)))
+        if not isinstance(path_delimiter, str) or len(path_delimiter) > 1:
+            config.error("path_delimiter must be a single character")
+        if not isinstance(path_escape, str) or len(path_escape) > 1:
+            config.error("path_escape must be a single character")
+        if not isinstance(authenticator, VaultAuthenticator):
+            config.error("authenticator must be instance of VaultAuthenticator while it is {}"
+                         .format(type(authenticator)))
+        if api_version not in [1, 2]:
+            config.error("api_version {} is not supported".format(api_version))
+
+    def reconfigService(self, vault_server=None, authenticator=None, secrets_mount=None,
+                        api_version=2, path_delimiter='|', path_escape='\\'):
+        try:
+            import hvac
+        except ImportError:
+            config.error("SecretInVaultKv needs the hvac package installed (pip install hvac)")
+
+        if secrets_mount is None:
+            secrets_mount = "secret"
+
+        self.secrets_mount = secrets_mount
+        self.path_delimiter = path_delimiter
+        self.path_escape = path_escape
+        self.authenticator = authenticator
+        self.api_version = api_version
+        if vault_server.endswith('/'):
+            vault_server = vault_server[:-1]
+        self.client = hvac.Client(vault_server)
+        self.client.secrets.kv.default_kv_version = api_version
+        return self
+
+    def escaped_split(self, s):
+        """
+        parse and split string, respecting escape characters
+        """
+        ret = []
+        current = []
+        itr = iter(s)
+        for ch in itr:
+            if ch == self.path_escape:
+                try:
+                    # skip the next character; it has been escaped and remove
+                    # escape character
+                    current.append(next(itr))
+                except StopIteration:
+                    # escape character on end of the string is safest to ignore, as buildbot for
+                    # each secret identifier tries all secret providers until value is found,
+                    # meaning we may end up parsing identifiers for other secret providers, where
+                    # our escape character may be valid on end of string
+                    pass
+            elif ch == self.path_delimiter:
+                # split! (add current to the list and reset it)
+                ret.append(''.join(current))
+                current = []
+            else:
+                current.append(ch)
+        ret.append(''.join(current))
+        return ret
+
+    def thd_hvac_wrap_read(self, path):
+        if self.api_version == 1:
+            return self.client.secrets.kv.v1.read_secret(path=path, mount_point=self.secrets_mount)
+        else:
+            return self.client.secrets.kv.v2.read_secret_version(path=path,
+                                                                 mount_point=self.secrets_mount)
+
+    def thd_hvac_get(self, path):
+        """
+        query secret from Vault and try to re-authenticate in case Unauthorized
+        exception when active token reaches its TTL
+        """
+
+        # no need to "try" import, it was already handled by reconfigService()
+        import hvac
+
+        try:
+            response = self.thd_hvac_wrap_read(path=path)
+        except (hvac.exceptions.Unauthorized, hvac.exceptions.InvalidRequest):
+            self.authenticator.authenticate(self.client)
+            response = self.thd_hvac_wrap_read(path=path)
+
+        return response
+
+    @defer.inlineCallbacks
+    def get(self, entry):
+        """
+        get the value from vault secret backend
+        """
+
+        parts = self.escaped_split(entry)
+        if len(parts) == 1:
+            raise KeyError("Vault secret specification must contain attribute name separated from "
+                           "path by '{}'".format(self.path_delimiter))
+        if len(parts) > 2:
+            raise KeyError("Multiple separators ('{0}') found in vault path '{1}'. All occurences "
+                           "of '{0}' in path or attribute name must be escaped using '{2}'"
+                           .format(self.path_delimiter, entry, self.path_escape))
+        name = parts[0]
+        key = parts[1]
+
+        response = yield threads.deferToThread(self.thd_hvac_get, path=name)
+
+        # in KVv2 we have extra "data" dictionary, as vault provides metadata as well
+        if self.api_version == 2:
+            response = response['data']
+
+        try:
+            return response['data'][key]
+        except KeyError as e:
+            raise KeyError(
+                "The secret {} does not exist in Vault provider: {}".format(entry, e)) from e

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -101,7 +101,7 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
         self.path_escape = path_escape
         self.authenticator = authenticator
         self.api_version = api_version
-        if vault_server.endswith('/'):
+        if vault_server.endswith('/'):  # pragma: no cover
             vault_server = vault_server[:-1]
         self.client = hvac.Client(vault_server)
         self.client.secrets.kv.default_kv_version = api_version

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -67,6 +67,13 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
 
     def checkConfig(self, vault_server=None, authenticator=None, secrets_mount=None,
                     api_version=2, path_delimiter='|', path_escape='\\'):
+        try:
+            import hvac
+            [hvac]
+        except ImportError:  # pragma: no cover
+            config.error(f"{self.__class__.__name__} needs the hvac package installed " +
+                         "(pip install hvac)")
+
         if not isinstance(vault_server, str):
             config.error("vault_server must be a string while it is {}".format(type(vault_server)))
         if not isinstance(path_delimiter, str) or len(path_delimiter) > 1:
@@ -83,12 +90,12 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
                         api_version=2, path_delimiter='|', path_escape='\\'):
         try:
             import hvac
-        except ImportError:
-            config.error("SecretInVaultKv needs the hvac package installed (pip install hvac)")
+        except ImportError:  # pragma: no cover
+            config.error(f"{self.__class__.__name__} needs the hvac package installed " +
+                         "(pip install hvac)")
 
         if secrets_mount is None:
             secrets_mount = "secret"
-
         self.secrets_mount = secrets_mount
         self.path_delimiter = path_delimiter
         self.path_escape = path_escape

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -108,6 +108,9 @@ warnings.filterwarnings('ignore', r".*Use 'list\(elem\)' or iteration over elem 
 if sys.version_info[0] >= 3 and "pg8000" in os.getenv("BUILDBOT_TEST_DB_URL", ""):
     warnings.filterwarnings('ignore', ".*unclosed .*socket", ResourceWarning)
 
+# ignore ResourceWarnings when connecting to a HashiCorp vault via hvac in integration tests
+warnings.filterwarnings('ignore', r".*unclosed .*socket.*raddr=.*, 8200[^\d]", ResourceWarning)
+
 # Python 3.5-3.8 shows this warning
 warnings.filterwarnings('ignore', ".*the imp module is deprecated in favour of importlib*")
 

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -23,6 +23,8 @@ from buildbot.process.properties import Interpolate
 from buildbot.secrets.providers.vault import HashiCorpVaultSecretProvider
 from buildbot.steps.shell import ShellCommand
 from buildbot.test.util.integration import RunMasterBase
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 # This integration test creates a master and worker environment,
 # with one builders and a shellcommand step
@@ -63,7 +65,8 @@ class SecretsConfig(RunMasterBase):
 
     @defer.inlineCallbacks
     def do_secret_test(self, secret_specifier, expected_obfuscation, expected_value):
-        yield self.setupConfig(masterConfig(secret_specifier=secret_specifier))
+        with assertProducesWarning(DeprecatedApiWarning):
+            yield self.setupConfig(masterConfig(secret_specifier=secret_specifier))
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
 

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault_hvac.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault_hvac.py
@@ -1,0 +1,121 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import base64
+import subprocess
+import time
+from unittest.case import SkipTest
+
+from twisted.internet import defer
+
+from buildbot.process.properties import Interpolate
+from buildbot.secrets.providers.vault_hvac import HashiCorpVaultKvSecretProvider
+from buildbot.secrets.providers.vault_hvac import VaultAuthenticatorToken
+from buildbot.steps.shell import ShellCommand
+from buildbot.test.util.integration import RunMasterBase
+
+# This integration test creates a master and worker environment,
+# with one builders and a shellcommand step
+
+
+class TestVaultHvac(RunMasterBase):
+    def setUp(self):
+        try:
+            subprocess.check_call(['docker', 'pull', 'vault'])
+
+            subprocess.check_call(['docker', 'run', '-d',
+                                   '-e', 'SKIP_SETCAP=yes',
+                                   '-e', 'VAULT_DEV_ROOT_TOKEN_ID=my_vaulttoken',
+                                   '-e', 'VAULT_TOKEN=my_vaulttoken',
+                                   '--name=vault_for_buildbot',
+                                   '-p', '8200:8200', 'vault'])
+            time.sleep(1)  # the container needs a little time to setup itself
+            self.addCleanup(self.remove_container)
+
+            subprocess.check_call(['docker', 'exec',
+                                   '-e', 'VAULT_ADDR=http://127.0.0.1:8200/',
+                                   'vault_for_buildbot',
+                                   'vault', 'kv', 'put', 'secret/key', 'value=word'])
+
+            subprocess.check_call(['docker', 'exec',
+                                   '-e', 'VAULT_ADDR=http://127.0.0.1:8200/',
+                                   'vault_for_buildbot',
+                                   'vault', 'kv', 'put', 'secret/anykey', 'anyvalue=anyword'])
+
+            subprocess.check_call(['docker', 'exec',
+                                   '-e', 'VAULT_ADDR=http://127.0.0.1:8200/',
+                                   'vault_for_buildbot',
+                                   'vault', 'kv', 'put', 'secret/key1/key2', 'id=val'])
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise SkipTest("Vault integration needs docker environment to be setup")
+
+    def remove_container(self):
+        subprocess.call(['docker', 'rm', '-f', 'vault_for_buildbot'])
+
+    @defer.inlineCallbacks
+    def do_secret_test(self, secret_specifier, expected_obfuscation, expected_value):
+        yield self.setupConfig(master_config(secret_specifier=secret_specifier))
+        build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+
+        patterns = [
+            "echo {}".format(expected_obfuscation),
+            base64.b64encode((expected_value + "\n").encode('utf-8')).decode('utf-8'),
+        ]
+
+        res = yield self.checkBuildStepLogExist(build, patterns)
+        self.assertTrue(res)
+
+    @defer.inlineCallbacks
+    def test_key(self):
+        yield self.do_secret_test('%(secret:key|value)s', '<key|value>', 'word')
+
+    @defer.inlineCallbacks
+    def test_key_any_value(self):
+        yield self.do_secret_test('%(secret:anykey|anyvalue)s', '<anykey|anyvalue>', 'anyword')
+
+    @defer.inlineCallbacks
+    def test_nested_key(self):
+        yield self.do_secret_test('%(secret:key1/key2|id)s', '<key1/key2|id>', 'val')
+
+
+def master_config(secret_specifier):
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import schedulers
+
+    c['schedulers'] = [
+        schedulers.ForceScheduler(name="force", builderNames=["testy"])
+    ]
+
+    # note that as of August 2021, the vault docker image default to kv
+    # version 2 to be enabled by default
+    c['secretsProviders'] = [
+        HashiCorpVaultKvSecretProvider(authenticator=VaultAuthenticatorToken('my_vaulttoken'),
+                                       vault_server="http://localhost:8200",
+                                       secrets_mount="secret")
+    ]
+
+    f = BuildFactory()
+    f.addStep(ShellCommand(command=Interpolate('echo {} | base64'.format(secret_specifier))))
+
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      workernames=["local1"],
+                      factory=f)
+    ]
+
+    return c

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -191,6 +191,7 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.secrets.manager.SecretManager',
             'buildbot.secrets.providers.base.SecretProviderBase',
             'buildbot.secrets.secret.SecretDetails',
+            'buildbot.secrets.providers.vault_hvac.VaultAuthenticator',
         }
         self.verify_plugins_registered('secrets', 'buildbot.secrets', None, known_not_exported)
 

--- a/master/buildbot/test/unit/test_secret_in_hvac.py
+++ b/master/buildbot/test/unit/test_secret_in_hvac.py
@@ -1,0 +1,201 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from unittest.mock import patch
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.secrets.providers.vault_hvac import HashiCorpVaultKvSecretProvider
+from buildbot.secrets.providers.vault_hvac import VaultAuthenticatorApprole
+from buildbot.secrets.providers.vault_hvac import VaultAuthenticatorToken
+from buildbot.test.util import interfaces
+
+try:
+    import hvac
+    assert hvac
+except ImportError:
+    hvac = None
+
+
+class FakeHvacApprole:
+    def login(self, role_id, secret_id):
+        self.role_id = role_id
+        self.secret_id = secret_id
+
+
+class FakeHvacAuth:
+    approle = FakeHvacApprole()
+
+
+class FakeHvacKvV1:
+    token = None
+
+    def read_secret(self, path, mount_point):
+        if self.token is None:
+            raise hvac.exceptions.Unauthorized
+        if path == "wrong/path":
+            raise hvac.exceptions.InvalidPath(message="Fake InvalidPath exception")
+        return {'data': {'key': "value"}}
+
+
+class FakeHvacKvV2:
+    token = None
+
+    def read_secret_version(self, path, mount_point):
+        if self.token is None:
+            raise hvac.exceptions.Unauthorized(message="Fake Unauthorized exception")
+        if path == "wrong/path":
+            raise hvac.exceptions.InvalidPath(message="Fake InvalidPath exception")
+        return {'data': {'data': {'key': "value"}}}
+
+
+class FakeHvacKv:
+    default_kv_version = 2
+    v1 = FakeHvacKvV1()
+    v2 = FakeHvacKvV2()
+
+
+class FakeHvacSecrets:
+    kv = FakeHvacKv()
+
+
+class FakeHvacClient:
+    auth = FakeHvacAuth()
+    secrets = FakeHvacSecrets()
+
+    _token = None
+
+    @property
+    def token(self):
+        return self._token
+
+    @token.setter
+    def token(self, new_token):
+        self._token = new_token
+        self.secrets.kv.v1.token = new_token
+        self.secrets.kv.v2.token = new_token
+
+
+def mock_vault(*args, **kwargs):
+    client = FakeHvacClient()
+    client.token = "mockToken"
+    return client
+
+
+class TestSecretInVaultAuthenticator(interfaces.InterfaceTests):
+
+    def test_authenticate(self):
+        raise NotImplementedError
+
+
+class TestSecretInVaultAuthenticatorToken(unittest.TestCase, TestSecretInVaultAuthenticator):
+
+    def setUp(self):
+        if hvac is None:
+            raise unittest.SkipTest(
+                "Need to install hvac to test VaultAuthenticatorToken")
+
+    def test_authenticate(self):
+        token = "mockToken"
+        authenticator = VaultAuthenticatorToken(token)
+        client = hvac.Client()
+        authenticator.authenticate(client)
+        self.assertEqual(client.token, token)
+
+
+class TestSecretInVaultAuthenticatorApprole(unittest.TestCase, TestSecretInVaultAuthenticator):
+
+    def test_authenticate(self):
+        authenticator = VaultAuthenticatorApprole("testRole", "testSecret")
+        client = FakeHvacClient()
+        authenticator.authenticate(client)
+        self.assertEqual(client.auth.approle.secret_id, "testSecret")
+
+
+class TestSecretInHashiCorpVaultKvSecretProvider(unittest.TestCase):
+
+    def setUp(self):
+        if hvac is None:
+            raise unittest.SkipTest(
+                "Need to install hvac to test HashiCorpVaultKvSecretProvider")
+        param = dict(vault_server="", authenticator=VaultAuthenticatorToken("mockToken"),
+                     path_delimiter='|', path_escape='\\', api_version=2)
+        self.provider = HashiCorpVaultKvSecretProvider(**param)
+        self.provider.reconfigService(**param)
+        self.provider.client = FakeHvacClient()
+        self.provider.client.secrets.kv.default_kv_version = param['api_version']
+        self.provider.client.token = "mockToken"
+
+    def test_escaped_split(self):
+        parts = self.provider.escaped_split("a/b\\|c/d|e/f\\|g/h")
+        self.assertEqual(parts, ["a/b|c/d", "e/f|g/h"])
+
+    def test_thd_hvac_wrap_read_v1(self):
+        self.provider.api_version = 1
+        self.provider.client.token = "mockToken"
+        value = self.provider.thd_hvac_wrap_read("some/path")
+        self.assertEqual(value['data']['key'], "value")
+
+    def test_thd_hvac_wrap_read_v2(self):
+        self.provider.client.token = "mockToken"
+        value = self.provider.thd_hvac_wrap_read("some/path")
+        self.assertEqual(value['data']['data']['key'], "value")
+
+    # for some reason, errors regarding generator function were thrown
+    @patch("hvac.Client", side_effect=mock_vault)
+    def test_thd_hvac_wrap_read_unauthorized(self, mock_vault):
+        self.provider.client.token = None
+        yield self.assertFailure(self.provider.thd_hvac_wrap_read("some/path"),
+                                 hvac.exceptions.Unauthorized)
+
+    def test_thd_hvac_get_reauthorize(self):
+        """
+        When token is None, provider gets unauthorized exception and is forced to re-authenticate
+        """
+        self.provider.client.token = None
+        value = self.provider.thd_hvac_get("some/path")
+        self.assertEqual(value['data']['data']['key'], "value")
+
+    @defer.inlineCallbacks
+    def test_get_v1(self):
+        self.provider.api_version = 1
+        self.provider.client.token = "mockToken"
+        value = yield self.provider.get("some/path|key")
+        self.assertEqual(value, "value")
+
+    @defer.inlineCallbacks
+    def test_get_v2(self):
+        self.provider.client.token = "mockToken"
+        value = yield self.provider.get("some/path|key")
+        self.assertEqual(value, "value")
+
+    @defer.inlineCallbacks
+    def test_get_fail_no_key(self):
+        self.provider.client.token = "mockToken"
+        with self.assertRaises(KeyError):
+            yield self.provider.get("some/path")
+
+    @defer.inlineCallbacks
+    def test_get_fail_wrong_key(self):
+        self.provider.client.token = "mockToken"
+        with self.assertRaises(KeyError):
+            yield self.provider.get("some/path|wrong_key")
+
+    @defer.inlineCallbacks
+    def test_get_fail_multiple_separators(self):
+        self.provider.client.token = "mockToken"
+        with self.assertRaises(KeyError):
+            yield self.provider.get("some/path|unescaped|key")

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+import warnings
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -28,6 +30,7 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
 
     @defer.inlineCallbacks
     def setUp(self, version):
+        warnings.simplefilter('ignore')
         self.setUpTestReactor()
         self.srvcVault = HashiCorpVaultSecretProvider(vaultServer="http://vaultServer",
                                                       vaultToken="someToken",

--- a/master/docs/developer/secrets.rst
+++ b/master/docs/developer/secrets.rst
@@ -50,14 +50,13 @@ Vault provider
 
 .. code-block:: python
 
-    c['secretsProviders'] = [secrets.SecretInVault(vaultToken=open('VAULT_TOKEN').read(),
-                                                vaultServer="http://localhost:8200",
-                                                apiVersion=2)]
+    c['secretsProviders'] = [secrets.HashiCorpVaultKvSecretProvider(authenticator=secrets.VaultAuthenticatorApprole(roleId="xxx", secretId="yyy"),
+                                                                    vault_server="http://localhost:8200")]
 
-In the master configuration, the provider is instantiated through a Buildbot service secret manager with the Vault token and the Vault server address.
+In the master configuration, the provider is instantiated through a Buildbot service secret manager with the Vault authenticator and the Vault server address.
 Vault secrets provider accesses the Vault backend asking the key wanted by Buildbot and returns the contained text value.
-SecretInVault provider allows Buildbot to read secrets in the Vault.
-Currently only v1 and v2 of the Key-Value backends are supported.
+SecretInVaultKv provider allows Buildbot to read secrets only in the Vault KV store, other secret engines are not supported by this provider.
+Currently v1 and v2 of the Key-Value secret engines are supported, v2 being the default version.
 
 Interpolate secret
 ``````````````````

--- a/master/docs/manual/secretsmanagement.rst
+++ b/master/docs/manual/secretsmanagement.rst
@@ -115,10 +115,68 @@ Arguments:
 ``strip``
   (optional) if ``True`` (the default), trailing newlines are removed from the file contents.
 
+.. _HashiCorpVaultKvSecretProvider:
+
+HashiCorpVaultKvSecretProvider
+``````````````````````````````
+
+.. code-block:: python
+
+    c['secretsProviders'] = [
+        secrets.HashiCorpVaultKvSecretProvider(
+            authenticator=secrets.VaultAuthenticatorApprole(roleId="<role-guid>",
+                                                            secretId="<secret-guid>"),
+            vault_server="http://localhost:8200",
+            secrets_mount="kv")
+    ]
+
+HashiCorpVaultKvSecretProvider allows to use HashiCorp Vault KV secret engine as secret provider.
+Other secret engines are not supported by this particular provider.
+For more information about Vault please visit: _`Vault`: https://www.vaultproject.io/
+
+In order to use this secret provider, optional dependency ``hvac`` needs to be installed (``pip install hvac``).
+
+It supports different authentication methods with ability to re-authenticate when authentication token expires (not possible using ``HvacAuthenticatorToken``).
+
+Parameters accepted by ``HashiCorpVaultKvSecretProvider``:
+
+ - ``authenticator``: required parameter, specifies Vault authentication method.
+   Possible authenticators are:
+
+    - ``VaultAuthenticatorToken(token)``: simplest authentication by directly providing the authentication token.
+      This method cannot benefit from re-authentication mechanism and when token expires, secret provider will just stop working.
+
+    - ``VaultAuthenticatorApprole(roleId, secretId)``: approle authentication using roleId and secretId.
+      This is common method for automation tools fetching secrets from vault.
+
+ - ``vault_server``: required parameter, specifies URL of vault server.
+
+ - ``secrets_mount``: specifies mount point of KV secret engine in vault, default value is "secret".
+
+ - ``api_version``: version of vault KV secret engine.
+   Supported versions are 1 and 2, default value is 2.
+
+ - ``path_delimiter``: character used to separate path and key name in secret identifiers.
+   Default value is "|".
+
+ - ``path_escape``: escape character used in secret identifiers to allow escaping of ``path_delimiter`` character in path or key values.
+   Default value is "\".
+
+The secret identifiers that need to be passed to, e.g. :ref:`Interpolate`, have format: ``"path/to/secret:key"``.
+In case path or key name does contain colon character, it is possible to escape it using "\" or specify different separator character using ``path_delimiter`` parameter when initializing secret provider.
+
+Example use:
+
+.. code-block:: python
+
+    passwd = util.Secret('path/to/secret:password')
+
 .. _HashiCorpVaultSecretProvider:
 
 HashiCorpVaultSecretProvider
 ````````````````````````````
+
+.. note:: Use of ``HashiCorpVaultSecretProvider`` is deprecated in favor of newer :ref:`HashiCorpVaultKvSecretProvider` and will be removed in future releases.
 
 .. code-block:: python
 
@@ -139,7 +197,6 @@ Vault policies, and subsequent tokens assigned to them, provide for a more restr
 
 In the master configuration, the Vault provider is instantiated through the Buildbot service manager as a secret provider with the Vault server address and the Vault token.
 The provider SecretInVault allows Buildbot to read secrets in Vault.
-For more information about Vault please visit: _`Vault`: https://www.vaultproject.io/
 
 The secret identifiers that need to be passed to, e.g. :ref:`Interpolate`, accept one of the following
 formats:
@@ -181,7 +238,7 @@ SecretInPass
 .. code-block:: python
 
     c['secretsProviders'] = [secrets.SecretInPass(
-                            gpgPassphrase="passphrase", 
+                            gpgPassphrase="passphrase",
                             dirname="/path/to/password/store"
     )]
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -20,6 +20,7 @@ apiVersion
 app
 apparmor
 appart
+approle
 apps
 ar
 aren
@@ -35,6 +36,8 @@ Atlassian
 attrs
 auth
 Auth
+authenticator
+authenticators
 authorisation
 authUri
 authz
@@ -717,6 +720,7 @@ rmdir
 rmfile
 rmtree
 Robocopy
+roleId
 rootlink
 routingkeys
 rpmlint
@@ -737,6 +741,7 @@ schemas
 scp
 sdist
 searchable
+secretId
 secretsmount
 sed
 selectable

--- a/master/setup.py
+++ b/master/setup.py
@@ -250,7 +250,10 @@ setup_args = {
         ('buildbot.secrets', [
             ('buildbot.secrets.providers.file', ['SecretInAFile']),
             ('buildbot.secrets.providers.passwordstore', ['SecretInPass']),
-            ('buildbot.secrets.providers.vault', ['HashiCorpVaultSecretProvider'])
+            ('buildbot.secrets.providers.vault', ['HashiCorpVaultSecretProvider']),
+            ('buildbot.secrets.providers.vault_hvac', [
+                'HashiCorpVaultKvSecretProvider', 'VaultAuthenticatorToken',
+                'VaultAuthenticatorApprole'])
         ]),
         ('buildbot.worker', [
             ('buildbot.worker.base', ['Worker']),

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,6 +25,7 @@ flake8==3.9.2
 funcsigs==1.0.2
 future==0.18.2
 graphql-core==3.1.5
+hvac==0.10.11
 idna==2.10  # pyup: ignore (conflicts with moto on master)
 imagesize==1.2.0
 incremental==17.5.0


### PR DESCRIPTION
Added new HashiCorp Vault secret provider `HvacKvSecretProvider` in order to replace old bugged `HashiCorpVaultSecretProvider` implementation (https://github.com/buildbot/buildbot/issues/5903).

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
