### PR TITLE
Message formatter improvements

### DIFF
--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -55,9 +55,9 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
         want_previous_build = False if is_new else self._want_previous_build()
 
         yield utils.getDetailsForBuild(master, build,
-                                       wantProperties=self.formatter.wantProperties,
-                                       wantSteps=self.formatter.wantSteps,
-                                       wantPreviousBuild=want_previous_build,
+                                       want_properties=self.formatter.want_properties,
+                                       want_steps=self.formatter.want_steps,
+                                       want_previous_build=want_previous_build,
                                        want_logs=self.formatter.want_logs,
                                        want_logs_content=self.formatter.want_logs_content)
 
@@ -102,8 +102,8 @@ class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
         formatter = self.start_formatter if is_new else self.end_formatter
 
         yield utils.getDetailsForBuild(master, build,
-                                       wantProperties=formatter.wantProperties,
-                                       wantSteps=formatter.wantSteps,
+                                       want_properties=formatter.want_properties,
+                                       want_steps=formatter.want_steps,
                                        want_logs=formatter.want_logs,
                                        want_logs_content=formatter.want_logs_content)
 

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -58,7 +58,8 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
                                        wantProperties=self.formatter.wantProperties,
                                        wantSteps=self.formatter.wantSteps,
                                        wantPreviousBuild=want_previous_build,
-                                       wantLogs=self.formatter.wantLogs)
+                                       want_logs=self.formatter.wantLogs,
+                                       want_logs_content=self.formatter.wantLogs)
 
         if not self.is_message_needed_by_props(build):
             return None
@@ -103,7 +104,8 @@ class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
         yield utils.getDetailsForBuild(master, build,
                                        wantProperties=formatter.wantProperties,
                                        wantSteps=formatter.wantSteps,
-                                       wantLogs=formatter.wantLogs)
+                                       want_logs=formatter.wantLogs,
+                                       want_logs_content=formatter.wantLogs)
 
         if not self.is_message_needed_by_props(build):
             return None

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -58,8 +58,8 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
                                        wantProperties=self.formatter.wantProperties,
                                        wantSteps=self.formatter.wantSteps,
                                        wantPreviousBuild=want_previous_build,
-                                       want_logs=self.formatter.wantLogs,
-                                       want_logs_content=self.formatter.wantLogs)
+                                       want_logs=self.formatter.want_logs,
+                                       want_logs_content=self.formatter.want_logs_content)
 
         if not self.is_message_needed_by_props(build):
             return None
@@ -104,8 +104,8 @@ class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
         yield utils.getDetailsForBuild(master, build,
                                        wantProperties=formatter.wantProperties,
                                        wantSteps=formatter.wantSteps,
-                                       want_logs=formatter.wantLogs,
-                                       want_logs_content=formatter.wantLogs)
+                                       want_logs=formatter.want_logs,
+                                       want_logs_content=formatter.want_logs_content)
 
         if not self.is_message_needed_by_props(build):
             return None

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -46,9 +46,9 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
     def generate(self, master, reporter, key, message):
         bsid = message['bsid']
         res = yield utils.getDetailsForBuildset(master, bsid,
-                                                wantProperties=self.formatter.wantProperties,
-                                                wantSteps=self.formatter.wantSteps,
-                                                wantPreviousBuild=self._want_previous_build(),
+                                                want_properties=self.formatter.want_properties,
+                                                want_steps=self.formatter.want_steps,
+                                                want_previous_build=self._want_previous_build(),
                                                 want_logs=self.formatter.want_logs,
                                                 want_logs_content=self.formatter.want_logs_content)
 

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -49,7 +49,8 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
                                                 wantProperties=self.formatter.wantProperties,
                                                 wantSteps=self.formatter.wantSteps,
                                                 wantPreviousBuild=self._want_previous_build(),
-                                                wantLogs=self.formatter.wantLogs)
+                                                want_logs=self.formatter.wantLogs,
+                                                want_logs_content=self.formatter.wantLogs)
 
         builds = res['builds']
         buildset = res['buildset']

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -49,8 +49,8 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
                                                 wantProperties=self.formatter.wantProperties,
                                                 wantSteps=self.formatter.wantSteps,
                                                 wantPreviousBuild=self._want_previous_build(),
-                                                want_logs=self.formatter.wantLogs,
-                                                want_logs_content=self.formatter.wantLogs)
+                                                want_logs=self.formatter.want_logs,
+                                                want_logs_content=self.formatter.want_logs_content)
 
         builds = res['builds']
         buildset = res['buildset']

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -322,8 +322,8 @@ class GerritStatusPush(service.BuildbotService):
         yield utils.getDetailsForBuilds(self.master,
                                         buildset,
                                         [build],
-                                        wantProperties=True,
-                                        wantSteps=self.wantSteps)
+                                        want_properties=True,
+                                        want_steps=self.wantSteps)
 
     def isBuildReported(self, build):
         return self.builders is None or build['builder']['name'] in self.builders
@@ -333,8 +333,8 @@ class GerritStatusPush(service.BuildbotService):
         if not self.summaryCB:
             return
         bsid = msg['bsid']
-        res = yield utils.getDetailsForBuildset(self.master, bsid, wantProperties=True,
-                                                wantSteps=self.wantSteps, want_logs=self.wantLogs,
+        res = yield utils.getDetailsForBuildset(self.master, bsid, want_properties=True,
+                                                want_steps=self.wantSteps, want_logs=self.wantLogs,
                                                 want_logs_content=self.wantLogs)
         builds = res['builds']
         buildset = res['buildset']

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -333,9 +333,9 @@ class GerritStatusPush(service.BuildbotService):
         if not self.summaryCB:
             return
         bsid = msg['bsid']
-        res = yield utils.getDetailsForBuildset(
-            self.master, bsid, wantProperties=True,
-            wantSteps=self.wantSteps, wantLogs=self.wantLogs)
+        res = yield utils.getDetailsForBuildset(self.master, bsid, wantProperties=True,
+                                                wantSteps=self.wantSteps, want_logs=self.wantLogs,
+                                                want_logs_content=self.wantLogs)
         builds = res['builds']
         buildset = res['buildset']
         self.sendBuildSetSummary(buildset, builds)

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -150,18 +150,30 @@ class MessageFormatterBase(util.ComparableMixin):
 
     template_type = 'plain'
 
-    def __init__(self, ctx=None, wantProperties=True, wantSteps=False, wantLogs=None,
+    def __init__(self, ctx=None, want_properties=True, wantProperties=None,
+                 want_steps=False, wantSteps=None, wantLogs=None,
                  want_logs=False, want_logs_content=False):
         if ctx is None:
             ctx = {}
         self.context = ctx
-        self.wantProperties = wantProperties
-        self.wantSteps = wantSteps
+        if wantProperties is not None:
+            warn_deprecated('3.4.0', f'{self.__class__.__name__}: wantProperties has been '
+                                     'deprecated, use want_properties')
+            self.want_properties = wantProperties
+        else:
+            self.want_properties = want_properties
+        if wantSteps is not None:
+            warn_deprecated('3.4.0', f'{self.__class__.__name__}: wantSteps has been deprecated, ' +
+                                     'use want_steps')
+            self.want_steps = wantSteps
+        else:
+            self.want_steps = want_steps
         if wantLogs is not None:
             warn_deprecated('3.4.0', f'{self.__class__.__name__}: wantLogs has been deprecated, ' +
                                      'use want_logs and want_logs_content')
         else:
             wantLogs = False
+
         self.want_logs = want_logs or wantLogs
         self.want_logs_content = want_logs_content or wantLogs
 

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -27,6 +27,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
+from buildbot.warnings import warn_deprecated
 
 
 def get_detected_status_text(mode, results, previous_results):
@@ -149,13 +150,20 @@ class MessageFormatterBase(util.ComparableMixin):
 
     template_type = 'plain'
 
-    def __init__(self, ctx=None, wantProperties=True, wantSteps=False, wantLogs=False):
+    def __init__(self, ctx=None, wantProperties=True, wantSteps=False, wantLogs=None,
+                 want_logs=False, want_logs_content=False):
         if ctx is None:
             ctx = {}
         self.context = ctx
         self.wantProperties = wantProperties
         self.wantSteps = wantSteps
-        self.wantLogs = wantLogs
+        if wantLogs is not None:
+            warn_deprecated('3.4.0', f'{self.__class__.__name__}: wantLogs has been deprecated, ' +
+                                     'use want_logs and want_logs_content')
+        else:
+            wantLogs = False
+        self.want_logs = want_logs or wantLogs
+        self.want_logs_content = want_logs_content or wantLogs
 
     def buildAdditionalContext(self, master, ctx):
         pass

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -129,6 +129,11 @@ def getDetailsForBuilds(master, buildset, builds, wantProperties=False, wantStep
     else:  # we still need a list for the big zip
         prev_builds = list(range(len(builds)))
 
+    if want_logs_content:
+        want_logs = True
+    if want_logs:
+        wantSteps = True
+
     if wantSteps:
         buildsteps = yield defer.gatherResults(
             [master.data.get(("builds", build['buildid'], 'steps'))

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -67,7 +67,8 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
         }
         formatter.wantProperties = False
         formatter.wantSteps = False
-        formatter.wantLogs = False
+        formatter.want_logs = False
+        formatter.want_logs_content = False
         generator = BuildStatusGenerator(message_formatter=formatter, **kwargs)
 
         mn = yield self.setupNotifier(generators=[generator])

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -65,8 +65,8 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
             "type": "text",
             "subject": "subject"
         }
-        formatter.wantProperties = False
-        formatter.wantSteps = False
+        formatter.want_properties = False
+        formatter.want_steps = False
         formatter.want_logs = False
         formatter.want_logs_content = False
         generator = BuildStatusGenerator(message_formatter=formatter, **kwargs)

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -481,7 +481,8 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
         }
         formatter.wantProperties = True
         formatter.wantSteps = False
-        formatter.wantLogs = False
+        formatter.want_logs = False
+        formatter.want_logs_content = False
 
         generator = generator_class(message_formatter=formatter)
 

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -479,8 +479,8 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             "type": "text",
             "subject": "subject"
         }
-        formatter.wantProperties = True
-        formatter.wantSteps = False
+        formatter.want_properties = True
+        formatter.want_steps = False
         formatter.want_logs = False
         formatter.want_logs_content = False
 

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -43,7 +43,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):
         build = yield self.insert_build_finished(results, **kwargs)
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        yield utils.getDetailsForBuild(self.master, build, want_properties=True)
         return build
 
     @defer.inlineCallbacks
@@ -239,7 +239,7 @@ class TestBuildStartEndGenerator(ConfigErrorsMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):
         build = yield self.insert_build_finished(results, **kwargs)
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        yield utils.getDetailsForBuild(self.master, build, want_properties=True)
         return build
 
     @parameterized.expand([

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -41,7 +41,7 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):
         build = yield self.insert_build_finished(results, **kwargs)
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        yield utils.getDetailsForBuild(self.master, build, want_properties=True)
         return build
 
     @defer.inlineCallbacks
@@ -64,7 +64,7 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
         g.formatter.format_message_for_build.return_value = message
         g.formatter.want_logs = False
         g.formatter.want_logs_content = False
-        g.formatter.wantSteps = False
+        g.formatter.want_steps = False
 
         return (g, build, buildset)
 

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -62,7 +62,8 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
 
         g.formatter = Mock(spec=g.formatter)
         g.formatter.format_message_for_build.return_value = message
-        g.formatter.wantLogs = False
+        g.formatter.want_logs = False
+        g.formatter.want_logs_content = False
         g.formatter.wantSteps = False
 
         return (g, build, buildset)

--- a/master/buildbot/test/unit/reporters/test_generators_utils.py
+++ b/master/buildbot/test/unit/reporters/test_generators_utils.py
@@ -46,7 +46,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):
         build = yield self.insert_build_finished(results, **kwargs)
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        yield utils.getDetailsForBuild(self.master, build, want_properties=True)
         return build
 
     def create_generator(self, mode=("failing", "passing", "warnings"),

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -164,7 +164,7 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults, finalResult):
         self.insertTestData(buildResults, finalResult)
-        res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True)
+        res = yield utils.getDetailsForBuildset(self.master, 98, want_properties=True)
         builds = res['builds']
         buildset = res['buildset']
 

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -192,7 +192,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         }
         formatter.wantProperties = False
         formatter.wantSteps = False
-        formatter.wantLogs = False
+        formatter.want_logs = False
+        formatter.want_logs_content = False
 
         generator = BuildStatusGenerator(message_formatter=formatter, **generator_kwargs)
 
@@ -331,7 +332,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         }
         formatter.wantProperties = False
         formatter.wantSteps = False
-        formatter.wantLogs = False
+        formatter.want_logs = False
+        formatter.want_logs_content = False
 
         generator = BuildStatusGenerator(message_formatter=formatter)
 

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -64,7 +64,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
     def do_test_createEmail_cte(self, funnyChars, expEncoding):
         build = yield self.insert_build_finished(SUCCESS)
 
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        yield utils.getDetailsForBuild(self.master, build, want_properties=True)
 
         msgdict = create_msgdict(funnyChars)
         mn = yield self.setupMailNotifier('from@example.org')
@@ -138,7 +138,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def test_createEmail_extraHeaders_two_builds(self):
         build = yield self.insert_build_finished(SUCCESS)
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        yield utils.getDetailsForBuild(self.master, build, want_properties=True)
 
         builds = [build, copy.deepcopy(build)]
         builds[1]['builder']['name'] = 'builder2'
@@ -190,8 +190,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
             "type": "text",
             "subject": "subject"
         }
-        formatter.wantProperties = False
-        formatter.wantSteps = False
+        formatter.want_properties = False
+        formatter.want_steps = False
         formatter.want_logs = False
         formatter.want_logs_content = False
 
@@ -330,8 +330,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
             "type": "text",
             "subject": "subject"
         }
-        formatter.wantProperties = False
-        formatter.wantSteps = False
+        formatter.want_properties = False
+        formatter.want_steps = False
         formatter.want_logs = False
         formatter.want_logs_content = False
 

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -34,6 +34,8 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.misc import BuildDictLookAlike
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestMessageFormatting(unittest.TestCase):
@@ -161,8 +163,8 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def do_one_test(self, formatter, lastresults, results, mode="all"):
         self.setupDb(lastresults, results)
-        res = yield utils.getDetailsForBuildset(self.master, 99, wantProperties=True,
-                                                wantPreviousBuild=True)
+        res = yield utils.getDetailsForBuildset(self.master, 99, want_properties=True,
+                                                want_previous_build=True)
         build = res['builds'][0]
         res = yield formatter.format_message_for_build(self.master, build, mode=mode,
                                                        users=["him@bar", "me@foo"])
@@ -170,6 +172,23 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
 
 
 class TestMessageFormatter(MessageFormatterTestBase):
+
+    def test_want_properties_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning, "wantProperties has been deprecated"):
+            formatter = message.MessageFormatter(wantProperties=True)
+        self.assertEqual(formatter.want_properties, True)
+
+    def test_want_steps_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning, "wantSteps has been deprecated"):
+            formatter = message.MessageFormatter(wantSteps=True)
+        self.assertEqual(formatter.want_steps, True)
+
+    def test_want_logs_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning, "wantLogs has been deprecated"):
+            formatter = message.MessageFormatter(wantLogs=True)
+        self.assertEqual(formatter.want_logs, True)
+        self.assertEqual(formatter.want_logs_content, True)
+
     @defer.inlineCallbacks
     def test_message_success(self):
         formatter = message.MessageFormatter()

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -13,7 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+import datetime
 import textwrap
+
+from dateutil.tz import tzutc
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -151,6 +154,238 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
         self.assertEqual(build1['steps'][0]['logs'][0]['content']['content'], self.LOGCONTENT)
         self.assertEqual(build1['steps'][0]['logs'][0]['url'],
                          'http://localhost:8080/#builders/80/builds/2/steps/29/logs/stdio')
+
+    @defer.inlineCallbacks
+    def test_get_details_for_buildset_all(self):
+        self.setupDb()
+        res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
+                                                wantSteps=True, wantPreviousBuild=True,
+                                                want_logs=True, want_logs_content=True)
+
+        self.assertEqual(res, {
+            'builds': [{
+                'builder': {
+                    'builderid': 80,
+                    'description': None,
+                    'masterids': [],
+                    'name': 'Builder1',
+                    'tags': []
+                },
+                'builderid': 80,
+                'buildid': 20,
+                'buildrequestid': 11,
+                'buildset': {
+                    'bsid': 98,
+                    'complete': False,
+                    'complete_at': None,
+                    'external_idstring': 'extid',
+                    'parent_buildid': None,
+                    'parent_relationship': None,
+                    'reason': 'testReason1',
+                    'results': 0,
+                    'sourcestamps': [{
+                        'branch': 'master',
+                        'codebase': '',
+                        'created_at': datetime.datetime(1972, 11, 5, 18, 7, 14, tzinfo=tzutc()),
+                        'patch': None,
+                        'project': 'proj',
+                        'repository': 'repo',
+                        'revision': 'abcd',
+                        'ssid': 234
+                    }],
+                    'submitted_at': 12345678
+                },
+                'complete': False,
+                'complete_at': None,
+                'masterid': 92,
+                'number': 2,
+                'prev_build': {
+                    'builderid': 80,
+                    'buildid': 18,
+                    'buildrequestid': 9,
+                    'complete': False,
+                    'complete_at': None,
+                    'masterid': 92,
+                    'number': 0,
+                    'properties': {},
+                    'results': 2,
+                    'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                    'state_string': 'test',
+                    'workerid': 13
+                },
+                'properties': {
+                    'owner': ('him', 'fakedb'),
+                    'reason': ('because', 'fakedb'),
+                    'workername': ('wrk', 'fakedb')
+                },
+                'results': 0,
+                'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                'state_string': 'test',
+                'steps': [{
+                    'buildid': 20,
+                    'complete': False,
+                    'complete_at': None,
+                    'hidden': False,
+                    'logs': [{
+                        'complete': False,
+                        'content': {
+                            'content': 'line zero\nline 1\n',
+                            'firstline': 0,
+                            'logid': 80
+                        },
+                        'logid': 80,
+                        'name': 'stdio',
+                        'num_lines': 2,
+                        'slug': 'stdio',
+                        'stepid': 120,
+                        'type': 's',
+                        'url': 'http://localhost:8080/#builders/80/builds/2/steps/29/logs/stdio'
+                    }],
+                    'name': 'step1',
+                    'number': 29,
+                    'results': None,
+                    'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                    'state_string': '',
+                    'stepid': 120,
+                    'urls': []
+                }, {
+                    'buildid': 20,
+                    'complete': False,
+                    'complete_at': None,
+                    'hidden': False,
+                    'logs': [],
+                    'name': 'step2',
+                    'number': 29,
+                    'results': None,
+                    'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                    'state_string': '',
+                    'stepid': 220,
+                    'urls': []
+                }],
+                'url': 'http://localhost:8080/#builders/80/builds/2',
+                'workerid': 13
+            }, {
+                'builder': {
+                    'builderid': 80,
+                    'description': None,
+                    'masterids': [],
+                    'name': 'Builder1',
+                    'tags': []
+                },
+                'builderid': 80,
+                'buildid': 21,
+                'buildrequestid': 12,
+                'buildset': {
+                    'bsid': 98,
+                    'complete': False,
+                    'complete_at': None,
+                    'external_idstring': 'extid',
+                    'parent_buildid': None,
+                    'parent_relationship': None,
+                    'reason': 'testReason1',
+                    'results': 0,
+                    'sourcestamps': [{
+                        'branch': 'master',
+                        'codebase': '',
+                        'created_at': datetime.datetime(1972, 11, 5, 18, 7, 14, tzinfo=tzutc()),
+                        'patch': None,
+                        'project': 'proj',
+                        'repository': 'repo',
+                        'revision': 'abcd',
+                        'ssid': 234
+                    }],
+                    'submitted_at': 12345678
+                },
+                'complete': False,
+                'complete_at': None,
+                'masterid': 92,
+                'number': 3,
+                'prev_build': {
+                    'builderid': 80,
+                'buildid': 20,
+                    'buildrequestid': 11,
+                    'complete': False,
+                    'complete_at': None,
+                    'masterid': 92,
+                    'number': 2,
+                    'properties': {},
+                    'results': 0,
+                    'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                    'state_string': 'test',
+                    'workerid': 13
+                },
+                'properties': {
+                    'owner': ('him', 'fakedb'),
+                    'reason': ('because', 'fakedb'),
+                    'workername': ('wrk', 'fakedb')
+                },
+                'results': 0,
+                'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                'state_string': 'test',
+                'steps': [{
+                    'buildid': 21,
+                    'complete': False,
+                    'complete_at': None,
+                    'hidden': False,
+                    'logs': [{
+                        'complete': False,
+                        'content': {'content': 'line zero\nline 1\n',
+                        'firstline': 0,
+                        'logid': 81},
+                        'logid': 81,
+                        'name': 'stdio',
+                        'num_lines': 2,
+                        'slug': 'stdio',
+                        'stepid': 121,
+                        'type': 's',
+                        'url': 'http://localhost:8080/#builders/80/builds/3/steps/29/logs/stdio'
+                    }],
+                    'name': 'step1',
+                    'number': 29,
+                    'results': None,
+                    'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                    'state_string': '',
+                    'stepid': 121,
+                    'urls': []
+                }, {
+                    'buildid': 21,
+                    'complete': False,
+                    'complete_at': None,
+                    'hidden': False,
+                    'logs': [],
+                    'name': 'step2',
+                    'number': 29,
+                    'results': None,
+                    'started_at': datetime.datetime(2011, 5, 1, 15, 3, 42, tzinfo=tzutc()),
+                    'state_string': '',
+                    'stepid': 221,
+                    'urls': []
+                }],
+                'url': 'http://localhost:8080/#builders/80/builds/3',
+                'workerid': 13
+            }],
+            'buildset': {
+                'bsid': 98,
+                'complete': False,
+                'complete_at': None,
+                'external_idstring': 'extid',
+                'parent_buildid': None,
+                'parent_relationship': None,
+                'reason': 'testReason1',
+                'results': 0,
+                'sourcestamps': [{
+                    'branch': 'master',
+                    'codebase': '',
+                    'created_at': datetime.datetime(1972, 11, 5, 18, 7, 14, tzinfo=tzutc()),
+                    'patch': None,
+                    'project': 'proj',
+                    'repository': 'repo',
+                    'revision': 'abcd',
+                    'ssid': 234
+                }],
+                'submitted_at': 12345678
+            }
+        })
 
     @defer.inlineCallbacks
     def test_getResponsibleUsers(self):

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -124,7 +124,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
         build = yield self.master.data.get(("builds", 21))
         yield utils.getDetailsForBuild(self.master, build, wantProperties=False,
                                        wantSteps=False, wantPreviousBuild=False,
-                                       wantLogs=False)
+                                       want_logs=False)
 
         self.assertEqual(build['parentbuild'], None)
         self.assertEqual(build['parentbuilder'], None)
@@ -135,7 +135,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
         build = yield self.master.data.get(("builds", 22))
         yield utils.getDetailsForBuild(self.master, build, wantProperties=False,
                                        wantSteps=False, wantPreviousBuild=False,
-                                       wantLogs=False)
+                                       want_logs=False)
 
         self.assertEqual(build['parentbuild']['buildid'], 21)
         self.assertEqual(build['parentbuilder']['name'], "Builder1")
@@ -145,7 +145,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
         self.setupDb()
         res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
                                                 wantSteps=True, wantPreviousBuild=True,
-                                                wantLogs=True)
+                                                want_logs=True, want_logs_content=True)
 
         build1 = res['builds'][0]
         self.assertEqual(

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -148,8 +148,9 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                                                 want_logs=True, want_logs_content=True)
 
         build1 = res['builds'][0]
-        self.assertEqual(
-            build1['steps'][0]['logs'][0]['content']['content'], self.LOGCONTENT)
+        self.assertEqual(build1['steps'][0]['logs'][0]['content']['content'], self.LOGCONTENT)
+        self.assertEqual(build1['steps'][0]['logs'][0]['url'],
+                         'http://localhost:8080/#builders/80/builds/2/steps/29/logs/stdio')
 
     @defer.inlineCallbacks
     def test_getResponsibleUsers(self):

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -103,8 +103,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     @defer.inlineCallbacks
     def test_getDetailsForBuildset(self):
         self.setupDb()
-        res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
-                                                wantSteps=True, wantPreviousBuild=True)
+        res = yield utils.getDetailsForBuildset(self.master, 98, want_properties=True,
+                                                want_steps=True, want_previous_build=True)
         self.assertEqual(len(res['builds']), 2)
         build1 = res['builds'][0]
         build2 = res['builds'][1]
@@ -125,8 +125,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     def test_getDetailsForBuild(self):
         self.setupDb()
         build = yield self.master.data.get(("builds", 21))
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=False,
-                                       wantSteps=False, wantPreviousBuild=False,
+        yield utils.getDetailsForBuild(self.master, build, want_properties=False,
+                                       want_steps=False, want_previous_build=False,
                                        want_logs=False)
 
         self.assertEqual(build['parentbuild'], None)
@@ -136,8 +136,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     def test_getDetailsForBuildWithParent(self):
         self.setupDb()
         build = yield self.master.data.get(("builds", 22))
-        yield utils.getDetailsForBuild(self.master, build, wantProperties=False,
-                                       wantSteps=False, wantPreviousBuild=False,
+        yield utils.getDetailsForBuild(self.master, build, want_properties=False,
+                                       want_steps=False, want_previous_build=False,
                                        want_logs=False)
 
         self.assertEqual(build['parentbuild']['buildid'], 21)
@@ -146,8 +146,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     @defer.inlineCallbacks
     def test_getDetailsForBuildsetWithLogs(self):
         self.setupDb()
-        res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
-                                                wantSteps=True, wantPreviousBuild=True,
+        res = yield utils.getDetailsForBuildset(self.master, 98, want_properties=True,
+                                                want_steps=True, want_previous_build=True,
                                                 want_logs=True, want_logs_content=True)
 
         build1 = res['builds'][0]
@@ -158,8 +158,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     @defer.inlineCallbacks
     def test_get_details_for_buildset_all(self):
         self.setupDb()
-        res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
-                                                wantSteps=True, wantPreviousBuild=True,
+        res = yield utils.getDetailsForBuildset(self.master, 98, want_properties=True,
+                                                want_steps=True, want_previous_build=True,
                                                 want_logs=True, want_logs_content=True)
 
         self.assertEqual(res, {

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -48,12 +48,12 @@ The constructor of the class takes the following arguments:
 
 ``want_logs``
     This parameter (defaults to False) will extend the content of the steps of the given ``build`` object with the log metadata of each steps from the build.
-    This requires ``wantSteps`` to be True.
+    This implies ``wantSteps`` to be `True`.
     Use it only when mandatory, as this greatly increases the overhead in terms of CPU and memory on the master.
 
 ``want_logs_content``
     This parameter (defaults to False) will extend the content of the logs with the log contents of each steps from the build.
-    This requires ``want_logs`` to be True.
+    This implies ``want_logs`` and ``wantSteps`` to be `True`.
     Use it only when mandatory, as this greatly increases the overhead in terms of CPU and memory on the master.
 
 Context

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -112,6 +112,7 @@ The context that is given to the template consists of the following data:
         This attribute is populated only if ``wantSteps`` is set to ``True``.
 
         Additionally, if ``want_logs`` is set to ``True`` then the step dictionaries will contain ``logs`` attribute with a list of :bb:rtype:`log` dictionaries from the data API that describe the logs of the step.
+        The log dictionaries will additionally contain ``url`` key with URL to the log in the web UI as the value.
 
         Additionally, if ``want_logs_content`` is set to ``True`` then the log dictionaries will contain ``contents`` key with full contents of the log.
 

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -44,8 +44,16 @@ The constructor of the class takes the following arguments:
     Use it only when necessary as this increases the overhead in terms of CPU and memory on the master.
 
 ``wantLogs``
-    This parameter (defaults to False) will extend the content of the steps of the given ``build`` object with the full logs of each steps from the build.
+    Deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
+
+``want_logs``
+    This parameter (defaults to False) will extend the content of the steps of the given ``build`` object with the log metadata of each steps from the build.
     This requires ``wantSteps`` to be True.
+    Use it only when mandatory, as this greatly increases the overhead in terms of CPU and memory on the master.
+
+``want_logs_content``
+    This parameter (defaults to False) will extend the content of the logs with the log contents of each steps from the build.
+    This requires ``want_logs`` to be True.
     Use it only when mandatory, as this greatly increases the overhead in terms of CPU and memory on the master.
 
 Context

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -36,12 +36,18 @@ The constructor of the class takes the following arguments:
 
         default implementation will add ``self.ctx`` into the current template context
 
-``wantProperties``
+``want_properties``
     This parameter (defaults to True) will extend the content of the given ``build`` object with the Properties from the build.
 
-``wantSteps``
+``wantProperties``
+    Deprecated, use ``want_properties`` set to the same value.
+
+``want_steps``
     This parameter (defaults to False) will extend the content of the given ``build`` object with information about the steps of the build.
     Use it only when necessary as this increases the overhead in terms of CPU and memory on the master.
+
+``wantSteps``
+    Deprecated, use ``want_steps`` set to the same value.
 
 ``wantLogs``
     Deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
@@ -81,7 +87,7 @@ The context that is given to the template consists of the following data:
 
 ``build``
     The :bb:rtype:`build` dictionary from data API.
-    The ``properties`` attribute is populated only if ``wantProperties`` is set to ``True``.
+    The ``properties`` attribute is populated only if ``want_properties`` is set to ``True``.
     It has the following extra properties:
 
     ``builder``

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -61,8 +61,88 @@ Context
 
 The context that is given to the template consists of the following data:
 
+``results``
+    The results of the build.
+    Equivalent to ``build['results']``.
 
-The following table describes how to get some useful pieces of information from the various data objects:
+``buildername``
+    The name of the builder.
+    Equivalent to ``build['builder']['name']``
+
+``mode``
+    The mode argument that has been passed to the report generator.
+
+``workername``
+    The name of the worker.
+    Equivalent to the ``workername`` property of the build or ``<unknown>`` if it's not available.
+
+``buildset``
+    The :bb:rtype:`buildset` dictionary from data API.
+
+``build``
+    The :bb:rtype:`build` dictionary from data API.
+    The ``properties`` attribute is populated only if ``wantProperties`` is set to ``True``.
+    It has the following extra properties:
+
+    ``builder``
+        The :bb:rtype:`builder` dictionary from the data API that describes the builder of the build.
+
+    ``buildrequest``
+        The :bb:rtype:`buildrequest` dictionary from the data API that describes the build request that the build was built for.
+
+    ``buildset``
+        The :bb:rtype:`buildset` dictionary from the data API that describes the buildset that the build was built for.
+
+    ``parentbuild``
+        The :bb:rtype:`build` dictionary from the data API that describes the parent build.
+        This build is identified by the ``parent_buildid`` attribute of the buildset.
+
+    ``parentbuilder``
+        The :bb:rtype:`builder` dictionary from the data API that describes the builder of the parent build.
+
+    ``url``
+        URL to the build in the Buildbot UI.
+
+    ``prev_build``
+        The :bb:rtype:`build` dictionary from the data API that describes previous build, if any.
+        This attribute is populated only if ``wantPreviousBuild`` is set to ``True``.
+
+    ``steps``
+        A list of :bb:rtype:`step` dictionaries from the data API that describe steps in the build, if any.
+        This attribute is populated only if ``wantSteps`` is set to ``True``.
+
+        Additionally, if ``want_logs`` is set to ``True`` then the step dictionaries will contain ``logs`` attribute with a list of :bb:rtype:`log` dictionaries from the data API that describe the logs of the step.
+
+        Additionally, if ``want_logs_content`` is set to ``True`` then the log dictionaries will contain ``contents`` key with full contents of the log.
+
+``projects``
+    A string identifying the projects that the build was built for.
+
+``previous_results``
+    Results of the previous build, if available, otherwise ``None``.
+
+``status_detected``
+    String that describes the build in terms of current build results, previous build results and ``mode``.
+
+``build_url``
+    URL to the build in the Buildbot UI.
+
+``buildbot_url``
+    URL to the Buildbot instance.
+
+``blamelist``
+    The list of users responsible for the build.
+
+``summary``
+    A string that summarizes the build result.
+
+``sourcestamps``
+    A string identifying the source stamps for which the build was made.
+
+Examples
+~~~~~~~~
+
+The following examples describe how to get some useful pieces of information from the various data objects:
 
 Name of the builder that generated this event
     ``{{ buildername }}``

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -8,13 +8,15 @@ MessageFormatterFunction
 This formatter can be used to generate arbitrary messages according to arbitrary calculations.
 As opposed to :ref:`MessageFormatterRenderable`, more information is made available to this reporter.
 
-.. py:class:: MessageFormatterFunction(function, template_type, wantProperties=True, wantSteps=False, wantLogs=False, want_logs=False, want_logs_content=False)
+.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, wantProperties=None, want_steps=False, wantSteps=None, wantLogs=None, want_logs=False, want_logs_content=False)
 
     :param callable function: A callable that will be called with a dictionary that contains ``build`` key with the value that contains the build dictionary as received from the data API.
     :param string template_type: either ``plain``, ``html`` or ``json`` depending on the output of the formatter.
         JSON output must not be encoded.
-    :param boolean wantProperties: include 'properties' in the build dictionary
-    :param boolean wantSteps: include 'steps' in the build dictionary
+    :param boolean want_properties: include 'properties' in the build dictionary
+    :param boolean wantProperties: deprecated, use ``want_properties`` instead
+    :param boolean want_steps: include 'steps' in the build dictionary
+    :param boolean wantSteps: deprecated, use ``want_steps`` instead
     :param boolean wantLogs: deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
     :param boolean want_logs: include 'logs' in the steps dictionaries.
         This implies `wantSteps=True`.

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -8,13 +8,17 @@ MessageFormatterFunction
 This formatter can be used to generate arbitrary messages according to arbitrary calculations.
 As opposed to :ref:`MessageFormatterRenderable`, more information is made available to this reporter.
 
-.. py:class:: MessageFormatterFunction(function, template_type, wantProperties=True, wantSteps=False, wantLogs=False)
+.. py:class:: MessageFormatterFunction(function, template_type, wantProperties=True, wantSteps=False, wantLogs=False, want_logs=False, want_logs_content=False)
 
     :param callable function: A callable that will be called with a dictionary that contains ``build`` key with the value that contains the build dictionary as received from the data API.
     :param string template_type: either ``plain``, ``html`` or ``json`` depending on the output of the formatter.
         JSON output must not be encoded.
     :param boolean wantProperties: include 'properties' in the build dictionary
     :param boolean wantSteps: include 'steps' in the build dictionary
-    :param boolean wantLogs: include 'logs' in the steps dictionaries.
+    :param boolean wantLogs: deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
+    :param boolean want_logs: include 'logs' in the steps dictionaries.
         This needs wantSteps=True.
+        This includes only log metadata, for content use ``want_logs_content``.
+    :param boolean want_logs_content: include logs content in the logs dictionaries.
+        This needs want_logs=True.
         This dumps the *full* content of logs and may consume lots of memory and CPU depending on the log size.

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -17,8 +17,8 @@ As opposed to :ref:`MessageFormatterRenderable`, more information is made availa
     :param boolean wantSteps: include 'steps' in the build dictionary
     :param boolean wantLogs: deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
     :param boolean want_logs: include 'logs' in the steps dictionaries.
-        This needs wantSteps=True.
+        This implies `wantSteps=True`.
         This includes only log metadata, for content use ``want_logs_content``.
     :param boolean want_logs_content: include logs content in the logs dictionaries.
-        This needs want_logs=True.
+        This implies `want_logs=True` and `wantSteps=True`.
         This dumps the *full* content of logs and may consume lots of memory and CPU depending on the log size.

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -9,7 +9,7 @@ This formatter is used to format messages in :ref:`Reportgen-WorkerMissingGenera
 
 It formats a message using the Jinja2_ templating language and picks the template either from a string or from a file.
 
-The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``wantProperties``, ``wantSteps``.
+The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``wantProperties``, ``wantSteps``.
 
 ``template``
     The content of the template used to generate the body of the mail as string.

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -9,7 +9,7 @@ This formatter is used to format messages in :ref:`Reportgen-WorkerMissingGenera
 
 It formats a message using the Jinja2_ templating language and picks the template either from a string or from a file.
 
-The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``wantProperties``, ``wantSteps``.
+The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``wantProperties``, ``want_properties``, ``wantSteps``, ``want_steps``.
 
 ``template``
     The content of the template used to generate the body of the mail as string.

--- a/master/docs/manual/configuration/reporters/mail_notifier.rst
+++ b/master/docs/manual/configuration/reporters/mail_notifier.rst
@@ -114,7 +114,7 @@ Another example of a function delivering a customized HTML email is given below:
         mode=('failing',),
         message_formatter=reporters.MessageFormatter(
             template=template, template_type='html',
-            wantProperties=True, wantSteps=True))
+            want_properties=True, want_steps=True))
 
     mn = reporters.MailNotifier(fromaddr="buildbot@example.org",
                                 sendToInterestedUsers=False,

--- a/master/docs/manual/upgrading/4.0-upgrade.rst
+++ b/master/docs/manual/upgrading/4.0-upgrade.rst
@@ -24,3 +24,5 @@ Message formatters
 
 The ``wantLogs`` argument to message formatters has been removed.
 The equivalent is setting both ``want_logs`` and ``want_logs_content`` to the previous value of ``wantLogs``.
+
+The ``wantSteps`` and ``wantProperties`` arguments have been renamed to ``want_steps`` and ``want_properties`` respectively.

--- a/master/docs/manual/upgrading/4.0-upgrade.rst
+++ b/master/docs/manual/upgrading/4.0-upgrade.rst
@@ -1,0 +1,26 @@
+.. _4.0_Upgrading:
+
+Upgrading to Buildbot 4.0 (not released)
+========================================
+
+Upgrading a Buildbot instance from 3.x to 4.0 may require some work to achieve.
+
+The recommended upgrade procedure is as follows:
+
+  - Upgrade to the last released BuildBot version in 3.x series.
+
+  - Remove usage of the deprecated APIs.
+    All usages of deprecated APIs threw a deprecation warning at the point of use.
+    If the code does not emit deprecation warnings, it's in a good shape in this regard.
+    You may need to run the master on a real workload in order to force all deprecated code paths to be exercised.
+
+  - Upgrade to the latest Buildbot 4.0.x release.
+
+  - (Optional) Upgrade to newest Buildbot 4.x.
+    The newest point release will contain bug fixes and functionality improvements.
+
+Message formatters
+------------------
+
+The ``wantLogs`` argument to message formatters has been removed.
+The equivalent is setting both ``want_logs`` and ``want_logs_content`` to the previous value of ``wantLogs``.

--- a/master/docs/manual/upgrading/index.rst
+++ b/master/docs/manual/upgrading/index.rst
@@ -37,6 +37,7 @@ Finally, upgrade to the next major release.
 .. toctree::
    :maxdepth: 1
 
+   4.0-upgrade
    3.0-upgrade
    2.0-upgrade
    1.0-upgrade

--- a/newsfragments/message-formatter-args-imply.feature
+++ b/newsfragments/message-formatter-args-imply.feature
@@ -1,0 +1,1 @@
+The ``want_logs`` (previously ``wantLogs``) argument to message formatters will now imply ``wantSteps`` if selected.

--- a/newsfragments/message-formatter-context-log-urls.feature
+++ b/newsfragments/message-formatter-context-log-urls.feature
@@ -1,0 +1,1 @@
+Log URL information has been added to message formatter context.

--- a/newsfragments/message-formatter-context.doc
+++ b/newsfragments/message-formatter-context.doc
@@ -1,0 +1,1 @@
+Added documentation of properties available in the formatting context that is presented to message formatters.

--- a/newsfragments/message-formatter-logs-metadata.feature
+++ b/newsfragments/message-formatter-logs-metadata.feature
@@ -1,0 +1,1 @@
+Implemented a way to ask for logs metadata but not content in message formatters via ``want_logs`` and ``want_logs_content`` arguments.

--- a/newsfragments/message-formatter-want-logs.removal
+++ b/newsfragments/message-formatter-want-logs.removal
@@ -1,2 +1,4 @@
 The ``wantLogs`` argument of message formatters has been deprecated.
 Please replace any uses with both ``want_logs`` and ``want_logs_content`` set to the same value.
+
+The ``wantProperties`` and ``wantSteps`` arguments of message formatters have been renamed to ``want_properties`` and ``want_steps`` respectively.

--- a/newsfragments/message-formatter-want-logs.removal
+++ b/newsfragments/message-formatter-want-logs.removal
@@ -1,0 +1,2 @@
+The ``wantLogs`` argument of message formatters has been deprecated.
+Please replace any uses with both ``want_logs`` and ``want_logs_content`` set to the same value.


### PR DESCRIPTION
This PR adds a way to limit logs presented to reporters to just the metadata, add urls to logs to that metadata and adds documentation for whole context dictionary.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
