### PR TITLE
test: Increase reliability of exponential backoff engine tests

### DIFF
--- a/master/buildbot/test/unit/util/test_backoff.py
+++ b/master/buildbot/test/unit/util/test_backoff.py
@@ -105,4 +105,6 @@ class ExponentialBackoffEngineSyncTests(unittest.TestCase):
         begin = time.monotonic()
         engine.wait_on_failure()
         end = time.monotonic()
-        self.assertGreaterEqual(end - begin, 0.05)
+        # Note that if time is adjusted back even a little bit during the test it will fail.
+        # So we add a little bit of wiggle room.
+        self.assertGreater(end - begin, 0.04)


### PR DESCRIPTION
This fixes the following test instability: https://ci.appveyor.com/project/djmitche/buildbot/builds/40034341/job/auyhxon0gy0puap9

```===============================================================================
[FAIL]
Traceback (most recent call last):
  File "c:\projects\buildbot\master\buildbot\test\unit\util\test_backoff.py", line 108, in test_wait_on_failure
    self.assertGreaterEqual(end - begin, 0.05)
  File "c:\python37\lib\unittest\case.py", line 1257, in assertGreaterEqual
    self.fail(self._formatMessage(msg, standardMsg))
twisted.trial.unittest.FailTest: 0.047000000000025466 not greater than or equal to 0.05
buildbot.test.unit.util.test_backoff.ExponentialBackoffEngineSyncTests.test_wait_on_failure
-------------------------------------------------------------------------------```

Looks like the time has been shifted a little bit while the test was running.