### PR TITLE
Convert change sources to ReconfigurablePollingChangeSource

### DIFF
--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -98,7 +98,7 @@ class ReconfigurablePollingChangeSource(ChangeSource):
     @poll_method
     def doPoll(self):
         d = defer.maybeDeferred(self.poll)
-        d.addErrback(log.err, 'while polling for changes')
+        d.addErrback(log.err, '{}: while polling for changes'.format(self))
         return d
 
     def force(self):

--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -22,6 +22,7 @@ from buildbot import config
 from buildbot.interfaces import IChangeSource
 from buildbot.util import service
 from buildbot.util.poll import method as poll_method
+from buildbot.warnings import warn_deprecated
 
 
 @implementer(IChangeSource)
@@ -122,6 +123,10 @@ class PollingChangeSource(ReconfigurablePollingChangeSource):
                     pollRandomDelayMin=0, pollRandomDelayMax=0, **kwargs):
         super().checkConfig(name=name, pollInterval=60 * 10, pollAtLaunch=False,
                             pollRandomDelayMin=0, pollRandomDelayMax=0)
+
+        warn_deprecated('3.3.0', 'PollingChangeSource has been deprecated: ' +
+                        'please use ReconfigurablePollingChangeSource')
+
         self.pollInterval = pollInterval
         self.pollAtLaunch = pollAtLaunch
         self.pollRandomDelayMin = pollRandomDelayMin

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -37,7 +37,7 @@ class GitError(Exception):
     """Raised when git exits with code 128."""
 
 
-class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
+class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
 
     """This source will poll a remote git repo for changes and submit
     them to the change master."""
@@ -49,11 +49,52 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
 
     secrets = ("sshPrivateKey", "sshHostKey", "sshKnownHosts")
 
-    def __init__(self, repourl, branches=None, branch=None, workdir=None, pollInterval=10 * 60,
-                 gitbin="git", usetimestamps=True, category=None, project=None, pollinterval=-2,
-                 fetch_refspec=None, encoding="utf-8", name=None, pollAtLaunch=False,
-                 buildPushesWithNoCommits=False, only_tags=False, sshPrivateKey=None,
-                 sshHostKey=None, sshKnownHosts=None, pollRandomDelayMin=0, pollRandomDelayMax=0):
+    def __init__(self, repourl, **kwargs):
+        name = kwargs.get("name", None)
+        if name is None:
+            kwargs["name"] = repourl
+        super().__init__(repourl, **kwargs)
+
+    def checkConfig(self, repourl, branches=None, branch=None, workdir=None,
+                    pollInterval=10 * 60, gitbin="git", usetimestamps=True, category=None,
+                    project=None, pollinterval=-2, fetch_refspec=None, encoding="utf-8",
+                    name=None, pollAtLaunch=False, buildPushesWithNoCommits=False,
+                    only_tags=False, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
+                    pollRandomDelayMin=0, pollRandomDelayMax=0):
+
+        # for backward compatibility; the parameter used to be spelled with 'i'
+        if pollinterval != -2:
+            pollInterval = pollinterval
+
+        if only_tags and (branch or branches):
+            config.error("GitPoller: can't specify only_tags and branch/branches")
+        if branch and branches:
+            config.error("GitPoller: can't specify both branch and branches")
+
+        self.sshPrivateKey = sshPrivateKey
+        self.sshHostKey = sshHostKey
+        self.sshKnownHosts = sshKnownHosts
+        self.setupGit(logname='GitPoller')  # check the configuration
+
+        if fetch_refspec is not None:
+            config.error("GitPoller: fetch_refspec is no longer supported. "
+                         "Instead, only the given branches are downloaded.")
+
+        if name is None:
+            name = repourl
+
+        super().checkConfig(name=name,
+                            pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
+                            pollRandomDelayMin=pollRandomDelayMin,
+                            pollRandomDelayMax=pollRandomDelayMax)
+
+    @defer.inlineCallbacks
+    def reconfigService(self, repourl, branches=None, branch=None, workdir=None,
+                        pollInterval=10 * 60, gitbin="git", usetimestamps=True, category=None,
+                        project=None, pollinterval=-2, fetch_refspec=None, encoding="utf-8",
+                        name=None, pollAtLaunch=False, buildPushesWithNoCommits=False,
+                        only_tags=False, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
+                        pollRandomDelayMin=0, pollRandomDelayMax=0):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -62,19 +103,10 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         if name is None:
             name = repourl
 
-        super().__init__(name=name, pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
-                         pollRandomDelayMin=pollRandomDelayMin,
-                         pollRandomDelayMax=pollRandomDelayMax, sshPrivateKey=sshPrivateKey,
-                         sshHostKey=sshHostKey, sshKnownHosts=sshKnownHosts)
-
         if project is None:
             project = ''
 
-        if only_tags and (branch or branches):
-            config.error("GitPoller: can't specify only_tags and branch/branches")
-        if branch and branches:
-            config.error("GitPoller: can't specify both branch and branches")
-        elif branch:
+        if branch:
             branches = [branch]
         elif not branches:
             if only_tags:
@@ -99,12 +131,19 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         self.sshKnownHosts = sshKnownHosts
         self.setupGit(logname='GitPoller')
 
-        if fetch_refspec is not None:
-            config.error("GitPoller: fetch_refspec is no longer supported. "
-                         "Instead, only the given branches are downloaded.")
-
         if self.workdir is None:
             self.workdir = 'gitpoller-work'
+
+        # make our workdir absolute, relative to the master's basedir
+
+        if not os.path.isabs(self.workdir):
+            self.workdir = os.path.join(self.master.basedir, self.workdir)
+            log.msg("gitpoller: using workdir '{}'".format(self.workdir))
+
+        yield super().reconfigService(name=name,
+                                      pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
+                                      pollRandomDelayMin=pollRandomDelayMin,
+                                      pollRandomDelayMax=pollRandomDelayMax)
 
     @defer.inlineCallbacks
     def _checkGitFeatures(self):
@@ -120,11 +159,6 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
 
     @defer.inlineCallbacks
     def activate(self):
-        # make our workdir absolute, relative to the master's basedir
-        if not os.path.isabs(self.workdir):
-            self.workdir = os.path.join(self.master.basedir, self.workdir)
-            log.msg("gitpoller: using workdir '{}'".format(self.workdir))
-
         try:
             self.lastRev = yield self.getState('lastRev', {})
 

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -27,7 +27,7 @@ from buildbot.util import runprocess
 from buildbot.util.state import StateMixin
 
 
-class HgPoller(base.PollingChangeSource, StateMixin):
+class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
 
     """This source will poll a remote hg repo for changes and submit
     them to the change master."""
@@ -38,11 +38,47 @@ class HgPoller(base.PollingChangeSource, StateMixin):
 
     db_class_name = 'HgPoller'
 
-    def __init__(self, repourl, branch=None, branches=None, bookmarks=None, workdir=None,
-                 pollInterval=10 * 60, hgbin="hg", usetimestamps=True, category=None,
-                 project="", pollinterval=-2, encoding="utf-8", name=None, pollAtLaunch=False,
-                 revlink=lambda branch, revision: (""), pollRandomDelayMin=0,
-                 pollRandomDelayMax=0):
+    def __init__(self, repourl, **kwargs):
+        name = kwargs.get("name", None)
+        if not name:
+            branches = self.build_branches(kwargs.get('branch', None), kwargs.get('branches', None))
+            kwargs["name"] = self.build_name(None, repourl, kwargs.get('bookmarks', None), branches)
+
+        self.initLock = defer.DeferredLock()
+
+        super().__init__(repourl, **kwargs)
+
+    def checkConfig(self, repourl, branch=None, branches=None, bookmarks=None, workdir=None,
+                    pollInterval=10 * 60, hgbin="hg", usetimestamps=True, category=None,
+                    project="", pollinterval=-2, encoding="utf-8", name=None,
+                    pollAtLaunch=False, revlink=lambda branch, revision: (""),
+                    pollRandomDelayMin=0, pollRandomDelayMax=0):
+
+        # for backward compatibility; the parameter used to be spelled with 'i'
+        if pollinterval != -2:
+            pollInterval = pollinterval
+
+        if branch and branches:
+            config.error("HgPoller: can't specify both branch and branches")
+
+        if not callable(revlink):
+            config.error("You need to provide a valid callable for revlink")
+
+        if workdir is None:
+            config.error("workdir is mandatory for now in HgPoller")
+
+        name = self.build_name(name, repourl, bookmarks, self.build_branches(branch, branches))
+
+        super().checkConfig(name=name, pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
+                            pollRandomDelayMin=pollRandomDelayMin,
+                            pollRandomDelayMax=pollRandomDelayMax)
+
+    @defer.inlineCallbacks
+    def reconfigService(self, repourl, branch=None, branches=None, bookmarks=None, workdir=None,
+                        pollInterval=10 * 60, hgbin="hg", usetimestamps=True, category=None,
+                        project="", pollinterval=-2, encoding="utf-8", name=None,
+                        pollAtLaunch=False, revlink=lambda branch, revision: (""),
+                        pollRandomDelayMin=0, pollRandomDelayMax=0):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -50,32 +86,14 @@ class HgPoller(base.PollingChangeSource, StateMixin):
 
         self.repourl = repourl
 
-        if branch and branches:
-            config.error("HgPoller: can't specify both branch and branches")
-        elif branch:
-            self.branches = [branch]
-        else:
-            self.branches = branches or []
-
+        self.branches = self.build_branches(branch, branches)
         self.bookmarks = bookmarks or []
 
-        if name is None:
-            name = repourl
-            if self.bookmarks:
-                name += "_" + "_".join(self.bookmarks)
-            if self.branches:
-                name += "_" + "_".join(self.branches)
+        name = self.build_name(name, repourl, bookmarks, self.branches)
 
         if not self.branches and not self.bookmarks:
             self.branches = ['default']
 
-        if not callable(revlink):
-            config.error(
-                "You need to provide a valid callable for revlink")
-
-        super().__init__(name=name, pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
-                         pollRandomDelayMin=pollRandomDelayMin,
-                         pollRandomDelayMax=pollRandomDelayMax)
         self.encoding = encoding
         self.lastChange = time.time()
         self.lastPoll = time.time()
@@ -85,12 +103,29 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         self.category = category if callable(
             category) else bytes2unicode(category)
         self.project = project
-        self.initLock = defer.DeferredLock()
         self.lastRev = {}
         self.revlink_callable = revlink
 
-        if self.workdir is None:
-            config.error("workdir is mandatory for now in HgPoller")
+        yield super().reconfigService(name=name, pollInterval=pollInterval,
+                                      pollAtLaunch=pollAtLaunch,
+                                      pollRandomDelayMin=pollRandomDelayMin,
+                                      pollRandomDelayMax=pollRandomDelayMax)
+
+    def build_name(self, name, repourl, bookmarks, branches):
+        if name is not None:
+            return name
+
+        name = repourl
+        if bookmarks:
+            name += "_" + "_".join(bookmarks)
+        if branches:
+            name += "_" + "_".join(branches)
+        return name
+
+    def build_branches(self, branch, branches):
+        if branch:
+            return [branch]
+        return branches or []
 
     @defer.inlineCallbacks
     def activate(self):

--- a/master/buildbot/newsfragments/change-sources-non-reconfigurable.removal
+++ b/master/buildbot/newsfragments/change-sources-non-reconfigurable.removal
@@ -1,0 +1,1 @@
+``changes.base.PollingChangeSource`` has been fully deprecated as internal uses of it were migrated to replacement APIs.

--- a/master/buildbot/test/fakedb/state.py
+++ b/master/buildbot/test/fakedb/state.py
@@ -100,9 +100,13 @@ class FakeStateComponent(FakeDBComponent):
 
     # fake methods
 
-    def fakeState(self, name, class_name, **kwargs):
-        id = self.objects[(name, class_name)] = self._newId()
-        self.objects[(name, class_name)] = id
+    def set_fake_state(self, object, **kwargs):
+        state_key = (object.name, object.__class__.__name__)
+        if state_key in self.objects:
+            id = self.objects[state_key]
+        else:
+            id = self.objects[state_key] = self._newId()
+
         self.states[id] = dict((k, json.dumps(v))
                                for k, v in kwargs.items())
         return id

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -47,7 +47,7 @@ class TestChangeSource(changesource.ChangeSourceMixin,
         cs.deactivate = mock.Mock(return_value=defer.succeed(None))
 
         # set the changesourceid, and claim the changesource on another master
-        self.attachChangeSource(cs)
+        yield self.attachChangeSource(cs)
         self.setChangeSourceToMaster(self.OTHER_MASTER_ID)
 
         yield cs.startService()
@@ -89,7 +89,7 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin,
         self.setUpTestReactor()
         yield self.setUpChangeSource()
 
-        self.attachChangeSource(self.Subclass(name="DummyCS"))
+        yield self.attachChangeSource(self.Subclass(name="DummyCS"))
 
     def tearDown(self):
         return self.tearDownChangeSource()
@@ -196,7 +196,7 @@ class TestReconfigurablePollingChangeSource(changesource.ChangeSourceMixin,
 
         yield self.setUpChangeSource()
 
-        self.attachChangeSource(self.Subclass(name="DummyCS"))
+        yield self.attachChangeSource(self.Subclass(name="DummyCS"))
 
     def tearDown(self):
         return self.tearDownChangeSource()

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -22,6 +22,8 @@ from buildbot.changes import base
 from buildbot.config import ConfigErrors
 from buildbot.test.util import changesource
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestChangeSource(changesource.ChangeSourceMixin,
@@ -89,7 +91,10 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin,
         self.setUpTestReactor()
         yield self.setUpChangeSource()
 
-        yield self.attachChangeSource(self.Subclass(name="DummyCS"))
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern="use ReconfigurablePollingChangeSource"):
+            cs = self.Subclass(name="DummyCS")
+        yield self.attachChangeSource(cs)
 
     def tearDown(self):
         return self.tearDownChangeSource()

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -438,10 +438,9 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def test_wrongRepoLink(self):
-        yield self.assertFailure(
-            self.newChangeSource(
-                'defunkt', 'defunkt', token='1234', repository_type='defunkt'),
-            ConfigErrors)
+        with self.assertRaises(ConfigErrors):
+            yield self.newChangeSource('defunkt', 'defunkt', token='1234',
+                                       repository_type='defunkt')
 
     @defer.inlineCallbacks
     def test_magicLink(self):

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -1488,8 +1488,8 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_startService_loadLastRev(self):
-        self.master.db.state.fakeState(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+        self.master.db.state.set_fake_state(
+            self.poller,
             lastRev={"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"},
         )
 

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -210,8 +210,8 @@ class TestGitPoller(TestGitPollerBase):
             .stdout(b'git ')
         )
 
-        yield self.assertFailure(self.poller._checkGitFeatures(),
-                                 EnvironmentError)
+        with self.assertRaises(EnvironmentError):
+            yield self.poller._checkGitFeatures()
 
         self.assert_all_commands_ran()
 

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -45,6 +45,8 @@ class TestGitPollerBase(MasterRunProcessMixin,
     REPOURL = 'git@example.com:~foo/baz.git'
     REPOURL_QUOTED = 'git%40example.com%3A%7Efoo%2Fbaz.git'
 
+    POLLER_WORKDIR = os.path.join('basedir', 'gitpoller-work')
+
     def createPoller(self):
         # this is overridden in TestGitPollerWithSshPrivateKey
         return gitpoller.GitPoller(self.REPOURL)
@@ -54,12 +56,14 @@ class TestGitPollerBase(MasterRunProcessMixin,
         self.setUpTestReactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
+        yield self.master.startService()
 
-        self.poller = self.createPoller()
-        yield self.poller.setServiceParent(self.master)
+        self.poller = yield self.attachChangeSource(self.createPoller())
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownChangeSource()
+        yield self.master.stopService()
+        yield self.tearDownChangeSource()
 
 
 class TestGitPoller(TestGitPollerBase):
@@ -73,7 +77,7 @@ class TestGitPoller(TestGitPollerBase):
 
         self.expect_commands(
             ExpectMaster(['git'] + args)
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
         )
 
         # we should get an Exception with empty output from git
@@ -92,7 +96,7 @@ class TestGitPoller(TestGitPollerBase):
         # and the method shouldn't suppress any exceptions
         self.expect_commands(
             ExpectMaster(['git'] + args)
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
 
@@ -107,7 +111,7 @@ class TestGitPoller(TestGitPollerBase):
         # finally we should get what's expected from good output
         self.expect_commands(
             ExpectMaster(['git'] + args)
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(desiredGoodOutput)
         )
 
@@ -220,16 +224,16 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
@@ -251,7 +255,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
@@ -267,7 +271,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work'])
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR])
             .exit(1),
         )
 
@@ -281,11 +285,11 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL]),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
 
@@ -299,15 +303,15 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
 
@@ -323,23 +327,23 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
 
@@ -357,33 +361,34 @@ class TestGitPoller(TestGitPollerBase):
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
         })
 
+    @defer.inlineCallbacks
     def test_poll_GitError(self):
         # Raised when git exits with status code 128. See issue 2468
         self.expect_commands(
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work'])
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR])
             .exit(128),
         )
 
-        d = self.assertFailure(self.poller._dovccmd('init', ['--bare',
-                                                             'gitpoller-work']), gitpoller.GitError)
+        with self.assertRaises(gitpoller.GitError):
+            yield self.poller._dovccmd('init', ['--bare', self.POLLER_WORKDIR])
 
-        d.addCallback(lambda _: self.assert_all_commands_ran())
-        return d
+        self.assert_all_commands_ran()
 
+    @defer.inlineCallbacks
     def test_poll_GitError_log(self):
         self.setUpLogging()
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work'])
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR])
             .exit(128),
         )
 
         self.poller.doPoll.running = True
-        d = self.poller.poll()
-        d.addCallback(lambda _: self.assert_all_commands_ran())
+        yield self.poller.poll()
+
+        self.assert_all_commands_ran()
         self.assertLogged("command.*on repourl.*failed.*exit code 128.*")
-        return d
 
     @defer.inlineCallbacks
     def test_poll_nothingNew(self):
@@ -395,24 +400,24 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
@@ -435,7 +440,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
                     b'refs/heads/release\n'
@@ -444,14 +449,14 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
         )
 
@@ -471,7 +476,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
                     b'refs/heads/release\n'
@@ -480,10 +485,10 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
@@ -491,13 +496,13 @@ class TestGitPoller(TestGitPollerBase):
                           '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
@@ -505,7 +510,7 @@ class TestGitPoller(TestGitPollerBase):
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
             ])),
@@ -604,24 +609,24 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
 
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
@@ -645,24 +650,24 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
 
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
@@ -725,17 +730,17 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
 
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
@@ -743,7 +748,7 @@ class TestGitPoller(TestGitPollerBase):
                           '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
@@ -807,24 +812,24 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
 
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
@@ -887,22 +892,22 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
@@ -972,24 +977,24 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
@@ -1009,7 +1014,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
@@ -1018,29 +1023,29 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
             ExpectMaster(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
             ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
                           '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
                           '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
 
@@ -1113,7 +1118,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
@@ -1121,17 +1126,17 @@ class TestGitPoller(TestGitPollerBase):
             ])),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241']))
@@ -1204,7 +1209,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
@@ -1215,17 +1220,17 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED +
                           '/refs/pull/410/head'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
             ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
                           '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
                           '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
 
@@ -1292,24 +1297,24 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing',
                           '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'
@@ -1393,22 +1398,22 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 1.7.5\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMaster(['git', 'log', '--ignore-missing', '--format=%H',
                           '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                           '^fa3ae8ed68e664d4db24798611b352e3c6509930',
                           '--'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([
                 b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
@@ -1476,18 +1481,14 @@ class TestGitPoller(TestGitPollerBase):
         self.assertEqual(added[1]['src'], 'git')
         self.assertEqual(added[1]['category'], '64a5dc')
 
-    @defer.inlineCallbacks
     def test_startService(self):
-        yield self.poller.startService()
-
-        self.assertEqual(
-            self.poller.workdir, os.path.join('basedir', 'gitpoller-work'))
+        self.assertEqual(self.poller.workdir, self.POLLER_WORKDIR)
         self.assertEqual(self.poller.lastRev, {})
-
-        yield self.poller.stopService()
 
     @defer.inlineCallbacks
     def test_startService_loadLastRev(self):
+        yield self.poller.stopService()
+
         self.master.db.state.set_fake_state(
             self.poller,
             lastRev={"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"},
@@ -1498,8 +1499,6 @@ class TestGitPoller(TestGitPollerBase):
         self.assertEqual(self.poller.lastRev, {
             "master": "fa3ae8ed68e664d4db24798611b352e3c6509930"
         })
-
-        yield self.poller.stopService()
 
 
 class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
@@ -1530,12 +1529,12 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
-        key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
+        key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
                           'ls-remote', '--refs', self.REPOURL]),
@@ -1543,10 +1542,10 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
                           'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
@@ -1563,7 +1562,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
 
-        temp_dir_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@')
+        temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
@@ -1575,22 +1574,22 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
     def test_poll_initial_2_3(self, write_local_file_mock, temp_dir_mock):
-        key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
+        key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.3.0\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             ExpectMaster(['git', 'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .env({'GIT_SSH_COMMAND': 'ssh -o "BatchMode=yes" -i "{0}"'.format(key_path)}),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
@@ -1607,7 +1606,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
 
-        temp_dir_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@')
+        temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
@@ -1620,13 +1619,13 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_failFetch_git_2_10(self, write_local_file_mock,
                                      temp_dir_mock):
-        key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
+        key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         # make sure we cleanup the private key when fetch fails
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
                           'ls-remote', '--refs', self.REPOURL]),
@@ -1634,7 +1633,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
                           'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
 
@@ -1643,7 +1642,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
 
         self.assert_all_commands_ran()
 
-        temp_dir_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@')
+        temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
@@ -1663,14 +1662,14 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
 
-        key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
-        known_hosts_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@',
+        key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
+        known_hosts_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@',
                                         'ssh-known-hosts')
 
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
                           '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
@@ -1680,10 +1679,10 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
                           '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
                           'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
@@ -1700,7 +1699,7 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
 
-        temp_dir_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@')
+        temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
@@ -1728,14 +1727,14 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
 
-        key_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
-        known_hosts_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@',
+        key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
+        known_hosts_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@',
                                         'ssh-known-hosts')
 
         self.expect_commands(
             ExpectMaster(['git', '--version'])
             .stdout(b'git version 2.10.0\n'),
-            ExpectMaster(['git', 'init', '--bare', 'gitpoller-work']),
+            ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
                           '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
@@ -1745,10 +1744,10 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                           '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
                           'fetch', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work'),
+            .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
                           'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir('gitpoller-work')
+            .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
@@ -1765,7 +1764,7 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
 
-        temp_dir_path = os.path.join('gitpoller-work', '.buildbot-ssh@@@')
+        temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
@@ -1781,55 +1780,80 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                          write_local_file_mock.call_args_list)
 
 
-class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):
+class TestGitPollerConstructor(unittest.TestCase, TestReactorMixin, changesource.ChangeSourceMixin,
+                               config.ConfigErrorsMixin):
 
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor()
+        yield self.setUpChangeSource()
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+        yield self.tearDownChangeSource()
+
+    @defer.inlineCallbacks
     def test_deprecatedFetchRefspec(self):
         with self.assertRaisesConfigError(
                 "fetch_refspec is no longer supported"):
-            gitpoller.GitPoller("/tmp/git.git", fetch_refspec='not-supported')
+            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git",
+                                          fetch_refspec='not-supported'))
 
+    @defer.inlineCallbacks
     def test_oldPollInterval(self):
-        poller = gitpoller.GitPoller("/tmp/git.git", pollinterval=10)
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", pollinterval=10))
         self.assertEqual(poller.pollInterval, 10)
 
+    @defer.inlineCallbacks
     def test_branches_default(self):
-        poller = gitpoller.GitPoller("/tmp/git.git")
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git"))
         self.assertEqual(poller.branches, ["master"])
 
+    @defer.inlineCallbacks
     def test_branches_oldBranch(self):
-        poller = gitpoller.GitPoller("/tmp/git.git", branch='magic')
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", branch='magic'))
         self.assertEqual(poller.branches, ["magic"])
 
+    @defer.inlineCallbacks
     def test_branches(self):
-        poller = gitpoller.GitPoller("/tmp/git.git",
-                                     branches=['magic', 'marker'])
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git",
+                                                                   branches=['magic', 'marker']))
         self.assertEqual(poller.branches, ["magic", "marker"])
 
+    @defer.inlineCallbacks
     def test_branches_True(self):
-        poller = gitpoller.GitPoller("/tmp/git.git", branches=True)
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", branches=True))
         self.assertEqual(poller.branches, True)
 
+    @defer.inlineCallbacks
     def test_only_tags_True(self):
-        poller = gitpoller.GitPoller("/tmp/git.git", only_tags=True)
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", only_tags=True))
         self.assertIsNotNone(poller.branches)
 
+    @defer.inlineCallbacks
     def test_branches_andBranch(self):
         with self.assertRaisesConfigError(
                 "can't specify both branch and branches"):
-            gitpoller.GitPoller("/tmp/git.git", branch='bad',
-                                branches=['listy'])
+            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", branch='bad',
+                                                              branches=['listy']))
 
+    @defer.inlineCallbacks
     def test_branches_and_only_tags(self):
         with self.assertRaisesConfigError(
                 "can't specify only_tags and branch/branches"):
-            gitpoller.GitPoller("/tmp/git.git", only_tags=True,
-                                branches=['listy'])
+            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", only_tags=True,
+                                                              branches=['listy']))
 
+    @defer.inlineCallbacks
     def test_branch_and_only_tags(self):
         with self.assertRaisesConfigError(
                 "can't specify only_tags and branch/branches"):
-            gitpoller.GitPoller("/tmp/git.git", only_tags=True, branch='bad')
+            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", only_tags=True,
+                                                              branch='bad'))
 
+    @defer.inlineCallbacks
     def test_gitbin_default(self):
-        poller = gitpoller.GitPoller("/tmp/git.git")
+        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git"))
         self.assertEqual(poller.gitbin, "git")

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -41,6 +41,7 @@ class TestHgPollerBase(MasterRunProcessMixin,
     def setUp(self):
         self.setUpTestReactor()
         self.setup_master_run_process()
+        yield self.setUpChangeSource()
 
         # To test that environment variables get propagated to subprocesses
         # (See #2116)
@@ -63,7 +64,12 @@ class TestHgPollerBase(MasterRunProcessMixin,
         yield self.poller.setServiceParent(self.master)
         self.poller._isRepositoryReady = _isRepositoryReady
 
-        yield self.master.db.setup()
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+        yield self.tearDownChangeSource()
 
     @defer.inlineCallbacks
     def check_current_rev(self, wished, branch='default'):

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -70,7 +70,7 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
     def test_messageReceived_svn(self):
         self.populateMaildir()
         mds = mail.MaildirSource(self.maildir)
-        self.attachChangeSource(mds)
+        yield self.attachChangeSource(mds)
 
         # monkey-patch in a parse method
         def parse(message, prefix):
@@ -102,7 +102,7 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
     def test_messageReceived_bzr(self):
         self.populateMaildir()
         mds = mail.MaildirSource(self.maildir)
-        self.attachChangeSource(mds)
+        yield self.attachChangeSource(mds)
 
         # monkey-patch in a parse method
         def parse(message, prefix):

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -23,6 +23,8 @@ from buildbot.changes import base
 from buildbot.changes import manager
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestChangeManager(unittest.TestCase, TestReactorMixin):
@@ -85,10 +87,14 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_reconfigService_change_legacy(self):
-        src1, = self.make_sources(1, base.PollingChangeSource, pollInterval=1)
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern="use ReconfigurablePollingChangeSource"):
+            src1, = self.make_sources(1, base.PollingChangeSource, pollInterval=1)
         yield src1.setServiceParent(self.cm)
 
-        src2, = self.make_sources(1, base.PollingChangeSource, pollInterval=2)
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern="use ReconfigurablePollingChangeSource"):
+            src2, = self.make_sources(1, base.PollingChangeSource, pollInterval=2)
 
         self.new_config.change_sources = [src2]
 

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -134,10 +134,9 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
         when = datetime.datetime.strptime(timestring, datefmt)
         return when
 
-    # tests
-
+    @defer.inlineCallbacks
     def test_describe(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1)))
@@ -159,7 +158,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
     @defer.inlineCallbacks
     def do_test_poll_successful(self, **kwargs):
         encoding = kwargs.get('encoding', 'utf8')
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1),
@@ -256,7 +255,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_poll_failed_changes(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1)))
@@ -273,7 +272,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_poll_failed_describe(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1)))
@@ -297,7 +296,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_poll_unicode_error(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1)))
@@ -320,7 +319,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_poll_unicode_error2(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1),
@@ -336,7 +335,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_acquire_ticket_auth(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user='buildbot_user', p4passwd='pass',
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1),
@@ -364,7 +363,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_acquire_ticket_auth_fail(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None, p4passwd='pass',
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1),
@@ -393,7 +392,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
     @defer.inlineCallbacks
     def test_poll_split_file(self):
         """Make sure split file works on branch only changes"""
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=get_simple_split))
@@ -457,7 +456,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
     @defer.inlineCallbacks
     def test_server_tz(self):
         """Verify that the server_tz parameter is handled correctly"""
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
                      p4base='//depot/myproject/',
                      split_file=get_simple_split,

--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -72,10 +72,11 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
         # but expect that it will NOT register
         return self._test_registration(None, **self.DEFAULT_CONFIG)
 
+    @defer.inlineCallbacks
     def test_registration_later_if_master_can_do_it(self):
         # get the changesource running but not active due to the other master
         self.setChangeSourceToMaster(self.OTHER_MASTER_ID)
-        self.attachChangeSource(pb.PBChangeSource(**self.DEFAULT_CONFIG))
+        yield self.attachChangeSource(pb.PBChangeSource(**self.DEFAULT_CONFIG))
         self.startChangeSource()
         self.assertNotRegistered()
 
@@ -120,8 +121,9 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
             self.assertUnregistered(*exp_registration)
         self.assertEqual(self.changesource.registration, None)
 
+    @defer.inlineCallbacks
     def test_perspective(self):
-        self.attachChangeSource(
+        yield self.attachChangeSource(
             pb.PBChangeSource('alice', 'sekrit', port='8888'))
         persp = self.changesource.getPerspective(mock.Mock(), 'alice')
         self.assertIsInstance(persp, pb.ChangePerspective)
@@ -153,7 +155,7 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
     @defer.inlineCallbacks
     def test_reconfigService_no_change(self):
         config = mock.Mock()
-        self.attachChangeSource(pb.PBChangeSource(port='9876'))
+        yield self.attachChangeSource(pb.PBChangeSource(port='9876'))
 
         self.startChangeSource()
         yield self.changesource.reconfigServiceWithBuildbotConfig(config)
@@ -168,7 +170,7 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
     def test_reconfigService_default_changed(self):
         config = mock.Mock()
         config.protocols = {'pb': {'port': '9876'}}
-        self.attachChangeSource(pb.PBChangeSource())
+        yield self.attachChangeSource(pb.PBChangeSource())
 
         self.startChangeSource()
         yield self.changesource.reconfigServiceWithBuildbotConfig(config)
@@ -191,7 +193,7 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
         """reconfig one that's not active on this master"""
         config = mock.Mock()
         config.protocols = {'pb': {'port': '9876'}}
-        self.attachChangeSource(pb.PBChangeSource())
+        yield self.attachChangeSource(pb.PBChangeSource())
         self.setChangeSourceToMaster(self.OTHER_MASTER_ID)
 
         self.startChangeSource()

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -264,31 +264,34 @@ class TestSVNPoller(MasterRunProcessMixin,
     def tearDown(self):
         return self.tearDownChangeSource()
 
+    @defer.inlineCallbacks
     def attachSVNPoller(self, *args, **kwargs):
         s = svnpoller.SVNPoller(*args, **kwargs)
-        self.attachChangeSource(s)
+        yield self.attachChangeSource(s)
         return s
 
-    # tests
+    @defer.inlineCallbacks
     def test_describe(self):
-        s = self.attachSVNPoller('file://')
+        s = yield self.attachSVNPoller('file://')
         self.assertSubstring("SVNPoller", s.describe())
 
+    @defer.inlineCallbacks
     def test_name(self):
-        s = self.attachSVNPoller('file://')
+        s = yield self.attachSVNPoller('file://')
         self.assertEqual("file://", s.name)
 
-        s = self.attachSVNPoller('file://', name='MyName')
+        s = yield self.attachSVNPoller('file://', name='MyName')
         self.assertEqual("MyName", s.name)
 
+    @defer.inlineCallbacks
     def test_strip_repourl(self):
         base = "svn+ssh://svn.twistedmatrix.com/svn/Twisted/trunk"
-        s = self.attachSVNPoller(base + "/")
+        s = yield self.attachSVNPoller(base + "/")
         self.assertEqual(s.repourl, base)
 
     @defer.inlineCallbacks
     def do_test_get_prefix(self, base, output, expected):
-        s = self.attachSVNPoller(base)
+        s = yield self.attachSVNPoller(base)
         self.expect_commands(
             ExpectMaster(['svn', 'info', '--xml', '--non-interactive', base])
             .stdout(output)
@@ -316,15 +319,17 @@ class TestSVNPoller(MasterRunProcessMixin,
                 "svnpoller/_trial_temp/test_vc/repositories/SVN-Repository/sample/trunk")
         return self.do_test_get_prefix(base, prefix_output_3, 'sample/trunk')
 
+    @defer.inlineCallbacks
     def test_log_parsing(self):
-        s = self.attachSVNPoller('file:///foo')
+        s = yield self.attachSVNPoller('file:///foo')
         output = make_changes_output(4)
         entries = s.parse_logs(output)
         # no need for elaborate assertions here; this is minidom's logic
         self.assertEqual(len(entries), 4)
 
+    @defer.inlineCallbacks
     def test_get_new_logentries(self):
-        s = self.attachSVNPoller('file:///foo')
+        s = yield self.attachSVNPoller('file:///foo')
         entries = make_logentry_elements(4)
 
         s.last_change = 4
@@ -348,6 +353,7 @@ class TestSVNPoller(MasterRunProcessMixin,
         self.assertEqual(s.last_change, 4)
         self.assertEqual(len(new), 0)
 
+    @defer.inlineCallbacks
     def test_get_text(self):
         doc = xml.dom.minidom.parseString("""
             <parent>
@@ -357,15 +363,16 @@ class TestSVNPoller(MasterRunProcessMixin,
                     <grandchild>2</grandchild>
                 </child>
             </parent>""".strip())
-        s = self.attachSVNPoller('http://', split_file=split_file)
+        s = yield self.attachSVNPoller('http://', split_file=split_file)
 
         self.assertEqual(s._get_text(doc, 'grandchild'), '1')
         self.assertEqual(s._get_text(doc, 'nonexistent'), 'unknown')
 
+    @defer.inlineCallbacks
     def test_create_changes(self):
         base = ("file:///home/warner/stuff/Projects/Buildbot/trees/" +
                 "svnpoller/_trial_temp/test_vc/repositories/SVN-Repository/sample")
-        s = self.attachSVNPoller(base, split_file=split_file)
+        s = yield self.attachSVNPoller(base, split_file=split_file)
         s._prefix = "sample"
 
         logentries = dict(
@@ -415,6 +422,7 @@ class TestSVNPoller(MasterRunProcessMixin,
         args.extend(['--limit=100', sample_base])
         return ExpectMaster(args)
 
+    @defer.inlineCallbacks
     def test_create_changes_overridden_project(self):
         def custom_split_file(path):
             f = split_file(path)
@@ -426,7 +434,7 @@ class TestSVNPoller(MasterRunProcessMixin,
 
         base = ("file:///home/warner/stuff/Projects/Buildbot/trees/" +
                 "svnpoller/_trial_temp/test_vc/repositories/SVN-Repository/sample")
-        s = self.attachSVNPoller(base, split_file=custom_split_file)
+        s = yield self.attachSVNPoller(base, split_file=custom_split_file)
         s._prefix = "sample"
 
         logentries = dict(
@@ -450,8 +458,8 @@ class TestSVNPoller(MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_poll(self):
-        s = self.attachSVNPoller(sample_base, split_file=split_file,
-                                 svnuser='dustin', svnpasswd='bbrocks')
+        s = yield self.attachSVNPoller(sample_base, split_file=split_file,
+                                       svnuser='dustin', svnpasswd='bbrocks')
 
         self.expect_commands(
             self.makeInfoExpect().stdout(sample_info_output),
@@ -535,9 +543,10 @@ class TestSVNPoller(MasterRunProcessMixin,
         self.assertEqual(s.last_change, 4)
         self.assert_all_commands_ran()
 
+    @defer.inlineCallbacks
     def test_poll_empty_password(self):
-        s = self.attachSVNPoller(sample_base, split_file=split_file,
-                                 svnuser='dustin', svnpasswd='')
+        s = yield self.attachSVNPoller(sample_base, split_file=split_file,
+                                       svnuser='dustin', svnpasswd='')
 
         self.expect_commands(
             self.makeInfoExpect(password="").stdout(sample_info_output),
@@ -546,11 +555,11 @@ class TestSVNPoller(MasterRunProcessMixin,
             self.makeLogExpect(password="").stdout(make_changes_output(2)),
             self.makeLogExpect(password="").stdout(make_changes_output(4)),
         )
-        s.poll()
+        yield s.poll()
 
+    @defer.inlineCallbacks
     def test_poll_no_password(self):
-        s = self.attachSVNPoller(sample_base, split_file=split_file,
-                                 svnuser='dustin')
+        s = yield self.attachSVNPoller(sample_base, split_file=split_file, svnuser='dustin')
 
         self.expect_commands(
             self.makeInfoExpect(password=None).stdout(sample_info_output),
@@ -559,11 +568,12 @@ class TestSVNPoller(MasterRunProcessMixin,
             self.makeLogExpect(password=None).stdout(make_changes_output(2)),
             self.makeLogExpect(password=None).stdout(make_changes_output(4)),
         )
-        s.poll()
+        yield s.poll()
 
+    @defer.inlineCallbacks
     def test_poll_interpolated_password(self):
-        s = self.attachSVNPoller(sample_base, split_file=split_file,
-                                 svnuser='dustin', svnpasswd=Interpolate('pa$$'))
+        s = yield self.attachSVNPoller(sample_base, split_file=split_file,
+                                       svnuser='dustin', svnpasswd=Interpolate('pa$$'))
 
         self.expect_commands(
             self.makeInfoExpect(password='pa$$').stdout(sample_info_output),
@@ -572,12 +582,12 @@ class TestSVNPoller(MasterRunProcessMixin,
             self.makeLogExpect(password='pa$$').stdout(make_changes_output(2)),
             self.makeLogExpect(password='pa$$').stdout(make_changes_output(4)),
         )
-        s.poll()
+        yield s.poll()
 
     @defer.inlineCallbacks
     def test_poll_get_prefix_exception(self):
-        s = self.attachSVNPoller(sample_base, split_file=split_file,
-                                 svnuser='dustin', svnpasswd='bbrocks')
+        s = yield self.attachSVNPoller(sample_base, split_file=split_file,
+                                       svnuser='dustin', svnpasswd='bbrocks')
 
         self.expect_commands(
             self.makeInfoExpect().stderr(b"error"))
@@ -589,8 +599,8 @@ class TestSVNPoller(MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def test_poll_get_logs_exception(self):
-        s = self.attachSVNPoller(sample_base, split_file=split_file,
-                                 svnuser='dustin', svnpasswd='bbrocks')
+        s = yield self.attachSVNPoller(sample_base, split_file=split_file,
+                                       svnuser='dustin', svnpasswd='bbrocks')
         s._prefix = "abc"  # skip the get_prefix stuff
 
         self.expect_commands(
@@ -601,18 +611,20 @@ class TestSVNPoller(MasterRunProcessMixin,
         self.assertEqual(len(self.flushLoggedErrors(EnvironmentError)), 1)
         self.assert_all_commands_ran()
 
+    @defer.inlineCallbacks
     def test_cachepath_empty(self):
         cachepath = os.path.abspath('revcache')
         if os.path.exists(cachepath):
             os.unlink(cachepath)
-        s = self.attachSVNPoller(sample_base, cachepath=cachepath)
+        s = yield self.attachSVNPoller(sample_base, cachepath=cachepath)
         self.assertEqual(s.last_change, None)
 
+    @defer.inlineCallbacks
     def test_cachepath_full(self):
         cachepath = os.path.abspath('revcache')
         with open(cachepath, "w") as f:
             f.write('33')
-        s = self.attachSVNPoller(sample_base, cachepath=cachepath)
+        s = yield self.attachSVNPoller(sample_base, cachepath=cachepath)
         self.assertEqual(s.last_change, 33)
 
         s.last_change = 44
@@ -620,30 +632,33 @@ class TestSVNPoller(MasterRunProcessMixin,
         with open(cachepath) as f:
             self.assertEqual(f.read().strip(), '44')
 
+    @defer.inlineCallbacks
     def test_cachepath_bogus(self):
         cachepath = os.path.abspath('revcache')
         with open(cachepath, "w") as f:
             f.write('nine')
-        s = self.attachSVNPoller(sample_base, cachepath=cachepath)
+        s = yield self.attachSVNPoller(sample_base, cachepath=cachepath)
         self.assertEqual(s.last_change, None)
         self.assertEqual(s.cachepath, None)
         # it should have called log.err once with a ValueError
         self.assertEqual(len(self.flushLoggedErrors(ValueError)), 1)
 
     def test_constructor_pollinterval(self):
-        self.attachSVNPoller(sample_base, pollinterval=100)  # just don't fail!
+        return self.attachSVNPoller(sample_base, pollinterval=100)  # just don't fail!
 
+    @defer.inlineCallbacks
     def test_extra_args(self):
         extra_args = ['--no-auth-cache', ]
         base = "svn+ssh://svn.twistedmatrix.com/svn/Twisted/trunk"
 
-        s = self.attachSVNPoller(repourl=base, extra_args=extra_args)
+        s = yield self.attachSVNPoller(repourl=base, extra_args=extra_args)
         self.assertEqual(s.extra_args, extra_args)
 
+    @defer.inlineCallbacks
     def test_use_svnurl(self):
         base = "svn+ssh://svn.twistedmatrix.com/svn/Twisted/trunk"
         with self.assertRaises(TypeError):
-            self.attachSVNPoller(svnurl=base)
+            yield self.attachSVNPoller(svnurl=base)
 
 
 class TestSplitFile(unittest.TestCase):

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -62,12 +62,12 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_getCodebaseDict_existing(self):
-        self.db.state.fakeState('fake-name', 'FakeObject',
-                                lastCodebases={'a': {
-                                    'repository': 'A',
-                                    'revision': '1234:abc',
-                                    'branch': 'master',
-                                    'lastChange': 10}})
+        self.db.state.set_fake_state(self.object, lastCodebases={'a': {
+            'repository': 'A',
+            'revision': '1234:abc',
+            'branch': 'master',
+            'lastChange': 10
+        }})
         cbd = yield self.object.getCodebaseDict('a')
         self.assertEqual(cbd, {'repository': 'A', 'revision': '1234:abc',
                                'branch': 'master', 'lastChange': 10})
@@ -83,12 +83,12 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_recordChange_older(self):
-        self.db.state.fakeState('fake-name', 'FakeObject',
-                                lastCodebases={'a': {
-                                    'repository': 'A',
-                                    'revision': '2345:bcd',
-                                    'branch': 'master',
-                                    'lastChange': 20}})
+        self.db.state.set_fake_state(self.object, lastCodebases={'a': {
+            'repository': 'A',
+            'revision': '2345:bcd',
+            'branch': 'master',
+            'lastChange': 20
+        }})
         yield self.object.getCodebaseDict('a')
         yield self.object.recordChange(self.mkch(codebase='a', repository='A', revision='1234:abc',
                                                  branch='master', number=10))
@@ -97,12 +97,13 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_recordChange_newer(self):
-        self.db.state.fakeState('fake-name', 'FakeObject',
-                                lastCodebases={'a': {
-                                    'repository': 'A',
-                                    'revision': '1234:abc',
-                                    'branch': 'master',
-                                    'lastChange': 10}})
+        self.db.state.set_fake_state(self.object, lastCodebases={'a': {
+            'repository': 'A',
+            'revision': '1234:abc',
+            'branch': 'master',
+            'lastChange': 10
+        }})
+
         yield self.object.getCodebaseDict('a')
         yield self.object.recordChange(self.mkch(codebase='a', repository='A', revision='2345:bcd',
                                                  branch='master', number=20))

--- a/master/buildbot/test/unit/util/test_state.py
+++ b/master/buildbot/test/unit/util/test_state.py
@@ -39,8 +39,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getState(self):
-        self.master.db.state.fakeState('fake-name', 'FakeObject',
-                                       fav_color=['red', 'purple'])
+        self.master.db.state.set_fake_state(self.object, fav_color=['red', 'purple'])
         res = yield self.object.getState('fav_color')
 
         self.assertEqual(res, ['red', 'purple'])
@@ -52,8 +51,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
         self.assertEqual(res, 'black')
 
     def test_getState_KeyError(self):
-        self.master.db.state.fakeState('fake-name', 'FakeObject',
-                                       fav_color=['red', 'purple'])
+        self.master.db.state.set_fake_state(self.object, fav_color=['red', 'purple'])
         d = self.object.getState('fav_book')
 
         def cb(_):
@@ -74,7 +72,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_setState_existing(self):
-        self.master.db.state.fakeState('fake-name', 'FakeObject', x=13)
+        self.master.db.state.set_fake_state(self.object, x=13)
         yield self.object.setState('x', 14)
 
         self.master.db.state.assertStateByClass('fake-name', 'FakeObject',

--- a/master/buildbot/test/unit/www/test_hooks_poller.py
+++ b/master/buildbot/test/unit/www/test_hooks_poller.py
@@ -23,6 +23,8 @@ from buildbot.changes.manager import ChangeManager
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 from buildbot.www import change_hook
 
 
@@ -136,8 +138,10 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_trigger_old_poller(self):
-        yield self.setUpRequest({b"poller": [b"example"]},
-                                poller_cls=self.OldstyleSubclass)
+        with assertProducesWarnings(DeprecatedApiWarning, num_warnings=2,
+                                    message_pattern="use ReconfigurablePollingChangeSource"):
+            yield self.setUpRequest({b"poller": [b"example"]},
+                                    poller_cls=self.OldstyleSubclass)
         self.assertEqual(self.request.written, b"no change found")
         self.assertEqual(self.changesrc.called, True)
         self.assertEqual(self.otherpoller.called, False)

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -52,6 +52,7 @@ class ChangeSourceMixin:
         yield self.changesource.disownServiceParent()
         return
 
+    @defer.inlineCallbacks
     def attachChangeSource(self, cs):
         "Set up a change source for testing; sets its .master attribute"
         self.changesource = cs
@@ -60,11 +61,14 @@ class ChangeSourceMixin:
         try:
             self.changesource.master = self.master
         except AttributeError:
-            self.changesource.setServiceParent(self.master)
+            yield self.changesource.setServiceParent(self.master)
 
         # configure the service to let secret manager render the secrets
-        d = self.changesource.configureService()
-        d.addErrback(lambda _: None)
+        try:
+            yield self.changesource.configureService()
+        except NotImplementedError:  # non-reconfigurable change sources can't reconfig
+            pass
+
         # also, now that changesources are ClusteredServices, setting up
         # the clock here helps in the unit tests that check that behavior
         self.changesource.clock = task.Clock()

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -72,6 +72,7 @@ class ChangeSourceMixin:
         # also, now that changesources are ClusteredServices, setting up
         # the clock here helps in the unit tests that check that behavior
         self.changesource.clock = task.Clock()
+        return cs
 
     def startChangeSource(self):
         "start the change source as a service"


### PR DESCRIPTION
This PR moves away from legacy PollingChangeSource and makes it possible to really deprecate it.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* n/a I have updated the appropriate documentation
