### PR TITLE
Fix WorkerLock's maxCountForWorker when used with buildsteps

### DIFF
--- a/master/buildbot/newsfragments/workerlock-maxcountforworker.bugfix
+++ b/master/buildbot/newsfragments/workerlock-maxcountforworker.bugfix
@@ -1,0 +1,1 @@
+Fixed worker lock handling that caused max lock count to be ignored (:issue:`6132`).

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -434,7 +434,7 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         # then narrow WorkerLocks down to the worker that this build is being
         # run on
-        self.locks = [(l.getLockForWorker(self.build.workerforbuilder.worker),
+        self.locks = [(l.getLockForWorker(self.build.workerforbuilder.worker.workername),
                        la)
                       for l, la in self.locks]
 

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -41,6 +41,7 @@ class FakeBuild(properties.PropertiesMixin):
             spec=workerforbuilder.WorkerForBuilder)
         self.workerforbuilder.worker = mock.Mock(spec=base.Worker)
         self.workerforbuilder.worker.info = properties.Properties()
+        self.workerforbuilder.worker.workername = 'workername'
         self.builder.config = config.BuilderConfig(
             name='bldr',
             workernames=['a'],


### PR DESCRIPTION
There has been an issue where the Worker object, rather than just the
worker's name, has been passed to 'RealWorkerLock.getLockForWorker'
when the lock was acquired for a single build step. As a result, the
erroneous 'workername' value was not found in the 'maxCountForWorker'
dictionary, and so we fell back to the 'maxCount' value.

We fix this by passing the workername rather than the Worker object
from 'BuildStep.startStep' into 'getLockForWorker'.

## Contributor Checklist:

* [x] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
