### PR TITLE
ec2: Set AMI for latent worker before making spot request

### DIFF
--- a/master/buildbot/newsfragments/enable-ami-runtime-determinism.bugfix
+++ b/master/buildbot/newsfragments/enable-ami-runtime-determinism.bugfix
@@ -1,0 +1,1 @@
+Set AMI for latent worker before making spot request to enable dynamically setting AMIs for instantiating workers

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -448,6 +448,7 @@ class EC2LatentWorker(AbstractLatentWorker):
         log.msg('%s %s requesting spot instance with price %0.4f' %
                 (self.__class__.__name__, self.workername, bid_price))
 
+        image = self.get_image()
         reservations = self.ec2.meta.client.request_spot_instances(
             SpotPrice=str(bid_price),
             LaunchSpecification=self._remove_none_opts(
@@ -473,7 +474,6 @@ class EC2LatentWorker(AbstractLatentWorker):
             raise LatentWorkerFailedToSubstantiate()
         instance_id = request['InstanceId']
         self.instance = self.ec2.Instance(instance_id)
-        image = self.get_image()
         instance_id, start_time = self._wait_for_instance()
         return instance_id, image.id, start_time
 


### PR DESCRIPTION
When trying to set up latent workers where the AMI is dynamically
discovered as part of instantiating workers, we want to make sure
that AMI is set before we make the spot request so that it is used
for the spot request.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
