### PR TITLE
appveyor: Upgrade setuptools before installing requirements-ci.txt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - "python -c \"import sys; print(sys.exec_prefix)\""
   - "python -c \"import sys; print(sys.executable)\""
   - "python -V -V"
-  - "python -m pip install -U pip"
+  - "python -m pip install -U pip setuptools"
   - "python -m pip install -r requirements-ci.txt"
   - "python -m pip list"
   # Check that pywin32 is properly installed


### PR DESCRIPTION
Looks like setuptools_scm broke its compatibility with older setuptools. See https://github.com/pypa/setuptools_scm/issues/605. Recommended solution is to upgrade pip and setuptools to newest version. Since we're upgrading setuptools on our Linux CI anyway, do the same on appveyor.
