### PR TITLE
Fix several build request collapsing bugs

### DIFF
--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -63,6 +63,9 @@ class Model(base.DBConnectorComponent):
     #
     # * sqlalchemy does not handle sa.Boolean very well on MySQL or Postgres;
     #   use sa.SmallInteger instead
+    #
+    # * BuildRequest.canBeCollapsed() depends on buildrequest.id being auto-incremented which is
+    #   sqlalchemy default.
 
     # Tables related to build requests
     # --------------------------------

--- a/master/buildbot/newsfragments/buildrequest-collapse-check-scheduler-props.bugfix
+++ b/master/buildbot/newsfragments/buildrequest-collapse-check-scheduler-props.bugfix
@@ -1,0 +1,1 @@
+Improved default build request collapsing functionality to take into account properties set by the scheduler and not collapse build requests if they differ (:issue:`4686`).

--- a/master/buildbot/newsfragments/buildrequest-collapse-ensure-claim.bugfix
+++ b/master/buildbot/newsfragments/buildrequest-collapse-ensure-claim.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition that would result in attempts to complete unclaimed buildrequests (:issue:`3762`).

--- a/master/buildbot/newsfragments/buildrequest-collapse-fix-cancel-each-other.bugfix
+++ b/master/buildbot/newsfragments/buildrequest-collapse-fix-cancel-each-other.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition in default buildrequest collapse function which resulted in two concurrently submitted build requests potentially being able to cancel each other (:issue:`4642`).

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -168,10 +168,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_codebases(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]
@@ -185,10 +181,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_codebases_branches(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]
@@ -202,10 +194,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_codebases_repository(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]
@@ -219,10 +207,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_codebases_projects(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]
@@ -237,10 +221,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
     # * Neither source stamp has a patch (e.g., from a try scheduler)
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_a_patch(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]
@@ -255,10 +235,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
     # * Either both source stamps are associated with changes..
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_changes(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]
@@ -273,10 +249,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
     # * ... or neither are associated with changes but they have matching revisions.
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_non_matching_revision(self):
-
-        def collapseRequests_fn(master, builder, brdict1, brdict2):
-            return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
-
         rows = [
             fakedb.Builder(id=77, name='A'),
         ]

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -180,6 +180,19 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         yield self.do_request_collapse(rows, [21], [19, 20])
 
     @defer.inlineCallbacks
+    def test_collapseRequests_collapse_default_does_not_collapse_older(self):
+        rows = [
+            fakedb.Builder(id=77, name='A'),
+        ]
+        rows += self.makeBuildRequestRows(21, 121, None, 221, 'C')
+        rows += self.makeBuildRequestRows(19, 119, None, 210, 'C')
+        rows += self.makeBuildRequestRows(20, 120, None, 220, 'C')
+        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        yield self.do_request_collapse(rows, [19], [])
+        yield self.do_request_collapse(rows, [20], [19])
+        yield self.do_request_collapse(rows, [21], [20])
+
+    @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_with_codebases_branches(self):
         rows = [
             fakedb.Builder(id=77, name='A'),


### PR DESCRIPTION
This PR is a collection of 3 bug fixes in the default build request collapsing functionality. The collapsed build requests are not seen anywhere in the UI, so to the end users it would look like as if the schedulers were the broken piece.

Fixes #4686. Fixes #3762. Fixes #4642.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* n/a I have updated the appropriate documentation
