### PR TITLE
Fix worker test excluding

### DIFF
--- a/common/maketarball.sh
+++ b/common/maketarball.sh
@@ -4,7 +4,7 @@ pkg=$1
 (
     cd ${pkg}
     rm -rf MANIFEST dist
-    if [ ${pkg} == "master" ]; then
+    if [ ${pkg} == "master" ] || [ ${pkg} == "worker" ]; then
         python setup.py sdist
         # wheels must be build separately in order to properly omit tests
         python setup.py bdist_wheel


### PR DESCRIPTION
This PR fixes smokes test that's run only on master branch and not PRs.

See https://buildbot.buildbot.net/#/builders/53/builds/2563/steps/9/logs/stdio.