### PR TITLE
docs: Decrease spaces between lines

### DIFF
--- a/master/docs/_static/buildbot_rtd.css
+++ b/master/docs/_static/buildbot_rtd.css
@@ -24,3 +24,20 @@ html.writer-html5 .rst-content dl.field-list dd {
     padding-right: 1.618em;
     padding-left: 1.618em;
 }
+
+/* The vertical margin seems excessive on descriptions of parameters when there are many
+   parameter sets. The structure of the page becomes visually unclear.
+*/
+.rst-content dl dd,
+.rst-content dl dt,
+.rst-content dl ol,
+.rst-content dl p,
+.rst-content dl table,
+.rst-content dl ul {
+    margin-bottom: 4px;
+}
+
+/* The default is one line per paragraph spacing which seems excessive. */
+p {
+    margin-bottom: 8px;
+}


### PR DESCRIPTION
This PR decreases spaces between the lines so now it is easier to read since paragraphs are more distinct. That is especially true in the list of Worker-Side Methods, see screenshots. 

<img width="599" alt="old_style" src="https://user-images.githubusercontent.com/37383410/134938960-a9e58adb-72f1-46ea-bc58-8258cee7c562.png">
<img width="601" alt="new_style" src="https://user-images.githubusercontent.com/37383410/134938978-a6c28541-7b3a-4bd0-94e0-b66cd444b28b.png">

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
