### PR TITLE
Recommend to not use links to point to classes in newsfragments

### DIFF
--- a/master/buildbot/newsfragments/README.txt
+++ b/master/buildbot/newsfragments/README.txt
@@ -14,4 +14,4 @@ Buildbot project does not require a tracking ticket to be made for each contribu
 
 Please point to the trac bug using syntax: (:bug:`NNN`)
 Please point to the github bug using syntax: (:issue:`NNN`)
-please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusPush`
+please point to classes using syntax: `HttpStatusPush`.


### PR DESCRIPTION
Adding links to release notes causes old release notes to point to no longer existing functionality and thus require periodic cleanup. These links don't work in e.g. github release notes anyway.
