### PR TITLE
debounce new buildrequests events

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -200,9 +200,12 @@ class BuildRequest(base.ResourceType):
 
     @defer.inlineCallbacks
     def generateEvent(self, brids, event):
+        events = []
         for brid in brids:
             # get the build and munge the result for the notification
             br = yield self.master.data.get(('buildrequests', str(brid)))
+            events.append(br)
+        for br in events:
             self.produceEvent(br, event)
 
     @defer.inlineCallbacks

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -252,12 +252,8 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
     def getBuilders(self):
         return list(self.builders.values())
 
-    @defer.inlineCallbacks
     def getBuilderById(self, builderid):
-        for builder in self.getBuilders():
-            if builderid == (yield builder.getBuilderId()):
-                return builder
-        return None
+        return self._builders_byid.get(builderid)
 
     @defer.inlineCallbacks
     def startService(self):
@@ -380,6 +376,9 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
                 yield builder.setServiceParent(self)
 
         self.builderNames = list(self.builders)
+        self._builders_byid = {}
+        for builder in self.builders.values():
+            self._builders_byid[(yield builder.getBuilderId())] = builder
 
         yield self.master.data.updates.updateBuilderList(
             self.master.masterid, [util.bytes2unicode(n) for n in self.builderNames]

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -29,6 +29,7 @@ from buildbot.process.buildrequestdistributor import BuildRequestDistributor
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import RETRY
 from buildbot.process.workerforbuilder import States
+from buildbot.util import debounce
 from buildbot.util import service
 from buildbot.util.render_description import render_description
 from buildbot.worker.latent import AbstractLatentWorker
@@ -113,6 +114,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
         # a distributor for incoming build requests; see below
         self.brd = BuildRequestDistributor(self)
         self.brd.setServiceParent(self)
+        self._pending_builderids = set()
 
         # Dictionary of build request ID to False or cancellation reason string in case cancellation
         # has been requested.
@@ -252,25 +254,38 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
     def getBuilders(self):
         return list(self.builders.values())
 
+    def _buildrequest_added(self, key, msg):
+        self._pending_builderids.add(msg['builderid'])
+        self._flush_pending_builders()
+
+    # flush pending builders needs to be debounced, as per design the
+    # buildrequests events will arrive in burst.
+    # We debounce them to let the brd manage them as a whole
+    # without having to debounce the brd itself
+    @debounce.method(wait=0.1, until_idle=True)
+    def _flush_pending_builders(self):
+        if not self._pending_builderids:
+            return
+        buildernames = []
+        for builderid in self._pending_builderids:
+            builder = self.getBuilderById(builderid)
+            if builder:
+                buildernames.append(builder.name)
+        self._pending_builderids.clear()
+        self.brd.maybeStartBuildsOn(buildernames)
+
     def getBuilderById(self, builderid):
         return self._builders_byid.get(builderid)
 
     @defer.inlineCallbacks
     def startService(self):
-        @defer.inlineCallbacks
-        def buildRequestAdded(key, msg):
-            builderid = msg['builderid']
-            builder = yield self.getBuilderById(builderid)
-            if builder is not None:
-                self.maybeStartBuildsForBuilder(builder.name)
-
-        # consume both 'new' and 'unclaimed' build requests
+        # consume both 'new' and 'unclaimed' build requests events
         startConsuming = self.master.mq.startConsuming
         self.buildrequest_consumer_new = yield startConsuming(
-            buildRequestAdded, ('buildrequests', None, "new")
+            self._buildrequest_added, ('buildrequests', None, "new")
         )
         self.buildrequest_consumer_unclaimed = yield startConsuming(
-            buildRequestAdded, ('buildrequests', None, 'unclaimed')
+            self._buildrequest_added, ('buildrequests', None, 'unclaimed')
         )
         self.buildrequest_consumer_cancel = yield startConsuming(
             self._buildrequest_canceled, ('control', 'buildrequests', None, 'cancel')
@@ -398,6 +413,8 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
         if self.buildrequest_consumer_cancel:
             self.buildrequest_consumer_cancel.stopConsuming()
             self.buildrequest_consumer_cancel = None
+        self._pending_builderids.clear()
+        self._flush_pending_builders.stop()
         return super().stopService()
 
     # Used to track buildrequests that are in progress of being started on this master.

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -298,7 +298,7 @@ class BuildStep(
         self._start_unhandled_deferreds = None
         self._interrupt_deferwaiter = deferwaiter.DeferWaiter()
         self._update_summary_debouncer = debounce.Debouncer(
-            1.0, self._update_summary_impl, lambda: self.master.reactor
+            1.0, self._update_summary_impl, lambda: self.master.reactor, until_idle=False
         )
         self._test_result_submitters = {}
 

--- a/master/buildbot/test/integration/worker/test_misc.py
+++ b/master/buildbot/test/integration/worker/test_misc.py
@@ -108,6 +108,7 @@ class Tests(RunFakeMasterTestCase):
                 {'codebase': '', 'repository': '', 'branch': None, 'revision': None, 'project': ''},
             ],
         )
+        self.master.reactor.advance(1)
 
         # The worker fails to substantiate.
         controller.start_instance(True)
@@ -160,6 +161,7 @@ class Tests(RunFakeMasterTestCase):
                 {'codebase': '', 'repository': '', 'branch': None, 'revision': None, 'project': ''},
             ],
         )
+        self.master.reactor.advance(1)
 
         self.assertEqual(len(started_builds), 1)
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -245,6 +245,8 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin, DebugIntegratio
             ],
             properties=properties,
         )
+        # run debounced calls
+        self.master.reactor.advance(1)
         return ret
 
     @defer.inlineCallbacks

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -464,22 +464,25 @@ It's often necessary to perform some action in response to a particular type of 
 For example, steps need to update their status after updates arrive from the worker.
 However, when many events arrive in quick succession, it's more efficient to only perform the action once, after the last event has occurred.
 
-The ``debounce.method(wait)`` decorator is the tool for the job.
+The ``debounce.method(wait, until_idle=False)`` decorator is the tool for the job.
 
-.. py:function:: method(wait, get_reactor)
+.. py:function:: method(wait, until_idle=False, get_reactor)
 
     :param wait: time to wait before invoking, in seconds
+    :param until_idle: resets the timer on every call
     :param get_reactor: A callable that takes the underlying instance and returns the reactor to use. Defaults to ``instance.master.reactor``.
 
     Returns a decorator that debounces the underlying method.
     The underlying method must take no arguments (except ``self``).
 
-    For each call to the decorated method, the underlying method will be invoked at least once within *wait* seconds (plus the time the method takes to execute).
-    Calls are "debounced" during that time, meaning that multiple calls to the decorated method will result in a single invocation.
+    Calls are "debounced", meaning that multiple calls to the decorated method will result in a single invocation.
 
-    .. note::
+    When `until_idle` is `True`, the underlying method will be called after *wait* seconds have elapsed since the last time the decorated method have been called.
+    In case of constant stream, it will never be called.
 
-        This functionality is similar to Underscore's ``debounce``, except that the Underscore method resets its timer on every call.
+    When `until_idle` is `False`, the underlying method will be called after *wait* seconds have elapsed since the first time the decorated method have been called.
+    In case of constant stream, it will called about once every *wait* seconds (plus the time the method takes to execute)
+
 
     The decorated method is an instance of :py:class:`Debouncer`, allowing it to be started and stopped.
     This is useful when the method is a part of a Buildbot service: call ``method.start()`` from ``startService`` and ``method.stop()`` from ``stopService``, handling its Deferred appropriately.

--- a/newsfragments/buildrequest-prioritize.bugfix
+++ b/newsfragments/buildrequest-prioritize.bugfix
@@ -1,0 +1,1 @@
+Improved new build prioritization when many builds arrive at similar time.

--- a/newsfragments/debounce-until-idle.feature
+++ b/newsfragments/debounce-until-idle.feature
@@ -1,0 +1,1 @@
+Enhanced ``debounce.method`` to support calling target function only when the burst is finished.


### PR DESCRIPTION

Fix #6285

new buildrequests arrive one by one in a burst. Problem is that the brd is triggered right at the first event, so all the fancy prioritization API we have are useless in this case.

This PR
- improve the debouncer so that we can only call target function when the burst is finished
- makes sure we send the events as fast as possible (in the buildset case)
- optimize a bit the getBuilderById by precomputing the dictionary at reconfig

The drawback of this technic is that the tests need to manage the time and to make sure to advance the time when they send a buildrequest
