### PR TITLE
fix vault integration test to work on macos

### DIFF
--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -68,8 +68,8 @@ class SecretsConfig(RunMasterBase):
         self.assertEqual(build['buildid'], 1)
 
         patterns = [
-            "echo -n {}".format(expected_obfuscation),
-            base64.b64encode(expected_value.encode('utf-8')).decode('utf-8'),
+            "echo {}".format(expected_obfuscation),
+            base64.b64encode((expected_value + "\n").encode('utf-8')).decode('utf-8'),
         ]
 
         res = yield self.checkBuildStepLogExist(build, patterns)
@@ -112,7 +112,7 @@ def masterConfig(secret_specifier):
     )]
 
     f = BuildFactory()
-    f.addStep(ShellCommand(command=Interpolate('echo -n {} | base64'.format(secret_specifier))))
+    f.addStep(ShellCommand(command=Interpolate('echo {} | base64'.format(secret_specifier))))
 
     c['builders'] = [
         BuilderConfig(name="testy",


### PR DESCRIPTION
echo -n is not posix. so it will print "-n <passwd" on macos, breaking the test

