### PR TITLE
graphql subresources with integration tests

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -410,6 +410,7 @@ dirs
 dirwatcher
 disownserviceparent
 distutils
+distros
 dn
 dnotify
 doclobber
@@ -1140,6 +1141,7 @@ refactor
 refcount
 refetch
 regex
+regen
 regexes
 regexp
 regexps
@@ -1226,6 +1228,7 @@ rstrip
 rtd
 rtype
 rtypes
+ruamel
 runcommand
 runinteraction
 runprocess
@@ -1665,6 +1668,7 @@ xhtml
 xml
 xxab
 xxx
+yaml
 yieldmetricsvalue
 za
 zadka

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -27,7 +27,7 @@ class ResourceType:
     name = None
     plural = None
     endpoints = []
-    keyFields = []
+    keyField = None
     eventPathPatterns = ""
     entityType = None
     subresources = []
@@ -124,10 +124,10 @@ class Endpoint:
                     "Collection endpoint should implement get_kwargs_from_graphql")
             return {}
         ret = {}
-        for k in self.rtype.keyFields:
-            v = args.pop(k)
-            if v is not None:
-                ret[k] = v
+        k = self.rtype.keyField
+        v = args.pop(k)
+        if v is not None:
+            ret[k] = v
         return ret
 
     def __repr__(self):

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -68,7 +68,7 @@ class ResourceType:
     @functools.lru_cache(1)
     def getCollectionEndpoint(self):
         for ep in self.getEndpoints():
-            if ep.isCollection:
+            if ep.isCollection or ep.isPseudoCollection:
                 return ep
         return None
 
@@ -101,7 +101,9 @@ class Endpoint:
     pathPatterns = ""
     rootLinkName = None
     isCollection = False
+    isPseudoCollection = False
     isRaw = False
+    parentMapping = {}
 
     def __init__(self, rtype, master):
         self.rtype = rtype
@@ -117,11 +119,28 @@ class Endpoint:
             raise exceptions.InvalidControlException("action: {} is not supported".format(action))
         return action_method(args, kwargs)
 
-    def get_kwargs_from_graphql(self, parent, resolve_info, args):
-        if self.isCollection:
-            if parent is not None:
+    def get_kwargs_from_graphql_parent(self, parent, parent_type):
+        if parent_type not in self.parentMapping:
+            rtype = self.master.data.getResourceTypeForGraphQlType(parent_type)
+            if rtype.keyField in parent:
+                parentid = rtype.keyField
+            else:
                 raise NotImplementedError(
-                    "Collection endpoint should implement get_kwargs_from_graphql")
+                    "Collection endpoint should implement "
+                    "get_kwargs_from_graphql or parentMapping"
+                )
+        else:
+            parentid = self.parentMapping[parent_type]
+        ret = {}
+        ret[parentid] = parent[parentid]
+        return ret
+
+    def get_kwargs_from_graphql(self, parent, resolve_info, args):
+        if self.isCollection or self.isPseudoCollection:
+            if parent is not None:
+                return self.get_kwargs_from_graphql_parent(
+                    parent, resolve_info.parent_type.name
+                )
             return {}
         ret = {}
         k = self.rtype.keyField

--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -102,7 +102,7 @@ class BuildData(base.ResourceType):
     name = "build_data"
     plural = "build_data"
     endpoints = [BuildDatasNoValueEndpoint, BuildDataNoValueEndpoint, BuildDataEndpoint]
-    keyFields = []
+    keyField = "name"
 
     class EntityType(types.Entity):
         buildid = types.Integer()

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -74,7 +74,7 @@ class Builder(base.ResourceType):
     name = "builder"
     plural = "builders"
     endpoints = [BuilderEndpoint, BuildersEndpoint]
-    keyFields = ['builderid']
+    keyField = 'builderid'
     eventPathPatterns = """
         /builders/:builderid
     """

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -68,6 +68,11 @@ class BuildersEndpoint(base.Endpoint):
                      tags=bd['tags'])
                for bd in bdicts]
 
+    def get_kwargs_from_graphql(self, parent, resolve_info, args):
+        if parent is not None:
+            return {'masterid': parent['masterid']}
+        return {}
+
 
 class Builder(base.ResourceType):
 
@@ -78,6 +83,7 @@ class Builder(base.ResourceType):
     eventPathPatterns = """
         /builders/:builderid
     """
+    subresources = ["Build", "Forcescheduler", "Scheduler", "Buildrequest"]
 
     class EntityType(types.Entity):
         builderid = types.Integer()

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -180,7 +180,7 @@ class BuildRequest(base.ResourceType):
     name = "buildrequest"
     plural = "buildrequests"
     endpoints = [BuildRequestEndpoint, BuildRequestsEndpoint]
-    keyFields = ['buildsetid', 'builderid', 'buildrequestid']
+    keyField = 'buildrequestid'
     eventPathPatterns = """
         /buildsets/:buildsetid/builders/:builderid/buildrequests/:buildrequestid
         /buildrequests/:buildrequestid

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -187,6 +187,8 @@ class BuildRequest(base.ResourceType):
         /builders/:builderid/buildrequests/:buildrequestid
     """
 
+    subresources = ["Build"]
+
     class EntityType(types.Entity):
         buildrequestid = types.Integer()
         buildsetid = types.Integer()

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -189,7 +189,7 @@ class Build(base.ResourceType):
     name = "build"
     plural = "builds"
     endpoints = [BuildEndpoint, BuildsEndpoint]
-    keyFields = ['builderid', 'buildid', 'workerid']
+    keyField = "buildid"
     eventPathPatterns = """
         /builders/:builderid/builds/:number
         /builds/:buildid

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -195,6 +195,7 @@ class Build(base.ResourceType):
         /builds/:buildid
         /workers/:workerid/builds/:buildid
     """
+    subresources = ["Step"]
 
     class EntityType(types.Entity):
         buildid = types.Integer()

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -114,7 +114,7 @@ class Buildset(base.ResourceType):
     name = "buildset"
     plural = "buildsets"
     endpoints = [BuildsetEndpoint, BuildsetsEndpoint]
-    keyFields = ['bsid']
+    keyField = 'bsid'
     eventPathPatterns = """
         /buildsets/:bsid
     """

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -121,6 +121,7 @@ class Change(base.ResourceType):
         codebase = types.String()
         sourcestamp = sourcestamps.SourceStamp.entityType
     entityType = EntityType(name)
+    subresources = ["Build"]
 
     @base.updateMethod
     @defer.inlineCallbacks

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -101,6 +101,7 @@ class Change(base.ResourceType):
     eventPathPatterns = """
         /changes/:changeid
     """
+    keyField = "changeid"
 
     class EntityType(types.Entity):
         changeid = types.Integer()

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -79,7 +79,7 @@ class ChangeSource(base.ResourceType):
     name = "changesource"
     plural = "changesources"
     endpoints = [ChangeSourceEndpoint, ChangeSourcesEndpoint]
-    keyFields = ['changesourceid']
+    keyField = 'changesourceid'
 
     class EntityType(types.Entity):
         changesourceid = types.Integer()

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -186,23 +186,23 @@ class DataConnector(service.AsyncService):
         filters, properties = [], []
         for arg in req_args:
             argStr = bytes2unicode(arg)
-            if arg == b'order':
+            if argStr == 'order':
                 order = tuple([bytes2unicode(o) for o in req_args[arg]])
                 checkFields(order, True)
-            elif arg == b'field':
+            elif argStr == 'field':
                 fields = req_args[arg]
                 checkFields(fields, False)
-            elif arg == b'limit':
+            elif argStr == 'limit':
                 try:
                     limit = int(req_args[arg][0])
                 except Exception as e:
                     raise exceptions.InvalidQueryParameter('invalid limit') from e
-            elif arg == b'offset':
+            elif argStr == 'offset':
                 try:
                     offset = int(req_args[arg][0])
                 except Exception as e:
                     raise exceptions.InvalidQueryParameter('invalid offset') from e
-            elif arg == b'property':
+            elif argStr == 'property':
                 try:
                     props = []
                     for v in req_args[arg]:

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -132,7 +132,9 @@ class DataConnector(service.AsyncService):
         return None
 
     def getResourceTypeForGraphQlType(self, type):
-        return self.graphql_rtypes.get(type.name)
+        if type not in self.graphql_rtypes:
+            raise RuntimeError(f"Can't get rtype for {type}: {self.graphql_rtypes.keys()}")
+        return self.graphql_rtypes.get(type)
 
     def get(self, path, filters=None, fields=None, order=None,
             limit=None, offset=None):

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -97,7 +97,7 @@ class ForceScheduler(base.ResourceType):
     name = "forcescheduler"
     plural = "forceschedulers"
     endpoints = [ForceSchedulerEndpoint, ForceSchedulersEndpoint]
-    keyFields = []
+    keyField = "name"
 
     class EntityType(types.Entity):
         name = types.Identifier(50)

--- a/master/buildbot/data/graphql.py
+++ b/master/buildbot/data/graphql.py
@@ -43,11 +43,12 @@ class GraphQLConnector(service.AsyncService):
     with as_future()
     """
     data = None
+    asyncio_loop = None
 
     def reconfigServiceWithBuildbotConfig(self, new_config):
         if self.data is None:
             self.data = self.master.data
-        config = new_config.get('www', {}).get('graphql')
+        config = new_config.www.get('graphql')
         self.enabled = False
         if config is None:
             return
@@ -57,13 +58,27 @@ class GraphQLConnector(service.AsyncService):
 
         self.enabled = True
         self.config = config
-        if not isinstance(asyncio.get_event_loop(), AsyncIOLoopWithTwisted):
-            asyncio_loop = AsyncIOLoopWithTwisted(self.master.reactor)
-            asyncio.set_event_loop(asyncio_loop)
-            asyncio_loop.start()
+        loop = None
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            pass
+        if not isinstance(loop, AsyncIOLoopWithTwisted):
+            self.asyncio_loop = AsyncIOLoopWithTwisted(self.master.reactor)
+            asyncio.set_event_loop(self.asyncio_loop)
+            self.asyncio_loop.start()
 
         self.debug = self.config.get("debug")
         self.schema = graphql.build_schema(self.get_schema())
+
+    def stopService(self):
+        if self.asyncio_loop:
+            self.asyncio_loop.stop()
+            self.asyncio_loop.close()
+            asyncio.set_event_loop(None)
+            self.asyncio_loop = None
+
+        return super().stopService()
 
     @functools.lru_cache(1)
     def get_schema(self):
@@ -81,7 +96,9 @@ class GraphQLConnector(service.AsyncService):
         # type dependencies must be added recursively
         def add_dependent_types(ent):
             typename = ent.toGraphQLTypeName()
-            if typename not in types and isinstance(ent, Entity):
+            if typename in types:
+                return
+            if isinstance(ent, Entity):
                 types[typename] = ent
             for dtyp in ent.graphQLDependentTypes():
                 add_dependent_types(dtyp)
@@ -89,7 +106,8 @@ class GraphQLConnector(service.AsyncService):
             rtype = self.data.getResourceType(ent.name)
             if rtype is not None:
                 for subresource in rtype.subresources:
-                    add_dependent_types(subresource.rtype.entityType)
+                    rtype = self.data.getResourceTypeForGraphQlType(subresource)
+                    add_dependent_types(rtype.entityType)
 
         # root query contain the list of item available directly
         # mapped against the rootLinks
@@ -118,8 +136,13 @@ class GraphQLConnector(service.AsyncService):
                     query_fields.append(f"{field}__{op}: {field_type_graphql}")
 
             query_fields.extend(["order: String", "limit: Int", "offset: Int"])
+            ep = self.data.getEndPointForResourceName(rtype.plural)
+            if ep is None or not ep.isPseudoCollection:
+                plural_typespec = f"[{typename}]"
+            else:
+                plural_typespec = typename
             queries_schema += (
-                f"  {rtype.plural}{format_query_fields(query_fields)}: [{typename}]!\n"
+                f"  {rtype.plural}{format_query_fields(query_fields)}: {plural_typespec}!\n"
             )
 
             # build the queriable parameter, via keyField
@@ -157,7 +180,8 @@ class GraphQLConnector(service.AsyncService):
             rtype = self.data.getResourceType(typ.name)
             if rtype is not None:
                 for subresource in rtype.subresources:
-                    schema += format_subresource(subresource.rtype)
+                    rtype = self.data.getResourceTypeForGraphQlType(subresource)
+                    schema += format_subresource(rtype)
             schema += "}\n"
         return schema
 
@@ -183,7 +207,7 @@ class GraphQLConnector(service.AsyncService):
             rspec = None
             kwargs = ep.get_kwargs_from_graphql(parent, resolve_info, args)
 
-            if ep.isCollection:
+            if ep.isCollection or ep.isPseudoCollection:
                 args = {k: [v] for k, v in args.items()}
                 rspec = self.data.resultspec_from_jsonapi(args, ep.rtype.entityType, True)
 

--- a/master/buildbot/data/graphql.py
+++ b/master/buildbot/data/graphql.py
@@ -122,12 +122,14 @@ class GraphQLConnector(service.AsyncService):
                 f"  {rtype.plural}{format_query_fields(query_fields)}: [{typename}]!\n"
             )
 
-            # build the queriable parameters, via keyFields
+            # build the queriable parameter, via keyField
             keyfields = []
-            for field in sorted(rtype.keyFields):
-                field_type = rtype.entityType.fields[field]
-                field_type_graphql = field_type.toGraphQLTypeName()
-                keyfields.append(f"{field}: {field_type_graphql}")
+            field = rtype.keyField
+            if field not in rtype.entityType.fields:
+                raise RuntimeError(f"bad keyField {field} not in entityType {rtype.entityType}")
+            field_type = rtype.entityType.fields[field]
+            field_type_graphql = field_type.toGraphQLTypeName()
+            keyfields.append(f"{field}: {field_type_graphql}")
 
             queries_schema += (
                 f"  {rtype.name}{format_query_fields(keyfields)}: {typename}\n"

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -127,7 +127,7 @@ class LogChunk(base.ResourceType):
     name = "logchunk"
     plural = "logchunks"
     endpoints = [LogChunkEndpoint, RawLogChunkEndpoint]
-    keyFields = ['stepid', 'logid']
+    keyField = "logid"
 
     class EntityType(types.Entity):
         logid = types.Integer()

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -124,8 +124,8 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
 
 class LogChunk(base.ResourceType):
 
-    name = "logchunk"
-    plural = "logchunks"
+    name = "log_chunk"
+    plural = "log_chunks"
     endpoints = [LogChunkEndpoint, RawLogChunkEndpoint]
     keyField = "logid"
 

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -46,7 +46,9 @@ class LogChunkEndpoint(LogChunkEndpointBase):
     # Note that this is a singular endpoint, even though it overrides the
     # offset/limit query params in ResultSpec
     isCollection = False
+    isPseudoCollection = True
     pathPatterns = """
+        /logchunks
         /logs/n:logid/contents
         /steps/n:stepid/logs/i:log_slug/contents
         /builds/n:buildid/steps/i:step_name/logs/i:log_slug/contents
@@ -54,6 +56,7 @@ class LogChunkEndpoint(LogChunkEndpointBase):
         /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/contents
         /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/contents
     """
+    rootLinkName = "logchunks"
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -82,6 +85,13 @@ class LogChunkEndpoint(LogChunkEndpointBase):
         return {'logid': logid,
                 'firstline': firstline,
                 'content': logLines}
+
+    def get_kwargs_from_graphql(self, parent, resolve_info, args):
+        if parent is not None:
+            return self.get_kwargs_from_graphql_parent(
+                parent, resolve_info.parent_type.name
+            )
+        return {"logid": args["logid"]}
 
 
 class RawLogChunkEndpoint(LogChunkEndpointBase):
@@ -133,4 +143,5 @@ class LogChunk(base.ResourceType):
         logid = types.Integer()
         firstline = types.Integer()
         content = types.String()
+
     entityType = EntityType(name)

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -100,6 +100,7 @@ class Log(base.ResourceType):
         /logs/:logid
         /steps/:stepid/logs/:slug
     """
+    subresources = ["LogChunk"]
 
     class EntityType(types.Entity):
         logid = types.Integer()
@@ -109,6 +110,7 @@ class Log(base.ResourceType):
         complete = types.Boolean()
         num_lines = types.Integer()
         type = types.Identifier(1)
+
     entityType = EntityType(name)
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -95,7 +95,7 @@ class Log(base.ResourceType):
     name = "log"
     plural = "logs"
     endpoints = [LogEndpoint, LogsEndpoint]
-    keyFields = ['stepid', 'logid']
+    keyField = "logid"
     eventPathPatterns = """
         /logs/:logid
         /steps/:stepid/logs/:slug

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -88,6 +88,7 @@ class Master(base.ResourceType):
         /masters/:masterid
     """
     keyField = "masterid"
+    subresources = ["Builder"]
 
     class EntityType(types.Entity):
         masterid = types.Integer()

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -87,6 +87,7 @@ class Master(base.ResourceType):
     eventPathPatterns = """
         /masters/:masterid
     """
+    keyField = "masterid"
 
     class EntityType(types.Entity):
         masterid = types.Integer()

--- a/master/buildbot/data/patches.py
+++ b/master/buildbot/data/patches.py
@@ -25,7 +25,7 @@ class Patch(base.ResourceType):
     name = "patch"
     plural = "patches"
     endpoints = []
-    keyFields = ['patchid']
+    keyField = 'patchid'
 
     class EntityType(types.Entity):
         patchid = types.Integer()

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -50,7 +50,7 @@ class Properties(base.ResourceType):
     name = "property"
     plural = "properties"
     endpoints = [BuildsetPropertiesEndpoint, BuildPropertiesEndpoint]
-    keyFields = []
+    keyField = "name"
 
     entityType = types.SourcedProperties()
 

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -89,7 +89,7 @@ class Scheduler(base.ResourceType):
     name = "scheduler"
     plural = "schedulers"
     endpoints = [SchedulerEndpoint, SchedulersEndpoint]
-    keyFields = ['schedulerid']
+    keyField = 'schedulerid'
     eventPathPatterns = """
         /schedulers/:schedulerid
     """

--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -78,6 +78,7 @@ class SourceStamp(base.ResourceType):
     plural = "sourcestamps"
     endpoints = [SourceStampEndpoint, SourceStampsEndpoint]
     keyField = 'ssid'
+    subresources = ["Change"]
 
     class EntityType(types.Entity):
         ssid = types.Integer()

--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -77,7 +77,7 @@ class SourceStamp(base.ResourceType):
     name = "sourcestamp"
     plural = "sourcestamps"
     endpoints = [SourceStampEndpoint, SourceStampsEndpoint]
-    keyFields = ['ssid']
+    keyField = 'ssid'
 
     class EntityType(types.Entity):
         ssid = types.Integer()

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -101,7 +101,7 @@ class Step(base.ResourceType):
     name = "step"
     plural = "steps"
     endpoints = [StepEndpoint, StepsEndpoint]
-    keyFields = ['builderid', 'stepid']
+    keyField = 'stepid'
     eventPathPatterns = """
         /builds/:buildid/steps/:stepid
         /steps/:stepid

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -106,6 +106,7 @@ class Step(base.ResourceType):
         /builds/:buildid/steps/:stepid
         /steps/:stepid
     """
+    subresources = ["Log"]
 
     class EntityType(types.Entity):
         stepid = types.Integer()

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -101,7 +101,7 @@ class TestResultSet(base.ResourceType):
     name = "test_result_set"
     plural = "test_result_sets"
     endpoints = [TestResultSetsEndpoint, TestResultSetEndpoint]
-    keyFields = ['test_result_setid']
+    keyField = 'test_result_setid'
     eventPathPatterns = """
         /test_result_sets/:test_result_setid
     """

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -67,7 +67,7 @@ class TestResult(base.ResourceType):
     name = "test_result"
     plural = "test_results"
     endpoints = [TestResultsEndpoint]
-    keyFields = ['test_resultid']
+    keyField = 'test_resultid'
     eventPathPatterns = """
         /test_result_sets/:test_result_setid/results
     """

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -117,7 +117,7 @@ class Worker(base.ResourceType):
     name = "worker"
     plural = "workers"
     endpoints = [WorkerEndpoint, WorkersEndpoint]
-    keyFields = ['workerid']
+    keyField = 'workerid'
     eventPathPatterns = """
         /workers/:workerid
     """

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -121,6 +121,7 @@ class Worker(base.ResourceType):
     eventPathPatterns = """
         /workers/:workerid
     """
+    subresources = ["Build"]
 
     class EntityType(types.Entity):
         workerid = types.Integer()

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -118,7 +118,7 @@ class Step(base.ResourceType):
     name = "step"
     plural = "steps"
     endpoints = [StepsEndpoint, StepEndpoint]
-    keyFields = ["stepid"]
+    keyField = "stepid"
 
     class EntityType(types.Entity):
         stepid = types.Integer()
@@ -131,7 +131,7 @@ class Test(base.ResourceType):
     name = "test"
     plural = "tests"
     endpoints = [TestsEndpoint, TestEndpoint, FailEndpoint, RawTestsEndpoint]
-    keyFields = ["testid"]
+    keyField = "testid"
     subresources = [base.SubResource(Step)]
 
     class EntityType(types.Entity):

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -93,11 +93,6 @@ class StepsEndpoint(base.Endpoint):
     isCollection = True
     pathPatterns = "/tests/n:testid/steps"
 
-    def get_kwargs_from_graphql(self, parent, resolve_info, args):
-        if parent is not None:
-            return {'testid': parent['testid']}
-        return {}
-
     def get(self, resultSpec, kwargs):
         data = [step for step in stepData.values() if step['testid'] == kwargs['testid']]
         # results are sorted by ID for test stability
@@ -132,7 +127,7 @@ class Test(base.ResourceType):
     plural = "tests"
     endpoints = [TestsEndpoint, TestEndpoint, FailEndpoint, RawTestsEndpoint]
     keyField = "testid"
-    subresources = [base.SubResource(Step)]
+    subresources = ["Step"]
 
     class EntityType(types.Entity):
         testid = types.Integer()

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -521,3 +521,6 @@ class FakeDataConnector(service.AsyncMultiService):
 
     def resultspec_from_jsonapi(self, args, entityType, is_collection):
         return self.realConnector.resultspec_from_jsonapi(args, entityType, is_collection)
+
+    def getResourceTypeForGraphQlType(self, type):
+        return self.realConnector.getResourceTypeForGraphQlType(type)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -158,8 +158,9 @@ def make_master(testcase, wantMq=False, wantDb=False, wantData=False,
         master.graphql.setServiceParent(master)
         master.graphql.data = master.data.realConnector
         master.data._scanModule(endpoint)
+        master.config.www = {'graphql': {"debug": True}}
         try:
-            master.graphql.reconfigServiceWithBuildbotConfig({'www': {'graphql': {'debug': True}}})
+            master.graphql.reconfigServiceWithBuildbotConfig(master.config)
         except ImportError:
             pass
     return master

--- a/master/buildbot/test/integration/test_graphql.py
+++ b/master/buildbot/test/integration/test_graphql.py
@@ -1,0 +1,265 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import json
+import os
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.data import connector as dataconnector
+from buildbot.data.graphql import GraphQLConnector
+from buildbot.mq import connector as mqconnector
+from buildbot.process.results import SUCCESS
+from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util import toJson
+
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    YAML = None
+
+
+try:
+    import graphql as graphql_core
+except ImportError:
+    graphql_core = None
+
+
+class GraphQL(unittest.TestCase, TestReactorMixin):
+    if not graphql_core:
+        skip = "graphql-core is required for GraphQL integration tests"
+
+    master = None
+
+    def load_yaml(self, f):
+        if YAML is None:
+            # for running the test ruamel is not needed (to avoid a build dependency for distros)
+            import yaml
+            return yaml.safe_load(f)
+        self.yaml = YAML()
+        self.yaml.default_flow_style = False
+        # default is round-trip
+        return self.yaml.load(f)
+
+    def save_yaml(self, data, f):
+        if YAML is None:
+            raise ImportError("please install ruamel.yaml for test regeneration")
+        self.yaml.dump(data, f)
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor(use_asyncio=True)
+
+        master = fakemaster.make_master(self)
+        master.db = fakedb.FakeDBConnector(self)
+        yield master.db.setServiceParent(master)
+
+        master.config.mq = {'type': "simple"}
+        master.mq = mqconnector.MQConnector()
+        yield master.mq.setServiceParent(master)
+        yield master.mq.setup()
+
+        master.data = dataconnector.DataConnector()
+        yield master.data.setServiceParent(master)
+
+        master.graphql = GraphQLConnector()
+        yield master.graphql.setServiceParent(master)
+
+        master.config.www = {'graphql': {"debug": True}}
+        master.graphql.reconfigServiceWithBuildbotConfig(master.config)
+
+        self.master = master
+        scheds = [ForceScheduler(
+            name="force",
+            builderNames=["runtests0", "runtests1", "runtests2", "slowruntests"])]
+        self.master.allSchedulers = lambda: scheds
+
+        yield self.master.startService()
+
+        yield self.insert_initial_data()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+
+    def insert_initial_data(self):
+        self.master.db.insertTestData([
+            fakedb.Master(id=1),
+            fakedb.Worker(id=1, name='example-worker'),
+
+            fakedb.Scheduler(id=1, name='custom', enabled=1),
+            fakedb.Scheduler(id=2, name='all', enabled=2),
+            fakedb.Scheduler(id=3, name='force', enabled=3),
+
+            fakedb.SchedulerMaster(schedulerid=1, masterid=1),
+            fakedb.SchedulerMaster(schedulerid=2, masterid=1),
+            fakedb.SchedulerMaster(schedulerid=3, masterid=1),
+
+            fakedb.Builder(id=1, name='runtests1'),
+            fakedb.Builder(id=2, name='runtests2'),
+            fakedb.Builder(id=3, name='runtests3'),
+
+            fakedb.BuilderMaster(id=1, builderid=1, masterid=1),
+            fakedb.BuilderMaster(id=2, builderid=2, masterid=1),
+            fakedb.BuilderMaster(id=3, builderid=3, masterid=1),
+
+            fakedb.Tag(id=1, name='tag1'),
+            fakedb.Tag(id=2, name='tag12'),
+            fakedb.Tag(id=3, name='tag23'),
+
+            fakedb.BuildersTags(id=1, builderid=1, tagid=1),
+            fakedb.BuildersTags(id=2, builderid=1, tagid=2),
+            fakedb.BuildersTags(id=3, builderid=2, tagid=2),
+            fakedb.BuildersTags(id=4, builderid=2, tagid=3),
+            fakedb.BuildersTags(id=5, builderid=3, tagid=3),
+
+            fakedb.Buildset(id=1, results=SUCCESS, reason="Force reason 1",
+                            submitted_at=100000, complete_at=100110, complete=1),
+            fakedb.Buildset(id=2, results=SUCCESS, reason="Force reason 2",
+                            submitted_at=100200, complete_at=100330, complete=1),
+            fakedb.Buildset(id=3, results=SUCCESS, reason="Force reason 3",
+                            submitted_at=100400, complete_at=100550, complete=1),
+
+            fakedb.BuildsetProperty(buildsetid=1, property_name='scheduler',
+                                    property_value='["custom", "Scheduler"]'),
+            fakedb.BuildsetProperty(buildsetid=2, property_name='scheduler',
+                                    property_value='["all", "Scheduler"]'),
+            fakedb.BuildsetProperty(buildsetid=3, property_name='scheduler',
+                                    property_value='["force", "Scheduler"]'),
+            fakedb.BuildsetProperty(buildsetid=3, property_name='owner',
+                                    property_value='["some@example.com", "Force Build Form"]'),
+
+            fakedb.SourceStamp(id=1, branch='master', revision='1234abcd'),
+            fakedb.Change(changeid=1, branch='master', revision='1234abcd', sourcestampid=1),
+
+            fakedb.BuildsetSourceStamp(id=1, buildsetid=1, sourcestampid=1),
+            fakedb.BuildsetSourceStamp(id=2, buildsetid=2, sourcestampid=1),
+            fakedb.BuildsetSourceStamp(id=3, buildsetid=3, sourcestampid=1),
+
+            fakedb.BuildRequest(id=1, buildsetid=1, builderid=1, results=SUCCESS,
+                                submitted_at=100001, complete_at=100109, complete=1),
+            fakedb.BuildRequest(id=2, buildsetid=2, builderid=1, results=SUCCESS,
+                                submitted_at=100201, complete_at=100329, complete=1),
+            fakedb.BuildRequest(id=3, buildsetid=3, builderid=2, results=SUCCESS,
+                                submitted_at=100401, complete_at=100549, complete=1),
+
+            fakedb.Build(id=1, number=1, buildrequestid=1, builderid=1, workerid=1,
+                         masterid=1001, started_at=100002, complete_at=100108,
+                         state_string='build successful', results=SUCCESS),
+            fakedb.Build(id=2, number=2, buildrequestid=2, builderid=1, workerid=1,
+                         masterid=1001, started_at=100202, complete_at=100328,
+                         state_string='build successful', results=SUCCESS),
+            fakedb.Build(id=3, number=1, buildrequestid=3, builderid=2, workerid=1,
+                         masterid=1001, started_at=100402, complete_at=100548,
+                         state_string='build successful', results=SUCCESS),
+
+            fakedb.BuildProperty(buildid=3, name='reason', value='"force build"',
+                                 source="Force Build Form"),
+            fakedb.BuildProperty(buildid=3, name='owner', value='"some@example.com"',
+                                 source="Force Build Form"),
+            fakedb.BuildProperty(buildid=3, name='scheduler', value='"force"',
+                                 source="Scheduler"),
+            fakedb.BuildProperty(buildid=3, name='buildername', value='"runtests3"',
+                                 source="Builder"),
+            fakedb.BuildProperty(buildid=3, name='workername', value='"example-worker"',
+                                 source="Worker"),
+
+            fakedb.Step(id=1, number=1, name='step1', buildid=1,
+                        started_at=100010, complete_at=100019, state_string='step1 done'),
+            fakedb.Step(id=2, number=2, name='step2', buildid=1,
+                        started_at=100020, complete_at=100029, state_string='step2 done'),
+            fakedb.Step(id=3, number=3, name='step3', buildid=1,
+                        started_at=100030, complete_at=100039, state_string='step3 done'),
+            fakedb.Step(id=11, number=1, name='step1', buildid=2,
+                        started_at=100210, complete_at=100219, state_string='step1 done'),
+            fakedb.Step(id=12, number=2, name='step2', buildid=2,
+                        started_at=100220, complete_at=100229, state_string='step2 done'),
+            fakedb.Step(id=13, number=3, name='step3', buildid=2,
+                        started_at=100230, complete_at=100239, state_string='step3 done'),
+            fakedb.Step(id=21, number=1, name='step1', buildid=3,
+                        started_at=100410, complete_at=100419, state_string='step1 done'),
+            fakedb.Step(id=22, number=2, name='step2', buildid=3,
+                        started_at=100420, complete_at=100429, state_string='step2 done'),
+            fakedb.Step(id=23, number=3, name='step3', buildid=3,
+                        started_at=100430, complete_at=100439, state_string='step3 done'),
+
+            fakedb.Log(id=1, name='stdio', slug='stdio', stepid=1, complete=1, num_lines=10),
+            fakedb.Log(id=2, name='stdio', slug='stdio', stepid=2, complete=1, num_lines=20),
+            fakedb.Log(id=3, name='stdio', slug='stdio', stepid=3, complete=1, num_lines=30),
+            fakedb.Log(id=11, name='stdio', slug='stdio', stepid=11, complete=1, num_lines=30),
+            fakedb.Log(id=12, name='stdio', slug='stdio', stepid=12, complete=1, num_lines=40),
+            fakedb.Log(id=13, name='stdio', slug='stdio', stepid=13, complete=1, num_lines=50),
+            fakedb.Log(id=21, name='stdio', slug='stdio', stepid=21, complete=1, num_lines=50),
+            fakedb.Log(id=22, name='stdio', slug='stdio', stepid=22, complete=1, num_lines=60),
+            fakedb.Log(id=23, name='stdio', slug='stdio', stepid=23, complete=1, num_lines=70),
+
+            fakedb.LogChunk(logid=1, first_line=0, last_line=2,
+                            content='o line1\no line2\n'),
+            fakedb.LogChunk(logid=1, first_line=2, last_line=3,
+                            content='o line3\n'),
+            fakedb.LogChunk(logid=2, first_line=0, last_line=4,
+                            content='o line1\no line2\no line3\no line4\n'),
+        ])
+
+    @defer.inlineCallbacks
+    def test_examples_from_yaml(self):
+        """This test takes input from yaml file containing queries to execute and
+        expected results. In order to ease writing of tests, if the expected key is not found,
+        it is automatically generated, so developer only has to review results
+        Full regen can still be done with regen local variable just below
+        """
+        regen = False
+        need_save = False
+        fn = os.path.join(os.path.dirname(__file__), "test_graphql_queries.yaml")
+        with open(fn) as f:
+            data = self.load_yaml(f)
+        for test in data:
+            query = test['query']
+
+            result = yield self.master.graphql.query(
+                query
+            )
+            self.assertIsNone(result.errors)
+            if 'xpected' in test:
+                del test['xpected']
+            if 'expected' not in test or regen:
+                need_save = True
+                test['expected'] = result.data
+            else:
+                # remove ruamel metadata before compare (it is needed for round-trip regen,
+                # but confuses the comparison)
+                data = json.loads(json.dumps(result.data, default=toJson))
+                expected = json.loads(json.dumps(test['expected'], default=toJson))
+                self.assertEqual(
+                    data, expected, f"for {query}")
+        if need_save:
+            with open(fn, 'w') as f:
+                self.save_yaml(data, f)
+
+    @defer.inlineCallbacks
+    def test_buildrequests_builds(self):
+        data = yield self.master.graphql.query(
+            "{buildrequests{buildrequestid, builds{number, buildrequestid}}}"
+        )
+
+        self.assertEqual(data.errors, None)
+        for br in data.data["buildrequests"]:
+            for build in br["builds"]:
+                self.assertEqual(build["buildrequestid"], br["buildrequestid"])

--- a/master/buildbot/test/integration/test_graphql_queries.yaml
+++ b/master/buildbot/test/integration/test_graphql_queries.yaml
@@ -1,0 +1,152 @@
+- query: |
+    {masters{name, builders(name:"runtests1"){name, builds(limit:1){number}}}}
+  expected:
+    masters:
+    - name: some:master
+      builders:
+      - name: runtests1
+        builds:
+        - number: 1
+- query: |
+    {masters{name, builders(name:"runtests1"){name, builds(limit:10){number}}}}
+  expected:
+    masters:
+    - name: some:master
+      builders:
+      - name: runtests1
+        builds:
+        - number: 1
+        - number: 2
+- query: |
+    {builders(name:"runtests2"){name, builds(limit:1){number}}}
+  expected:
+    builders:
+    - name: runtests2
+      builds:
+      - number: 1
+- query: |
+    {builders(name:"runtests3"){name, builds(limit:1){number}}}
+  expected:
+    builders:
+    - name: runtests3
+      builds: []
+- query: |
+    {buildrequests(limit:1){buildrequestid, builds(limit:1){number}}}
+  expected:
+    buildrequests:
+    - buildrequestid: 1
+      builds:
+      - number: 1
+- query: |
+    {changes{author, builds(limit:1){number}}}
+  expected:
+    changes:
+    - author: frank
+      builds:
+      - number: 1
+- query: |
+    {workers{name, builds(limit:1){number}}}
+  expected:
+    workers:
+    - name: example-worker
+      builds:
+      - number: 1
+- query: |
+    {builds(limit:1){number, steps(limit:1){name}}}
+  expected:
+    builds:
+    - number: 1
+      steps:
+      - name: step1
+- query: |
+    {
+      builds(limit:1){
+          number
+          steps(limit:1,offset:1){
+              name
+              logs {
+                  name
+                  num_lines
+              }
+          }
+      }
+    }
+  expected:
+    builds:
+    - number: 1
+      steps:
+      - name: step2
+        logs:
+        - name: stdio
+          num_lines: 20
+- query: |
+    {
+        build(buildid:1){
+            step(stepid:1){
+                log(logid:1){
+                    log_chunks(offset:1, limit:2){
+                        content
+                    }
+                }
+            }
+        }
+    }
+  expected:
+    build:
+      step:
+        log:
+          log_chunks:
+            content: "o line2\no line3\n"
+- query: |
+    {
+        log_chunks(logid: 1, offset:1, limit:2){
+            content
+        }
+    }
+  expected:
+    log_chunks:
+      content: "o line2\no line3\n"
+- query: |
+    {
+        sourcestamp(ssid: 1){
+            created_at
+        }
+    }
+  expected:
+    sourcestamp:
+      created_at: 89834834
+- query: |
+    {
+        sourcestamps {
+            changes {changeid}
+        }
+    }
+  expected:
+    sourcestamps:
+    - changes:
+      - changeid: 1
+- query: |
+    {builders(limit:1){name, forceschedulers{name}}}
+  expected:
+    builders:
+    - name: runtests1
+      forceschedulers:
+      - name: force
+- query: |-
+    {builders(limit:1){name, schedulers{name}}}
+  expected:
+    builders:
+    - name: runtests1
+      schedulers:
+      - name: custom
+      - name: all
+      - name: force
+- query: |
+    {builders(builderid:2){name, builderid, buildrequests{buildrequestid, builderid}}}
+  expected:
+    builders:
+    - name: runtests2
+      builderid: 2
+      buildrequests:
+      - buildrequestid: 3
+        builderid: 2

--- a/master/buildbot/test/integration/test_integration_template.py
+++ b/master/buildbot/test/integration/test_integration_template.py
@@ -63,4 +63,5 @@ def masterConfig():
         BuilderConfig(name="testy",
                       workernames=["local1"],
                       factory=f)]
+    c['www'] = {'graphql': True}
     return c

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -251,7 +251,7 @@ class TestResourceType(base.ResourceType):
     plural = 'tests'
 
     endpoints = [TestsEndpoint, TestEndpoint, TestsEndpointSubclass]
-    keyFields = ('testid', )
+    keyField = 'testid'
 
     class EntityType(types.Entity):
         testid = types.Integer()

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -20,7 +20,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.test.fake import endpoint
+from buildbot.data import connector
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
@@ -37,6 +37,7 @@ class V3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         skip = "graphql is required for V3RootResource tests"
 
     def setUp(self):
+        self.patch(connector.DataConnector, 'submodules', [])
         self.setUpTestReactor(use_asyncio=True)
         self.master = self.make_master(url="http://server/path/", wantGraphql=True)
         self.master.config.www["graphql"] = {"debug": True}
@@ -237,7 +238,6 @@ class DisabledV3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCa
     def setUp(self):
         self.setUpTestReactor()
         self.master = self.make_master(url="http://server/path/")
-        self.master.data._scanModule(endpoint)
         self.rsrc = graphql.V3RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -368,7 +368,8 @@ class RunMasterBase(unittest.TestCase):
                     if onlyStdout and line[0] != 'o':
                         continue
                     expectedLog = self._match_patterns_consume(line, expectedLog, is_regex=regex)
-
+        if expectedLog:
+            print(f"{expectedLog} not found in logs")
         return len(expectedLog) == 0
 
     def printLog(self, log, out):

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -49,6 +49,7 @@ pbr==5.6.0
 pep8==1.7.1
 Pillow==8.3.2
 pyaml==20.4.0
+ruamel.yaml==0.17.16
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.7.0


### PR DESCRIPTION
As there will be lots of queries to test, we do this in integration mode with a real db.

We use some smoketests database with some cleanups for size and privacy
so that it is easier to reason than some made up test data (like in db tests)
