### PR TITLE
Fix for SecretInPass provider with gpgPassphrase

### DIFF
--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -48,7 +48,7 @@ class SecretInPass(SecretProviderBase):
     def reconfigService(self, gpgPassphrase=None, dirname=None):
         self._env = {**os.environ}
         if gpgPassphrase:
-            self._env["PASSWORD_STORE_GPG_OPTS"] = "--passphrase {}".format(gpgPassphrase)
+            self._env["PASSWORD_STORE_GPG_OPTS"] = "--batch --yes --pinentry-mode loopback --passphrase {}".format(gpgPassphrase)
         if dirname:
             self._env["PASSWORD_STORE_DIR"] = dirname
 


### PR DESCRIPTION
We need this addional parameter to make it working, fixes #4953

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
