### PR TITLE
Fix create-master --db option help text

### DIFF
--- a/master/buildbot/newsfragments/fix_help_text_for_create-master.doc
+++ b/master/buildbot/newsfragments/fix_help_text_for_create-master.doc
@@ -1,0 +1,1 @@
+Fix help text for `buildbot create-master` so it states that --db option is passed verbatim to master.cfg.sample instead of buildbot.tac

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -141,7 +141,7 @@ class CreateMasterOptions(base.BasedirMixin, base.SubcommandOptions):
     To use a remote MySQL database instead, use something like:
 
       --db='mysql://bbuser:bbpasswd@dbhost/bbdb'
-    The --db string is stored verbatim in the buildbot.tac file, and
+    The --db string is stored verbatim in the master.cfg.sample file, and
     evaluated at 'buildbot start' time to pass a DBConnector instance into
     the newly-created BuildMaster object.
     """)


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
