### PR TITLE
util: Log failures in callbacks submitted to deferwaiter

### DIFF
--- a/master/buildbot/test/unit/util/test_deferwaiter.py
+++ b/master/buildbot/test/unit/util/test_deferwaiter.py
@@ -90,6 +90,8 @@ class WaiterTests(unittest.TestCase):
         with self.assertRaises(defer.CancelledError):
             yield d1
 
+        self.flushLoggedErrors(defer.CancelledError)
+
     @defer.inlineCallbacks
     def test_cancel_called(self):
         w = DeferWaiter()
@@ -107,6 +109,8 @@ class WaiterTests(unittest.TestCase):
         self.assertTrue(d1_waited.called)
         with self.assertRaises(defer.CancelledError):
             yield d1
+
+        self.flushLoggedErrors(defer.CancelledError)
 
 
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):

--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from twisted.internet import defer
+from twisted.python import failure
 from twisted.python import log
 
 from buildbot.util import Notifier
@@ -27,6 +28,10 @@ class DeferWaiter:
         self._finish_notifier = Notifier()
 
     def _finished(self, result, d):
+        # most likely nothing is consuming the errors, so do it here
+        if isinstance(result, failure.Failure):
+            log.err(result)
+
         self._waited.pop(id(d))
         if not self._waited:
             self._finish_notifier.notify(None)


### PR DESCRIPTION
Ignoring failures of things submitted to deferwaiter will result in very confusing bugs because we would not see anything related in the logs.