### PR TITLE
Allow setting io_timeout on GitPoller subprocesses

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -45,7 +45,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
     compare_attrs = ("repourl", "branches", "workdir", "pollInterval", "gitbin", "usetimestamps",
                      "category", "project", "pollAtLaunch", "buildPushesWithNoCommits",
                      "sshPrivateKey", "sshHostKey", "sshKnownHosts", "pollRandomDelayMin",
-                     "pollRandomDelayMax")
+                     "pollRandomDelayMax", "io_timeout")
 
     secrets = ("sshPrivateKey", "sshHostKey", "sshKnownHosts")
 
@@ -60,7 +60,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                     project=None, pollinterval=-2, fetch_refspec=None, encoding="utf-8",
                     name=None, pollAtLaunch=False, buildPushesWithNoCommits=False,
                     only_tags=False, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
-                    pollRandomDelayMin=0, pollRandomDelayMax=0):
+                    pollRandomDelayMin=0, pollRandomDelayMax=0, io_timeout=300):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -94,7 +94,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                         project=None, pollinterval=-2, fetch_refspec=None, encoding="utf-8",
                         name=None, pollAtLaunch=False, buildPushesWithNoCommits=False,
                         only_tags=False, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
-                        pollRandomDelayMin=0, pollRandomDelayMax=0):
+                        pollRandomDelayMin=0, pollRandomDelayMax=0, io_timeout=300):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -129,6 +129,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         self.sshPrivateKey = sshPrivateKey
         self.sshHostKey = sshHostKey
         self.sshKnownHosts = sshKnownHosts
+        self.io_timeout = io_timeout
         self.setupGit(logname='GitPoller')
 
         if self.workdir is None:
@@ -474,7 +475,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         full_args += [command] + args
 
         res = yield runprocess.run_process(self.master.reactor, [self.gitbin] + full_args, path,
-                                           env=full_env)
+                                           env=full_env, io_timeout=self.io_timeout)
         (code, stdout, stderr) = res
         stdout = bytes2unicode(stdout, self.encoding)
         stderr = bytes2unicode(stderr, self.encoding)

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -962,6 +962,11 @@ It accepts the following arguments:
    `sshPrivateKey` must be specified in order to use this option.
    `sshHostKey` must not be specified in order to use this option.
 
+``io_timeout`` (optional)
+   How long to wait before terminating the git subprocess for inactivity.
+   Default value is 300 seconds, set it to higher if you are having trouble
+   starting a Buildbot master with a huge git repository.
+
 A configuration for the Git poller might look like this:
 
 .. code-block:: python

--- a/newsfragments/gitpoller-io_timeout.feature
+++ b/newsfragments/gitpoller-io_timeout.feature
@@ -1,0 +1,1 @@
+Allow setting io_timeout on GitPoller subprocesses


### PR DESCRIPTION
This fixes Buildbot startup for huge repos.

We were having trouble starting a fresh Buildbot instance for our existing repository.  The repository is nearing 20GB and cloning it from scratch takes many minutes.  Since the default `io_timeout` on the `git fetch` subprocess call is 300 seconds, this resulted in Buildbot getting stuck in a loop like the following:

```
2021-09-21 09:37:58+0000 [-] <RunProcess '['git', 'fetch', '[repourl]', ...]'>: killing process because <RunProcess '['git', 'fetch', '[repourl]', ...]>: command timed out: 300 seconds without output
2021-09-21 09:37:58+0000 [-] <RunProcess '['git', 'fetch', '[repourl]', ...]'>: killing process using TERM
2021-09-21 09:38:03+0000 [-] <buildbot.changes.gitpoller.GitPoller object at 0x7ff56cced0a0>: while polling for changes
	Traceback (most recent call last):
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 701, in errback
	    self._startRunCallbacks(fail)
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 764, in _startRunCallbacks
	    self._runCallbacks()
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 858, in _runCallbacks
	    current.result = callback(  # type: ignore[misc]
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 1751, in gotResult
	    current_context.run(_inlineCallbacks, r, gen, status)
	--- <exception caught here> ---
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 1657, in _inlineCallbacks
	    result = current_context.run(
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
	    return g.throw(self.type, self.value, self.tb)
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/buildbot/changes/gitpoller.py", line 250, in poll
	    yield self._dovccmd('fetch', [self.repourl] + refspecs,
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 1657, in _inlineCallbacks
	    result = current_context.run(
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/python/failure.py", line 500, in throwExceptionIntoGenerator
	    return g.throw(self.type, self.value, self.tb)
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/buildbot/changes/gitpoller.py", line 453, in _dovccmd
	    stdout = yield self._dovccmdImpl(command, args, path, None)
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/twisted/internet/defer.py", line 1661, in _inlineCallbacks
	    result = current_context.run(gen.send, result)
	  File "/home/build/buildbot-configuration/.venv/lib/python3.9/site-packages/buildbot/changes/gitpoller.py", line 485, in _dovccmdImpl
	    raise EnvironmentError(('command {} in {} on repourl {} failed with exit code {}: {}'
	builtins.OSError: command ['fetch','[repourl]', ...] on repourl [repourl] failed with exit code -1: fatal: early EOF
```

Worse than that, Buildbot was attempting to run this command in a loop, and every time git was killed, it would leave behind a multiple-GB patchfile which would quickly fill even a 300gb disk.

Perhaps the default timeout should be more generous, but my solution allows for setting a custom `io_timeout` on GitPoller allows for enough flexibility.  (In my case, I set `io_timeout=1500` and the master finished setting up correctly.)

## Contributor Checklist:

* [ ] I have updated the unit tests

I found no test for GitPoller timeout, please guide me if I should update or implement a specific test.  Existing tests pass.

* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
