### PR TITLE
Separate worker paused state and worker quarantine state

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1527,6 +1527,9 @@ unlinked
 unparsable
 unparseable
 unpatch
+unpause
+unpaused
+unpausing
 unregister
 unregisters
 unserialized

--- a/master/buildbot/newsfragments/separate_worker_paused_and_quarantine_concepts.feature
+++ b/master/buildbot/newsfragments/separate_worker_paused_and_quarantine_concepts.feature
@@ -1,0 +1,1 @@
+Pausing a worker is a manual operation which the quarantine timer was overrwriting. Worker paused state and quarantine state are now independent. (:issue:`5611`)

--- a/master/buildbot/newsfragments/separate_worker_paused_and_quarantine_concepts.feature
+++ b/master/buildbot/newsfragments/separate_worker_paused_and_quarantine_concepts.feature
@@ -1,1 +1,1 @@
-Pausing a worker is a manual operation which the quarantine timer was overrwriting. Worker paused state and quarantine state are now independent. (:issue:`5611`)
+Pausing a worker is a manual operation which the quarantine timer was overwriting. Worker paused state and quarantine state are now independent. (:issue:`5611`)

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -678,11 +678,111 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
     def test_worker_actions_pause(self):
         worker = yield self.createWorker(attached=False)
         yield worker.startService()
-        worker.controlWorker(("worker", 1, "pause"), {'reason': "none"})
-        self.assertEqual(worker._paused, True)
+        self.assertTrue(worker.canStartBuild())
 
-        worker.controlWorker(("worker", 1, "unpause"), {'reason': "none"})
+        worker.controlWorker(("worker", 1, "pause"), {"reason": "none"})
+        self.assertEqual(worker._paused, True)
+        self.assertFalse(worker.canStartBuild())
+
+        worker.controlWorker(("worker", 1, "unpause"), {"reason": "none"})
         self.assertEqual(worker._paused, False)
+        self.assertTrue(worker.canStartBuild())
+
+    @defer.inlineCallbacks
+    def test_worker_quarantine_wait_times(self):
+        worker = yield self.createWorker(attached=False)
+        yield worker.startService()
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+        for quarantine_wait in (10, 20, 40, 80, 160, 320, 640, 1280, 2560, 3600, 3600):
+            # put worker into quarantine
+            worker.putInQuarantine()
+            self.assertFalse(worker.canStartBuild())
+            self.assertIsNotNone(worker.quarantine_timer)
+
+            # simulate wait just before quarantine ends
+            self.master.reactor.advance(quarantine_wait - 1)
+            self.assertFalse(worker.canStartBuild())
+            self.assertIsNotNone(worker.quarantine_timer)
+
+            # simulate wait to just after quarantine ends
+            self.master.reactor.advance(1)
+            self.assertTrue(worker.canStartBuild())
+            self.assertIsNone(worker.quarantine_timer)
+
+    @defer.inlineCallbacks
+    def test_worker_quarantine_reset(self):
+        worker = yield self.createWorker(attached=False)
+        yield worker.startService()
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+        # pump up the quarantine wait time
+        for quarantine_wait in (10, 20, 40, 80):
+            worker.putInQuarantine()
+            self.assertFalse(worker.canStartBuild())
+            self.assertIsNotNone(worker.quarantine_timer)
+            self.master.reactor.advance(quarantine_wait)
+            self.assertTrue(worker.canStartBuild())
+            self.assertIsNone(worker.quarantine_timer)
+
+        # Now get a successful build
+        worker.resetQuarantine()
+
+        # the workers quarantine period should reset back to 10
+        worker.putInQuarantine()
+        self.master.reactor.advance(10)
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+    @defer.inlineCallbacks
+    def test_worker_quarantine_whilst_quarantined(self):
+        worker = yield self.createWorker(attached=False)
+        yield worker.startService()
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+        # put worker in quaratine
+        worker.putInQuarantine()
+        self.assertFalse(worker.canStartBuild())
+        self.assertIsNotNone(worker.quarantine_timer)
+
+        # simulate wait for half the time, and put in quarantine again
+        self.master.reactor.advance(5)
+        worker.putInQuarantine()
+        self.assertFalse(worker.canStartBuild())
+        self.assertIsNotNone(worker.quarantine_timer)
+
+        # simulate wait for another 5 seconds, and we should leave quarantine
+        self.master.reactor.advance(5)
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+        # simulate wait for yet another 5 seconds, and ensure nothing changes
+        self.master.reactor.advance(5)
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+    @defer.inlineCallbacks
+    def test_worker_quarantine_stop_timer(self):
+        worker = yield self.createWorker(attached=False)
+        yield worker.startService()
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+        # Call stopQuarantineTimer whilst not quarantined
+        worker.stopQuarantineTimer()
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
+
+        # Call stopQuarantineTimer whilst quarantined
+        worker.putInQuarantine()
+        self.assertFalse(worker.canStartBuild())
+        self.assertIsNotNone(worker.quarantine_timer)
+        worker.stopQuarantineTimer()
+        self.assertTrue(worker.canStartBuild())
+        self.assertIsNone(worker.quarantine_timer)
 
 
 class TestAbstractLatentWorker(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -696,7 +696,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         self.assertIsNone(worker.quarantine_timer)
         self.assertFalse(worker._paused)
 
-        # put worker into quaratine.
+        # put worker into quarantine.
         # Check canStartBuild() is False, and paused state is not changed
         worker.putInQuarantine()
         self.assertFalse(worker._paused)
@@ -708,7 +708,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         self.assertTrue(worker._paused)
         self.assertFalse(worker.canStartBuild())
 
-        # simulate wait for quaratine to end
+        # simulate wait for quarantine to end
         # Check canStartBuild() is still False, and paused state is not changed
         self.master.reactor.advance(10)
         self.assertTrue(worker._paused)
@@ -722,7 +722,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         self.assertTrue(worker.canStartBuild())
         self.assertIsNone(worker.quarantine_timer)
 
-        # put worker into quaratine whilst unpaused.
+        # put worker into quarantine whilst unpaused.
         worker.putInQuarantine()
         self.assertFalse(worker._paused)
         self.assertFalse(worker.canStartBuild())
@@ -733,7 +733,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         worker.controlWorker(("worker", 1, "unpause"), {"reason": "none"})
         self.assertTrue(worker.canStartBuild())
 
-        # put worker into quaratine whilst paused.
+        # put worker into quarantine whilst paused.
         worker.controlWorker(("worker", 1, "pause"), {"reason": "none"})
         worker.putInQuarantine()
         self.assertTrue(worker._paused)
@@ -836,7 +836,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         self.assertTrue(worker.canStartBuild())
         self.assertIsNone(worker.quarantine_timer)
 
-        # put worker in quaratine
+        # put worker in quarantine
         worker.putInQuarantine()
         self.assertFalse(worker.canStartBuild())
         self.assertIsNotNone(worker.quarantine_timer)

--- a/master/docs/manual/configuration/workers.rst
+++ b/master/docs/manual/configuration/workers.rst
@@ -178,7 +178,7 @@ Those actions will put the worker in either of two states:
 - *graceful*: the worker is graceful if it doesn't accept new builds, and will shutdown when builds are finished.
 
 
-A worker might be put to ``paused`` state automatically if buildbot detects a misbehavior.
+A worker might not be able to accept a job for a period of time if buildbot detects a misbehavior.
 This is called the *quarantine timer*.
 
 Quarantine timer is an exponential back-off mechanism for workers.
@@ -187,6 +187,8 @@ When misbehavior is detected, the timer will pause the worker for 10 seconds, an
 
 The first case of misbehavior is for a latent worker to not start properly.
 The second case of misbehavior is for a build to end with an ``EXCEPTION`` status.
+
+Pausing and unpausing a worker will force it to leave quarantine immediately. The quarantine timeout will not be reset until the worker finishes a build.
 
 Worker states are stored in the database, can be queried via :ref:`REST_API`, and are visible in the UI's workers page.
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -898,6 +898,9 @@ unsubscription
 untracked
 untrusted
 unversioned
+unpause
+unpaused
+unpausing
 UpCloud
 uploadDirectory
 uploader


### PR DESCRIPTION
Fixes #5611 

I think this changeset is a step in the right direction. It separates "paused" (which is a manual operation) and "quarantined" (which is an automatic process). Thought process behind my changeset:
- If I manually pause a worker, then I do not want it to be unpaused by the quarantine timer.
- If I unpause a worker, I would like it to leave quarantine immediately so I can see if it is now working. The quarantine timeout should not be reset as if the worker is still broken, then it should go back into quarantine for some time and not eat the build queue.

With this changeset, it's now more difficult to see when a worker is in quarantine from the UI (as it won't be paused). The worker would have a streak of red so you'd know it's borked. Ideally the quarantine state would go into the db and be visible from the UI/API. Quarantine state could include:
- is worker in quarantine
- how long quarantine was set for
- when the worker will leave quarantine

Plumbing the UI/DB parts would increase the changeset size, and I'm not sure I'm that comfortable with the full buildbot stack to do it. This changeset does stand on it's own as an improvement on what already exists.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
