### PR TITLE
Restore worker paused state after restarting buildbot master. Fixes #6074

### DIFF
--- a/master/buildbot/newsfragments/restore-worker-paused-state.bugfix
+++ b/master/buildbot/newsfragments/restore-worker-paused-state.bugfix
@@ -1,0 +1,1 @@
+Restore worker paused state after restarting buildbot master (:issue:`6074`)

--- a/master/buildbot/test/fakedb/workers.py
+++ b/master/buildbot/test/fakedb/workers.py
@@ -77,8 +77,8 @@ class FakeWorkersComponent(FakeDBComponent):
                 self.workers[row.id] = dict(
                     id=row.id,
                     name=row.name,
-                    paused=0,
-                    graceful=0,
+                    paused=row.paused,
+                    graceful=row.graceful,
                     info=row.info)
             elif isinstance(row, ConfiguredWorker):
                 row.id = row.buildermasterid * 10000 + row.workerid

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -471,6 +471,34 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         yield bs.setServiceParent(bsmanager)
 
     @defer.inlineCallbacks
+    def test_startService_paused_true(self):
+        """Test that paused state is restored on a buildbot restart"""
+        self.master.db.insertTestData([
+            fakedb.Worker(id=9292, name='bot', paused=1)
+        ])
+
+        worker = yield self.createWorker()
+
+        yield worker.startService()
+
+        self.assertTrue(worker.isPaused())
+        self.assertFalse(worker._graceful)
+
+    @defer.inlineCallbacks
+    def test_startService_graceful_true(self):
+        """Test that graceful state is NOT restored on a buildbot restart"""
+        self.master.db.insertTestData([
+            fakedb.Worker(id=9292, name='bot', graceful=1)
+        ])
+
+        worker = yield self.createWorker()
+
+        yield worker.startService()
+
+        self.assertFalse(worker.isPaused())
+        self.assertFalse(worker._graceful)
+
+    @defer.inlineCallbacks
     def test_startService_getWorkerInfo_empty(self):
         worker = yield self.createWorker()
         yield worker.startService()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -235,6 +235,7 @@ class AbstractWorker(service.BuildbotService):
     def _getWorkerInfo(self):
         worker = yield self.master.data.get(
             ('workers', self.workerid))
+        self._paused = worker["paused"]
         self._applyWorkerInfo(worker['workerinfo'])
 
     def setServiceParent(self, parent):


### PR DESCRIPTION
Fixes #6074
## Contributor Checklist:

* [X] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
