### PR TITLE
docs: Simplify 'Launching worker as Windows service'

### DIFF
--- a/master/docs/manual/installation/misc.rst
+++ b/master/docs/manual/installation/misc.rst
@@ -81,87 +81,29 @@ Launching worker as Windows service
 
 .. admonition:: Security consideration
 
-  Installation process of Buildbot worker on Windows may require some steps to be executed with Windows administrator rights.
+  Setting up the buildbot worker as a Windows service requires Windows administrator rights.
   It is important to distinguish installation stage from service execution. It is strongly recommended run Buildbot worker
   with lowest required access rights. It is recommended run a service under machine local non-privileged account.
 
   If you decide run Buildbot worker under domain account it is recommended to create dedicated
   strongly limited user account that will run Buildbot worker service.
 
-  Installation process outside of virtualenv must be done by under user with Administrator access rights.
-
-
-Installation
-````````````
-This guide assumes Buildbot worker is installed on ``c:\bbw\`` path. If you install it on different location
-please update the commands arguments.
-
-
-Prerequisite
-````````````
-Installation assumes you have installed fresh new Windows 10.
-Download cutting edge of Python 3 and install it for all users like:
-
-.. code-block:: bat
-
-   python-3.9.5-amd64.exe /quiet InstallAllUsers=1 PrependPath=1 TargetDir=c:\Python39
-
-
-Upgrade pip, setuptools and wheel
-`````````````````````````````````
-
-.. code-block:: bat
-
-   cd c:\Python39
-   python.exe -m pip install --upgrade pip setuptools wheel
-
-Install, create and activate virtualenv
-```````````````````````````````````````
-
-.. code-block:: bat
-
-   python.exe -m pip install virtualenv==16.7.10
-   Scripts\virtualenv.exe --no-site-packages c:\bbw\sandbox
-   cd c:\bbw
-   c:\bbw\sandbox\Scripts\activate
-
-
-Install pywin32 with system wide installation
-`````````````````````````````````````````````
-
-.. code-block:: bat
-
-  python.exe -m pip install pywin32
-  python.exe .\sandbox\Scripts\pywin32_postinstall.py -install
-
-
-Install buildbot-worker and set it up
-`````````````````````````````````````
-
-.. code-block:: bat
-
-  python.exe -m pip install buildbot-worker
-  .\sandbox\scripts\buildbot-worker create-worker worker master01.mycompany.com %COMPUTERNAME% password
-
-Edit worker info about admin and host
-`````````````````````````````````````
-
-.. code-block:: bat
-
-  echo %COMPUTERNAME%> c:\bbw\worker\info\host
-  echo Admin Name ^<admin@email.com^> >c:\bbw\worker\info\admin
 
 Windows service setup
 `````````````````````
-This step assumes existence of local/domain `bbworker` user.
-In case worker should run under domain user account please replace .\bbworker with <domain>\bbworker.
-Please replace <bbworker.passwd> with given user password.
+In this description, we assume that the buildbot worker account is the
+local domain account `worker`.
+
+In case worker should run under domain user account please replace ``.\worker`` with ``<domain>\worker``.
+Please replace ``<worker.passwd>`` with given user password.
+Please replace ``<worker.basedir>`` with the full/absolute directory
+specification to the created worker (what is called ``BASEDIR`` in :ref:`Creating-a-worker`).
 
 .. code-block:: bat
 
-  .\sandbox\Scripts\buildbot_worker_windows_service.exe --user .\bbworker --password <bbworker.passwd> --startup auto install
+  buildbot_worker_windows_service --user .\worker --password <worker.passwd> --startup auto install
   powershell -command "& {&'New-Item' -path Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\BuildBot\Parameters}"
-  powershell -command "& {&'set-ItemProperty' -path Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\BuildBot\Parameters -Name directories -Value 'c:\bbw\worker'}"
+  powershell -command "& {&'set-ItemProperty' -path Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\BuildBot\Parameters -Name directories -Value '<worker.basedir>'}"
 
 The first command automatically adds user rights to run Buildbot as service.
 


### PR DESCRIPTION
This section used to repeat what's already described in much more and
better detail in installation.rst and worker.rst.  That's all dropped,
making this section a more true "Next Steps" section.

All that remains is the additional steps that turns an already created
buildbot worker into a Windows service.

-----

Replaces #6174