### PR TITLE
Adding ability to use `--filter` in `git clone`

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -73,9 +73,9 @@ class Git(Source, GitStepMixin):
 
     def __init__(self, repourl=None, branch='HEAD', mode='incremental', method=None,
                  reference=None, submodules=False, remoteSubmodules=False, shallow=False,
-                 progress=True, retryFetch=False, clobberOnFailure=False, getDescription=False,
-                 config=None, origin=None, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
-                 **kwargs):
+                 filters=None, progress=True, retryFetch=False, clobberOnFailure=False,
+                 getDescription=False, config=None, origin=None, sshPrivateKey=None,
+                 sshHostKey=None, sshKnownHosts=None, **kwargs):
 
         if not getDescription and not isinstance(getDescription, dict):
             getDescription = False
@@ -88,6 +88,7 @@ class Git(Source, GitStepMixin):
         self.submodules = submodules
         self.remoteSubmodules = remoteSubmodules
         self.shallow = shallow
+        self.filters = filters
         self.clobberOnFailure = clobberOnFailure
         self.mode = mode
         self.prog = progress
@@ -380,6 +381,12 @@ class Git(Source, GitStepMixin):
             command += ['--reference', self.reference]
         if self.origin:
             command += ['--origin', self.origin]
+        if self.filters:
+            if self.supportsFilters:
+                for filter in self.filters:
+                    command += ['--filter', filter]
+            else:
+                log.msg("Git versions < 2.27.0 don't support filters on clone")
         command += [self.repourl, '.']
 
         if self.prog:

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -53,6 +53,66 @@ class TestGit(sourcesteps.SourceStepMixin,
     def tearDown(self):
         return self.tearDownSourceStep()
 
+    def test_mode_full_filters_2_26(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', filters=['tree:0']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.26.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', [])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clone',
+                                 'http://github.com/buildbot/buildbot.git', '.', '--progress'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_mode_full_filters_2_27(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', filters=['tree:0']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.27.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', [])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clone', '--filter', 'tree:0',
+                                 'http://github.com/buildbot/buildbot.git', '.', '--progress'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
     def test_mode_full_clean(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -74,27 +74,30 @@ class GitMixin:
         self.supportsSubmoduleCheckout = False
         self.supportsSshPrivateKeyAsEnvOption = False
         self.supportsSshPrivateKeyAsConfigOption = False
+        self.supportsFilters = False
 
     def parseGitFeatures(self, version_stdout):
         match = re.match(r"^git version (\d+(\.\d+)*)", version_stdout)
         if not match:
             return
 
-        version = match.group(1)
+        version = parse_version(match.group(1))
 
         self.gitInstalled = True
-        if parse_version(version) >= parse_version("1.6.5"):
+        if version >= parse_version("1.6.5"):
             self.supportsBranch = True
-        if parse_version(version) >= parse_version("1.7.2"):
+        if version >= parse_version("1.7.2"):
             self.supportsProgress = True
-        if parse_version(version) >= parse_version("1.7.6"):
+        if version >= parse_version("1.7.6"):
             self.supportsSubmoduleForce = True
-        if parse_version(version) >= parse_version("1.7.8"):
+        if version >= parse_version("1.7.8"):
             self.supportsSubmoduleCheckout = True
-        if parse_version(version) >= parse_version("2.3.0"):
+        if version >= parse_version("2.3.0"):
             self.supportsSshPrivateKeyAsEnvOption = True
-        if parse_version(version) >= parse_version("2.10.0"):
+        if version >= parse_version("2.10.0"):
             self.supportsSshPrivateKeyAsConfigOption = True
+        if version >= parse_version("2.27.0"):
+            self.supportsFilters = True
 
     def adjustCommandParamsForSshPrivateKey(self, command, env,
                                             keyPath, sshWrapperPath=None,

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -47,6 +47,11 @@ The Git step takes the following arguments:
    By default, any clone will use the name "origin" as the remote repository (eg, "origin/master").
    This renderable option allows that to be configured to an alternate name.
 
+``filters`` (optional, type: ``list``)
+   For each string in the passed in list, adds a ``--filter <filter>`` argument to :command:`git clone`.
+   This allows for adding filters like ``--filter "tree:0"`` to speed up the clone step.
+   This requires git version 2.27 or higher.
+
 ``progress`` (optional)
    Passes the (``--progress``) flag to (:command:`git fetch`).
    This solves issues of long fetches being killed due to lack of output, but requires Git 1.7.2 or later.

--- a/newsfragments/add_git_filters.feature
+++ b/newsfragments/add_git_filters.feature
@@ -1,0 +1,1 @@
+adding ability to pass --filter to git clone


### PR DESCRIPTION
Adding a new parameter to the Git step for adding filters to the git clone step. The main advantage of this is adding the ability to do either `--filter=tree:0` or `--filter=blob:none` which both reduce the amount of data downloaded during a copy.

The version 2.27 was used as that is the earliest mention I found of `--filter` existing when looking in the docs https://git-scm.com/docs/git-clone/2.27.0

For more information about how the tree or blob filter work, you can look at https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
