### PR TITLE
gerrit: Ignore ref-updated events if they are for change branch

### DIFF
--- a/master/buildbot/newsfragments/gerrit-missing-reporter-on-second-patchset.bugfix
+++ b/master/buildbot/newsfragments/gerrit-missing-reporter-on-second-patchset.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that caused Gerrit review comments sometimes not to be reported.

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -376,6 +376,26 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
         })
 
     @defer.inlineCallbacks
+    def test_lineReceived_ref_updated_for_change(self):
+        s = yield self.newChangeSource('somehost', 'someuser')
+        yield s.lineReceived(json.dumps({
+            'type': 'ref-updated',
+            'submitter': {
+                'name': 'tester',
+                'email': 'tester@example.com',
+                'username': 'tester'
+            },
+            'refUpdate': {
+                'oldRev': '00000000',
+                'newRev': '56785678',
+                'refName': 'refs/changes/12/432112/1',
+                'project': 'test'
+            },
+            'eventCreatedOn': 1614528683
+        }))
+        self.assertEqual(len(self.master.data.updates.changesAdded), 0)
+
+    @defer.inlineCallbacks
     def test_duplicate_events_ignored(self):
         s = yield self.newChangeSource('somehost', 'someuser')
         yield s.lineReceived(json.dumps(self.patchset_created_event))


### PR DESCRIPTION
This fixes an issue of gerrit reporter not commenting on gerrit changes sometimes. It turns out that if a build is created for a change coming from ref-updated event as opposed to patchset-created event then gerrit reporter thinks that there is no change related to the build and that commenting is not needed.