### PR TITLE
Add support for configuring worker password for DockerLatentWorker via secrets management

### DIFF
--- a/master/buildbot/newsfragments/worker-passord-secret.feature
+++ b/master/buildbot/newsfragments/worker-passord-secret.feature
@@ -1,0 +1,1 @@
+Buildbot secret management can now be used to configure worker passwords.

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -278,7 +278,7 @@ class AbstractWorker(service.BuildbotService):
         # without disconnecting the worker, yet there's no reason to do that.
 
         assert self.name == name
-        self.password = password
+        self.password = yield self.renderSecrets(password)
 
         # adopt new instance's configuration parameters
         self.max_builds = max_builds

--- a/master/docs/manual/configuration/workers.rst
+++ b/master/docs/manual/configuration/workers.rst
@@ -23,6 +23,7 @@ These are the same two values that need to be provided to the worker administrat
 
 The ``workername`` must be unique, of course.
 The password exists to prevent evildoers from interfering with Buildbot by inserting their own (broken) workers into the system and thus displacing the real ones.
+Password may be a :ref:`Secret`.
 
 Workers with an unrecognized ``workername`` or a non-matching password will be rejected when they attempt to connect, and a message describing the problem will be written to the log file (see :ref:`Logfiles`).
 


### PR DESCRIPTION
* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
