### PR TITLE
Reduce sensitivity of subunit test logs

### DIFF
--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import io
+import re
 import sys
 
 from twisted.trial import unittest
@@ -118,12 +119,9 @@ class TestSubUnit(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         )
 
         self.expectOutcome(result=FAILURE, state_string="shell Total 1 test(s) 1 error (failure)")
-        self.expectLogfile('problems', '''\
-test1
-testtools.testresult.real._StringException: Traceback (most recent call last):
-ValueError: invalid literal for int() with base 10: '_error1'
-
-''')
+        self.expectLogfile('problems', re.compile(r'''test1
+testtools.testresult.real._StringException:.*ValueError: invalid literal for int\(\) with base 10: '_error1'
+.*''', re.MULTILINE | re.DOTALL))  # noqa pylint: disable=line-too-long
         return self.runStep()
 
     def test_multiple_errors(self):
@@ -146,16 +144,12 @@ ValueError: invalid literal for int() with base 10: '_error1'
         )
 
         self.expectOutcome(result=FAILURE, state_string="shell Total 2 test(s) 2 errors (failure)")
-        self.expectLogfile('problems', '''\
-test1
-testtools.testresult.real._StringException: Traceback (most recent call last):
-ValueError: invalid literal for int() with base 10: '_error1'
+        self.expectLogfile('problems', re.compile(r'''test1
+testtools.testresult.real._StringException:.*ValueError: invalid literal for int\(\) with base 10: '_error1'
 
 test2
-testtools.testresult.real._StringException: Traceback (most recent call last):
-ValueError: invalid literal for int() with base 10: '_error2'
-
-''')
+testtools.testresult.real._StringException:.*ValueError: invalid literal for int\(\) with base 10: '_error2'
+.*''', re.MULTILINE | re.DOTALL))  # noqa pylint: disable=line-too-long
         return self.runStep()
 
     def test_warnings(self):
@@ -178,10 +172,8 @@ ValueError: invalid literal for int() with base 10: '_error2'
         self.expectOutcome(result=SUCCESS,  # N.B. not WARNINGS
                            state_string="shell 1 test passed")
         # note that the warnings list is ignored..
-        self.expectLogfile('warnings', '''\
-error: test2 [
-Traceback (most recent call last):
-ValueError: invalid literal for int() with base 10: '_error2'
-]
-''')
+        self.expectLogfile('warnings', re.compile(r'''error: test2 \[.*
+ValueError: invalid literal for int\(\) with base 10: '_error2'
+\]
+''', re.MULTILINE | re.DOTALL))  # noqa pylint: disable=line-too-long
         return self.runStep()

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -402,17 +402,11 @@ class BuildStepMixin:
 
         for l, exp in self.exp_logfiles.items():
             got = self.step.logs[l].stdout
-            if got != exp:
-                log.msg("Unexpected stdout log output:\n" + got)
-                log.msg("Expected stdout log output:\n" + exp)
-                raise AssertionError("Unexpected stdout log output; see logs")
+            self._match_log(exp, got, 'stdout')
 
         for l, exp in self._exp_logfiles_stderr.items():
             got = self.step.logs[l].stderr
-            if got != exp:
-                log.msg("Unexpected stderr log output:\n" + got)
-                log.msg("Expected stderr log output:\n" + exp)
-                raise AssertionError("Unexpected stderr log output; see logs")
+            self._match_log(exp, got, 'stderr')
 
         if self.exp_exception:
             self.assertEqual(
@@ -424,6 +418,18 @@ class BuildStepMixin:
 
         # XXX TODO: hidden
         # self.step_status.setHidden.assert_called_once_with(self.exp_hidden)
+
+    def _match_log(self, exp, got, log_type):
+        if hasattr(exp, 'match'):
+            if exp.match(got) is None:
+                log.msg("Unexpected {} log output:\n{}".format(log_type, exp))
+                log.msg("Expected {} to match:\n{}".format(log_type, got))
+                raise AssertionError("Unexpected {} log output; see logs".format(log_type))
+        else:
+            if got != exp:
+                log.msg("Unexpected {} log output:\n{}".format(log_type, exp))
+                log.msg("Expected {} log output:\n{}".format(log_type, got))
+                raise AssertionError("Unexpected {} log output; see logs".format(log_type))
 
     # callbacks from the running step
 


### PR DESCRIPTION
During the last two weeks the tests started failing without any changes. It looks like we're testing exception debug output which is not stable.