### PR TITLE
Fix GitPoller fetch commands timing out on huge repositories

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -247,7 +247,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         ]
 
         try:
-            yield self._dovccmd('fetch', [self.repourl] + refspecs,
+            yield self._dovccmd('fetch', ['--progress', self.repourl] + refspecs,
                                 path=self.workdir)
         except GitError as e:
             log.msg(e.args[0])

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -228,7 +228,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -287,7 +287,7 @@ class TestGitPoller(TestGitPollerBase):
             .stdout(b'git version 1.7.5\n'),
             ExpectMaster(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL]),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
@@ -307,7 +307,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
@@ -331,7 +331,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -404,7 +404,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
@@ -446,7 +446,7 @@ class TestGitPoller(TestGitPollerBase):
                     b'refs/heads/release\n'
                     b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
@@ -482,7 +482,7 @@ class TestGitPoller(TestGitPollerBase):
                     b'refs/heads/release\n'
                     b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
@@ -613,7 +613,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
 
@@ -654,7 +654,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
 
@@ -734,7 +734,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
 
@@ -816,7 +816,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/release\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
 
@@ -896,7 +896,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -981,7 +981,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
@@ -1020,7 +1020,7 @@ class TestGitPoller(TestGitPollerBase):
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
             ])),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
                           '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
             .workdir(self.POLLER_WORKDIR),
@@ -1124,7 +1124,7 @@ class TestGitPoller(TestGitPollerBase):
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
             ])),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -1217,7 +1217,7 @@ class TestGitPoller(TestGitPollerBase):
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
                 b'refs/pull/410/head',
             ])),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED +
                           '/refs/pull/410/head'])
             .workdir(self.POLLER_WORKDIR),
@@ -1301,7 +1301,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
@@ -1402,7 +1402,7 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -1540,7 +1540,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                           'ls-remote', '--refs', self.REPOURL]),
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
-                          'fetch', self.REPOURL,
+                          'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -1583,7 +1583,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
             ExpectMaster(['git', 'ls-remote', '--refs', self.REPOURL])
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
-            ExpectMaster(['git', 'fetch', self.REPOURL,
+            ExpectMaster(['git', 'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR)
             .env({'GIT_SSH_COMMAND': 'ssh -o "BatchMode=yes" -i "{0}"'.format(key_path)}),
@@ -1631,7 +1631,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                           'ls-remote', '--refs', self.REPOURL]),
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}"'.format(key_path),
-                          'fetch', self.REPOURL,
+                          'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
@@ -1677,7 +1677,7 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
                           '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
-                          'fetch', self.REPOURL,
+                          'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',
@@ -1742,7 +1742,7 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
             ExpectMaster(['git',
                           '-c', 'core.sshCommand=ssh -o "BatchMode=yes" -i "{0}" '
                           '-o "UserKnownHostsFile={1}"'.format(key_path, known_hosts_path),
-                          'fetch', self.REPOURL,
+                          'fetch', '--progress', self.REPOURL,
                           '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
             .workdir(self.POLLER_WORKDIR),
             ExpectMaster(['git', 'rev-parse',

--- a/newsfragments/fix-huge-git-fetches.bugfix
+++ b/newsfragments/fix-huge-git-fetches.bugfix
@@ -1,0 +1,1 @@
+Fix GitPoller fetch commands timing out on huge repositories


### PR DESCRIPTION
This pull request supersedes #6238 and fixes the same problem in a simpler and more general way, please check that issue for details.

Long story, short, git fetch would timeout on huge repositories, making Buildbot not start properly.  By adding the `--progress` to the command, git will continuously output into `stderr` even if no tty is present.  Therefore, Buildbot will not kill the command due to an IO timeout, allowing the fetch to complete.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

No update needed for this bugfix.
