### PR TITLE
hanlde `KeyError: 'message'` in gitlab reporter

### DIFF
--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -133,7 +133,7 @@ class GitLabStatusPush(ReporterBase):
                 log.msg(
                     'Unknown (or hidden) gitlab project'
                     '{repo}: {message}'.format(
-                        repo=project_full_name, **proj))
+                        repo=project_full_name, message=proj.get('message')))
                 return None
             self.project_ids[project_full_name] = proj['id']
 


### PR DESCRIPTION
Hi! I got this error and I've seen it pop up in the issues. Let's have an easy fix.
```
2021-06-23 19:56:34+0300 [-] Starting factory _HTTP11ClientFactory(<function HTTPConnectionPool._newConnection.<locals>.quiescentCallback at 0x7f9d9c8c8268>, <twisted.internet.endpoints._WrapperEndpoint object at 0x7f9d9c8428d0>)
2021-06-23 19:56:34+0300 [HTTP11ClientProtocol (TLSMemoryBIOProtocol),client] Got exception when handling reporter events
        Traceback (most recent call last):
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/internet/defer.py", line 1443, in _inlineCallbacks
            result = current_context.run(result.throwExceptionIntoGenerator, g)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/internet/defer.py", line 47, in run
            return f(*args, **kwargs)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/home/devel/.local/lib/python3.6/site-packages/buildbot/reporters/base.py", line 95, in _got_event
            log.err(e, 'Got exception when handling reporter events')
        --- <exception caught here> ---
          File "/home/devel/.local/lib/python3.6/site-packages/buildbot/reporters/base.py", line 93, in _got_event
            yield self.sendMessage(reports)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/internet/defer.py", line 1443, in _inlineCallbacks
            result = current_context.run(result.throwExceptionIntoGenerator, g)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/internet/defer.py", line 47, in run
            return f(*args, **kwargs)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/home/devel/.local/lib/python3.6/site-packages/buildbot/reporters/gitlab.py", line 175, in sendMessage
            proj_id = yield self.getProjectId(sourcestamp)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/internet/defer.py", line 1445, in _inlineCallbacks
            result = current_context.run(g.send, result)
          File "/home/devel/.local/lib/python3.6/site-packages/twisted/internet/defer.py", line 47, in run
            return f(*args, **kwargs)
          File "/home/devel/.local/lib/python3.6/site-packages/buildbot/reporters/gitlab.py", line 136, in getProjectId
            repo=project_full_name, **proj))
        builtins.KeyError: 'message'

2021-06-23 20:00:34+0300 [-] Stopping factory _HTTP11ClientFactory(<function HTTPConnectionPool._newConnection.<locals>.quiescentCallback at 0x7f9d9c8c8268>, <twisted.internet.endpoints._WrapperEndpoint object at 0x7f9d9c8428d0>)
```