### PR TITLE
Fixed typo in tutorial introduction

### DIFF
--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -32,7 +32,7 @@ The worker daemons connect to the master daemon and execute builds whenever mast
 
 In this tutorial we will run a single master and a single worker on the same machine.
 
-A more throughout explanation can be found in the :ref:`manual section <Introduction>` of the Buildbot documentation.
+A more thorough explanation can be found in the :ref:`manual section <Introduction>` of the Buildbot documentation.
 
 .. _Docker: https://docker.com
 


### PR DESCRIPTION
## Fix Typo in the Tutorial First Run Introduction
This pull request literally changes only a single word of the source code, as it is simply fixing a typo. Since no actual code was touched, no unit tests were updated, and the news file was also left as is.

However, I did make sure to read both the [developer quickstart](http://docs.buildbot.net/latest/developer/quickstart.html) and the [pull request guidelines](http://docs.buildbot.net/latest/developer/pull-request.html). In keeping with the standards laid out therein, the documentation formatting was left intact (each documentation line corresponds to one line within the ReStructured text file), and the git commit message was made as descriptive as possible, I suppose (this is a pretty simple pull request, so there wasn't much to describe, honestly).

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
