### PR TITLE
invalid property selector name

### DIFF
--- a/master/docs/manual/configuration/properties.rst
+++ b/master/docs/manual/configuration/properties.rst
@@ -215,7 +215,7 @@ The following selectors are supported.
     The key refers to a keyword argument passed to ``Interpolate``.
     Those keyword arguments may be ordinary values or renderables.
 
-``secrets``
+``secret``
     The key refers to a secret provided by a provider declared in :bb:cfg:`secretsProviders` .
 
 ``worker``


### PR DESCRIPTION
it's singular form there https://github.com/buildbot/buildbot/blob/master/master/buildbot/process/properties.py#L649-L655