### PR TITLE
Fix support for SQLAlchemy 1.4

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -56,6 +56,7 @@ env:
 
   # Test different versions of SQLAlchemy
   - TWISTED=17.9.0 SQLALCHEMY=1.2.0 TESTS=trial
+  - TWISTED=17.9.0 SQLALCHEMY=1.3.0 TESTS=trial
   - TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
 
   # Tests for the worker on old versions of twisted.

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -29,7 +29,6 @@ import re
 
 import migrate
 import sqlalchemy as sa
-from sqlalchemy.engine import strategies
 from sqlalchemy.engine import url
 from sqlalchemy.pool import NullPool
 
@@ -151,148 +150,129 @@ def get_sqlalchemy_migrate_version():
     return tuple(map(int, version.split('.')))
 
 
-class BuildbotEngineStrategy(strategies.PlainEngineStrategy):
-    # A subclass of the PlainEngineStrategy that can effectively interact
-    # with Buildbot.
-    #
-    # This adjusts the passed-in parameters to ensure that we get the behaviors
-    # Buildbot wants from particular drivers, and wraps the outgoing Engine
-    # object so that its methods run in threads and return deferreds.
+def special_case_sqlite(u, kwargs):
+    """For sqlite, percent-substitute %(basedir)s and use a full
+    path to the basedir.  If using a memory database, force the
+    pool size to be 1."""
+    max_conns = 1
 
-    name = 'buildbot'
+    # when given a database path, stick the basedir in there
+    if u.database:
 
-    def special_case_sqlite(self, u, kwargs):
-        """For sqlite, percent-substitute %(basedir)s and use a full
-        path to the basedir.  If using a memory database, force the
-        pool size to be 1."""
-        max_conns = 1
+        # Use NullPool instead of the sqlalchemy-0.6.8-default
+        # SingletonThreadPool for sqlite to suppress the error in
+        # http://groups.google.com/group/sqlalchemy/msg/f8482e4721a89589,
+        # which also explains that NullPool is the new default in
+        # sqlalchemy 0.7 for non-memory SQLite databases.
+        kwargs.setdefault('poolclass', NullPool)
 
-        # when given a database path, stick the basedir in there
-        if u.database:
+        u.database = u.database % dict(basedir=kwargs['basedir'])
+        if not os.path.isabs(u.database[0]):
+            u.database = os.path.join(kwargs['basedir'], u.database)
 
-            # Use NullPool instead of the sqlalchemy-0.6.8-default
-            # SingletonThreadPool for sqlite to suppress the error in
-            # http://groups.google.com/group/sqlalchemy/msg/f8482e4721a89589,
-            # which also explains that NullPool is the new default in
-            # sqlalchemy 0.7 for non-memory SQLite databases.
-            kwargs.setdefault('poolclass', NullPool)
+    else:
+        # For in-memory database SQLAlchemy will use SingletonThreadPool
+        # and we will run connection creation and all queries in the single
+        # thread.
+        # However connection destruction will be run from the main
+        # thread, which is safe in our case, but not safe in general,
+        # so SQLite will emit warning about it.
+        # Silence that warning.
+        kwargs.setdefault('connect_args', {})['check_same_thread'] = False
 
-            u.database = u.database % dict(basedir=kwargs['basedir'])
-            if not os.path.isabs(u.database[0]):
-                u.database = os.path.join(kwargs['basedir'], u.database)
+    # ignore serializing access to the db
+    if 'serialize_access' in u.query:
+        u.query.pop('serialize_access')
 
-        else:
-            # For in-memory database SQLAlchemy will use SingletonThreadPool
-            # and we will run connection creation and all queries in the single
-            # thread.
-            # However connection destruction will be run from the main
-            # thread, which is safe in our case, but not safe in general,
-            # so SQLite will emit warning about it.
-            # Silence that warning.
-            kwargs.setdefault('connect_args', {})['check_same_thread'] = False
-
-        # ignore serializing access to the db
-        if 'serialize_access' in u.query:
-            u.query.pop('serialize_access')
-
-        return u, kwargs, max_conns
-
-    def special_case_mysql(self, u, kwargs):
-        """For mysql, take max_idle out of the query arguments, and
-        use its value for pool_recycle.  Also, force use_unicode and
-        charset to be True and 'utf8', failing if they were set to
-        anything else."""
-        kwargs['pool_recycle'] = int(u.query.pop('max_idle', 3600))
-
-        # default to the MyISAM storage engine
-        storage_engine = u.query.pop('storage_engine', 'MyISAM')
-        kwargs['connect_args'] = {
-            'init_command': 'SET default_storage_engine={}'.format(storage_engine)
-        }
-
-        if 'use_unicode' in u.query:
-            if u.query['use_unicode'] != "True":
-                raise TypeError("Buildbot requires use_unicode=True " +
-                                "(and adds it automatically)")
-        else:
-            u.query['use_unicode'] = "True"
-
-        if 'charset' in u.query:
-            if u.query['charset'] != "utf8":
-                raise TypeError("Buildbot requires charset=utf8 " +
-                                "(and adds it automatically)")
-        else:
-            u.query['charset'] = 'utf8'
-
-        return u, kwargs, None
-
-    def check_sqlalchemy_version(self):
-        version = getattr(sa, '__version__', '0')
-        try:
-            version_digits = re.sub('[^0-9.]', '', version)
-            version_tup = tuple(map(int, version_digits.split('.')))
-        except TypeError:
-            return  # unparseable -- oh well
-
-        if version_tup < (0, 6):
-            raise RuntimeError("SQLAlchemy version {} is too old".format(version))
-        if version_tup > (0, 7, 10):
-            mvt = get_sqlalchemy_migrate_version()
-            if mvt < (0, 8, 0):
-                raise RuntimeError(("SQLAlchemy version {} is not supported by "
-                                    "SQLAlchemy-Migrate version {}.{}.{}").format(version, mvt[0],
-                                                                                  mvt[1], mvt[2]))
-
-    def get_drivers_strategy(self, drivername):
-        if drivername.startswith('sqlite'):
-            return SqlLiteStrategy()
-        elif drivername.startswith('mysql'):
-            return MySQLStrategy()
-        return Strategy()
-
-    def create(self, name_or_url, **kwargs):
-        if 'basedir' not in kwargs:
-            raise TypeError('no basedir supplied to create_engine')
-        self.check_sqlalchemy_version()
-
-        max_conns = None
-
-        # apply special cases
-        u = url.make_url(name_or_url)
-        if u.drivername.startswith('sqlite'):
-            u, kwargs, max_conns = self.special_case_sqlite(u, kwargs)
-        elif u.drivername.startswith('mysql'):
-            u, kwargs, max_conns = self.special_case_mysql(u, kwargs)
-
-        # remove the basedir as it may confuse sqlalchemy
-        basedir = kwargs.pop('basedir')
-
-        # calculate the maximum number of connections from the pool parameters,
-        # if it hasn't already been specified
-        if max_conns is None:
-            max_conns = kwargs.get(
-                'pool_size', 5) + kwargs.get('max_overflow', 10)
-        strategy = self.get_drivers_strategy(u.drivername)
-        engine = super().create(u, **kwargs)
-        strategy.set_up(u, engine)
-        engine.should_retry = strategy.should_retry
-        # annotate the engine with the optimal thread pool size; this is used
-        # by DBConnector to configure the surrounding thread pool
-        engine.optimal_thread_pool_size = max_conns
-
-        # keep the basedir
-        engine.buildbot_basedir = basedir
-        return engine
+    return u, kwargs, max_conns
 
 
-BuildbotEngineStrategy()
+def special_case_mysql(u, kwargs):
+    """For mysql, take max_idle out of the query arguments, and
+    use its value for pool_recycle.  Also, force use_unicode and
+    charset to be True and 'utf8', failing if they were set to
+    anything else."""
+    kwargs['pool_recycle'] = int(u.query.pop('max_idle', 3600))
 
-# this module is really imported for the side-effects, but pyflakes will like
-# us to use something from the module -- so offer a copy of create_engine,
-# which explicitly adds the strategy argument
+    # default to the MyISAM storage engine
+    storage_engine = u.query.pop('storage_engine', 'MyISAM')
+    kwargs['connect_args'] = {
+        'init_command': 'SET default_storage_engine={}'.format(storage_engine)
+    }
+
+    if 'use_unicode' in u.query:
+        if u.query['use_unicode'] != "True":
+            raise TypeError("Buildbot requires use_unicode=True " +
+                            "(and adds it automatically)")
+    else:
+        u.query['use_unicode'] = "True"
+
+    if 'charset' in u.query:
+        if u.query['charset'] != "utf8":
+            raise TypeError("Buildbot requires charset=utf8 " +
+                            "(and adds it automatically)")
+    else:
+        u.query['charset'] = 'utf8'
+
+    return u, kwargs, None
 
 
-def create_engine(*args, **kwargs):
-    kwargs['strategy'] = 'buildbot'
+def check_sqlalchemy_version():
+    version = getattr(sa, '__version__', '0')
+    try:
+        version_digits = re.sub('[^0-9.]', '', version)
+        version_tup = tuple(map(int, version_digits.split('.')))
+    except TypeError:
+        return  # unparseable -- oh well
 
-    return sa.create_engine(*args, **kwargs)
+    if version_tup < (0, 6):
+        raise RuntimeError("SQLAlchemy version {} is too old".format(version))
+    if version_tup > (0, 7, 10):
+        mvt = get_sqlalchemy_migrate_version()
+        if mvt < (0, 8, 0):
+            raise RuntimeError(("SQLAlchemy version {} is not supported by "
+                                "SQLAlchemy-Migrate version {}.{}.{}").format(version, mvt[0],
+                                                                              mvt[1], mvt[2]))
+
+
+def get_drivers_strategy(drivername):
+    if drivername.startswith('sqlite'):
+        return SqlLiteStrategy()
+    elif drivername.startswith('mysql'):
+        return MySQLStrategy()
+    return Strategy()
+
+
+def create_engine(name_or_url, **kwargs):
+    if 'basedir' not in kwargs:
+        raise TypeError('no basedir supplied to create_engine')
+    check_sqlalchemy_version()
+
+    max_conns = None
+
+    # apply special cases
+    u = url.make_url(name_or_url)
+    if u.drivername.startswith('sqlite'):
+        u, kwargs, max_conns = special_case_sqlite(u, kwargs)
+    elif u.drivername.startswith('mysql'):
+        u, kwargs, max_conns = special_case_mysql(u, kwargs)
+
+    # remove the basedir as it may confuse sqlalchemy
+    basedir = kwargs.pop('basedir')
+
+    # calculate the maximum number of connections from the pool parameters,
+    # if it hasn't already been specified
+    if max_conns is None:
+        max_conns = kwargs.get(
+            'pool_size', 5) + kwargs.get('max_overflow', 10)
+    driver_strategy = get_drivers_strategy(u.drivername)
+    engine = sa.create_engine(u, **kwargs)
+    driver_strategy.set_up(u, engine)
+    engine.should_retry = driver_strategy.should_retry
+    # annotate the engine with the optimal thread pool size; this is used
+    # by DBConnector to configure the surrounding thread pool
+    engine.optimal_thread_pool_size = max_conns
+
+    # keep the basedir
+    engine.buildbot_basedir = basedir
+    return engine

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -36,7 +36,7 @@ class MastersConnectorComponent(base.DBConnectorComponent):
                 name=name,
                 name_hash=self.hashColumns(name),
                 active=0,  # initially inactive
-                last_active=self.master.reactor.seconds()
+                last_active=int(self.master.reactor.seconds())
             ))
 
     # returns a Deferred that returns a value
@@ -66,7 +66,7 @@ class MastersConnectorComponent(base.DBConnectorComponent):
             q = tbl.update(whereclause=whereclause)
             q = q.values(active=1 if active else 0)
             if active:
-                q = q.values(last_active=self.master.reactor.seconds())
+                q = q.values(last_active=int(self.master.reactor.seconds()))
             conn.execute(q)
 
             # return True if there was a change in state

--- a/master/buildbot/db/types/json.py
+++ b/master/buildbot/db/types/json.py
@@ -24,6 +24,7 @@ class JsonObject(TypeDecorator):
 
     """Represents an immutable json-encoded string."""
 
+    cache_ok = True
     impl = Text
 
     def process_bind_param(self, value, dialect):

--- a/master/buildbot/newsfragments/sqlalchemy-1.4-support.bugfix
+++ b/master/buildbot/newsfragments/sqlalchemy-1.4-support.bugfix
@@ -1,0 +1,1 @@
+Fixed support of SQLAlchemy v1.4 (:issue:`5992`).

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -114,6 +114,11 @@ warnings.filterwarnings('ignore', ".*the imp module is deprecated in favour of i
 # sqlalchemy-migrate uses deprecated api from sqlalchemy https://review.openstack.org/#/c/648072/
 warnings.filterwarnings('ignore', ".*Engine.contextual_connect.*", DeprecationWarning)
 
+warnings.filterwarnings('ignore', r'.*The Table.exists\(\) method is deprecated.*',
+                        DeprecationWarning)
+warnings.filterwarnings('ignore', '.*is already present in table.*',
+                        DeprecationWarning)
+
 # ignore an attrs API warning for APIs used in dependencies
 warnings.filterwarnings('ignore', ".*The usage of `cmp` is deprecated and will be removed "
                                   "on or after.*", DeprecationWarning)

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -22,7 +22,7 @@ import tarfile
 
 import migrate
 import migrate.versioning.api
-from sqlalchemy.engine import reflection
+import sqlalchemy as sa
 from sqlalchemy.exc import DatabaseError
 
 from twisted.internet import defer
@@ -127,7 +127,7 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
                 return diff
 
             # check indexes manually
-            insp = reflection.Inspector.from_engine(engine)
+            insp = sa.inspect(engine)
             # unique, name, column_names
             diff = []
             for tbl in self.db.model.metadata.sorted_tables:

--- a/master/buildbot/test/unit/db/test_enginestrategy.py
+++ b/master/buildbot/test/unit/db/test_enginestrategy.py
@@ -22,7 +22,7 @@ from twisted.trial import unittest
 from buildbot.db import enginestrategy
 
 
-class BuildbotEngineStrategy_special_cases(unittest.TestCase):
+class BuildbotCreateEngineTest(unittest.TestCase):
 
     "Test the special case methods, without actually creating a db"
 
@@ -32,9 +32,6 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
         connect_args=dict(init_command='SET default_storage_engine=MyISAM'),
         pool_recycle=3600)
     sqlite_kwargs = dict(basedir='/my-base-dir', poolclass=NullPool)
-
-    def setUp(self):
-        self.strat = enginestrategy.BuildbotEngineStrategy()
 
     # utility
 
@@ -50,7 +47,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_sqlite_pct_sub(self):
         u = url.make_url("sqlite:///%(basedir)s/x/state.sqlite")
         kwargs = dict(basedir='/my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["sqlite:////my-base-dir/x/state.sqlite", 1,
                           self.sqlite_kwargs])
@@ -71,21 +68,21 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
 
         u = url.make_url(url_src)
         kwargs = dict(basedir=basedir)
-        u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          [expected_url, 1, exp_kwargs])
 
     def test_sqlite_abspath(self):
         u = url.make_url("sqlite:////x/state.sqlite")
         kwargs = dict(basedir='/my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["sqlite:////x/state.sqlite", 1, self.sqlite_kwargs])
 
     def test_sqlite_memory(self):
         u = url.make_url("sqlite://")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["sqlite://", 1,  # only one conn at a time
                           dict(basedir='my-base-dir',
@@ -94,7 +91,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_mysql_simple(self):
         u = url.make_url("mysql://host/dbname")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["mysql://host/dbname?charset=utf8&use_unicode=True", None,
                           self.mysql_kwargs])
@@ -102,7 +99,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_mysql_userport(self):
         u = url.make_url("mysql://user:pass@host:1234/dbname")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["mysql://user:pass@host:1234/dbname?"
                           "charset=utf8&use_unicode=True", None, self.mysql_kwargs])
@@ -110,7 +107,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_mysql_local(self):
         u = url.make_url("mysql:///dbname")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["mysql:///dbname?charset=utf8&use_unicode=True", None,
                           self.mysql_kwargs])
@@ -118,7 +115,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_mysql_args(self):
         u = url.make_url("mysql:///dbname?foo=bar")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["mysql:///dbname?charset=utf8&foo=bar&use_unicode=True",
                           None, self.mysql_kwargs])
@@ -126,7 +123,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_mysql_max_idle(self):
         u = url.make_url("mysql:///dbname?max_idle=1234")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         exp = self.mysql_kwargs.copy()
         exp['pool_recycle'] = 1234
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
@@ -136,7 +133,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
     def test_mysql_good_charset(self):
         u = url.make_url("mysql:///dbname?charset=utf8")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["mysql:///dbname?charset=utf8&use_unicode=True", None,
                           self.mysql_kwargs])
@@ -145,12 +142,12 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
         u = url.make_url("mysql:///dbname?charset=ebcdic")
         kwargs = dict(basedir='my-base-dir')
         with self.assertRaises(TypeError):
-            self.strat.special_case_mysql(u, kwargs)
+            enginestrategy.special_case_mysql(u, kwargs)
 
     def test_mysql_good_use_unicode(self):
         u = url.make_url("mysql:///dbname?use_unicode=True")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["mysql:///dbname?charset=utf8&use_unicode=True", None,
                           self.mysql_kwargs])
@@ -159,12 +156,12 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
         u = url.make_url("mysql:///dbname?use_unicode=maybe")
         kwargs = dict(basedir='my-base-dir')
         with self.assertRaises(TypeError):
-            self.strat.special_case_mysql(u, kwargs)
+            enginestrategy.special_case_mysql(u, kwargs)
 
     def test_mysql_storage_engine(self):
         u = url.make_url("mysql:///dbname?storage_engine=foo")
         kwargs = dict(basedir='my-base-dir')
-        u, kwargs, max_conns = self.strat.special_case_mysql(u, kwargs)
+        u, kwargs, max_conns = enginestrategy.special_case_mysql(u, kwargs)
         exp = self.mysql_kwargs.copy()
         exp['connect_args'] = dict(
             init_command='SET default_storage_engine=foo')

--- a/master/buildbot/test/unit/db_migrate/test_versions_045_worker_transition.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_045_worker_transition.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 import sqlalchemy as sa
-from sqlalchemy.engine.reflection import Inspector
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -350,7 +349,7 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
                 ])
 
             # Verify that there is no "slave"-named items in schema.
-            inspector = Inspector(conn)
+            inspector = sa.inspect(conn)
 
             def check_name(name, table_name, item_type):
                 if not name:

--- a/master/setup.py
+++ b/master/setup.py
@@ -490,7 +490,7 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
-    'sqlalchemy >= 1.2.0, < 1.4',
+    'sqlalchemy >= 1.2.0, < 1.5',
     'sqlalchemy-migrate>=0.13',
     'python-dateutil>=1.5',
     'txaio ' + txaio_ver,

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -74,7 +74,7 @@ setuptools-trial==0.6.0
 singledispatch==3.6.2
 six==1.16.0
 snowballstemmer==2.1.0
-SQLAlchemy==1.3.23  # pyup: ignore (master requires 1.3.x)
+SQLAlchemy==1.4.22
 sqlalchemy-migrate==0.13.0
 sqlparse==0.4.1
 Tempita==0.5.2

--- a/requirements-cidb.txt
+++ b/requirements-cidb.txt
@@ -1,5 +1,3 @@
 psycopg2-binary==2.9.1
 mysqlclient==2.0.3
-# Pre-1.4 SQLAlchemy does not support 1.16.6 due to incompatible change,
-# https://github.com/sqlalchemy/sqlalchemy/issues/5645
-pg8000==1.16.5  # pyup: ignore
+pg8000==1.16.6


### PR DESCRIPTION
Fixes #5992.

We should plan to migrate off sqlalchemy-migrate to Alembic as it uses more and more deprecated APIs that will be soon removed.