### PR TITLE
Allow the user of Renderables in JSONStringDownload

### DIFF
--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -555,8 +555,13 @@ class JSONStringDownload(StringDownload):
 
         if 's' in buildstep_kwargs:
             del buildstep_kwargs['s']
-        s = json.dumps(o)
-        super().__init__(s=s, workerdest=workerdest, **buildstep_kwargs)
+        super().__init__(s=o, workerdest=workerdest, **buildstep_kwargs)
+
+    @defer.inlineCallbacks
+    def run(self):
+        self.s = json.dumps(self.s)
+        res = yield super().run()
+        return res
 
 
 class JSONPropertiesDownload(StringDownload):

--- a/newsfragments/allow-renderables-in-jsonstringdownload.feature
+++ b/newsfragments/allow-renderables-in-jsonstringdownload.feature
@@ -1,0 +1,1 @@
+Allow the use of Renderables when constructing payload For `JSONStringDownload`


### PR DESCRIPTION
## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

 This is required to allow the use of json secrets or renderable subkeys in the json payload