### PR TITLE
pkg: Remove test for deprecated bdist_egg install method

### DIFF
--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -73,12 +73,6 @@ class BuildbotWWWPkg(unittest.TestCase):
         check_call("pip install dist/*.whl", shell=True, cwd=self.path)
         self.check_correct_installation()
 
-    def test_egg(self):
-        self.run_setup("bdist_egg")
-        # egg installation is not supported by pip, so we use easy_install
-        check_call("easy_install dist/*.egg", shell=True, cwd=self.path)
-        self.check_correct_installation()
-
     def test_develop(self):
         self.run_setup("develop")
         self.check_correct_installation()


### PR DESCRIPTION
Fixes `make frontend_install_tests` that were failing on master branch.