### PR TITLE
fakedb: Add explicit __init__ to row classes to simplify code

### DIFF
--- a/master/buildbot/test/fakedb/build_data.py
+++ b/master/buildbot/test/fakedb/build_data.py
@@ -22,22 +22,14 @@ from buildbot.test.fakedb.row import Row
 class BuildData(Row):
     table = 'build_data'
 
-    defaults = {
-        'id': None,
-        'buildid': None,
-        'name': None,
-        'value': None,
-        'length': None,
-        'source': None,
-    }
-
     id_column = 'id'
     foreignKeys = ('buildid',)
     required_columns = ('buildid', 'name', 'value', 'length', 'source')
     binary_columns = ('value',)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs, length=len(kwargs['value']))
+    def __init__(self, id=None, buildid=None, name=None, value=None, source=None):
+        super().__init__(id=id, buildid=buildid, name=name, value=value, source=source,
+                         length=len(value))
 
 
 class FakeBuildDataComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/builders.py
+++ b/master/buildbot/test/fakedb/builders.py
@@ -23,42 +23,32 @@ from buildbot.test.fakedb.row import Row
 class Builder(Row):
     table = "builders"
 
-    defaults = dict(
-        id=None,
-        name='some:builder',
-        name_hash=None,
-        description=None,
-    )
-
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
+
+    def __init__(self, id=None, name='some:builder', name_hash=None, description=None):
+        super().__init__(id=id, name=name, name_hash=name_hash, description=description)
 
 
 class BuilderMaster(Row):
     table = "builder_masters"
 
-    defaults = dict(
-        id=None,
-        builderid=None,
-        masterid=None
-    )
-
     id_column = 'id'
     required_columns = ('builderid', 'masterid')
+
+    def __init__(self, id=None, builderid=None, masterid=None):
+        super().__init__(id=id, builderid=builderid, masterid=masterid)
 
 
 class BuildersTags(Row):
     table = "builders_tags"
 
-    defaults = dict(
-        id=None,
-        builderid=None,
-        tagid=None,
-    )
-
     foreignKeys = ('builderid', 'tagid')
     required_columns = ('builderid', 'tagid', )
     id_column = 'id'
+
+    def __init__(self, id=None, builderid=None, tagid=None):
+        super().__init__(id=id, builderid=builderid, tagid=tagid)
 
 
 class FakeBuildersComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/buildrequests.py
+++ b/master/buildbot/test/fakedb/buildrequests.py
@@ -25,35 +25,28 @@ from buildbot.util import datetime2epoch
 class BuildRequest(Row):
     table = "buildrequests"
 
-    defaults = dict(
-        id=None,
-        buildsetid=None,
-        builderid=None,
-        buildername=None,
-        priority=0,
-        complete=0,
-        results=-1,
-        submitted_at=12345678,
-        complete_at=None,
-        waited_for=0,
-    )
     foreignKeys = ('buildsetid',)
 
     id_column = 'id'
     required_columns = ('buildsetid',)
 
+    def __init__(self, id=None, buildsetid=None, builderid=None, buildername=None,
+                 priority=0, complete=0, results=-1,
+                 submitted_at=12345678, complete_at=None, waited_for=0):
+        super().__init__(id=id, buildsetid=buildsetid, builderid=builderid, buildername=buildername,
+                         priority=priority, complete=complete, results=results,
+                         submitted_at=submitted_at, complete_at=complete_at, waited_for=waited_for)
+
 
 class BuildRequestClaim(Row):
     table = "buildrequest_claims"
 
-    defaults = dict(
-        brid=None,
-        masterid=None,
-        claimed_at=None
-    )
     foreignKeys = ('brid', 'masterid')
 
     required_columns = ('brid', 'masterid', 'claimed_at')
+
+    def __init__(self, brid=None, masterid=None, claimed_at=None):
+        super().__init__(brid=brid, masterid=masterid, claimed_at=claimed_at)
 
 
 class FakeBuildRequestsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/builds.py
+++ b/master/buildbot/test/fakedb/builds.py
@@ -25,34 +25,26 @@ from buildbot.util import epoch2datetime
 class Build(Row):
     table = "builds"
 
-    defaults = dict(
-        id=None,
-        number=29,
-        buildrequestid=None,
-        builderid=None,
-        workerid=-1,
-        masterid=None,
-        started_at=1304262222,
-        complete_at=None,
-        state_string="test",
-        results=None)
-
     id_column = 'id'
     foreignKeys = ('buildrequestid', 'masterid', 'workerid', 'builderid')
     required_columns = ('buildrequestid', 'masterid', 'workerid')
 
+    def __init__(self, id=None, number=29, buildrequestid=None, builderid=None,
+                 workerid=-1, masterid=None,
+                 started_at=1304262222, complete_at=None, state_string="test", results=None):
+        super().__init__(id=id, number=number, buildrequestid=buildrequestid, builderid=builderid,
+                         workerid=workerid, masterid=masterid, started_at=started_at,
+                         complete_at=complete_at, state_string=state_string, results=results)
+
 
 class BuildProperty(Row):
     table = "build_properties"
-    defaults = dict(
-        buildid=None,
-        name='prop',
-        value=42,
-        source='fakedb'
-    )
 
     foreignKeys = ('buildid',)
     required_columns = ('buildid',)
+
+    def __init__(self, buildid=None, name='prop', value=42, source='fakedb'):
+        super().__init__(buildid=buildid, name=name, value=value, source=source)
 
 
 class FakeBuildsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/buildsets.py
+++ b/master/buildbot/test/fakedb/buildsets.py
@@ -28,46 +28,37 @@ from buildbot.util import epoch2datetime
 class Buildset(Row):
     table = "buildsets"
 
-    defaults = dict(
-        id=None,
-        external_idstring='extid',
-        reason='because',
-        submitted_at=12345678,
-        complete=0,
-        complete_at=None,
-        results=-1,
-        parent_buildid=None,
-        parent_relationship=None,
-    )
-
     id_column = 'id'
+
+    def __init__(self, id=None, external_idstring='extid', reason='because',
+                 submitted_at=12345678, complete=0, complete_at=None, results=-1,
+                 parent_buildid=None, parent_relationship=None):
+        super().__init__(id=id, external_idstring=external_idstring, reason=reason,
+                         submitted_at=submitted_at, complete=complete, complete_at=complete_at,
+                         results=results, parent_buildid=parent_buildid,
+                         parent_relationship=parent_relationship)
 
 
 class BuildsetProperty(Row):
     table = "buildset_properties"
 
-    defaults = dict(
-        buildsetid=None,
-        property_name='prop',
-        property_value='[22, "fakedb"]',
-    )
-
     foreignKeys = ('buildsetid',)
     required_columns = ('buildsetid', )
+
+    def __init__(self, buildsetid=None, property_name='prop', property_value='[22, "fakedb"]'):
+        super().__init__(buildsetid=buildsetid, property_name=property_name,
+                         property_value=property_value)
 
 
 class BuildsetSourceStamp(Row):
     table = "buildset_sourcestamps"
 
-    defaults = dict(
-        id=None,
-        buildsetid=None,
-        sourcestampid=None,
-    )
-
     foreignKeys = ('buildsetid', 'sourcestampid')
     required_columns = ('buildsetid', 'sourcestampid', )
     id_column = 'id'
+
+    def __init__(self, id=None, buildsetid=None, sourcestampid=None):
+        super().__init__(id=id, buildsetid=buildsetid, sourcestampid=sourcestampid)
 
 
 class FakeBuildsetsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/changes.py
+++ b/master/buildbot/test/fakedb/changes.py
@@ -27,63 +27,51 @@ from buildbot.util import epoch2datetime
 class Change(Row):
     table = "changes"
 
-    defaults = dict(
-        changeid=None,
-        author='frank',
-        committer='steve',
-        comments='test change',
-        branch='master',
-        revision='abcd',
-        revlink='http://vc/abcd',
-        when_timestamp=1200000,
-        category='cat',
-        repository='repo',
-        codebase='',
-        project='proj',
-        sourcestampid=92,
-        parent_changeids=None,
-    )
-
     lists = ('files', 'uids')
     dicts = ('properties',)
     id_column = 'changeid'
+
+    def __init__(self, changeid=None, author='frank', committer='steve',
+                 comments='test change', branch='master', revision='abcd',
+                 revlink='http://vc/abcd', when_timestamp=1200000, category='cat',
+                 repository='repo', codebase='', project='proj', sourcestampid=92,
+                 parent_changeids=None):
+        super().__init__(changeid=changeid, author=author, committer=committer, comments=comments,
+                         branch=branch, revision=revision, revlink=revlink,
+                         when_timestamp=when_timestamp, category=category, repository=repository,
+                         codebase=codebase, project=project, sourcestampid=sourcestampid,
+                         parent_changeids=parent_changeids)
 
 
 class ChangeFile(Row):
     table = "change_files"
 
-    defaults = dict(
-        changeid=None,
-        filename=None,
-    )
-
     foreignKeys = ('changeid',)
     required_columns = ('changeid',)
+
+    def __init__(self, changeid=None, filename=None):
+        super().__init__(changeid=changeid, filename=filename)
 
 
 class ChangeProperty(Row):
     table = "change_properties"
 
-    defaults = dict(
-        changeid=None,
-        property_name=None,
-        property_value=None,
-    )
-
     foreignKeys = ('changeid',)
     required_columns = ('changeid',)
+
+    def __init__(self, changeid=None, property_name=None, property_value=None):
+        super().__init__(changeid=changeid, property_name=property_name,
+                         property_value=property_value)
 
 
 class ChangeUser(Row):
     table = "change_users"
 
-    defaults = dict(
-        changeid=None,
-        uid=None,
-    )
-
     foreignKeys = ('changeid',)
     required_columns = ('changeid',)
+
+    def __init__(self, changeid=None, uid=None):
+        super().__init__(changeid=changeid, uid=uid)
 
 
 class FakeChangesComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/changesources.py
+++ b/master/buildbot/test/fakedb/changesources.py
@@ -24,26 +24,21 @@ from buildbot.test.fakedb.row import Row
 class ChangeSource(Row):
     table = "changesources"
 
-    defaults = dict(
-        id=None,
-        name='csname',
-        name_hash=None,
-    )
-
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
+
+    def __init__(self, id=None, name='csname', name_hash=None):
+        super().__init__(id=id, name=name, name_hash=name_hash)
 
 
 class ChangeSourceMaster(Row):
     table = "changesource_masters"
 
-    defaults = dict(
-        changesourceid=None,
-        masterid=None,
-    )
-
     foreignKeys = ('changesourceid', 'masterid')
     required_columns = ('changesourceid', 'masterid')
+
+    def __init__(self, changesourceid=None, masterid=None):
+        super().__init__(changesourceid=changesourceid, masterid=masterid)
 
 
 class FakeChangeSourcesComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/logs.py
+++ b/master/buildbot/test/fakedb/logs.py
@@ -24,32 +24,25 @@ from buildbot.test.util import validation
 class Log(Row):
     table = "logs"
 
-    defaults = dict(
-        id=None,
-        name='log29',
-        slug='log29',
-        stepid=None,
-        complete=0,
-        num_lines=0,
-        type='s')
-
     id_column = 'id'
     required_columns = ('stepid', )
+
+    def __init__(self, id=None, name='log29', slug='log29', stepid=None, complete=0, num_lines=0,
+                 type='s'):
+        super().__init__(id=id, name=name, slug=slug, stepid=stepid, complete=complete,
+                         num_lines=num_lines, type=type)
 
 
 class LogChunk(Row):
     table = "logchunks"
 
-    defaults = dict(
-        logid=None,
-        first_line=0,
-        last_line=0,
-        content='',
-        compressed=0)
-
     required_columns = ('logid', )
     # 'content' column is sa.LargeBinary, it's bytestring.
     binary_columns = ('content',)
+
+    def __init__(self, logid=None, first_line=0, last_line=0, content='', compressed=0):
+        super().__init__(logid=logid, first_line=first_line, last_line=last_line, content=content,
+                         compressed=compressed)
 
 
 class FakeLogsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/masters.py
+++ b/master/buildbot/test/fakedb/masters.py
@@ -24,16 +24,12 @@ from buildbot.util import epoch2datetime
 class Master(Row):
     table = "masters"
 
-    defaults = dict(
-        id=None,
-        name='some:master',
-        name_hash=None,
-        active=1,
-        last_active=9998999,
-    )
-
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
+
+    def __init__(self, id=None, name='some:master', name_hash=None, active=1, last_active=9998999):
+        super().__init__(id=id, name=name, name_hash=name_hash, active=active,
+                         last_active=last_active)
 
 
 class FakeMastersComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/row.py
+++ b/master/buildbot/test/fakedb/row.py
@@ -26,9 +26,6 @@ class Row:
     Parent class for row classes, which are used to specify test data for
     database-related tests.
 
-    @cvar defaults: the column names and their default values
-    @type defaults: dictionary
-
     @cvar table: the table name
 
     @cvar id_column: specify a column that should be assigned an
@@ -58,8 +55,10 @@ class Row:
     _next_id = None
 
     def __init__(self, **kwargs):
-        self.values = self.defaults.copy()
-        self.values.update(kwargs)
+        if self.__init__.__func__ is Row.__init__:
+            raise Exception('Row.__init__ must be overridden to supply default values for columns')
+
+        self.values = kwargs.copy()
         if self.id_column:
             if self.values[self.id_column] is None:
                 self.values[self.id_column] = self.nextId()
@@ -69,8 +68,6 @@ class Row:
             setattr(self, col, [])
         for col in self.dicts:
             setattr(self, col, {})
-        for col in kwargs:
-            assert col in self.defaults, "{} is not a valid column".format(col)
         # cast to unicode
         for k, v in self.values.items():
             if isinstance(v, str):

--- a/master/buildbot/test/fakedb/schedulers.py
+++ b/master/buildbot/test/fakedb/schedulers.py
@@ -24,15 +24,11 @@ from buildbot.test.fakedb.row import Row
 class Scheduler(Row):
     table = "schedulers"
 
-    defaults = dict(
-        id=None,
-        name='schname',
-        name_hash=None,
-        enabled=1,
-    )
-
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
+
+    def __init__(self, id=None, name='schname', name_hash=None, enabled=1):
+        super().__init__(id=id, name=name, name_hash=name_hash, enabled=enabled)
 
 
 class SchedulerMaster(Row):
@@ -46,6 +42,9 @@ class SchedulerMaster(Row):
     foreignKeys = ('schedulerid', 'masterid')
     required_columns = ('schedulerid', 'masterid')
 
+    def __init__(self, schedulerid=None, masterid=None):
+        super().__init__(schedulerid=schedulerid, masterid=masterid)
+
 
 class SchedulerChange(Row):
     table = "scheduler_changes"
@@ -58,6 +57,9 @@ class SchedulerChange(Row):
 
     foreignKeys = ('schedulerid', 'changeid')
     required_columns = ('schedulerid', 'changeid')
+
+    def __init__(self, schedulerid=None, changeid=None, important=1):
+        super().__init__(schedulerid=schedulerid, changeid=changeid, important=important)
 
 
 class FakeSchedulersComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/sourcestamps.py
+++ b/master/buildbot/test/fakedb/sourcestamps.py
@@ -25,36 +25,27 @@ from buildbot.util import epoch2datetime
 class Patch(Row):
     table = "patches"
 
-    defaults = dict(
-        id=None,
-        patchlevel=0,
-        patch_base64='aGVsbG8sIHdvcmxk',  # 'hello, world',
-        patch_author=None,
-        patch_comment=None,
-        subdir=None,
-    )
-
     id_column = 'id'
+
+    def __init__(self, id=None, patchlevel=0,
+                 patch_base64='aGVsbG8sIHdvcmxk',  # 'hello, world',
+                 patch_author=None, patch_comment=None, subdir=None):
+        super().__init__(id=id, patchlevel=patchlevel, patch_base64=patch_base64,
+                         patch_author=patch_author, patch_comment=patch_comment, subdir=subdir)
 
 
 class SourceStamp(Row):
     table = "sourcestamps"
 
-    defaults = dict(
-        id=None,
-        branch='master',
-        revision='abcd',
-        patchid=None,
-        repository='repo',
-        codebase='',
-        project='proj',
-        created_at=89834834,
-        ss_hash=None,
-    )
-
     id_column = 'id'
     hashedColumns = [('ss_hash', ('branch', 'revision', 'repository',
                                   'project', 'codebase', 'patchid',))]
+
+    def __init__(self, id=None, branch='master', revision='abcd', patchid=None, repository='repo',
+                 codebase='', project='proj', created_at=89834834, ss_hash=None):
+        super().__init__(id=id, branch=branch, revision=revision, patchid=patchid,
+                         repository=repository, codebase=codebase, project=project,
+                         created_at=created_at, ss_hash=ss_hash)
 
 
 class FakeSourceStampsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/state.py
+++ b/master/buildbot/test/fakedb/state.py
@@ -25,25 +25,19 @@ from buildbot.util import bytes2unicode
 class Object(Row):
     table = "objects"
 
-    defaults = dict(
-        id=None,
-        name='nam',
-        class_name='cls',
-    )
-
     id_column = 'id'
+
+    def __init__(self, id=None, name='nam', class_name='cls'):
+        super().__init__(id=id, name=name, class_name=class_name)
 
 
 class ObjectState(Row):
     table = "object_state"
 
-    defaults = dict(
-        objectid=None,
-        name='nam',
-        value_json='{}',
-    )
-
     required_columns = ('objectid', )
+
+    def __init__(self, objectid=None, name='nam', value_json='{}'):
+        super().__init__(objectid=objectid, name=name, value_json=value_json)
 
 
 class FakeStateComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/steps.py
+++ b/master/buildbot/test/fakedb/steps.py
@@ -26,21 +26,16 @@ from buildbot.util import epoch2datetime
 class Step(Row):
     table = "steps"
 
-    defaults = dict(
-        id=None,
-        number=29,
-        name='step29',
-        buildid=None,
-        started_at=1304262222,
-        complete_at=None,
-        state_string='',
-        results=None,
-        urls_json='[]',
-        hidden=0)
-
     id_column = 'id'
     foreignKeys = ('buildid',)
     required_columns = ('buildid', )
+
+    def __init__(self, id=None, number=29, name='step29', buildid=None,
+                 started_at=1304262222, complete_at=None,
+                 state_string='', results=None, urls_json='[]', hidden=0):
+        super().__init__(id=id, number=number, name=name, buildid=buildid, started_at=started_at,
+                         complete_at=complete_at, state_string=state_string, results=results,
+                         urls_json=urls_json, hidden=hidden)
 
 
 class FakeStepsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/tags.py
+++ b/master/buildbot/test/fakedb/tags.py
@@ -22,14 +22,11 @@ from buildbot.test.fakedb.row import Row
 class Tag(Row):
     table = "tags"
 
-    defaults = dict(
-        id=None,
-        name='some:tag',
-        name_hash=None,
-    )
-
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
+
+    def __init__(self, id=None, name='some:tag', name_hash=None):
+        super().__init__(id=id, name=name, name_hash=name_hash)
 
 
 class FakeTagsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/test_result_sets.py
+++ b/master/buildbot/test/fakedb/test_result_sets.py
@@ -23,22 +23,16 @@ from buildbot.test.fakedb.row import Row
 class TestResultSet(Row):
     table = 'test_result_sets'
 
-    defaults = {
-        'id': None,
-        'builderid': None,
-        'buildid': None,
-        'stepid': None,
-        'description': None,
-        'category': None,
-        'value_unit': None,
-        'tests_passed': None,
-        'tests_failed': None,
-        'complete': None,
-    }
-
     id_column = 'id'
     foreignKeys = ('builderid', 'buildid', 'stepid')
     required_columns = ('builderid', 'buildid', 'stepid', 'category', 'value_unit', 'complete')
+
+    def __init__(self, id=None, builderid=None, buildid=None, stepid=None, description=None,
+                 category=None, value_unit=None, tests_passed=None, tests_failed=None,
+                 complete=None):
+        super().__init__(id=id, builderid=builderid, buildid=buildid, stepid=stepid,
+                         description=description, category=category, value_unit=value_unit,
+                         tests_passed=tests_passed, tests_failed=tests_failed, complete=complete)
 
 
 class FakeTestResultSetsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/test_results.py
+++ b/master/buildbot/test/fakedb/test_results.py
@@ -22,48 +22,37 @@ from buildbot.test.fakedb.row import Row
 class TestName(Row):
     table = 'test_names'
 
-    defaults = {
-        'id': None,
-        'builderid': None,
-        'name': 'nam'
-    }
-
     id_column = 'id'
     foreignKeys = ('builderid',)
     required_columns = ('builderid', 'name')
+
+    def __init__(self, id=None, builderid=None, name='nam'):
+        super().__init__(id=id, builderid=builderid, name=name)
 
 
 class TestCodePath(Row):
     table = 'test_code_paths'
 
-    defaults = {
-        'id': None,
-        'builderid': None,
-        'path': 'path/to/file'
-    }
-
     id_column = 'id'
     foreignKeys = ('builderid',)
     required_columns = ('builderid', 'path')
+
+    def __init__(self, id=None, builderid=None, path='path/to/file'):
+        super().__init__(id=id, builderid=builderid, path=path)
 
 
 class TestResult(Row):
     table = 'test_results'
 
-    defaults = {
-        'id': None,
-        'builderid': None,
-        'test_result_setid': None,
-        'test_nameid': None,
-        'test_code_pathid': None,
-        'line': None,
-        'duration_ns': None,
-        'value': None
-    }
-
     id_column = 'id'
     foreignKeys = ('builderid', 'test_result_setid', 'test_nameid', 'test_code_pathid')
     required_columns = ('builderid', 'test_result_setid', 'value')
+
+    def __init__(self, id=None, builderid=None, test_result_setid=None, test_nameid=None,
+                 test_code_pathid=None, line=None, duration_ns=None, value=None):
+        super().__init__(id=id, builderid=builderid, test_result_setid=test_result_setid,
+                         test_nameid=test_nameid, test_code_pathid=test_code_pathid,
+                         line=line, duration_ns=duration_ns, value=value)
 
 
 class FakeTestResultsComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/users.py
+++ b/master/buildbot/test/fakedb/users.py
@@ -23,27 +23,21 @@ from buildbot.test.fakedb.row import Row
 class User(Row):
     table = "users"
 
-    defaults = dict(
-        uid=None,
-        identifier='soap',
-        bb_username=None,
-        bb_password=None,
-    )
-
     id_column = 'uid'
+
+    def __init__(self, uid=None, identifier='soap', bb_username=None, bb_password=None):
+        super().__init__(uid=uid, identifier=identifier, bb_username=bb_username,
+                         bb_password=bb_password)
 
 
 class UserInfo(Row):
     table = "users_info"
 
-    defaults = dict(
-        uid=None,
-        attr_type='git',
-        attr_data='Tyler Durden <tyler@mayhem.net>',
-    )
-
     foreignKeys = ('uid',)
     required_columns = ('uid', )
+
+    def __init__(self, uid=None, attr_type='git', attr_data='Tyler Durden <tyler@mayhem.net>'):
+        super().__init__(uid=uid, attr_type=attr_type, attr_data=attr_data)
 
 
 class FakeUsersComponent(FakeDBComponent):

--- a/master/buildbot/test/fakedb/workers.py
+++ b/master/buildbot/test/fakedb/workers.py
@@ -26,42 +26,31 @@ from buildbot.test.util import validation
 class Worker(Row):
     table = "workers"
 
-    defaults = dict(
-        id=None,
-        name='some:worker',
-        info={"a": "b"},
-        paused=0,
-        graceful=0,
-    )
-
     id_column = 'id'
     required_columns = ('name', )
+
+    def __init__(self, id=None, name='some:worker', info={"a": "b"}, paused=0, graceful=0):
+        super().__init__(id=id, name=name, info=info, paused=paused, graceful=graceful)
 
 
 class ConnectedWorker(Row):
     table = "connected_workers"
 
-    defaults = dict(
-        id=None,
-        masterid=None,
-        workerid=None,
-    )
-
     id_column = 'id'
     required_columns = ('masterid', 'workerid')
+
+    def __init__(self, id=None, masterid=None, workerid=None):
+        super().__init__(id=id, masterid=masterid, workerid=workerid)
 
 
 class ConfiguredWorker(Row):
     table = "configured_workers"
 
-    defaults = dict(
-        id=None,
-        buildermasterid=None,
-        workerid=None,
-    )
-
     id_column = 'id'
     required_columns = ('buildermasterid', 'workerid')
+
+    def __init__(self, id=None, buildermasterid=None, workerid=None):
+        super().__init__(id=id, buildermasterid=buildermasterid, workerid=workerid)
 
 
 class FakeWorkersComponent(FakeDBComponent):


### PR DESCRIPTION
The defaults dictionary requires the reader to find the description in the parent Row class in order to understand what's happening and how to use the fakedb rows. Having an explicit __init__ makes it possible for autocomplete to work and the class interface is much more obvious.
