### PR TITLE
gerrit: Fix branch attribute that is supplied to changes

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -202,17 +202,10 @@ class GerritChangeSourceBase(base.ChangeSource):
             # eat failures..
             log.err('error adding change from GerritChangeSource')
 
-    def getGroupingPolicyFromEvent(self, event):
-        # At the moment, buildbot's change grouping strategy is hardcoded at various place
-        # to be the 'branch' of an event.
-        # With gerrit, you usually want to group by branch on post commit, and by changeid
-        # on pre-commit.
-        # we keep this customization point here, waiting to have a better grouping strategy support
-        # in the core
-        event_change = event["change"]
+    def get_branch_from_event(self, event):
         if event['type'] in ('patchset-created', 'comment-added'):
-            return "{}/{}".format(event_change["branch"], event_change['number'])
-        return event_change["branch"]
+            return event["patchSet"]["ref"]
+        return event["change"]["branch"]
 
     @defer.inlineCallbacks
     def addChangeFromEvent(self, properties, event):
@@ -241,7 +234,7 @@ class GerritChangeSourceBase(base.ChangeSource):
             'project': util.bytes2unicode(event_change["project"]),
             'repository': "{}/{}".format(
                 self.gitBaseURL, event_change["project"]),
-            'branch': self.getGroupingPolicyFromEvent(event),
+            'branch': self.get_branch_from_event(event),
             'revision': event["patchSet"]["revision"],
             'revlink': event_change["url"],
             'comments': event_change["subject"],

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -29,6 +29,7 @@ from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import runprocess
 from buildbot.util.protocol import LineProcessProtocol
+from buildbot.util.pullrequest import PullRequestMixin
 
 
 def _canonicalize_event(event):
@@ -92,7 +93,7 @@ def _gerrit_user_to_author(props, username="unknown"):
     return username
 
 
-class GerritChangeSourceBase(base.ChangeSource):
+class GerritChangeSourceBase(base.ChangeSource, PullRequestMixin):
 
     """This source will maintain a connection to gerrit ssh server
     that will provide us gerrit events in json format."""
@@ -100,7 +101,9 @@ class GerritChangeSourceBase(base.ChangeSource):
     compare_attrs = ("gerritserver", "gerritport")
     name = None
     # list of properties that are no of no use to be put in the event dict
-    EVENT_PROPERTY_BLACKLIST = ["event.eventCreatedOn"]
+    external_property_denylist = ["event.eventCreatedOn"]
+    external_property_whitelist = ['*']
+    property_basename = 'event'
 
     def checkConfig(self,
                     gitBaseURL=None,
@@ -141,19 +144,7 @@ class GerritChangeSourceBase(base.ChangeSource):
                 log.msg("the event type '{}' is not setup to handle".format(event['type']))
             return defer.succeed(None)
 
-        # flatten the event dictionary, for easy access with WithProperties
-        def flatten(properties, base, event):
-            for k, v in event.items():
-                name = "{}.{}".format(base, k)
-                if name in self.EVENT_PROPERTY_BLACKLIST:
-                    continue
-                if isinstance(v, dict):
-                    flatten(properties, name, v)
-                else:  # already there
-                    properties[name] = v
-
-        properties = {}
-        flatten(properties, "event", event)
+        properties = self.extractProperties(event)
         properties["event.source"] = self.__class__.__name__
         func_name = "eventReceived_{}".format(event["type"].replace("-", "_"))
         func = getattr(self, func_name, None)

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -210,7 +210,7 @@ class GerritChangeSourceBase(base.ChangeSource):
         # we keep this customization point here, waiting to have a better grouping strategy support
         # in the core
         event_change = event["change"]
-        if event['type'] in ('patchset-created',):
+        if event['type'] in ('patchset-created', 'comment-added'):
             return "{}/{}".format(event_change["branch"], event_change['number'])
         return event_change["branch"]
 

--- a/master/buildbot/newsfragments/gerrit-comment-branch.bugfix
+++ b/master/buildbot/newsfragments/gerrit-comment-branch.bugfix
@@ -1,0 +1,1 @@
+The ``comment-added`` event on Gerrit now produces the same branch as other events such as ``patchset-created``.

--- a/master/buildbot/newsfragments/gerrit-real-branch.bugfix
+++ b/master/buildbot/newsfragments/gerrit-real-branch.bugfix
@@ -1,0 +1,1 @@
+``GerritChangeSource`` and ``GerritEventLogPoller`` will now produce change events with ``branch`` attribute that corresponds to the actual git branch on the repository.

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -236,7 +236,7 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
         'committer': None,
         'comments': 'change subject',
         'project': 'test',
-        'branch': 'master',
+        'branch': 'master/4321',
         'revlink': 'http://example.com/c/test/+/4321',
         'codebase': None,
         'revision': '29b73c3eb1aeaa9e6c7da520a940d60810e883db',

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -244,7 +244,8 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
             'event.type': 'patchset-created',
             'event.uploader.email': 'uploader@example.com',
             'event.uploader.name': 'uploader uploader',
-            'event.uploader.username': 'uploader'
+            'event.uploader.username': 'uploader',
+            'target_branch': 'master',
         }
         self.maxDiff = None
         self.assert_changes([change], ignore_keys=[])

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -28,7 +28,6 @@ from buildbot.reporters.gerrit_verify_status import GerritVerifyStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
-from buildbot.test.unit.changes.test_gerritchangesource import TestGerritChangeSource
 from buildbot.test.util import logging
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.misc import TestReactorMixin
@@ -369,9 +368,21 @@ class TestGerritVerifyStatusPush(TestReactorMixin, ReporterTestMixin, ConfigErro
         yield self.createGerritStatus()
 
         # from chdict:
-        chdict = TestGerritChangeSource.expected_change
-        props = Properties.fromDict({
-            k: (v, 'change') for k, v in chdict['properties'].items()})
+        change_props = {
+            'event.change.owner.email': 'dustin@mozilla.com',
+            'event.change.subject': 'fix 1234',
+            'event.change.project': 'pr',
+            'event.change.owner.name': 'Dustin',
+            'event.change.number': '4321',
+            'event.change.url': 'http://buildbot.net',
+            'event.change.branch': 'br',
+            'event.type': 'patchset-created',
+            'event.patchSet.revision': 'abcdef',
+            'event.patchSet.number': '12',
+            'event.source': 'GerritChangeSource'
+        }
+
+        props = Properties.fromDict({k: (v, 'change') for k, v in change_props.items()})
         changes = self.sp.getGerritChanges(props)
         self.assertEqual(changes, [
             {'change_id': '4321', 'revision_id': '12'}

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -22,7 +22,6 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.source import repo
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
-from buildbot.test.unit.changes.test_gerritchangesource import TestGerritChangeSource
 from buildbot.test.util import sourcesteps
 from buildbot.test.util.misc import TestReactorMixin
 
@@ -531,8 +530,19 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
     def test_repo_downloads_from_change_source(self):
         """basic repo download from change source, and check that repo_downloaded is updated"""
         self.mySetupStep(repoDownloads=repo.RepoDownloadsFromChangeSource())
-        chdict = TestGerritChangeSource.expected_change
-        change = Change(None, None, None, properties=chdict['properties'])
+        change = Change(None, None, None, properties={
+            'event.change.owner.email': 'dustin@mozilla.com',
+            'event.change.subject': 'fix 1234',
+            'event.change.project': 'pr',
+            'event.change.owner.name': 'Dustin',
+            'event.change.number': '4321',
+            'event.change.url': 'http://buildbot.net',
+            'event.change.branch': 'br',
+            'event.type': 'patchset-created',
+            'event.patchSet.revision': 'abcdef',
+            'event.patchSet.number': '12',
+            'event.source': 'GerritChangeSource'
+        })
         self.build.allChanges = lambda x=None: [change]
         self.expectnoClobber()
         self.expectRepoSync()
@@ -550,8 +560,19 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
         """basic repo download from change source, and check that repo_downloaded is updated"""
         self.mySetupStep(
             repoDownloads=repo.RepoDownloadsFromChangeSource("mycodebase"))
-        chdict = TestGerritChangeSource.expected_change
-        change = Change(None, None, None, properties=chdict['properties'])
+        change = Change(None, None, None, properties={
+            'event.change.owner.email': 'dustin@mozilla.com',
+            'event.change.subject': 'fix 1234',
+            'event.change.project': 'pr',
+            'event.change.owner.name': 'Dustin',
+            'event.change.number': '4321',
+            'event.change.url': 'http://buildbot.net',
+            'event.change.branch': 'br',
+            'event.type': 'patchset-created',
+            'event.patchSet.revision': 'abcdef',
+            'event.patchSet.number': '12',
+            'event.source': 'GerritChangeSource'
+        })
         # getSourceStamp is faked by SourceStepMixin
         ss = self.build.getSourceStamp("")
         ss.changes = [change]

--- a/master/buildbot/util/pullrequest.py
+++ b/master/buildbot/util/pullrequest.py
@@ -18,11 +18,15 @@ from fnmatch import fnmatch
 
 
 class PullRequestMixin:
+    external_property_whitelist = []
+    external_property_denylist = []
 
     def extractProperties(self, payload):
         def flatten(properties, base, info_dict):
             for k, v in info_dict.items():
                 name = ".".join([base, k])
+                if name in self.external_property_denylist:
+                    continue
                 if isinstance(v, dict):
                     flatten(properties, name, v)
                 elif any([fnmatch(name, expr)


### PR DESCRIPTION
Gerrit change sources used a different definition of what the branch attribute of a change source means compared to the rest of change sources. Rather than using the actual git branch they invented a string that is common for all events coming from a Gerrit change so that these changes could be grouped in the UI.

Unfortunately this breaks event processing downstream such as event filtering and sourcestamp data.

This PR will make change event grouping in the UI for gerrit inconsistent with other pollers as only the changes for the specific patchset (in github terms, a specific iteration of a PR) will be shown.

For users who relied on data contained in the previous branch attribute, such as the target branch, a new `target_branch` property has been added to changes originating from gerrit change sources. We will eventually expose this as a proper attribute of a change once the feature is supported across all change sources so this is not documented yet.

For grouping of changes we should add a separate field instead of reusing the branch attribute.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
