### PR TITLE
Add support for configuring github auth token for github change dialect via secrets management

### DIFF
--- a/master/buildbot/newsfragments/github-event-handler.feature
+++ b/master/buildbot/newsfragments/github-event-handler.feature
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.www.hooks.github.GitHubEventHandler` can now configure authentication token via Secrets management for GitHub instances that do not allow anonymous access

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -241,7 +241,10 @@ class GitHubEventHandler(PullRequestMixin):
             'User-Agent': 'Buildbot',
         }
         if self._token:
-            headers['Authorization'] = 'token ' + self._token
+            p = Properties()
+            p.master = self.master
+            token = yield p.render(self._token)
+            headers['Authorization'] = 'token ' + token
 
         url = '/repos/{}/commits/{}'.format(repo, sha)
         http = yield httpclientservice.HTTPClientService.getService(
@@ -265,7 +268,10 @@ class GitHubEventHandler(PullRequestMixin):
         """
         headers = {"User-Agent": "Buildbot"}
         if self._token:
-            headers["Authorization"] = "token " + self._token
+            p = Properties()
+            p.master = self.master
+            token = yield p.render(self._token)
+            headers["Authorization"] = "token " + token
 
         url = "/repos/{}/pulls/{}/files".format(repo, number)
         http = yield httpclientservice.HTTPClientService.getService(


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

I have not actually been able to write the correct unit test for this. There is no existing test for `_get_pr_files` or `_get_commit_msg` but only `handle_pull_request`. All test in `test_hooks_github.py` are aimed at incoming POST requests, while this would have to be for an outgoing GET request in response to those. Still working on it, would appreciate any examples of a similar test that already exists