### PR TITLE
www: Don't show outdated browser warning for unindentified browsers

### DIFF
--- a/master/buildbot/newsfragments/unknown-browser-no-warning.bugfix
+++ b/master/buildbot/newsfragments/unknown-browser-no-warning.bugfix
@@ -1,0 +1,1 @@
+Old browser warning banner is no longer shown for browsers that could not be identified (:issue:`5237`).

--- a/www/base/src/app/app.browserwarning.notranspile.js
+++ b/www/base/src/app/app.browserwarning.notranspile.js
@@ -14,5 +14,5 @@ outdatedBrowserRework({
         'IE': false
     },
     requireChromeOnAndroid: false,
-    isUnknownBrowserOK: false,
+    isUnknownBrowserOK: true,
 });


### PR DESCRIPTION
By showing outdated browser warning we are mostly interested in users who are using a browser that is known to be not supported. If a browser is not identifiable it most likely means the user is on a custom setup, knows what he's doing and most likely has a browser that supports the required web standards.

Fixes #5237.