### PR TITLE
pb: Extract class UpdateRegistrationListener

### DIFF
--- a/master/buildbot/test/unit/worker/test_protocols_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_base.py
@@ -15,25 +15,12 @@
 
 import mock
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakeprotocol
 from buildbot.test.util import protocols
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker.protocols import base
-
-
-class TestListener(TestReactorMixin, unittest.TestCase):
-
-    @defer.inlineCallbacks
-    def test_constructor(self):
-        self.setUpTestReactor()
-        master = fakemaster.make_master(self)
-        listener = base.Listener()
-        yield listener.setServiceParent(master)
-        self.assertEqual(listener.master, master)
 
 
 class TestFakeConnection(protocols.ConnectionInterfaceTest,

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -66,8 +66,7 @@ class WorkerManager(MeasuredBuildbotServiceManager):
     def __init__(self, master):
         super().__init__()
 
-        self.pb = bbpb.Listener()
-        self.pb.setServiceParent(master)
+        self.pb = bbpb.Listener(master)
 
         # WorkerRegistration instances keyed by worker name
         self.registrations = {}

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -15,13 +15,61 @@
 
 from twisted.internet import defer
 
-from buildbot.util import service
+from buildbot.util import ComparableMixin
 from buildbot.util import subscription
 from buildbot.util.eventual import eventually
 
 
-class Listener(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+class Listener:
     pass
+
+
+class UpdateRegistrationListener(Listener):
+    def __init__(self):
+        super().__init__()
+        # username : (password, portstr, PBManager registration)
+        self._registrations = {}
+
+    @defer.inlineCallbacks
+    def updateRegistration(self, username, password, portStr):
+        # NOTE: this method is only present on the PB protocol; others do not
+        # use registrations
+        if username in self._registrations:
+            currentPassword, currentPortStr, currentReg = \
+                self._registrations[username]
+        else:
+            currentPassword, currentPortStr, currentReg = None, None, None
+
+        iseq = (ComparableMixin.isEquivalent(currentPassword, password) and
+                ComparableMixin.isEquivalent(currentPortStr, portStr))
+        if iseq:
+            return currentReg
+        if currentReg:
+            yield currentReg.unregister()
+            del self._registrations[username]
+
+        if portStr and password:
+            reg = yield self.get_manager().register(portStr, username, password,
+                                                    self._create_connection)
+            self._registrations[username] = (password, portStr, reg)
+            return reg
+        return currentReg
+
+    @defer.inlineCallbacks
+    def _create_connection(self, mind, workerName):
+        self.before_connection_setup(mind, workerName)
+        worker = self.master.workers.getWorkerByName(workerName)
+        conn = self.ConnectionClass(self.master, worker, mind)
+
+        # inform the manager, logging any problems in the deferred
+        accepted = yield self.master.workers.newConnection(conn, workerName)
+
+        # return the Connection as the perspective
+        if accepted:
+            return conn
+        else:
+            # TODO: return something more useful
+            raise RuntimeError("rejecting duplicate worker")
 
 
 class Connection:


### PR DESCRIPTION
This PR extracts code from perspective broker protocol to base class. Later when implementing additional protocols for sending messages (such as `msgpack`), class `UpdateRegistrationListener` will be used by both protocols.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
