### PR TITLE
Allow RemoveWorkerFileSecret to handle renderables

### DIFF
--- a/master/buildbot/steps/download_secret_to_worker.py
+++ b/master/buildbot/steps/download_secret_to_worker.py
@@ -52,17 +52,17 @@ class DownloadSecretsToWorker(BuildStep, CompositeStepMixin):
 
 class RemoveWorkerFileSecret(BuildStep, CompositeStepMixin):
 
+    renderables = ['secret_to_be_populated']
+
     def __init__(self, populated_secret_list, logEnviron=False, **kwargs):
-        self.paths = []
-        for path, secret in populated_secret_list:
-            self.paths.append(path)
-        self.logEnviron = logEnviron
         super().__init__(**kwargs)
+        self.logEnviron = logEnviron
+        self.secret_to_be_populated = populated_secret_list
 
     @defer.inlineCallbacks
     def runRemoveWorkerFileSecret(self):
         all_results = []
-        for path in self.paths:
+        for path, _ in self.secret_to_be_populated:
             res = yield self.runRmFile(path, abandonOnFailure=False)
             all_results.append(res)
         if FAILURE in all_results:


### PR DESCRIPTION

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
