### PR TITLE
Msbuild: Removed rogue speech-mark 

### DIFF
--- a/master/buildbot/newsfragments/msbuild-error.bugfix
+++ b/master/buildbot/newsfragments/msbuild-error.bugfix
@@ -1,0 +1,1 @@
+msbuild: fixed syntax error resulting in "... was unexpected at this time." 

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -532,7 +532,7 @@ class MsBuild141(VisualStudio):
         self.descriptionDone = 'built ' + self.describe_project()
         yield self.updateSummary()
 
-        command = (('FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')" '
+        command = (('FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\') '
                     ' do "%%I\\%VCENV_BAT%" x86 && msbuild "{}" /p:Configuration="{}" '
                     '/p:Platform="{}" /maxcpucount').format(self.projectfile, self.config,
                                                             self.platform))


### PR DESCRIPTION
Rogue speech-mark introduced in 7fb40b52529a52cd19220fd3d40ed6cd2df8eb5b resulted in, "...was unexpected at this time" error when running msbuild build-steps on windows. 



## Contributor Checklist:

* [ n] I have updated the unit tests
* [Y] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ n] I have updated the appropriate documentation
