### PR TITLE
Fix pywin32 dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,8 @@ install:
   - "python -V -V"
   - "python -m pip install -U pip"
   - "python -m pip install -r requirements-ci.txt"
-  # Twisted requires pywin32 on Windows in order to spawn processes.
-  # for some reason it needs to be installed last or there will be dll loading issues
-  - "python -m pip install \"pywin32\""
   - "python -m pip list"
+  # Check that pywin32 is properly installed
   - "python -c \"import win32api\""
 
 build: false

--- a/master/setup.py
+++ b/master/setup.py
@@ -500,6 +500,10 @@ setup_args['install_requires'] = [
     'pyyaml'
 ]
 
+# buildbot_windows_service needs pywin32
+if sys.platform == "win32":
+    setup_args['install_requires'].append('pywin32')
+
 # Unit test dependencies.
 test_deps = [
     # http client libraries

--- a/master/setup.py
+++ b/master/setup.py
@@ -442,8 +442,6 @@ setup_args = {
     ]), {
         'console_scripts': [
             'buildbot=buildbot.scripts.runner:run',
-            # this will also be shipped on non windows :-(
-            'buildbot_windows_service=buildbot.scripts.windows_service:HandleCommandLine',
         ]}
     )
 }
@@ -453,6 +451,9 @@ setup_args = {
 # see http://buildbot.net/trac/ticket/907
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
+    setup_args['entry_points']['console_scripts'].append(
+        'buildbot_windows_service=buildbot.scripts.windows_service:HandleCommandLine'
+    )
 
 py_36 = sys.version_info[0] > 3 or (
     sys.version_info[0] == 3 and sys.version_info[1] >= 6)

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -133,8 +133,6 @@ setup_args = {
     'entry_points': {
         'console_scripts': [
             'buildbot-worker=buildbot_worker.scripts.runner:run',
-            # this will also be shipped on non windows :-(
-            'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',  # noqa pylint: disable=line-too-long
         ]}
 }
 
@@ -143,6 +141,9 @@ setup_args = {
 # see http://buildbot.net/trac/ticket/907
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
+    setup_args['entry_points']['console_scripts'].append(
+        'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',  # noqa pylint: disable=line-too-long
+    )
 
 twisted_ver = ">= 17.9.0"
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -153,6 +153,10 @@ if setuptools is not None:
         'future',
     ]
 
+    # buildbot_worker_windows_service needs pywin32
+    if sys.platform == "win32":
+        setup_args['install_requires'].append('pywin32')
+
     # Unit test hard dependencies.
     test_deps = [
         'mock',


### PR DESCRIPTION
This modifies the setup.py scripts so the Windows Service programs are only built / installed on Windows.
This also modifies the setup.py scripts to add a dependency on pywin32 on Windows only.
Finally, the pywin32 installation step in appveyor.yml is removed