### PR TITLE
worker: Explain using seek() for reseting EOF flag on MAC OS X

### DIFF
--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -162,7 +162,14 @@ class LogFileWatcher(object):
             if self.follow:
                 self.f.seek(s[2], 0)
             self.started = True
+
+        # Mac OS X and Linux differ in behaviour when reading from a file that has previously
+        # reached EOF. On Linux, any new data that has been appended to the file will be returned.
+        # On Mac OS X, the empty string will always be returned. Seeking to the current position
+        # in the file resets the EOF flag on Mac OS X and will allow future reads to work as
+        # intended.
         self.f.seek(self.f.tell(), 0)
+
         while True:
             data = self.f.read(10000)
             if not data:


### PR DESCRIPTION
This PR adds a comment explaining how Mac OS X and Linux environments act differently when EOF is reached and why seek() for resetting EOF flag on MAC OS X is used.
Comment was copied from the message of commit 00adaf9c2fe59bcf2321cd47972939a95c90b9e2

## Contributor Checklist:

* [x] I have updated the unit tests