### PR TITLE
util: Improve handling of invalid usage of SubscriptionPoint

### DIFF
--- a/master/buildbot/util/subscription.py
+++ b/master/buildbot/util/subscription.py
@@ -60,7 +60,7 @@ class SubscriptionPoint:
 
     def pop_exceptions(self):
         exceptions = self._got_exceptions
-        self._got_exceptions = None
+        self._got_exceptions = None  # we no longer expect any exceptions
         return exceptions
 
     def _unsubscribe(self, subscription):
@@ -68,6 +68,10 @@ class SubscriptionPoint:
 
     def _notify_delivery_exception(self, e, sub):
         log.err(e, 'while invoking callback {} to {}'.format(sub.callback, self))
+        if self._got_exceptions is None:
+            log.err(e, 'exceptions have already been collected. '
+                    'This is serious error, please submit a bug report')
+            return
         self._got_exceptions.append(e)
 
     def _notify_delivery_finished(self, _, d):


### PR DESCRIPTION
Currently if waitForDeliveriesToFinish() is not called we will produce a completely unreadable error. We can detect the case and produce a more useful error that hints to what's happening.

## Contributor Checklist:

* [x] I have updated the unit tests
