### PR TITLE
Prepare test API for making it externally usable

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1437,6 +1437,7 @@ teardown
 teardownbasedir
 tempfile
 terminateprocess
+testbuildstepmixin
 testcase
 testcases
 testchanges

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -24,7 +24,7 @@ from buildbot.test.fake import fakemaster
 
 
 def fakeMasterForHooks(testcase):
-    # testcase must derive from TestReactorMixin and setUpTestReactor()
+    # testcase must derive from TestReactorMixin and setup_test_reactor()
     # must be called before calling this function.
 
     master = fakemaster.make_master(testcase, wantData=True)

--- a/master/buildbot/test/integration/test_graphql.py
+++ b/master/buildbot/test/integration/test_graphql.py
@@ -65,7 +65,7 @@ class GraphQL(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor(use_asyncio=True)
+        self.setup_test_reactor(use_asyncio=True)
 
         master = fakemaster.make_master(self)
         master.db = fakedb.FakeDBConnector(self)

--- a/master/buildbot/test/integration/test_graphql.py
+++ b/master/buildbot/test/integration/test_graphql.py
@@ -27,7 +27,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import toJson
 
 try:

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -111,7 +111,7 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
     # save subclasses the trouble of calling our setUp and tearDown methods
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpUpgradeTest()
 
     def tearDown(self):

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -34,9 +34,9 @@ from buildbot.db import connector
 from buildbot.db.model import UpgradeFromBefore0p9Error
 from buildbot.db.model import UpgradeFromBefore3p0Error
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import db
 from buildbot.test.util import querylog
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -163,7 +163,7 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
                                              wantDb=True)
 

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -32,7 +32,7 @@ from buildbot.process import botmaster
 from buildbot.process import builder
 from buildbot.process import factory
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util.eventual import eventually
 from buildbot.worker import manager as workermanager
 from buildbot.worker.protocols.manager.pb import PBManager

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -112,7 +112,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
                                              wantDb=True)
         # set the worker port to a loopback address with unspecified

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -30,7 +30,7 @@ from buildbot.process import botmaster
 from buildbot.process import builder
 from buildbot.process import factory
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.worker import manager as workermanager
 from buildbot.worker.protocols.manager.pb import PBManager
 

--- a/master/buildbot/test/reactor.py
+++ b/master/buildbot/test/reactor.py
@@ -30,7 +30,7 @@ class TestReactorMixin:
     Mix this in to get TestReactor as self.reactor which is correctly cleaned up
     at the end
     """
-    def setUpTestReactor(self, use_asyncio=False):
+    def setup_test_reactor(self, use_asyncio=False):
 
         self.patch(threadpool, 'ThreadPool', NonThreadPool)
         self.reactor = TestReactor()

--- a/master/buildbot/test/reactor.py
+++ b/master/buildbot/test/reactor.py
@@ -1,0 +1,59 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import asyncio
+
+from twisted.internet import threads
+from twisted.python import threadpool
+
+from buildbot.asyncio import AsyncIOLoopWithTwisted
+from buildbot.test.fake.reactor import NonThreadPool
+from buildbot.test.fake.reactor import TestReactor
+from buildbot.util.eventual import _setReactor
+
+
+class TestReactorMixin:
+
+    """
+    Mix this in to get TestReactor as self.reactor which is correctly cleaned up
+    at the end
+    """
+    def setUpTestReactor(self, use_asyncio=False):
+
+        self.patch(threadpool, 'ThreadPool', NonThreadPool)
+        self.reactor = TestReactor()
+        _setReactor(self.reactor)
+
+        def deferToThread(f, *args, **kwargs):
+            return threads.deferToThreadPool(self.reactor, self.reactor.getThreadPool(),
+                                             f, *args, **kwargs)
+        self.patch(threads, 'deferToThread', deferToThread)
+
+        # During shutdown sequence we must first stop the reactor and only then
+        # set unset the reactor used for eventually() because any callbacks
+        # that are run during reactor.stop() may use eventually() themselves.
+        self.addCleanup(_setReactor, None)
+        self.addCleanup(self.reactor.stop)
+
+        if use_asyncio:
+            self.asyncio_loop = AsyncIOLoopWithTwisted(self.reactor)
+            asyncio.set_event_loop(self.asyncio_loop)
+            self.asyncio_loop.start()
+
+            def stop():
+                self.asyncio_loop.stop()
+                self.asyncio_loop.close()
+                asyncio.set_event_loop(None)
+            self.addCleanup(stop)

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -105,15 +105,15 @@ class TestBuildStepMixin:
     @ivar properties: build properties (L{Properties} instance)
     """
 
-    def setup_build_step(self, wantData=True, wantDb=False, wantMq=False):
+    def setup_build_step(self, want_data=True, want_db=False, want_mq=False):
         """
-        @param wantData(bool): Set to True to add data API connector to master.
+        @param want_data(bool): Set to True to add data API connector to master.
             Default value: True.
 
-        @param wantDb(bool): Set to True to add database connector to master.
+        @param want_db(bool): Set to True to add database connector to master.
             Default value: False.
 
-        @param wantMq(bool): Set to True to add mq connector to master.
+        @param want_mq(bool): Set to True to add mq connector to master.
             Default value: False.
         """
 
@@ -144,13 +144,14 @@ class TestBuildStepMixin:
         self.expected_remote_commands = []
         self._expected_remote_commands_popped = 0
 
-        self.master = fakemaster.make_master(self, wantData=wantData, wantDb=wantDb, wantMq=wantMq)
+        self.master = fakemaster.make_master(self, wantData=want_data, wantDb=want_db,
+                                             wantMq=want_mq)
 
     def tear_down_build_step(self):
         pass
 
     def setup_step(self, step, worker_version=None, worker_env=None,
-                  buildFiles=None, wantDefaultWorkdir=True):
+                   build_files=None, want_default_work_dir=True):
         """
         Set up C{step} for testing.  This begins by using C{step} as a factory
         to create a I{new} step instance, thereby testing that the factory
@@ -174,19 +175,19 @@ class TestBuildStepMixin:
         if worker_env is None:
             worker_env = dict()
 
-        if buildFiles is None:
-            buildFiles = list()
+        if build_files is None:
+            build_files = list()
 
         step = self.step = buildstep.create_step_from_step_or_factory(step)
 
         # set defaults
-        if wantDefaultWorkdir:
+        if want_default_work_dir:
             step.workdir = step._workdir or 'wkdir'
 
         # step.build
 
         b = self.build = fakebuild.FakeBuild(master=self.master)
-        b.allFiles = lambda: buildFiles
+        b.allFiles = lambda: build_files
         b.master = self.master
 
         def getWorkerVersion(cmd, oldversion):

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -314,7 +314,7 @@ class TestBuildStepMixin:
         """
         self.exp_missing_properties.append(property)
 
-    def expect_logfile(self, logfile, contents):
+    def expect_log_file(self, logfile, contents):
         """
         Expect a logfile with the given contents
         """

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -105,7 +105,7 @@ class TestBuildStepMixin:
     @ivar properties: build properties (L{Properties} instance)
     """
 
-    def setup_build_step(self, want_data=True, want_db=False, want_mq=False):
+    def setup_test_build_step(self, want_data=True, want_db=False, want_mq=False):
         """
         @param want_data(bool): Set to True to add data API connector to master.
             Default value: True.
@@ -147,7 +147,7 @@ class TestBuildStepMixin:
         self.master = fakemaster.make_master(self, wantData=want_data, wantDb=want_db,
                                              wantMq=want_mq)
 
-    def tear_down_build_step(self):
+    def tear_down_test_build_step(self):
         pass
 
     def setup_step(self, step, worker_version=None, worker_env=None,

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -326,7 +326,7 @@ class TestBuildStepMixin:
     def expect_build_data(self, name, value, source):
         self._exp_build_data[name] = (value, source)
 
-    def expect_hidden(self, hidden):
+    def expect_hidden(self, hidden=True):
         """
         Set whether the step is expected to be hidden.
         """

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -86,7 +86,7 @@ def _describe_cmd_difference(exp_command, exp_args, got_command, got_args):
     return text
 
 
-class BuildStepMixin:
+class TestBuildStepMixin:
 
     """
     Support for testing build steps.  This class adds two capabilities:

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -36,7 +36,7 @@ class TestChangeSource(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
 
     def tearDown(self):
@@ -88,7 +88,7 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
 
         with assertProducesWarnings(DeprecatedApiWarning,
@@ -197,7 +197,7 @@ class TestReconfigurablePollingChangeSource(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         yield self.setUpChangeSource()
 

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -20,8 +20,8 @@ from twisted.trial import unittest
 
 from buildbot.changes import base
 from buildbot.config import ConfigErrors
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -260,7 +260,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
                                      unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         # create pull requests
         self.date = "2013-10-15T20:38:20.001797+00:00"

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -22,8 +22,8 @@ from twisted.web import client
 from twisted.web.error import Error
 
 from buildbot.changes.bitbucket import BitbucketPullrequestPoller
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class SourceRest():

--- a/master/buildbot/test/unit/changes/test_changes.py
+++ b/master/buildbot/test/unit/changes/test_changes.py
@@ -45,7 +45,7 @@ class Change(unittest.TestCase, TestReactorMixin):
     ]
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True)
         self.change23 = changes.Change(**dict(  # using **dict(..) forces kwargs
             category='devel',

--- a/master/buildbot/test/unit/changes/test_changes.py
+++ b/master/buildbot/test/unit/changes/test_changes.py
@@ -23,7 +23,7 @@ from twisted.trial import unittest
 from buildbot.changes import changes
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class Change(unittest.TestCase, TestReactorMixin):

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -28,8 +28,8 @@ from buildbot.changes import gerritchangesource
 from buildbot.test import fakedb
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.change import Change
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -93,7 +93,7 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
                              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         return self.setUpChangeSource()
 
@@ -590,7 +590,7 @@ class TestGerritEventLogPoller(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -180,7 +180,7 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
                                   unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
 
         fake_storage_service = FakeSecretStorage()

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -25,8 +25,8 @@ from buildbot.process.properties import Secret
 from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.secrets import FakeSecretStorage
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.misc import TestReactorMixin
 
 gitJsonPayloadSinglePullrequest = """
 {

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -23,10 +23,10 @@ from twisted.trial import unittest
 
 from buildbot.changes import gitpoller
 from buildbot.test.fake.private_tempdir import MockPrivateTemporaryDirectory
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import config
 from buildbot.test.util import logging
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 from buildbot.util import bytes2unicode

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -53,7 +53,7 @@ class TestGitPollerBase(MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
         yield self.master.startService()
@@ -1787,7 +1787,7 @@ class TestGitPollerConstructor(unittest.TestCase, TestReactorMixin, changesource
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -19,8 +19,8 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.changes import hgpoller
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -39,7 +39,7 @@ class TestHgPollerBase(MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
 

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -30,7 +30,7 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.maildir = os.path.abspath("maildir")
 
         yield self.setUpChangeSource()

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -19,9 +19,9 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.changes import mail
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import dirs
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -22,7 +22,7 @@ from twisted.trial import unittest
 from buildbot.changes import base
 from buildbot.changes import manager
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -31,7 +31,7 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
         self.cm = manager.ChangeManager()
         self.master.startService()

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -116,7 +116,7 @@ class TestP4Poller(changesource.ChangeSourceMixin, MasterRunProcessMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
 

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -26,9 +26,9 @@ from twisted.trial import unittest
 from buildbot.changes.p4poller import P4PollerError
 from buildbot.changes.p4poller import P4Source
 from buildbot.changes.p4poller import get_simple_split
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import config
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 from buildbot.util import datetime2epoch

--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -40,7 +40,7 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpPBChangeSource()
         yield self.setUpChangeSource()
 
@@ -216,7 +216,7 @@ class TestPBChangeSource(changesource.ChangeSourceMixin,
 class TestChangePerspective(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -21,9 +21,9 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.changes import pb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import pbmanager
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestPBChangeSource(changesource.ChangeSourceMixin,

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -22,8 +22,8 @@ from twisted.trial import unittest
 
 from buildbot.changes import svnpoller
 from buildbot.process.properties import Interpolate
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -257,7 +257,7 @@ class TestSVNPoller(MasterRunProcessMixin,
                     unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         return self.setUpChangeSource()
 

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -19,8 +19,8 @@ from twisted.trial import unittest
 
 from buildbot.data import base
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class ResourceType(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -26,7 +26,7 @@ from buildbot.test.util import endpoint
 class ResourceType(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     def makeResourceTypeSubclass(self, **attributes):
         attributes.setdefault('name', 'thing')

--- a/master/buildbot/test/unit/data/test_build_data.py
+++ b/master/buildbot/test/unit/data/test_build_data.py
@@ -21,9 +21,9 @@ from twisted.trial import unittest
 from buildbot.data import build_data
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestBuildDataNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_build_data.py
+++ b/master/buildbot/test/unit/data/test_build_data.py
@@ -295,7 +295,7 @@ class TestBuildDatasNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestBuildData(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = build_data.BuildData(self.master)
 

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -22,9 +22,9 @@ from buildbot.data import builders
 from buildbot.data import resultspec
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class BuilderEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -168,7 +168,7 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = builders.Builder(self.master)

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -257,7 +257,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         pass
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = buildrequests.BuildRequest(self.master)

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -25,9 +25,9 @@ from buildbot.data import buildrequests
 from buildbot.data import resultspec
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import UTC
 from buildbot.util import epoch2datetime
 

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -269,7 +269,7 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
                        'properties': {}}
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = builds.Build(self.master)

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -23,9 +23,9 @@ from buildbot.data import builds
 from buildbot.data import resultspec
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -128,7 +128,7 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests,
                unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = buildsets.Buildset(self.master)

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -24,9 +24,9 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces as util_interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 A_TIMESTAMP = 1341700729

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -24,9 +24,9 @@ from buildbot.data import resultspec
 from buildbot.process.users import users
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -179,7 +179,7 @@ class Change(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     }
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = changes.Change(self.master)

--- a/master/buildbot/test/unit/data/test_changesources.py
+++ b/master/buildbot/test/unit/data/test_changesources.py
@@ -24,9 +24,9 @@ from buildbot.data import changesources
 from buildbot.db.changesources import ChangeSourceAlreadyClaimedError
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class ChangeSourceEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_changesources.py
+++ b/master/buildbot/test/unit/data/test_changesources.py
@@ -147,7 +147,7 @@ class ChangeSource(TestReactorMixin, interfaces.InterfaceTests,
                    unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = changesources.ChangeSource(self.master)

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -91,7 +91,7 @@ class Tests(interfaces.InterfaceTests):
 class TestFakeData(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
                                              wantDb=True)
         self.data = self.master.data
@@ -101,7 +101,7 @@ class TestDataConnector(TestReactorMixin, unittest.TestCase, Tests):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True)
         self.data = connector.DataConnector()
         yield self.data.setServiceParent(self.master)
@@ -112,7 +112,7 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         # don't load by default
         self.patch(connector.DataConnector, 'submodules', [])

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -26,8 +26,8 @@ from buildbot.data import exceptions
 from buildbot.data import resultspec
 from buildbot.data import types
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Tests(interfaces.InterfaceTests):

--- a/master/buildbot/test/unit/data/test_graphql.py
+++ b/master/buildbot/test/unit/data/test_graphql.py
@@ -39,7 +39,7 @@ class TestGraphQlConnector(TestReactorMixin, unittest.TestCase, interfaces.Inter
     def setUp(self):
         if not graphql:
             raise unittest.SkipTest('Test requires graphql-core module installed')
-        self.setUpTestReactor(use_asyncio=True)
+        self.setup_test_reactor(use_asyncio=True)
         self.master = fakemaster.make_master(self)
         # don't load by default
         self.all_submodules = connector.DataConnector.submodules
@@ -137,7 +137,7 @@ class TestGraphQlConnectorService(TestReactorMixin, unittest.TestCase):
     def setUp(self):
         if not graphql:
             raise unittest.SkipTest('Test requires graphql-core module installed')
-        self.setUpTestReactor(use_asyncio=False)
+        self.setup_test_reactor(use_asyncio=False)
 
     @defer.inlineCallbacks
     def test_start_stop(self):

--- a/master/buildbot/test/unit/data/test_graphql.py
+++ b/master/buildbot/test/unit/data/test_graphql.py
@@ -23,8 +23,8 @@ from twisted.trial import unittest
 from buildbot.data import connector
 from buildbot.data.graphql import GraphQLConnector
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 try:
     import graphql

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -21,9 +21,9 @@ from twisted.trial import unittest
 from buildbot.data import logs
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class LogEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -190,7 +190,7 @@ class LogsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Log(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = logs.Log(self.master)

--- a/master/buildbot/test/unit/data/test_masters.py
+++ b/master/buildbot/test/unit/data/test_masters.py
@@ -23,9 +23,9 @@ from buildbot.data import masters
 from buildbot.process.results import RETRY
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 SOMETIME = 1349016870

--- a/master/buildbot/test/unit/data/test_masters.py
+++ b/master/buildbot/test/unit/data/test_masters.py
@@ -132,7 +132,7 @@ class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Master(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = masters.Master(self.master)

--- a/master/buildbot/test/unit/data/test_patches.py
+++ b/master/buildbot/test/unit/data/test_patches.py
@@ -23,7 +23,7 @@ from buildbot.test.reactor import TestReactorMixin
 class Patch(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = patches.Patch(self.master)

--- a/master/buildbot/test/unit/data/test_patches.py
+++ b/master/buildbot/test/unit/data/test_patches.py
@@ -17,7 +17,7 @@ from twisted.trial import unittest
 
 from buildbot.data import patches
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class Patch(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -23,9 +23,9 @@ from buildbot.data import properties
 from buildbot.process.properties import Properties as processProperties
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class BuildsetPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -97,7 +97,7 @@ class Properties(interfaces.InterfaceTests, TestReactorMixin,
                  unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=False, wantDb=True,
                                              wantData=True)
         self.rtype = properties.Properties(self.master)

--- a/master/buildbot/test/unit/data/test_schedulers.py
+++ b/master/buildbot/test/unit/data/test_schedulers.py
@@ -144,7 +144,7 @@ class Scheduler(TestReactorMixin, interfaces.InterfaceTests,
                 unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = schedulers.Scheduler(self.master)

--- a/master/buildbot/test/unit/data/test_schedulers.py
+++ b/master/buildbot/test/unit/data/test_schedulers.py
@@ -22,9 +22,9 @@ from twisted.trial import unittest
 from buildbot.data import schedulers
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 

--- a/master/buildbot/test/unit/data/test_steps.py
+++ b/master/buildbot/test/unit/data/test_steps.py
@@ -168,7 +168,7 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = steps.Step(self.master)

--- a/master/buildbot/test/unit/data/test_steps.py
+++ b/master/buildbot/test/unit/data/test_steps.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 from buildbot.data import steps
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 TIME1 = 2001111

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -128,7 +128,7 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestResultSet(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = test_result_sets.TestResultSet(self.master)
 

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 from buildbot.data import test_result_sets
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestResultSetEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 from buildbot.data import test_results
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -74,7 +74,7 @@ class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = test_results.TestResult(self.master)
 

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -23,9 +23,9 @@ from buildbot.data import resultspec
 from buildbot.data import workers
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 testData = [
     fakedb.Builder(id=40, name='b1'),

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -256,7 +256,7 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Worker(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = workers.Worker(self.master)

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -24,8 +24,8 @@ from buildbot import config
 from buildbot.db import connector
 from buildbot.db import exceptions
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import db
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin,

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -37,7 +37,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setUpRealDatabase(table_names=[
             'changes', 'change_properties', 'change_files', 'patches',
             'sourcestamps', 'buildset_properties', 'buildsets',

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -31,7 +31,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
         self.botmaster = BotMaster()
         yield self.botmaster.setServiceParent(self.master)
@@ -148,7 +148,7 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.master.botmaster.disownServiceParent()

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -24,7 +24,7 @@ from buildbot.process.botmaster import BotMaster
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import RETRY
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class TestCleanShutdown(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -178,7 +178,7 @@ def makeControllableStepFactory():
 class TestBuild(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         r = FakeRequest()
         r.sources = [FakeSource()]
         r.sources[0].changes = [FakeChange()]
@@ -1024,7 +1024,7 @@ class TestSetupProperties_MultipleSources(TestReactorMixin, unittest.TestCase):
     """
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.props = {}
         self.r = FakeRequest()
         self.r.sources = []
@@ -1070,7 +1070,7 @@ class TestSetupProperties_SingleSource(TestReactorMixin, unittest.TestCase):
     """
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.props = {}
         self.r = FakeRequest()
         self.r.sources = []

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -38,7 +38,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakeprotocol
 from buildbot.test.fake import worker
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class FakeChange:

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -111,7 +111,7 @@ class FakeLatentWorker(AbstractLatentWorker):
 class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         # a collection of rows that would otherwise clutter up every test
         self.setUpBuilderMixin()
         self.base_rows = [
@@ -480,7 +480,7 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
 class TestGetBuilderId(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpBuilderMixin()
 
     @defer.inlineCallbacks
@@ -505,7 +505,7 @@ class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -558,7 +558,7 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -600,7 +600,7 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
     """Tests that a reconfig properly updates all attributes"""
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpBuilderMixin()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -29,7 +29,7 @@ from buildbot.process.properties import Properties
 from buildbot.process.properties import renderer
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import epoch2datetime
 from buildbot.worker import AbstractLatentWorker

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -32,7 +32,7 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True)
         self.master.botmaster = mock.Mock(name='botmaster')
         self.master.botmaster.builders = {}
@@ -417,7 +417,7 @@ class TestSourceStamp(unittest.TestCase):
 class TestBuildRequest(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_fromBrdict(self):

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -25,7 +25,7 @@ from buildbot.process import buildrequest
 from buildbot.process.builder import Builder
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -27,7 +27,7 @@ from buildbot.process import buildrequestdistributor
 from buildbot.process import factory
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import epoch2datetime
 from buildbot.util.eventual import fireEventually

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -47,7 +47,7 @@ def nth_worker(n):
 class TestBRDBase(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.botmaster = mock.Mock(name='botmaster')
         self.botmaster.builders = {}
         self.builders = {}

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -102,7 +102,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
             return SUCCESS
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -902,7 +902,7 @@ class TestFakeItfc(unittest.TestCase,
                    InterfaceTests):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_build_step()
         self.setup_step(buildstep.BuildStep())
 
@@ -928,7 +928,7 @@ class TestCommandMixin(steps.BuildStepMixin, TestReactorMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setup_build_step()
         self.step = CommandMixinExample()
         self.setup_step(self.step)
@@ -1072,7 +1072,7 @@ class TestShellMixin(steps.BuildStepMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -45,9 +45,9 @@ from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import worker
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config
 from buildbot.test.util import interfaces
-from buildbot.test.util import steps
 from buildbot.util.eventual import eventually
 
 
@@ -63,7 +63,7 @@ class CustomActionBuildStep(buildstep.BuildStep):
         return self.action()
 
 
-class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
+class TestBuildStep(TestBuildStepMixin, config.ConfigErrorsMixin,
                     TestReactorMixin,
                     unittest.TestCase):
 
@@ -784,7 +784,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
 class InterfaceTests(interfaces.InterfaceTests):
 
-    # ensure that steps.BuildStepMixin creates a convincing facsimile of the
+    # ensure that TestBuildStepMixin creates a convincing facsimile of the
     # real BuildStep
 
     def test_signature_attributes(self):
@@ -898,7 +898,7 @@ class InterfaceTests(interfaces.InterfaceTests):
 
 
 class TestFakeItfc(unittest.TestCase,
-                   steps.BuildStepMixin, TestReactorMixin,
+                   TestBuildStepMixin, TestReactorMixin,
                    InterfaceTests):
 
     def setUp(self):
@@ -923,7 +923,7 @@ class CommandMixinExample(buildstep.CommandMixin, buildstep.BuildStep):
         return SUCCESS
 
 
-class TestCommandMixin(steps.BuildStepMixin, TestReactorMixin,
+class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
                        unittest.TestCase):
 
     @defer.inlineCallbacks
@@ -1065,7 +1065,7 @@ class SimpleShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
         return cmd.results()
 
 
-class TestShellMixin(steps.BuildStepMixin,
+class TestShellMixin(TestBuildStepMixin,
                      config.ConfigErrorsMixin,
                      TestReactorMixin,
                      unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -44,10 +44,10 @@ from buildbot.test.expect import ExpectStat
 from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import worker
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
 from buildbot.test.util import interfaces
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util.eventual import eventually
 
 

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1116,7 +1116,7 @@ class TestShellMixin(TestBuildStepMixin,
 
     @defer.inlineCallbacks
     def test_no_default_workdir(self):
-        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), wantDefaultWorkdir=False)
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), want_default_work_dir=False)
         self.expect_commands(
             ExpectShell(workdir='build', command=['cmd', 'arg'])
             .exit(0)
@@ -1126,7 +1126,7 @@ class TestShellMixin(TestBuildStepMixin,
 
     @defer.inlineCallbacks
     def test_build_workdir(self):
-        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), wantDefaultWorkdir=False)
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), want_default_work_dir=False)
         self.build.workdir = '/alternate'
         self.expect_commands(
             ExpectShell(workdir='/alternate', command=['cmd', 'arg'])
@@ -1137,7 +1137,7 @@ class TestShellMixin(TestBuildStepMixin,
 
     @defer.inlineCallbacks
     def test_build_workdir_callable(self):
-        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), wantDefaultWorkdir=False)
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), want_default_work_dir=False)
         self.build.workdir = lambda x: '/alternate'
         self.expect_commands(
             ExpectShell(workdir='/alternate', command=['cmd', 'arg'])
@@ -1148,14 +1148,14 @@ class TestShellMixin(TestBuildStepMixin,
 
     @defer.inlineCallbacks
     def test_build_workdir_callable_error(self):
-        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), wantDefaultWorkdir=False)
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), want_default_work_dir=False)
         self.build.workdir = lambda x: x.nosuchattribute  # will raise AttributeError
         self.expect_exception(buildstep.CallableAttributeError)
         yield self.run_step()
 
     @defer.inlineCallbacks
     def test_build_workdir_renderable(self):
-        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), wantDefaultWorkdir=False)
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), want_default_work_dir=False)
         self.build.workdir = properties.Property("myproperty")
         self.properties.setProperty("myproperty", "/myproperty", "test")
         self.expect_commands(

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -103,10 +103,10 @@ class TestBuildStep(TestBuildStepMixin, config.ConfigErrorsMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     # support
 
@@ -903,7 +903,7 @@ class TestFakeItfc(unittest.TestCase,
 
     def setUp(self):
         self.setup_test_reactor()
-        self.setup_build_step()
+        self.setup_test_build_step()
         self.setup_step(buildstep.BuildStep())
 
 
@@ -929,12 +929,12 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
-        yield self.setup_build_step()
+        yield self.setup_test_build_step()
         self.step = CommandMixinExample()
         self.setup_step(self.step)
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def test_runRmdir(self):
@@ -1073,10 +1073,10 @@ class TestShellMixin(TestBuildStepMixin,
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
-        yield self.setup_build_step()
+        yield self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_setupShellMixin_bad_arg(self):
         mixin = SimpleShellCommand()

--- a/master/buildbot/test/unit/process/test_debug.py
+++ b/master/buildbot/test/unit/process/test_debug.py
@@ -22,7 +22,7 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.process import debug
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import service
 
 

--- a/master/buildbot/test/unit/process/test_debug.py
+++ b/master/buildbot/test/unit/process/test_debug.py
@@ -33,7 +33,7 @@ class FakeManhole(service.AsyncService):
 class TestDebugServices(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = mock.Mock(name='master')
         self.config = config.MasterConfig()
 

--- a/master/buildbot/test/unit/process/test_log.py
+++ b/master/buildbot/test/unit/process/test_log.py
@@ -22,8 +22,8 @@ from twisted.trial import unittest
 from buildbot.process import log
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import logfile as fakelogfile
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Tests(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_log.py
+++ b/master/buildbot/test/unit/process/test_log.py
@@ -29,7 +29,7 @@ from buildbot.test.util import interfaces
 class Tests(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/process/test_logobserver.py
+++ b/master/buildbot/test/unit/process/test_logobserver.py
@@ -46,7 +46,7 @@ class MyLogObserver(logobserver.LogObserver):
 class TestLogObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
@@ -95,7 +95,7 @@ class MyLogLineObserver(logobserver.LogLineObserver):
 class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
@@ -160,7 +160,7 @@ class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
 class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
@@ -197,7 +197,7 @@ class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
 class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
@@ -217,7 +217,7 @@ class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
 class TestBufferObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/process/test_logobserver.py
+++ b/master/buildbot/test/unit/process/test_logobserver.py
@@ -22,7 +22,7 @@ from twisted.trial import unittest
 from buildbot.process import log
 from buildbot.process import logobserver
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class MyLogObserver(logobserver.LogObserver):

--- a/master/buildbot/test/unit/process/test_metrics.py
+++ b/master/buildbot/test/unit/process/test_metrics.py
@@ -21,7 +21,7 @@ from twisted.trial import unittest
 
 from buildbot.process import metrics
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class TestMetricBase(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_metrics.py
+++ b/master/buildbot/test/unit/process/test_metrics.py
@@ -27,7 +27,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestMetricBase(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.observer = metrics.MetricLogObserver()
         self.observer.parent = self.master = fakemaster.make_master(self)
         self.master.config.metrics = dict(log_interval=0, periodic_interval=0)

--- a/master/buildbot/test/unit/process/test_users_manual.py
+++ b/master/buildbot/test/unit/process/test_users_manual.py
@@ -50,7 +50,7 @@ class TestCommandlineUserManagerPerspective(TestReactorMixin,
                                             ManualUsersMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpManualUsers()
 
     def call_perspective_commandline(self, *args):
@@ -221,7 +221,7 @@ class TestCommandlineUserManager(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpManualUsers()
         self.manual_component = manual.CommandlineUserManager(username="user",
                                                               passwd="userpw",

--- a/master/buildbot/test/unit/process/test_users_manual.py
+++ b/master/buildbot/test/unit/process/test_users_manual.py
@@ -23,7 +23,7 @@ from twisted.trial import unittest
 
 from buildbot.process.users import manual
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class ManualUsersMixin:

--- a/master/buildbot/test/unit/process/test_users_users.py
+++ b/master/buildbot/test/unit/process/test_users_users.py
@@ -19,7 +19,7 @@ from twisted.trial import unittest
 from buildbot.process.users import users
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class UsersTests(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_users_users.py
+++ b/master/buildbot/test/unit/process/test_users_users.py
@@ -25,7 +25,7 @@ from buildbot.test.reactor import TestReactorMixin
 class UsersTests(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.test_sha = users.encrypt("cancer")

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -39,7 +39,7 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
                        unittest.TestCase, ReporterTestMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.setUpLogging()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -25,9 +25,9 @@ from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.reporters.generators.worker import WorkerMissingGenerator
 from buildbot.reporters.message import MessageFormatter
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -26,9 +26,9 @@ from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.message import MessageFormatter
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -37,7 +37,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
@@ -219,7 +219,7 @@ class TestBitbucketStatusPushProperties(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
@@ -296,7 +296,7 @@ class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -38,9 +38,9 @@ from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 HTTP_NOT_FOUND = 404

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -55,7 +55,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, ConfigErrorsMixin, unittes
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -191,7 +191,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
 
     @defer.inlineCallbacks
     def setupReporter(self, token=None, **kwargs):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
@@ -461,7 +461,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -26,8 +26,8 @@ from buildbot.reporters import utils
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -35,7 +35,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
                          unittest.TestCase, ReporterTestMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
@@ -231,7 +231,7 @@ class TestBuildStartEndGenerator(ConfigErrorsMixin, TestReactorMixin,
     all_messages = ('failing', 'passing', 'warnings', 'exception', 'cancelled')
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -35,7 +35,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
     all_messages = ('failing', 'passing', 'warnings', 'exception', 'cancelled')
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -24,8 +24,8 @@ from twisted.trial import unittest
 from buildbot.process.builder import Builder
 from buildbot.reporters.generators.buildrequest import BuildRequestGenerator
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -22,8 +22,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters import utils
 from buildbot.reporters.generators.buildset import BuildSetStatusGenerator
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -33,7 +33,7 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
     # BuildStatusGenerator and is tested there.
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_generators_utils.py
+++ b/master/buildbot/test/unit/reporters/test_generators_utils.py
@@ -29,8 +29,8 @@ from buildbot.process.results import WARNINGS
 from buildbot.reporters import utils
 from buildbot.reporters.generators.utils import BuildStatusGeneratorMixin
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_generators_utils.py
+++ b/master/buildbot/test/unit/reporters/test_generators_utils.py
@@ -38,7 +38,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
                          unittest.TestCase, ReporterTestMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_generators_worker.py
+++ b/master/buildbot/test/unit/reporters/test_generators_worker.py
@@ -20,8 +20,8 @@ from twisted.trial import unittest
 
 from buildbot.reporters.generators.worker import WorkerMissingGenerator
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestWorkerMissingGenerator(ConfigErrorsMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/reporters/test_generators_worker.py
+++ b/master/buildbot/test/unit/reporters/test_generators_worker.py
@@ -28,7 +28,7 @@ class TestWorkerMissingGenerator(ConfigErrorsMixin, TestReactorMixin,
                                  unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -36,7 +36,7 @@ from buildbot.reporters.gerrit import defaultReviewCB
 from buildbot.reporters.gerrit import defaultSummaryCB
 from buildbot.reporters.gerrit import makeReviewResult
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 warnings.filterwarnings('error', message='.*Gerrit status')

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -141,7 +141,7 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
                            ReporterTestMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -40,7 +40,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin, ReporterTestMixin, ConfigErro
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.reporter_test_props = {
             'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -28,9 +28,9 @@ from buildbot.reporters.gerrit_verify_status import GerritVerifyStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import logging
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -25,8 +25,8 @@ from buildbot.reporters.github import GitHubStatusPush
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -35,7 +35,7 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsMixi
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         # project must be in the form <owner>/<project>
@@ -223,7 +223,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         # project must be in the form <owner>/<project>

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -34,7 +34,7 @@ class TestGitLabStatusPush(TestReactorMixin, ConfigErrorsMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         # repository must be in the form http://gitlab/<owner>/<project>

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -23,9 +23,9 @@ from buildbot.reporters.gitlab import HOSTED_BASE_URL
 from buildbot.reporters.gitlab import GitLabStatusPush
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import logging
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -31,7 +31,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -21,9 +21,9 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters.http import HttpStatusPush
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.misc import BuildDictLookAlike
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -32,8 +32,8 @@ from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.reporters.mail import MailNotifier
 from buildbot.reporters.message import MessageFormatter
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import ssl

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -43,7 +43,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
                        unittest.TestCase, ReporterTestMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -133,7 +133,7 @@ class TestMessageFormatting(unittest.TestCase):
 class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
     def setupDb(self, results1, results2):

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -32,8 +32,8 @@ from buildbot.reporters import message
 from buildbot.reporters import utils
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.misc import BuildDictLookAlike
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.warnings import DeprecatedApiWarning
 

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -33,7 +33,7 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -24,8 +24,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters.pushjet import PushjetNotifier
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import httpclientservice
 
 

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -33,7 +33,7 @@ from buildbot.util import httpclientservice
 class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -25,8 +25,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters.pushover import PushoverNotifier
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import httpclientservice
 
 

--- a/master/buildbot/test/unit/reporters/test_telegram.py
+++ b/master/buildbot/test/unit/reporters/test_telegram.py
@@ -31,8 +31,8 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.web import FakeRequest
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.unit.reporters.test_words import ContactMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import service
 from buildbot.util import unicode2bytes
 

--- a/master/buildbot/test/unit/reporters/test_telegram.py
+++ b/master/buildbot/test/unit/reporters/test_telegram.py
@@ -554,7 +554,7 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
     PRIVATE = TestTelegramContact.PRIVATE
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.patch(reactor, 'callLater', self.reactor.callLater)
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -27,8 +27,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters import utils
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import logging
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -38,7 +38,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
         """)
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -445,7 +445,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 class TestURLUtils(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
 
     def test_UrlForBuild(self):

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -26,7 +26,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters import words
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import datetime2epoch
 
 

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -43,7 +43,7 @@ class ContactMixin(TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.patch(reactor, 'callLater', self.reactor.callLater)
         self.patch(reactor, 'seconds', self.reactor.seconds)
         self.patch(reactor, 'stop', self.reactor.stop)

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -29,7 +29,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                           TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = fakemaster.make_master(
             testcase=self, wantData=True, wantDb=True, wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -19,9 +19,9 @@ from twisted.trial import unittest
 from buildbot.reporters.zulip import ZulipStatusPush
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -37,7 +37,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
     exp_bsid_brids = (123, {'b': 456})
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -25,8 +25,8 @@ from buildbot.process import properties
 from buildbot.process.properties import Interpolate
 from buildbot.schedulers import base
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -95,7 +95,7 @@ class BaseBasicScheduler(CommonStuffMixin,
             return self.master.db.schedulers.getChangeClassifications(schedulerid)
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -356,7 +356,7 @@ class SingleBranchScheduler(CommonStuffMixin,
         return ch
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -492,7 +492,7 @@ class AnyBranchScheduler(CommonStuffMixin,
     OBJECTID = 246
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -22,8 +22,8 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.schedulers import basic
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class CommonStuffMixin:

--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -311,7 +311,7 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.master.mq.verifyMessages = False
 

--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -23,8 +23,8 @@ from buildbot.schedulers.canceller import _OldBuildFilterSet
 from buildbot.schedulers.canceller import _OldBuildTracker
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util.ssfilter import SourceStampFilter
 
 

--- a/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
@@ -29,7 +29,7 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.master.mq.verifyMessages = False
 

--- a/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
@@ -21,7 +21,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.schedulers.canceller_buildset import FailingBuildsetCanceller
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util.ssfilter import SourceStampFilter
 
 

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -24,8 +24,8 @@ from buildbot.process.results import WARNINGS
 from buildbot.schedulers import base
 from buildbot.schedulers import dependent
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 SUBMITTED_AT_TIME = 111111111
 COMPLETE_AT_TIME = 222222222

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -37,7 +37,7 @@ UPSTREAM_NAME = 'uppy'
 class Dependent(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -34,9 +34,9 @@ from buildbot.schedulers.forcesched import PatchParameter
 from buildbot.schedulers.forcesched import StringParameter
 from buildbot.schedulers.forcesched import UserNameParameter
 from buildbot.schedulers.forcesched import oneCodebase
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -47,7 +47,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
     maxDiff = None
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -110,7 +110,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         return ch
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -25,8 +25,8 @@ from twisted.trial import unittest
 from buildbot.changes import filter
 from buildbot.schedulers import timed
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -38,7 +38,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin,
     SCHEDULERID = 33
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -19,8 +19,8 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.schedulers import timed
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 try:
     from multiprocessing import Process

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -49,7 +49,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, TestReactorMixin,
         return sched
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -21,8 +21,8 @@ from twisted.trial import unittest
 from buildbot.process import properties
 from buildbot.schedulers import timed
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class NightlyTriggerable(scheduler.SchedulerMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
@@ -19,8 +19,8 @@ from twisted.trial import unittest
 
 from buildbot import config
 from buildbot.schedulers import timed
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestException(Exception):

--- a/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
@@ -33,7 +33,7 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     SCHEDULERID = 3
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def makeScheduler(self, firstBuildDuration=0, firstBuildError=False, exp_branch=None, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_timed_Timed.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Timed.py
@@ -18,8 +18,8 @@ from twisted.internet import task
 from twisted.trial import unittest
 
 from buildbot.schedulers import timed
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Timed(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/schedulers/test_timed_Timed.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Timed.py
@@ -27,7 +27,7 @@ class Timed(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     OBJECTID = 928754
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -38,7 +38,7 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin,
     SCHEDULERID = 13
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         # Necessary to get an assertable submitted_at time.
         self.reactor.advance(946684799)
 

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 from buildbot.process import properties
 from buildbot.schedulers import triggerable
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TriggerableInterfaceTest(unittest.TestCase, interfaces.InterfaceTests):

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -37,7 +37,7 @@ class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     SCHEDULERID = 6
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -131,7 +131,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     SCHEDULERID = 3
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
         self.jobdir = None
 
@@ -684,7 +684,7 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin,
     SCHEDULERID = 6
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -823,7 +823,7 @@ class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin,
     SCHEDULERID = 5
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -27,9 +27,9 @@ from twisted.protocols import basic
 from twisted.trial import unittest
 
 from buildbot.schedulers import trysched
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import dirs
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -23,11 +23,11 @@ from twisted.trial import unittest
 
 from buildbot.scripts import cleanupdb
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.unit.db import test_logs
 from buildbot.test.util import db
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
-from buildbot.test.util.misc import TestReactorMixin
 
 try:
     import lz4

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -60,7 +60,7 @@ class TestCleanupDb(misc.StdoutAssertionsMixin, dirs.DirsMixin,
                     TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.origcwd = os.getcwd()
         self.setUpDirs('basedir')
         with open(os.path.join('basedir', 'buildbot.tac'), 'wt') as f:

--- a/master/buildbot/test/unit/scripts/test_create_master.py
+++ b/master/buildbot/test/unit/scripts/test_create_master.py
@@ -23,10 +23,10 @@ from twisted.trial import unittest
 from buildbot.db import connector
 from buildbot.db import model
 from buildbot.scripts import create_master
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def mkconfig(**kwargs):

--- a/master/buildbot/test/unit/scripts/test_create_master.py
+++ b/master/buildbot/test/unit/scripts/test_create_master.py
@@ -88,7 +88,7 @@ class TestCreateMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
                                 unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()

--- a/master/buildbot/test/unit/scripts/test_logwatcher.py
+++ b/master/buildbot/test/unit/scripts/test_logwatcher.py
@@ -50,7 +50,7 @@ class TestLogWatcher(unittest.TestCase, dirs.DirsMixin, TestReactorMixin):
         self.setUpDirs('workdir')
         self.addCleanup(self.tearDownDirs)
 
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.spawned_process = mock.Mock()
         self.reactor.spawnProcess = mock.Mock(return_value=self.spawned_process)
 

--- a/master/buildbot/test/unit/scripts/test_logwatcher.py
+++ b/master/buildbot/test/unit/scripts/test_logwatcher.py
@@ -24,8 +24,8 @@ from buildbot.scripts.logwatcher import BuildmasterStartupError
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import ReconfigError
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import dirs
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 
 

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -112,7 +112,7 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
                                  unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -28,10 +28,10 @@ from buildbot.db import masters
 from buildbot.db import model
 from buildbot.scripts import base
 from buildbot.scripts import upgrade_master
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def mkconfig(**kwargs):

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -27,7 +27,7 @@ from buildbot.test.util.steps import BuildStepMixin
 class TestCMake(BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -20,7 +20,7 @@ from buildbot.process.properties import Property
 from buildbot.process.results import SUCCESS
 from buildbot.steps.cmake import CMake
 from buildbot.test.expect import ExpectShell
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.steps import BuildStepMixin
 
 

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -28,10 +28,10 @@ class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        self.setup_build_step()
+        self.setup_test_build_step()
 
     def tearDown(self):
-        self.tear_down_build_step()
+        self.tear_down_test_build_step()
 
     def expect_and_run_command(self, *params):
         command = [CMake.DEFAULT_CMAKE] + list(params)

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -21,10 +21,10 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.cmake import CMake
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util.steps import BuildStepMixin
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestCMake(BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -21,8 +21,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import cppcheck
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Cppcheck(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -28,7 +28,7 @@ from buildbot.test.util import steps
 class Cppcheck(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -22,10 +22,10 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import cppcheck
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class Cppcheck(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class Cppcheck(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -29,10 +29,10 @@ class Cppcheck(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_success(self):
         self.setup_step(cppcheck.Cppcheck(enable=['all'], inconclusive=True))

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -27,7 +27,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import http
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 try:
     import txrequests
@@ -61,7 +61,7 @@ class TestPage(Resource):
         return b"OK:" + request.content.read()
 
 
-class TestHTTPStep(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     timeout = 3  # those tests should not run long
 

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -97,8 +97,8 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def test_get(self):
         url = self.getURL()
         self.setup_step(http.GET(url))
-        self.expect_logfile('log', "URL: {}\nStatus: 200\n ------ Content ------\nOK".format(url))
-        self.expect_logfile('content', "OK")
+        self.expect_log_file('log', "URL: {}\nStatus: 200\n ------ Content ------\nOK".format(url))
+        self.expect_log_file('content', "OK")
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
         return self.run_step()
 
@@ -136,16 +136,16 @@ Status: 200
  ------ Content ------
 OK'''.format(self.get_connection_string())
 
-        self.expect_logfile('log', expected_log)
-        self.expect_logfile('content', "OK")
+        self.expect_log_file('log', expected_log)
+        self.expect_log_file('content', "OK")
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
         return self.run_step()
 
     def test_404(self):
         url = self.getURL("404")
         self.setup_step(http.GET(url))
-        self.expect_logfile('log', "URL: {}\n ------ Content ------\n404".format(url))
-        self.expect_logfile('content', "404")
+        self.expect_log_file('log', "URL: {}\n ------ Content ------\n404".format(url))
+        self.expect_log_file('content', "404")
         self.expect_outcome(result=FAILURE, state_string="Status code: 404 (failure)")
         return self.run_step()
 
@@ -159,17 +159,17 @@ OK'''.format(self.get_connection_string())
         url = self.getURL("path")
         self.setup_step(http.POST(url))
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
-        self.expect_logfile('log', "URL: {}\nStatus: 200\n ------ Content ------\nOK:".format(url))
-        self.expect_logfile('content', "OK:")
+        self.expect_log_file('log', "URL: {}\nStatus: 200\n ------ Content ------\nOK:".format(url))
+        self.expect_log_file('content', "OK:")
         return self.run_step()
 
     def test_post_data(self):
         url = self.getURL("path")
         self.setup_step(http.POST(url, data='mydata'))
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
-        self.expect_logfile('log',
+        self.expect_log_file('log',
                            "URL: {}\nStatus: 200\n ------ Content ------\nOK:mydata".format(url))
-        self.expect_logfile('content', "OK:mydata")
+        self.expect_log_file('content', "OK:mydata")
         return self.run_step()
 
     def test_post_data_dict(self):
@@ -177,18 +177,19 @@ OK'''.format(self.get_connection_string())
 
         self.setup_step(http.POST(url, data={'key1': 'value1'}))
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
-        self.expect_logfile('log', '''\
+        self.expect_log_file('log', '''\
 URL: {}
 Status: 200
  ------ Content ------
 OK:key1=value1'''.format(url))
-        self.expect_logfile('content', "OK:key1=value1")
+        self.expect_log_file('content', "OK:key1=value1")
         return self.run_step()
 
     def test_header(self):
         url = self.getURL("header")
         self.setup_step(http.GET(url, headers={"X-Test": "True"}))
-        self.expect_logfile('log', "URL: {}\nStatus: 200\n ------ Content ------\nTrue".format(url))
+        self.expect_log_file('log',
+                             "URL: {}\nStatus: 200\n ------ Content ------\nTrue".format(url))
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
         return self.run_step()
 
@@ -198,7 +199,8 @@ OK:key1=value1'''.format(url))
         self.setup_step(http.GET(url, headers={"X-Test": "True"},
                                 hide_request_headers=["X-Test"],
                                 hide_response_headers=["Content-Length"]))
-        self.expect_logfile('log', "URL: {}\nStatus: 200\n ------ Content ------\nTrue".format(url))
+        self.expect_log_file('log',
+                             "URL: {}\nStatus: 200\n ------ Content ------\nTrue".format(url))
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
         yield self.run_step()
         self.assertIn("X-Test: <HIDDEN>", self.step.logs['log'].header)
@@ -209,9 +211,9 @@ OK:key1=value1'''.format(url))
         self.setup_step(http.GET(url, params=properties.Property("x")))
         self.properties.setProperty(
             'x', {'param_1': 'param_1', 'param_2': 2}, 'here')
-        self.expect_logfile('log',
+        self.expect_log_file('log',
             ("URL: {}?param_1=param_1&param_2=2\nStatus: 200\n ------ Content ------\nOK"
              ).format(url))
-        self.expect_logfile('content', "OK")
+        self.expect_log_file('content', "OK")
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
         return self.run_step()

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -66,7 +66,7 @@ class TestHTTPStep(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     timeout = 3  # those tests should not run long
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         if txrequests is None:
             raise unittest.SkipTest(
                 "Need to install txrequests to test http steps")

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -26,8 +26,8 @@ from buildbot.process import properties
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import http
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 try:
     import txrequests

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -78,7 +78,7 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         # port 0 means random unused port
         self.listener = reactor.listenTCP(0, Site(TestPage()))
         self.port = self.listener.getHost().port
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     @defer.inlineCallbacks
     def tearDown(self):
@@ -86,7 +86,7 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         try:
             yield self.listener.stopListening()
         finally:
-            yield self.tear_down_build_step()
+            yield self.tear_down_test_build_step()
 
     def get_connection_string(self):
         return "http://127.0.0.1:{}".format(self.port)

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -45,7 +45,7 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
         if runtime.platformType == 'win32':
             self.comspec = os.environ.get(_COMSPEC_ENV)
             os.environ[_COMSPEC_ENV] = r'C:\WINDOWS\system32\cmd.exe'
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
         if runtime.platformType == 'win32':
@@ -53,7 +53,7 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
                 os.environ[_COMSPEC_ENV] = self.comspec
             else:
                 del os.environ[_COMSPEC_ENV]
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def patchSpawnProcess(self, exp_cmd, exp_argv, exp_path, exp_usePTY,
                           exp_env, outputs):
@@ -209,10 +209,10 @@ class TestSetProperty(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_simple(self):
         self.setup_step(master.SetProperty(property="testProperty", value=Interpolate(
@@ -232,10 +232,10 @@ class TestLogRenderable(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_simple(self):
         self.setup_step(master.LogRenderable(
@@ -255,10 +255,10 @@ class TestsSetProperties(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def doOneTest(self, **kwargs):
         # all three tests should create a 'a' property with 'b' value, all with different
@@ -288,10 +288,10 @@ class TestAssert(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_eq_pass(self):
         self.setup_step(master.Assert(

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -77,16 +77,16 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
         cmd = [sys.executable, '-c', 'print("hello")']
         self.setup_step(master.MasterShellCommand(command=cmd))
         if runtime.platformType == 'win32':
-            self.expect_logfile('stdio', "hello\r\n")
+            self.expect_log_file('stdio', "hello\r\n")
         else:
-            self.expect_logfile('stdio', "hello\n")
+            self.expect_log_file('stdio', "hello\n")
         self.expect_outcome(result=SUCCESS, state_string="Ran")
         return self.run_step()
 
     def test_real_cmd_interrupted(self):
         cmd = [sys.executable, '-c', 'while True: pass']
         self.setup_step(master.MasterShellCommand(command=cmd))
-        self.expect_logfile('stdio', "")
+        self.expect_log_file('stdio', "")
         if runtime.platformType == 'win32':
             # windows doesn't have signals, so we don't get 'killed',
             # but the "exception" part still works.
@@ -103,7 +103,7 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
         cmd = [sys.executable, '-c', 'import sys; sys.exit(1)']
         self.setup_step(
             master.MasterShellCommand(command=cmd))
-        self.expect_logfile('stdio', "")
+        self.expect_log_file('stdio', "")
         self.expect_outcome(result=FAILURE, state_string="failed (1) (failure)")
         return self.run_step()
 
@@ -134,9 +134,9 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(
             master.MasterShellCommand(command=cmd, env={'HELLO': '${WORLD}'}))
         if runtime.platformType == 'win32':
-            self.expect_logfile('stdio', "hello\r\n")
+            self.expect_log_file('stdio', "hello\r\n")
         else:
-            self.expect_logfile('stdio', "hello\n")
+            self.expect_log_file('stdio', "hello\n")
         self.expect_outcome(result=SUCCESS)
 
         d = self.run_step()
@@ -154,9 +154,9 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(master.MasterShellCommand(command=cmd,
                                                  env={'HELLO': ['${WORLD}', '${LIST}']}))
         if runtime.platformType == 'win32':
-            self.expect_logfile('stdio', "hello;world\r\n")
+            self.expect_log_file('stdio', "hello;world\r\n")
         else:
-            self.expect_logfile('stdio', "hello:world\n")
+            self.expect_log_file('stdio', "hello:world\n")
         self.expect_outcome(result=SUCCESS)
 
         d = self.run_step()
@@ -176,9 +176,9 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
                                                  env={'BUILD': WithProperties('%s', "project")}))
         self.properties.setProperty("project", "BUILDBOT-TEST", "TEST")
         if runtime.platformType == 'win32':
-            self.expect_logfile('stdio', "BUILDBOT-TEST\r\nBUILDBOT-TEST\r\n")
+            self.expect_log_file('stdio', "BUILDBOT-TEST\r\nBUILDBOT-TEST\r\n")
         else:
-            self.expect_logfile('stdio', "BUILDBOT-TEST\nBUILDBOT-TEST\n")
+            self.expect_log_file('stdio', "BUILDBOT-TEST\nBUILDBOT-TEST\n")
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
@@ -245,7 +245,7 @@ class TestLogRenderable(TestBuildStepMixin, TestReactorMixin,
         self.properties.setProperty(
             'workername', 'testWorker', source='TestSetProperty', runtime=True)
         self.expect_outcome(result=SUCCESS, state_string='Logged')
-        self.expect_logfile(
+        self.expect_log_file(
             'Output', pprint.pformat('sch=force, worker=testWorker'))
         return self.run_step()
 

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -41,7 +41,7 @@ class TestMasterShellCommand(steps.BuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         if runtime.platformType == 'win32':
             self.comspec = os.environ.get(_COMSPEC_ENV)
             os.environ[_COMSPEC_ENV] = r'C:\WINDOWS\system32\cmd.exe'
@@ -208,7 +208,7 @@ class TestSetProperty(steps.BuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -231,7 +231,7 @@ class TestLogRenderable(steps.BuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -254,7 +254,7 @@ class TestsSetProperties(steps.BuildStepMixin, TestReactorMixin,
                          unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -287,7 +287,7 @@ class TestAssert(steps.BuildStepMixin, TestReactorMixin,
                  unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -32,12 +32,12 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import master
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 _COMSPEC_ENV = 'COMSPEC'
 
 
-class TestMasterShellCommand(steps.BuildStepMixin, TestReactorMixin,
+class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
@@ -204,7 +204,7 @@ class TestMasterShellCommand(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestSetProperty(steps.BuildStepMixin, TestReactorMixin,
+class TestSetProperty(TestBuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
@@ -227,7 +227,7 @@ class TestSetProperty(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestLogRenderable(steps.BuildStepMixin, TestReactorMixin,
+class TestLogRenderable(TestBuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
@@ -250,7 +250,7 @@ class TestLogRenderable(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestsSetProperties(steps.BuildStepMixin, TestReactorMixin,
+class TestsSetProperties(TestBuildStepMixin, TestReactorMixin,
                          unittest.TestCase):
 
     def setUp(self):
@@ -283,7 +283,7 @@ class TestsSetProperties(steps.BuildStepMixin, TestReactorMixin,
         return self.doOneTest(properties=manipulate)
 
 
-class TestAssert(steps.BuildStepMixin, TestReactorMixin,
+class TestAssert(TestBuildStepMixin, TestReactorMixin,
                  unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -31,8 +31,8 @@ from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import master
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 _COMSPEC_ENV = 'COMSPEC'
 

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -21,10 +21,10 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps import maxq
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestShellCommandExecution(steps.BuildStepMixin, TestReactorMixin,
+class TestShellCommandExecution(TestBuildStepMixin, TestReactorMixin,
                                 unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -28,7 +28,7 @@ class TestShellCommandExecution(steps.BuildStepMixin, TestReactorMixin,
                                 unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -20,8 +20,8 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import maxq
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestShellCommandExecution(steps.BuildStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -29,10 +29,10 @@ class TestShellCommandExecution(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_testdir_required(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -36,7 +36,7 @@ class TestRobocopySimple(steps.BuildStepMixin, TestReactorMixin,
     """
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -37,10 +37,10 @@ class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def _run_simple_test(self, source, destination, expected_args=None, expected_code=0,
                          expected_res=SUCCESS, **kwargs):

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -24,8 +24,8 @@ from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
 from buildbot.steps import mswin
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestRobocopySimple(steps.BuildStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -25,10 +25,10 @@ from buildbot.process.results import Results
 from buildbot.steps import mswin
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestRobocopySimple(steps.BuildStepMixin, TestReactorMixin,
+class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin,
                          unittest.TestCase):
 
     """

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -27,7 +27,7 @@ class TestDebLintian(steps.BuildStepMixin, TestReactorMixin,
                      unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -28,10 +28,10 @@ class TestDebLintian(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_fileloc(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -20,10 +20,10 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.deb import lintian
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestDebLintian(steps.BuildStepMixin, TestReactorMixin,
+class TestDebLintian(TestBuildStepMixin, TestReactorMixin,
                      unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -19,8 +19,8 @@ from buildbot import config
 from buildbot.process.results import SUCCESS
 from buildbot.steps.package.deb import lintian
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestDebLintian(steps.BuildStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -33,7 +33,7 @@ class TestDebPbuilder(steps.BuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -279,7 +279,7 @@ class TestDebCowbuilder(steps.BuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -370,7 +370,7 @@ class TestUbuPbuilder(steps.BuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -405,7 +405,7 @@ class TestUbuCowbuilder(steps.BuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -26,10 +26,10 @@ from buildbot.steps.package.deb import pbuilder
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestDebPbuilder(steps.BuildStepMixin, TestReactorMixin,
+class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
@@ -275,7 +275,7 @@ class TestDebPbuilder(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestDebCowbuilder(steps.BuildStepMixin, TestReactorMixin,
+class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
@@ -366,7 +366,7 @@ class TestDebCowbuilder(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestUbuPbuilder(steps.BuildStepMixin, TestReactorMixin,
+class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
@@ -401,7 +401,7 @@ class TestUbuPbuilder(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestUbuCowbuilder(steps.BuildStepMixin, TestReactorMixin,
+class TestUbuCowbuilder(TestBuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -34,10 +34,10 @@ class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_new(self):
         self.setup_step(pbuilder.DebPbuilder())
@@ -280,10 +280,10 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_new(self):
         self.setup_step(pbuilder.DebCowbuilder())
@@ -371,10 +371,10 @@ class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_distribution(self):
         with self.assertRaises(config.ConfigErrors):
@@ -406,10 +406,10 @@ class TestUbuCowbuilder(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_distribution(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -25,8 +25,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.deb import pbuilder
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestDebPbuilder(steps.BuildStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -22,10 +22,10 @@ from buildbot.steps.package.rpm import mock
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestMock(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -96,7 +96,7 @@ class TestMock(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class TestMockBuildSRPM(steps.BuildStepMixin, TestReactorMixin,
+class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
@@ -128,7 +128,7 @@ class TestMockBuildSRPM(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestMockRebuild(steps.BuildStepMixin, TestReactorMixin,
+class TestMockRebuild(TestBuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -28,7 +28,7 @@ from buildbot.test.util import steps
 class TestMock(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -100,7 +100,7 @@ class TestMockBuildSRPM(steps.BuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -132,7 +132,7 @@ class TestMockRebuild(steps.BuildStepMixin, TestReactorMixin,
                       unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -29,10 +29,10 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_root(self):
         with self.assertRaises(config.ConfigErrors):
@@ -101,10 +101,10 @@ class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_spec(self):
         with self.assertRaises(config.ConfigErrors):
@@ -133,10 +133,10 @@ class TestMockRebuild(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_srpm(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -21,8 +21,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import mock
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestMock(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -32,7 +32,7 @@ from buildbot.test.util import steps
 class RpmBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -25,8 +25,8 @@ from buildbot.process.properties import Interpolate
 from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import rpmbuild
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class RpmBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -26,10 +26,10 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import rpmbuild
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class RpmBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class RpmBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -33,10 +33,10 @@ class RpmBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_specfile(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -26,10 +26,10 @@ class TestRpmLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_success(self):
         self.setup_step(rpmlint.RpmLint())

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -25,7 +25,7 @@ from buildbot.test.util import steps
 class TestRpmLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -19,10 +19,10 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import rpmlint
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class TestRpmLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestRpmLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -18,8 +18,8 @@ from twisted.trial import unittest
 from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import rpmlint
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestRpmLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -574,7 +574,7 @@ class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         )
         self.expect_outcome(result=WARNINGS,
                            state_string="sphinx 2 warnings (warnings)")
-        self.expect_logfile("warnings", warnings)
+        self.expect_log_file("warnings", warnings)
         yield self.run_step()
 
         self.assertEqual(self.step.statistics, {'warnings': 2})

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -128,10 +128,10 @@ class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_sample(self):
         self.setup_step(python.BuildEPYDoc())
@@ -149,10 +149,10 @@ class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @parameterized.expand([
         ('no_results', True),
@@ -415,10 +415,10 @@ class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_success(self):
         self.setup_step(python.PyFlakes())
@@ -503,10 +503,10 @@ class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_builddir_required(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -127,7 +127,7 @@ Warning: Unable to extract the base list for
 class BuildEPYDoc(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -148,7 +148,7 @@ class BuildEPYDoc(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -414,7 +414,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class PyFlakes(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -502,7 +502,7 @@ class PyFlakes(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class TestSphinx(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -25,7 +25,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import python
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 log_output_success = '''\
 Making output directory...
@@ -124,7 +124,7 @@ Warning: Unable to extract the base list for
 '''
 
 
-class BuildEPYDoc(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -145,7 +145,7 @@ class BuildEPYDoc(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -411,7 +411,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class PyFlakes(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -499,7 +499,7 @@ class PyFlakes(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class TestSphinx(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -24,8 +24,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import python
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 log_output_success = '''\
 Making output directory...

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -222,7 +222,7 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_build_changed_files(self):
         self.setup_step(python_twisted.Trial(workdir='build', testChanges=True, testpath=None),
-                       buildFiles=['my/test/file.py', 'my/test/file2.py'])
+                        build_files=['my/test/file.py', 'my/test/file2.py'])
 
         self.expect_commands(
             ExpectShell(workdir='build',
@@ -365,7 +365,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_run_ok(self):
         self.setup_step(python_twisted.HLint(workdir='build'),
-                       buildFiles=['foo.xhtml'])
+                        build_files=['foo.xhtml'])
         self.expect_commands(
             ExpectShell(workdir='build',
                         command=[
@@ -379,7 +379,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_custom_python(self):
         self.setup_step(python_twisted.HLint(workdir='build', python='/bin/mypython'),
-                       buildFiles=['foo.xhtml'])
+                        build_files=['foo.xhtml'])
         self.expect_commands(
             ExpectShell(workdir='build',
                         command=['/bin/mypython', 'bin/lore', '-p', '--output', 'lint',
@@ -392,7 +392,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_command_failure(self):
         self.setup_step(python_twisted.HLint(workdir='build'),
-                       buildFiles=['foo.xhtml'])
+                        build_files=['foo.xhtml'])
         self.expect_commands(
             ExpectShell(workdir='build',
                         command=['bin/lore', '-p', '--output', 'lint', 'foo.xhtml'],)
@@ -409,7 +409,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_run_warnings(self):
         self.setup_step(python_twisted.HLint(workdir='build'),
-                       buildFiles=['foo.xhtml'])
+                        build_files=['foo.xhtml'])
         self.expect_commands(
             ExpectShell(workdir='build',
                         command=[

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -195,8 +195,8 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         )
         self.expect_outcome(
             result=FAILURE, state_string='tests 8 failures (failure)')
-        self.expect_logfile('problems', failureLog.split('\n\n', 1)[1][:-1])
-        self.expect_logfile('warnings', textwrap.dedent('''\
+        self.expect_log_file('problems', failureLog.split('\n\n', 1)[1][:-1])
+        self.expect_log_file('warnings', textwrap.dedent('''\
                 buildbot.test.unit.test_steps_python_twisted.Trial.test_run_env_nodupe ... [FAILURE]/home/dustin/code/buildbot/t/buildbot/master/buildbot/test/fake/logfile.py:92: UserWarning: step uses removed LogFile method `getText`
                 buildbot.test.unit.test_steps_python_twisted.Trial.test_run_env_supplement ... [FAILURE]/home/dustin/code/buildbot/t/buildbot/master/buildbot/test/fake/logfile.py:92: UserWarning: step uses removed LogFile method `getText`
                 buildbot.test.unit.test_steps_python_twisted.Trial.test_run_jobs ... [FAILURE]/home/dustin/code/buildbot/t/buildbot/master/buildbot/test/fake/logfile.py:92: UserWarning: step uses removed LogFile method `getText`
@@ -373,7 +373,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .stdout("dunno what hlint output looks like..\n")
             .exit(0)
         )
-        self.expect_logfile('files', 'foo.xhtml\n')
+        self.expect_log_file('files', 'foo.xhtml\n')
         self.expect_outcome(result=SUCCESS, state_string='0 hlints')
         return self.run_step()
 
@@ -386,7 +386,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
                                  'foo.xhtml'])
             .exit(0)
         )
-        self.expect_logfile('files', 'foo.xhtml\n')
+        self.expect_log_file('files', 'foo.xhtml\n')
         self.expect_outcome(result=SUCCESS, state_string='0 hlints')
         return self.run_step()
 
@@ -398,7 +398,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['bin/lore', '-p', '--output', 'lint', 'foo.xhtml'],)
             .exit(1)
         )
-        self.expect_logfile('files', 'foo.xhtml\n')
+        self.expect_log_file('files', 'foo.xhtml\n')
         self.expect_outcome(result=FAILURE, state_string='hlint (failure)')
         return self.run_step()
 
@@ -417,7 +417,7 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .stdout("colon: meaning warning\n")
             .exit(0)
         )
-        self.expect_logfile('warnings', 'colon: meaning warning')
+        self.expect_log_file('warnings', 'colon: meaning warning')
         self.expect_outcome(result=WARNINGS, state_string='1 hlint (warnings)')
         return self.run_step()
 

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -94,7 +94,7 @@ FAILED (failures=8)
 class Trial(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -357,7 +357,7 @@ class Trial(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class HLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -425,7 +425,7 @@ class HLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class RemovePYCs(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -24,8 +24,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import python_twisted
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 failureLog = '''\
 buildbot.test.unit.test_steps_python_twisted.Trial.testProperties ... [FAILURE]

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -25,7 +25,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import python_twisted
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 failureLog = '''\
 buildbot.test.unit.test_steps_python_twisted.Trial.testProperties ... [FAILURE]
@@ -91,7 +91,7 @@ FAILED (failures=8)
 '''  # noqa pylint: disable=line-too-long
 
 
-class Trial(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -354,7 +354,7 @@ class Trial(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class HLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -422,7 +422,7 @@ class HLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class RemovePYCs(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -95,10 +95,10 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_run_env(self):
         self.setup_step(
@@ -358,10 +358,10 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_run_ok(self):
         self.setup_step(python_twisted.HLint(workdir='build'),
@@ -426,10 +426,10 @@ class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_run_ok(self):
         self.setup_step(python_twisted.RemovePYCs())

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -18,8 +18,8 @@ from twisted.trial import unittest
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.properties import Interpolate
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config as configmixin
-from buildbot.test.util import steps
 
 
 class TestBuildStep(BuildStep):
@@ -28,7 +28,7 @@ class TestBuildStep(BuildStep):
         return 0
 
 
-class TestBuildStepNameIsRenderable(steps.BuildStepMixin, unittest.TestCase,
+class TestBuildStepNameIsRenderable(TestBuildStepMixin, unittest.TestCase,
                                     TestReactorMixin,
                                     configmixin.ConfigErrorsMixin):
 

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -34,10 +34,10 @@ class TestBuildStepNameIsRenderable(TestBuildStepMixin, unittest.TestCase,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_name_is_renderable(self):
         step = TestBuildStep(name=Interpolate('%(kw:foo)s', foo='bar'))

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -33,7 +33,7 @@ class TestBuildStepNameIsRenderable(steps.BuildStepMixin, unittest.TestCase,
                                     configmixin.ConfigErrorsMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -17,9 +17,9 @@ from twisted.trial import unittest
 
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.properties import Interpolate
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestBuildStep(BuildStep):

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -31,9 +31,9 @@ from buildbot.steps import shell
 from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectUploadFile
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestShellCommandExecution(steps.BuildStepMixin,

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -42,7 +42,7 @@ class TestShellCommandExecution(steps.BuildStepMixin,
                                 unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -204,7 +204,7 @@ class TestShellCommandExecution(steps.BuildStepMixin,
 class TreeSize(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -252,7 +252,7 @@ class SetPropertyFromCommand(steps.BuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -415,7 +415,7 @@ class SetPropertyFromCommand(steps.BuildStepMixin, TestReactorMixin,
 class PerlModuleTest(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -542,7 +542,7 @@ class SetPropertyDeprecation(unittest.TestCase):
 class Configure(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -570,7 +570,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin,
                                   unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -912,7 +912,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin,
 class Compile(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -935,7 +935,7 @@ class Test(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
            unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -32,11 +32,11 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectUploadFile
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config as configmixin
-from buildbot.test.util import steps
 
 
-class TestShellCommandExecution(steps.BuildStepMixin,
+class TestShellCommandExecution(TestBuildStepMixin,
                                 configmixin.ConfigErrorsMixin,
                                 TestReactorMixin,
                                 unittest.TestCase):
@@ -201,7 +201,7 @@ class TestShellCommandExecution(steps.BuildStepMixin,
             shell.ShellCommand()
 
 
-class TreeSize(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -248,7 +248,7 @@ class TreeSize(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class SetPropertyFromCommand(steps.BuildStepMixin, TestReactorMixin,
+class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
@@ -412,7 +412,7 @@ class SetPropertyFromCommand(steps.BuildStepMixin, TestReactorMixin,
             shell.SetPropertyFromCommand(command=["echo", "value"])
 
 
-class PerlModuleTest(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -539,7 +539,7 @@ class SetPropertyDeprecation(unittest.TestCase):
                          )
 
 
-class Configure(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class Configure(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -564,7 +564,7 @@ class Configure(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class WarningCountingShellCommand(steps.BuildStepMixin,
+class WarningCountingShellCommand(TestBuildStepMixin,
                                   configmixin.ConfigErrorsMixin,
                                   TestReactorMixin,
                                   unittest.TestCase):
@@ -909,7 +909,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin,
             shell.WarningCountingShellCommand()
 
 
-class Compile(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -930,7 +930,7 @@ class Compile(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(step.command, ["make", "all"])
 
 
-class Test(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
+class Test(TestBuildStepMixin, configmixin.ConfigErrorsMixin,
            TestReactorMixin,
            unittest.TestCase):
 

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -274,7 +274,7 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
         self.expect_outcome(result=SUCCESS,
                            state_string="property 'res' set")
         self.expect_property("res", "abcdef")  # note: stripped
-        self.expect_logfile('property changes', r"res: " + repr('abcdef'))
+        self.expect_log_file('property changes', r"res: " + repr('abcdef'))
         return self.run_step()
 
     def test_renderable_workdir(self):
@@ -290,7 +290,7 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
         self.expect_outcome(result=SUCCESS,
                            state_string="property 'res' set")
         self.expect_property("res", "abcdef")  # note: stripped
-        self.expect_logfile('property changes', r"res: " + repr('abcdef'))
+        self.expect_log_file('property changes', r"res: " + repr('abcdef'))
         return self.run_step()
 
     def test_run_property_no_strip(self):
@@ -304,7 +304,7 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
         self.expect_outcome(result=SUCCESS,
                            state_string="property 'res' set")
         self.expect_property("res", "\n\nabcdef\n")
-        self.expect_logfile('property changes', r"res: " + repr('\n\nabcdef\n'))
+        self.expect_log_file('property changes', r"res: " + repr('\n\nabcdef\n'))
         return self.run_step()
 
     def test_run_failure(self):
@@ -339,7 +339,7 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
         )
         self.expect_outcome(result=SUCCESS,
                            state_string="2 properties set")
-        self.expect_logfile('property changes', 'a: 1\nb: 2')
+        self.expect_log_file('property changes', 'a: 1\nb: 2')
         self.expect_property("a", 1)
         self.expect_property("b", 2)
         return self.run_step()
@@ -358,7 +358,7 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
         # note that extract_fn *is* called anyway
         self.expect_outcome(result=FAILURE,
                            state_string="2 properties set (failure)")
-        self.expect_logfile('property changes', 'a: 1\nb: 2')
+        self.expect_log_file('property changes', 'a: 1\nb: 2')
         return self.run_step()
 
     def test_run_extract_fn_cmdfail_empty(self):
@@ -599,7 +599,7 @@ class WarningCountingShellCommand(TestBuildStepMixin,
         )
         self.expect_outcome(result=WARNINGS)
         self.expect_property("warnings-count", 2)
-        self.expect_logfile("warnings (2)",
+        self.expect_log_file("warnings (2)",
                            "warning: blarg!\nWARNING: blarg!\n")
         return self.run_step()
 
@@ -614,7 +614,7 @@ class WarningCountingShellCommand(TestBuildStepMixin,
         )
         self.expect_outcome(result=WARNINGS)
         self.expect_property("warnings-count", 2)
-        self.expect_logfile("warnings (2)", "scary: foo\nscary: bar\n")
+        self.expect_log_file("warnings (2)", "scary: foo\nscary: bar\n")
         return self.run_step()
 
     def test_maxWarnCount(self):
@@ -639,7 +639,7 @@ class WarningCountingShellCommand(TestBuildStepMixin,
         )
         self.expect_outcome(result=FAILURE)
         self.expect_property("warnings-count", 1)
-        self.expect_logfile("warnings (1)", "warning: I might fail\n")
+        self.expect_log_file("warnings (1)", "warning: I might fail\n")
         return self.run_step()
 
     def test_warn_with_decoderc(self):
@@ -701,7 +701,7 @@ class WarningCountingShellCommand(TestBuildStepMixin,
             if exp_warning_count != 0:
                 self.expect_outcome(result=WARNINGS,
                                    state_string="'make' (warnings)")
-                self.expect_logfile("warnings (%d)" % exp_warning_count,
+                self.expect_log_file("warnings (%d)" % exp_warning_count,
                                    exp_warning_log)
             else:
                 self.expect_outcome(result=SUCCESS,

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -43,10 +43,10 @@ class TestShellCommandExecution(TestBuildStepMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_doStepIf_False(self):
         self.setup_step(shell.ShellCommand(command="echo hello", doStepIf=False))
@@ -205,10 +205,10 @@ class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_run_success(self):
         self.setup_step(shell.TreeSize())
@@ -253,10 +253,10 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_constructor_conflict(self):
         with self.assertRaises(config.ConfigErrors):
@@ -416,10 +416,10 @@ class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_new_version_success(self):
         self.setup_step(shell.PerlModuleTest(command="cmd"))
@@ -543,10 +543,10 @@ class Configure(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_class_attrs(self):
         step = shell.Configure()
@@ -571,10 +571,10 @@ class WarningCountingShellCommand(TestBuildStepMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_no_warnings(self):
         self.setup_step(shell.WarningCountingShellCommand(workdir='w', command=['make']))
@@ -913,10 +913,10 @@ class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_class_args(self):
         # since this step is just a pre-configured WarningCountingShellCommand,
@@ -936,10 +936,10 @@ class Test(TestBuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        self.setup_build_step()
+        self.setup_test_build_step()
 
     def tearDown(self):
-        self.tear_down_build_step()
+        self.tear_down_test_build_step()
 
     def test_setTestResults(self):
         step = self.setup_step(shell.Test())

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -23,8 +23,8 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import shellsequence
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config as configmixin
-from buildbot.test.util import steps
 from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 
@@ -35,7 +35,7 @@ class DynamicRun(shellsequence.ShellSequence):
         return self.runShellSequence(self.dynamicCommands)
 
 
-class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
+class TestOneShellCommand(TestBuildStepMixin, configmixin.ConfigErrorsMixin,
                           TestReactorMixin, unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -39,7 +39,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
                           TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -40,10 +40,10 @@ class TestOneShellCommand(TestBuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_shell_arg_warn_deprecated_logfile(self):
         with assertProducesWarnings(DeprecatedApiWarning,

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -22,9 +22,9 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import shellsequence
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 
 from buildbot.process import results
 from buildbot.steps.source import Source
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class OldStyleSourceStep(Source):

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -21,8 +21,8 @@ from twisted.trial import unittest
 from buildbot.process import results
 from buildbot.steps.source import Source
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util import steps
 
 
 class OldStyleSourceStep(Source):
@@ -165,7 +165,7 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
         self.flushLoggedErrors(NotImplementedError)
 
 
-class TestSourceDescription(steps.BuildStepMixin, TestReactorMixin,
+class TestSourceDescription(TestBuildStepMixin, TestReactorMixin,
                             unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -35,7 +35,7 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
                  unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -169,7 +169,7 @@ class TestSourceDescription(steps.BuildStepMixin, TestReactorMixin,
                             unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -206,7 +206,7 @@ class TestSourceAttrGroup(sourcesteps.SourceStepMixin, TestReactorMixin,
                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -36,10 +36,10 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def setup_deferred_mock(self):
         m = mock.Mock()
@@ -170,10 +170,10 @@ class TestSourceDescription(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_constructor_args_strings(self):
         step = Source(workdir='build',
@@ -207,10 +207,10 @@ class TestSourceAttrGroup(sourcesteps.SourceStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_attrgroup_hasattr(self):
         step = AttrGroup()

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -31,8 +31,8 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -39,7 +39,7 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
               unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -38,7 +38,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
               unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -30,8 +30,8 @@ from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
 from buildbot.test.expect import ExpectUploadFile
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -35,7 +35,7 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
                 unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -27,8 +27,8 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -20,9 +20,9 @@ from buildbot.steps.source import gerrit
 from buildbot.test.expect import ExpectListdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -29,7 +29,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                  TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -3240,10 +3240,10 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_push_simple(self):
         url = 'ssh://github.com/test/test.git'
@@ -3547,10 +3547,10 @@ class TestGitTag(TestBuildStepMixin, config.ConfigErrorsMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_tag_annotated(self):
         messages = ['msg1', 'msg2']
@@ -3662,10 +3662,10 @@ class TestGitCommit(TestBuildStepMixin, config.ConfigErrorsMixin,
         self.message_list = ['my commit', '42']
         self.path_list = ['file1.txt', 'file2.txt']
 
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_add_fail(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -593,7 +593,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'),
-            wantDefaultWorkdir=False)
+            want_default_work_dir=False)
         workdir = '/myworkdir/workdir'
         self.build.workdir = workdir
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -35,11 +35,11 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.unit.steps.test_transfer import downloadString
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -51,7 +51,7 @@ class TestGit(sourcesteps.SourceStepMixin,
     stepClass = git.Git
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 
@@ -3239,7 +3239,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
     stepClass = git.GitPush
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -3546,7 +3546,7 @@ class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,
     stepClass = git.GitTag
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -3658,7 +3658,7 @@ class TestGitCommit(steps.BuildStepMixin, config.ConfigErrorsMixin,
     stepClass = git.GitCommit
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.message_list = ['my commit', '42']
         self.path_list = ['file1.txt', 'file2.txt']
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -36,10 +36,10 @@ from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.unit.steps.test_transfer import downloadString
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
-from buildbot.test.util import steps
 from buildbot.util import unicode2bytes
 
 
@@ -3233,7 +3233,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='full', method='unknown')
 
 
-class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
+class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                   TestReactorMixin,
                   unittest.TestCase):
     stepClass = git.GitPush
@@ -3541,7 +3541,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl="url")
 
 
-class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,
+class TestGitTag(TestBuildStepMixin, config.ConfigErrorsMixin,
                  TestReactorMixin, unittest.TestCase):
     stepClass = git.GitTag
 
@@ -3652,7 +3652,7 @@ class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.flushLoggedErrors(WorkerSetupError)
 
 
-class TestGitCommit(steps.BuildStepMixin, config.ConfigErrorsMixin,
+class TestGitCommit(TestBuildStepMixin, config.ConfigErrorsMixin,
                     TestReactorMixin,
                     unittest.TestCase):
     stepClass = git.GitCommit

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -20,9 +20,9 @@ from buildbot.steps.source import gitlab
 from buildbot.test.expect import ExpectListdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -31,7 +31,7 @@ class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
     stepClass = gitlab.GitLab
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -28,8 +28,8 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -36,7 +36,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
                     unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -42,7 +42,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
     MTN_VER = 'monotone 1.0 (base revision: UNKNOWN_REV)'
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -28,9 +28,9 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -26,9 +26,9 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.source.p4 import P4
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.properties import ConstantRenderable
 
 _is_windows = (platform.system() == 'Windows')

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -38,7 +38,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -24,8 +24,8 @@ from buildbot.test.expect import ExpectMkdir
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class RepoURL(unittest.TestCase):

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -61,7 +61,7 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
                unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.shouldRetry = False
         self.logEnviron = True
         return self.setUpSourceStep()

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -122,7 +122,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                             </info>"""
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -33,8 +33,8 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import sourcesteps
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.properties import ConstantRenderable
 
 

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -56,7 +56,7 @@ class TestSubUnit(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         if TestProtocolClient is None:
             raise unittest.SkipTest("Need to install python-subunit to test subunit step")
 
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -24,7 +24,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps import subunit
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 try:
     from subunit import TestProtocolClient
@@ -50,7 +50,7 @@ def create_error(name):
         return (exctype, value, None)
 
 
-class TestSubUnit(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestSubUnit(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         if TestProtocolClient is None:

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -57,10 +57,10 @@ class TestSubUnit(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             raise unittest.SkipTest("Need to install python-subunit to test subunit step")
 
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_empty(self):
         self.setup_step(subunit.SubunitShellCommand(command='test'))

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -118,7 +118,7 @@ class TestSubUnit(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         )
 
         self.expect_outcome(result=FAILURE, state_string="shell Total 1 test(s) 1 error (failure)")
-        self.expect_logfile('problems', re.compile(r'''test1
+        self.expect_log_file('problems', re.compile(r'''test1
 testtools.testresult.real._StringException:.*ValueError: invalid literal for int\(\) with base 10: '_error1'
 .*''', re.MULTILINE | re.DOTALL))  # noqa pylint: disable=line-too-long
         return self.run_step()
@@ -143,7 +143,7 @@ testtools.testresult.real._StringException:.*ValueError: invalid literal for int
         )
 
         self.expect_outcome(result=FAILURE, state_string="shell Total 2 test(s) 2 errors (failure)")
-        self.expect_logfile('problems', re.compile(r'''test1
+        self.expect_log_file('problems', re.compile(r'''test1
 testtools.testresult.real._StringException:.*ValueError: invalid literal for int\(\) with base 10: '_error1'
 
 test2
@@ -171,7 +171,7 @@ testtools.testresult.real._StringException:.*ValueError: invalid literal for int
         self.expect_outcome(result=SUCCESS,  # N.B. not WARNINGS
                            state_string="shell 1 test passed")
         # note that the warnings list is ignored..
-        self.expect_logfile('warnings', re.compile(r'''error: test2 \[.*
+        self.expect_log_file('warnings', re.compile(r'''error: test2 \[.*
 ValueError: invalid literal for int\(\) with base 10: '_error2'
 \]
 ''', re.MULTILINE | re.DOTALL))  # noqa pylint: disable=line-too-long

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -23,8 +23,8 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import subunit
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 try:
     from subunit import TestProtocolClient

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -39,8 +39,8 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectStat
 from buildbot.test.expect import ExpectUploadDirectory
 from buildbot.test.expect import ExpectUploadFile
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def downloadString(memoizer, timestamp=None):

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -59,7 +59,7 @@ def downloadString(memoizer, timestamp=None):
 class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
@@ -288,7 +288,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
@@ -439,7 +439,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
@@ -832,7 +832,7 @@ class TestFileDownload(steps.BuildStepMixin, TestReactorMixin,
                        unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
@@ -939,7 +939,7 @@ class TestStringDownload(steps.BuildStepMixin, TestReactorMixin,
                          unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -1036,7 +1036,7 @@ class TestJSONStringDownload(steps.BuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -1124,7 +1124,7 @@ class TestJSONStringDownload(steps.BuildStepMixin, TestReactorMixin,
 class TestJSONPropertiesDownload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -40,7 +40,7 @@ from buildbot.test.expect import ExpectStat
 from buildbot.test.expect import ExpectUploadDirectory
 from buildbot.test.expect import ExpectUploadFile
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
 def downloadString(memoizer, timestamp=None):
@@ -56,7 +56,7 @@ def downloadString(memoizer, timestamp=None):
     return behavior
 
 
-class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -284,7 +284,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
             transfer.FileUpload('src')
 
 
-class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
+class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin,
                           unittest.TestCase):
 
     def setUp(self):
@@ -435,7 +435,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
             transfer.DirectoryUpload('src')
 
 
-class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
+class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
@@ -828,7 +828,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             transfer.MultipleFileUpload(['srcfile'])
 
 
-class TestFileDownload(steps.BuildStepMixin, TestReactorMixin,
+class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
                        unittest.TestCase):
 
     def setUp(self):
@@ -935,7 +935,7 @@ class TestFileDownload(steps.BuildStepMixin, TestReactorMixin,
         yield self.run_step()
 
 
-class TestStringDownload(steps.BuildStepMixin, TestReactorMixin,
+class TestStringDownload(TestBuildStepMixin, TestReactorMixin,
                          unittest.TestCase):
 
     def setUp(self):
@@ -1032,7 +1032,7 @@ class TestStringDownload(steps.BuildStepMixin, TestReactorMixin,
             transfer.StringDownload('srcfile')
 
 
-class TestJSONStringDownload(steps.BuildStepMixin, TestReactorMixin,
+class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
@@ -1121,7 +1121,7 @@ class TestJSONStringDownload(steps.BuildStepMixin, TestReactorMixin,
             transfer.JSONStringDownload('srcfile')
 
 
-class TestJSONPropertiesDownload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -263,7 +263,7 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_outcome(result=CANCELLED,
                            state_string="uploading srcfile (cancelled)")
-        self.expect_logfile('interrupt', 'interrupt reason')
+        self.expect_log_file('interrupt', 'interrupt reason')
         yield self.run_step()
 
     def test_init_workersrc_keyword(self):
@@ -507,7 +507,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             .exit(1))
 
         self.expect_outcome(result=FAILURE, state_string="uploading 1 file (failure)")
-        self.expect_logfile('stderr',
+        self.expect_log_file('stderr',
                            "File wkdir/srcdir not available at worker")
 
         yield self.run_step()
@@ -522,7 +522,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             .exit(0))
 
         self.expect_outcome(result=FAILURE, state_string="uploading 1 file (failure)")
-        self.expect_logfile('stderr', 'srcdir is neither a regular file, nor a directory')
+        self.expect_log_file('stderr', 'srcdir is neither a regular file, nor a directory')
 
         yield self.run_step()
 
@@ -930,7 +930,7 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
         self.expect_outcome(result=FAILURE,
                            state_string="downloading to {0} (failure)".format(
                                os.path.basename(self.destfile)))
-        self.expect_logfile('stderr',
+        self.expect_log_file('stderr',
                            "File 'not existing file' not available at master")
         yield self.run_step()
 

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -63,12 +63,12 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def testConstructorModeType(self):
         with self.assertRaises(config.ConfigErrors):
@@ -293,13 +293,13 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin,
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def testBasic(self):
         self.setup_step(
@@ -444,13 +444,13 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def testEmpty(self):
         self.setup_step(
@@ -836,12 +836,12 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_init_workerdest_keyword(self):
         step = transfer.FileDownload(
@@ -940,10 +940,10 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     # check that ConfigErrors is raised on invalid 'mode' argument
 
@@ -1037,10 +1037,10 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def testBasic(self):
@@ -1125,10 +1125,10 @@ class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def testBasic(self):

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -31,7 +31,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps import trigger
 from buildbot.test import fakedb
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util.interfaces import InterfaceTests
 
 
@@ -96,7 +96,7 @@ def BRID_TO_BUILD_NUMBER(brid):
     return brid + 4000
 
 
-class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -100,10 +100,10 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def setup_step(self, step, sourcestampsInBuild=None, gotRevisionsInBuild=None, *args, **kwargs):

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -30,9 +30,9 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import trigger
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
 from buildbot.test.util.interfaces import InterfaceTests
-from buildbot.test.util.misc import TestReactorMixin
 
 
 @implementer(interfaces.ITriggerableScheduler)

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -99,7 +99,7 @@ def BRID_TO_BUILD_NUMBER(brid):
 class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -27,7 +27,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import vstudio
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 real_log = r"""
 1>------ Build started: Project: lib1, Configuration: debug Win32 ------
@@ -201,7 +201,7 @@ class VCx(vstudio.VisualStudio):
         return super().run()
 
 
-class VisualStudio(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     """
     Test L{VisualStudio} with a simple subclass, L{VCx}.
@@ -331,7 +331,7 @@ class VisualStudio(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
                 ['aa', 'bb', 'cc'])
 
 
-class TestVC6(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -428,7 +428,7 @@ class TestVC6(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class TestVC7(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestVC7(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -567,7 +567,7 @@ class VC8ExpectedEnvMixin:
         )
 
 
-class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
               unittest.TestCase):
 
     def setUp(self):
@@ -639,7 +639,7 @@ class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
         self.assertEqual(self.step.arch, 'x64')
 
 
-class TestVCExpress9(VC8ExpectedEnvMixin, steps.BuildStepMixin,
+class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin,
                      TestReactorMixin,
                      unittest.TestCase):
 
@@ -696,7 +696,7 @@ class TestVCExpress9(VC8ExpectedEnvMixin, steps.BuildStepMixin,
         return self.run_step()
 
 
-class TestVC9(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
               unittest.TestCase):
 
     def setUp(self):
@@ -721,7 +721,7 @@ class TestVC9(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestVC10(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
                unittest.TestCase):
 
     def setUp(self):
@@ -746,7 +746,7 @@ class TestVC10(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
                unittest.TestCase):
 
     def setUp(self):
@@ -771,7 +771,7 @@ class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestMsBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
@@ -856,7 +856,7 @@ class TestMsBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class TestMsBuild141(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -209,10 +209,10 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_default_config(self):
         vs = vstudio.VisualStudio()
@@ -335,10 +335,10 @@ class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
         include = [
@@ -432,10 +432,10 @@ class TestVC7(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
         include = [
@@ -572,10 +572,10 @@ class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_args(self):
         self.setup_step(vstudio.VC8(projectfile='pf', config='cfg',
@@ -645,10 +645,10 @@ class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_args(self):
         self.setup_step(vstudio.VCExpress9(projectfile='pf', config='cfg',
@@ -701,10 +701,10 @@ class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC9(projectfile='pf', config='cfg',
@@ -726,10 +726,10 @@ class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC10(projectfile='pf', config='cfg',
@@ -751,10 +751,10 @@ class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC11(projectfile='pf', config='cfg',
@@ -775,10 +775,10 @@ class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def test_no_platform(self):
@@ -860,10 +860,10 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def test_no_platform(self):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -208,7 +208,7 @@ class VisualStudio(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     """
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -334,7 +334,7 @@ class VisualStudio(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class TestVC6(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -431,7 +431,7 @@ class TestVC6(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class TestVC7(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -571,7 +571,7 @@ class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
               unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -644,7 +644,7 @@ class TestVCExpress9(VC8ExpectedEnvMixin, steps.BuildStepMixin,
                      unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -700,7 +700,7 @@ class TestVC9(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
               unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -725,7 +725,7 @@ class TestVC10(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
                unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -750,7 +750,7 @@ class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
                unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -774,7 +774,7 @@ class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
 class TestMsBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -859,7 +859,7 @@ class TestMsBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 class TestMsBuild141(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -26,8 +26,8 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import vstudio
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 real_log = r"""
 1>------ Build started: Project: lib1, Configuration: debug Win32 ------

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -36,8 +36,8 @@ from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectRmfile
 from buildbot.test.expect import ExpectStat
 from buildbot.test.expect import ExpectUploadFile
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def uploadString(string):

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -76,7 +76,7 @@ class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin,
         self.expect_property('four', 4, source='them')
         self.expect_property('five', 5, source='them')
         self.expect_property('six', '6', source='me')
-        self.expect_logfile("properties",
+        self.expect_log_file("properties",
                            "one = '1'\nsix = '6'")
         return self.run_step()
 
@@ -88,7 +88,7 @@ class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin,
         self.expect_outcome(result=SUCCESS,
                            state_string="Set")
         self.expect_property('eNv', 'EE', source='me')
-        self.expect_logfile("properties",
+        self.expect_log_file("properties",
                            "eNv = 'EE'")
         return self.run_step()
 

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -52,7 +52,7 @@ class TestSetPropertiesFromEnv(steps.BuildStepMixin, TestReactorMixin,
                                unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -97,7 +97,7 @@ class TestFileExists(steps.BuildStepMixin, TestReactorMixin,
                      unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -159,7 +159,7 @@ class TestCopyDirectory(steps.BuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -219,7 +219,7 @@ class TestRemoveDirectory(steps.BuildStepMixin, TestReactorMixin,
                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -261,7 +261,7 @@ class TestMakeDirectory(steps.BuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):
@@ -314,7 +314,7 @@ class TestCompositeStepMixin(steps.BuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -37,7 +37,7 @@ from buildbot.test.expect import ExpectRmfile
 from buildbot.test.expect import ExpectStat
 from buildbot.test.expect import ExpectUploadFile
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
 def uploadString(string):
@@ -48,7 +48,7 @@ def uploadString(string):
     return behavior
 
 
-class TestSetPropertiesFromEnv(steps.BuildStepMixin, TestReactorMixin,
+class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin,
                                unittest.TestCase):
 
     def setUp(self):
@@ -93,7 +93,7 @@ class TestSetPropertiesFromEnv(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestFileExists(steps.BuildStepMixin, TestReactorMixin,
+class TestFileExists(TestBuildStepMixin, TestReactorMixin,
                      unittest.TestCase):
 
     def setUp(self):
@@ -155,7 +155,7 @@ class TestFileExists(steps.BuildStepMixin, TestReactorMixin,
         self.flushLoggedErrors(WorkerSetupError)
 
 
-class TestCopyDirectory(steps.BuildStepMixin, TestReactorMixin,
+class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
@@ -215,7 +215,7 @@ class TestCopyDirectory(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestRemoveDirectory(steps.BuildStepMixin, TestReactorMixin,
+class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin,
                           unittest.TestCase):
 
     def setUp(self):
@@ -257,7 +257,7 @@ class TestRemoveDirectory(steps.BuildStepMixin, TestReactorMixin,
         return self.run_step()
 
 
-class TestMakeDirectory(steps.BuildStepMixin, TestReactorMixin,
+class TestMakeDirectory(TestBuildStepMixin, TestReactorMixin,
                         unittest.TestCase):
 
     def setUp(self):
@@ -310,7 +310,7 @@ class CompositeUser(buildstep.BuildStep, worker.CompositeStepMixin):
         return FAILURE if res else SUCCESS
 
 
-class TestCompositeStepMixin(steps.BuildStepMixin, TestReactorMixin,
+class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
                              unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -53,10 +53,10 @@ class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_simple(self):
         self.setup_step(worker.SetPropertiesFromEnv(
@@ -98,10 +98,10 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_found(self):
         self.setup_step(worker.FileExists(file="x"))
@@ -160,10 +160,10 @@ class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_success(self):
         self.setup_step(worker.CopyDirectory(src="s", dest="d"))
@@ -220,10 +220,10 @@ class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_success(self):
         self.setup_step(worker.RemoveDirectory(dir="d"))
@@ -262,10 +262,10 @@ class TestMakeDirectory(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_success(self):
         self.setup_step(worker.MakeDirectory(dir="d"))
@@ -315,10 +315,10 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_runRemoteCommand(self):
         cmd_args = ('foo', {'bar': False})

--- a/master/buildbot/test/unit/test_asyncio.py
+++ b/master/buildbot/test/unit/test_asyncio.py
@@ -20,7 +20,7 @@ from twisted.trial import unittest
 
 from buildbot import util
 from buildbot.asyncio import as_deferred
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class TestAsyncioTestLoop(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_asyncio.py
+++ b/master/buildbot/test/unit/test_asyncio.py
@@ -27,7 +27,7 @@ class TestAsyncioTestLoop(TestReactorMixin, unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
-        self.setUpTestReactor(use_asyncio=True)
+        self.setup_test_reactor(use_asyncio=True)
 
     def test_coroutine_schedule(self):
         d1 = defer.Deferred()

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -38,7 +38,7 @@ class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin,
                                             unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
@@ -75,7 +75,7 @@ class TestRemoveWorkerFileSecretCommand30(steps.BuildStepMixin,
                                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
@@ -114,7 +114,7 @@ class TestRemoveFileSecretToWorkerCommand(steps.BuildStepMixin,
                                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -42,10 +42,10 @@ class TestDownloadFileSecretToWorkerCommand(TestBuildStepMixin,
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def testBasic(self):
         self.setup_step(
@@ -79,10 +79,10 @@ class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin,
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def testBasic(self):
         self.setup_step(RemoveWorkerFileSecret(
@@ -118,10 +118,10 @@ class TestRemoveFileSecretToWorkerCommand(TestBuildStepMixin,
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def testBasic(self):
         self.setup_step(

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -28,9 +28,9 @@ from buildbot.test.expect import ExpectDownloadFile
 from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectRmfile
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin,

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -29,11 +29,11 @@ from buildbot.test.expect import ExpectRemoteRef
 from buildbot.test.expect import ExpectRmdir
 from buildbot.test.expect import ExpectRmfile
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config as configmixin
-from buildbot.test.util import steps
 
 
-class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin,
+class TestDownloadFileSecretToWorkerCommand(TestBuildStepMixin,
                                             TestReactorMixin,
                                             unittest.TestCase):
 
@@ -70,7 +70,7 @@ class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin,
         return d
 
 
-class TestRemoveWorkerFileSecretCommand30(steps.BuildStepMixin,
+class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin,
                                           TestReactorMixin,
                                           unittest.TestCase):
 
@@ -108,7 +108,7 @@ class TestRemoveWorkerFileSecretCommand30(steps.BuildStepMixin,
         return d
 
 
-class TestRemoveFileSecretToWorkerCommand(steps.BuildStepMixin,
+class TestRemoveFileSecretToWorkerCommand(TestBuildStepMixin,
                                           configmixin.ConfigErrorsMixin,
                                           TestReactorMixin,
                                           unittest.TestCase):

--- a/master/buildbot/test/unit/test_fake_secrets_manager.py
+++ b/master/buildbot/test/unit/test_fake_secrets_manager.py
@@ -12,7 +12,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestSecretsManager(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.master.config.secretsProviders = [FakeSecretStorage(secretdict={"foo": "bar",
                                                                              "other": "value"})]

--- a/master/buildbot/test/unit/test_fake_secrets_manager.py
+++ b/master/buildbot/test/unit/test_fake_secrets_manager.py
@@ -6,7 +6,7 @@ from buildbot.secrets.manager import SecretManager
 from buildbot.secrets.secret import SecretDetails
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake.secrets import FakeSecretStorage
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class TestSecretsManager(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -24,7 +24,7 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"foo": "bar",
@@ -53,7 +53,7 @@ class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase,
                                       ConfigErrorsMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.build = FakeBuildWithMaster(self.master)
 
@@ -70,7 +70,7 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         password = "bar"

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -8,8 +8,8 @@ from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake.fakebuild import FakeBuild
 from buildbot.test.fake.secrets import FakeSecretStorage
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class FakeBuildWithMaster(FakeBuild):

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -32,10 +32,10 @@ from buildbot.configurators.janitor import LogChunksJanitor
 from buildbot.process.results import SUCCESS
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import configurators
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import datetime2epoch
 from buildbot.worker.local import LocalWorker
 

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -72,11 +72,11 @@ class LogChunksJanitorTests(TestBuildStepMixin,
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
-        yield self.setup_build_step()
+        yield self.setup_test_build_step()
         self.patch(janitor, "now", lambda: datetime.datetime(year=2017, month=1, day=1))
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -33,9 +33,9 @@ from buildbot.process.results import SUCCESS
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import configurators
-from buildbot.test.util import steps
 from buildbot.util import datetime2epoch
 from buildbot.worker.local import LocalWorker
 
@@ -64,7 +64,7 @@ class JanitorConfiguratorTests(configurators.ConfiguratorMixin, unittest.Synchro
         self.expectNoConfigError()
 
 
-class LogChunksJanitorTests(steps.BuildStepMixin,
+class LogChunksJanitorTests(TestBuildStepMixin,
                             configmixin.ConfigErrorsMixin,
                             TestReactorMixin,
                             unittest.TestCase):

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -71,7 +71,7 @@ class LogChunksJanitorTests(steps.BuildStepMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         yield self.setup_build_step()
         self.patch(janitor, "now", lambda: datetime.datetime(year=2017, month=1, day=1))
 

--- a/master/buildbot/test/unit/test_machine_generic.py
+++ b/master/buildbot/test/unit/test_machine_generic.py
@@ -26,8 +26,8 @@ from buildbot.machine.generic import RemoteSshSuspendAction
 from buildbot.machine.generic import RemoteSshWakeAction
 from buildbot.machine.generic import RemoteSshWOLAction
 from buildbot.test.fake.private_tempdir import MockPrivateTemporaryDirectory
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 

--- a/master/buildbot/test/unit/test_machine_generic.py
+++ b/master/buildbot/test/unit/test_machine_generic.py
@@ -46,7 +46,7 @@ class FakeManager:
 class TestActions(MasterRunProcessMixin, config.ConfigErrorsMixin, TestReactorMixin,
                   unittest.TestCase):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -78,7 +78,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpLogging()
         self.basedir = os.path.abspath('basedir')
         yield self.setUpDirs(self.basedir)

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -34,9 +34,9 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakedata
 from buildbot.test.fake import fakemq
 from buildbot.test.fake.botmaster import FakeBotMaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import dirs
 from buildbot.test.util import logging
-from buildbot.test.util.misc import TestReactorMixin
 
 
 @implementer(IConfigLoader)

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -136,7 +136,7 @@ class RealTests(tuplematching.TupleMatchingMixin, Tests):
 class TestFakeMQ(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True)
         self.mq = self.master.mq
         self.mq.verifyMessages = False
@@ -146,7 +146,7 @@ class TestSimpleMQ(TestReactorMixin, unittest.TestCase, RealTests):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         yield self.mq.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 
 from buildbot.mq import simple
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
 from buildbot.test.util import tuplematching
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Tests(interfaces.InterfaceTests):

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -44,7 +44,7 @@ class MQConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.mqconfig = self.master.config.mq = {}
         self.conn = connector.MQConnector()

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -21,7 +21,7 @@ from twisted.trial import unittest
 from buildbot.mq import base
 from buildbot.mq import connector
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import service
 
 

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -20,7 +20,7 @@ from twisted.trial import unittest
 
 from buildbot.mq import simple
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 class SimpleMQ(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -27,7 +27,7 @@ class SimpleMQ(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         self.mq.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -127,7 +127,7 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.master.wamp = FakeWampConnector()
         self.mq = wamp.WampMQ()
@@ -251,7 +251,7 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         if "WAMP_ROUTER_URL" not in os.environ:
             raise unittest.SkipTest(self.HOW_TO_RUN)
         self.master = fakemaster.make_master(self)

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -26,7 +26,7 @@ from twisted.trial import unittest
 
 from buildbot.mq import wamp
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.wamp import connector
 
 

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -33,7 +33,7 @@ class TestSecretInPass(MasterRunProcessMixin, TestReactorMixin, ConfigErrorsMixi
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         self.master = fakemaster.make_master(self)
         with mock.patch.object(Path, "is_file", return_value=True):

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -22,8 +22,8 @@ from twisted.trial import unittest
 
 from buildbot.secrets.providers.passwordstore import SecretInPass
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -21,8 +21,8 @@ from twisted.trial import unittest
 from buildbot.secrets.providers.vault import HashiCorpVaultSecretProvider
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -31,7 +31,7 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def setUp(self, version):
         warnings.simplefilter('ignore')
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.srvcVault = HashiCorpVaultSecretProvider(vaultServer="http://vaultServer",
                                                       vaultToken="someToken",
                                                       apiVersion=version)

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -5,7 +5,7 @@ from buildbot.process.properties import Secret
 from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake.secrets import FakeSecretStorage
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util.service import BuildbotService
 
 

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -27,7 +27,7 @@ class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage(secretdict={"foo": "bar",
                                                        "other": "value"})

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -30,8 +30,8 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakestats
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import logging
-from buildbot.test.util import steps
 
 
 class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
@@ -179,7 +179,7 @@ class TestInfluxDB(TestStatsServicesBase, logging.LoggingMixin):
         self.assertLogged("Service.*not initialized")
 
 
-class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
+class TestStatsServicesConsumers(TestBuildStepMixin, TestStatsServicesBase):
 
     """
     Test the stats service from a fake step

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -29,9 +29,9 @@ from buildbot.statistics.storage_backends.influxdb_client import InfluxStorageSe
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakestats
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import logging
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -41,7 +41,7 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
                                              wantDb=True)
 

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -59,7 +59,7 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .log('stdio-diff', stderr='fatal: ambiguous argument')
             .exit(1),
             )
-        self.expect_logfile('stdio-merge-base', '1234123412341234')
+        self.expect_log_file('stdio-merge-base', '1234123412341234')
         self.expect_log_file_stderr('stdio-diff', 'fatal: ambiguous argument')
         self.expect_outcome(result=results.FAILURE, state_string="GitDiffInfo (failure)")
         return self.run_step()
@@ -75,7 +75,7 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .log('stdio-diff', stdout='')
             .exit(0),
             )
-        self.expect_logfile('stdio-merge-base', '1234123412341234')
+        self.expect_log_file('stdio-merge-base', '1234123412341234')
         self.expect_log_file_stderr('stdio-diff', '')
         self.expect_outcome(result=results.SUCCESS, state_string="GitDiffInfo")
         self.expect_build_data('diffinfo-master', b'[]', 'GitDiffInfo')
@@ -123,7 +123,7 @@ index 0000000..632e269
 ''')
             .exit(0)
             )
-        self.expect_logfile('stdio-merge-base', '1234123412341234')
+        self.expect_log_file('stdio-merge-base', '1234123412341234')
         self.expect_outcome(result=results.SUCCESS, state_string="GitDiffInfo")
 
         diff_info = (

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -19,7 +19,7 @@ from buildbot.process import results
 from buildbot.steps import gitdiffinfo
 from buildbot.test.expect import ExpectShell
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 try:
     import unidiff
@@ -27,7 +27,7 @@ except ImportError:
     unidiff = None
 
 
-class TestDiffInfo(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     if not unidiff:
         skip = 'unidiff is required for GitDiffInfo tests'
 

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -18,8 +18,8 @@ from twisted.trial import unittest
 from buildbot.process import results
 from buildbot.steps import gitdiffinfo
 from buildbot.test.expect import ExpectShell
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import steps
-from buildbot.test.util.misc import TestReactorMixin
 
 try:
     import unidiff

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -33,10 +33,10 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setup_test_reactor()
-        return self.setup_build_step()
+        return self.setup_test_build_step()
 
     def tearDown(self):
-        return self.tear_down_build_step()
+        return self.tear_down_test_build_step()
 
     def test_merge_base_failure(self):
         self.setup_step(gitdiffinfo.GitDiffInfo())

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -32,7 +32,7 @@ class TestDiffInfo(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         skip = 'unidiff is required for GitDiffInfo tests'
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         return self.setup_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -21,7 +21,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import service
 from buildbot.wamp import connector
 

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -59,7 +59,7 @@ class WampConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         master = fakemaster.make_master(self)
         self.connector = TestedWampConnector()
 

--- a/master/buildbot/test/unit/util/test_backoff.py
+++ b/master/buildbot/test/unit/util/test_backoff.py
@@ -18,7 +18,7 @@ import time
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import backoff
 
 

--- a/master/buildbot/test/unit/util/test_backoff.py
+++ b/master/buildbot/test/unit/util/test_backoff.py
@@ -28,7 +28,7 @@ class TestException(Exception):
 
 class ExponentialBackoffEngineAsyncTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     def test_construct_asserts(self):
         with self.assertRaises(ValueError):

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -17,8 +17,8 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import codebase
 from buildbot.util import state
 

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -40,7 +40,7 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
                  'b': {'repository': '', 'branch': 'master'}}
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.db = self.master.db
         self.object = FakeObject(self.master, self.codebases)

--- a/master/buildbot/test/unit/util/test_deferwaiter.py
+++ b/master/buildbot/test/unit/util/test_deferwaiter.py
@@ -116,7 +116,7 @@ class WaiterTests(unittest.TestCase):
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_does_not_add_action_on_start(self):

--- a/master/buildbot/test/unit/util/test_deferwaiter.py
+++ b/master/buildbot/test/unit/util/test_deferwaiter.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import asyncSleep
 from buildbot.util.deferwaiter import DeferWaiter
 from buildbot.util.deferwaiter import RepeatedActionHandler

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -33,8 +33,8 @@ from buildbot.process.properties import Interpolate
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttp
 from buildbot.test.fake import kube as fakekube
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import kubeclientservice
 
 

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -269,7 +269,7 @@ class RealKubeClientServiceTest(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.createKube()
         yield self.kube.setServiceParent(self.master)

--- a/master/buildbot/test/unit/util/test_misc.py
+++ b/master/buildbot/test/unit/util/test_misc.py
@@ -17,7 +17,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import util
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import misc
 
 

--- a/master/buildbot/test/unit/util/test_misc.py
+++ b/master/buildbot/test/unit/util/test_misc.py
@@ -86,7 +86,7 @@ class deferredLocked(unittest.TestCase):
 class TestCancelAfter(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.d = defer.Deferred()
 
     def test_succeeds(self):

--- a/master/buildbot/test/unit/util/test_poll.py
+++ b/master/buildbot/test/unit/util/test_poll.py
@@ -33,7 +33,7 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
             raise RuntimeError('oh noes')
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = mock.Mock()
         self.master.reactor = self.reactor
 
@@ -193,7 +193,7 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
             raise RuntimeError('oh noes')
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = mock.Mock()
         self.master.reactor = self.reactor
 

--- a/master/buildbot/test/unit/util/test_poll.py
+++ b/master/buildbot/test/unit/util/test_poll.py
@@ -20,7 +20,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import poll
 
 

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -40,7 +40,7 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
     FAKE_PID = 1234
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpLogging()
         self.process = None
         self.reactor.spawnProcess = self.fake_spawn_process

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -22,8 +22,8 @@ from twisted.internet import defer
 from twisted.python import runtime
 from twisted.trial import unittest
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.logging import LoggingMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util.runprocess import RunProcess
 
 # windows returns rc 1, because exit status cannot indicate "signalled";

--- a/master/buildbot/test/unit/util/test_state.py
+++ b/master/buildbot/test/unit/util/test_state.py
@@ -33,7 +33,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
     OBJECTID = 19
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True)
         self.object = FakeObject(self.master)
 

--- a/master/buildbot/test/unit/util/test_state.py
+++ b/master/buildbot/test/unit/util/test_state.py
@@ -17,7 +17,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import state
 
 

--- a/master/buildbot/test/unit/util/test_test_result_submitter.py
+++ b/master/buildbot/test/unit/util/test_test_result_submitter.py
@@ -18,7 +18,7 @@ from twisted.trial import unittest
 
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util.test_result_submitter import TestResultSubmitter
 
 

--- a/master/buildbot/test/unit/util/test_test_result_submitter.py
+++ b/master/buildbot/test/unit/util/test_test_result_submitter.py
@@ -26,7 +26,7 @@ class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True)
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -32,9 +32,9 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakeprotocol
 from buildbot.test.fake import worker
 from buildbot.test.fake.secrets import FakeSecretStorage
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
 from buildbot.test.util import logging
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker import AbstractLatentWorker
 from buildbot.worker import base
 

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -118,7 +118,7 @@ class WorkerInterfaceTests(interfaces.InterfaceTests):
 class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.wrk = ConcreteWorker('wrk', 'pa')
 
     @defer.inlineCallbacks
@@ -137,7 +137,7 @@ class FakeWorkerItfc(TestReactorMixin, unittest.TestCase,
                      WorkerInterfaceTests):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.wrk = worker.FakeWorker(self.master)
 
@@ -150,7 +150,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpLogging()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
@@ -899,7 +899,7 @@ class TestAbstractLatentWorker(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         yield self.master.workers.disownServiceParent()

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -24,7 +24,7 @@ from buildbot.process.properties import Properties
 from buildbot.process.properties import Property
 from buildbot.test.fake import docker
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.worker import docker as dockerworker
 
 

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -42,7 +42,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
         return worker
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.build = Properties(
             image='busybox:latest', builder='docker_worker', distro='wheezy')

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -23,7 +23,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake.fakebuild import FakeBuildForRendering as FakeBuild
 from buildbot.test.fake.fakeprotocol import FakeTrivialConnection as FakeBot
 from buildbot.test.fake.kube import KubeClientService
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util.kubeclientservice import KubeError
 from buildbot.util.kubeclientservice import KubeHardcodedConfig
 from buildbot.worker import kubernetes

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -41,7 +41,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
     worker = None
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):

--- a/master/buildbot/test/unit/worker/test_libvirt.py
+++ b/master/buildbot/test/unit/worker/test_libvirt.py
@@ -25,7 +25,7 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.test.fake import libvirt as libvirtfake
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.runprocess import ExpectMasterShell
 from buildbot.test.util.runprocess import MasterRunProcessMixin
 from buildbot.test.util.warnings import assertProducesWarnings

--- a/master/buildbot/test/unit/worker/test_libvirt.py
+++ b/master/buildbot/test/unit/worker/test_libvirt.py
@@ -66,7 +66,7 @@ class TestException(Exception):
 
 class TestLibVirtWorker(TestReactorMixin, MasterRunProcessMixin, unittest.TestCase):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setup_master_run_process()
         self.connections = {}
         self.patch(libvirtworker, "libvirt", libvirtfake)

--- a/master/buildbot/test/unit/worker/test_local.py
+++ b/master/buildbot/test/unit/worker/test_local.py
@@ -33,7 +33,7 @@ class TestLocalWorker(TestReactorMixin, unittest.TestCase):
         skip = "buildbot-worker package is not installed"
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         self.workers = self.master.workers

--- a/master/buildbot/test/unit/worker/test_local.py
+++ b/master/buildbot/test/unit/worker/test_local.py
@@ -21,7 +21,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.worker import local
 
 

--- a/master/buildbot/test/unit/worker/test_manager.py
+++ b/master/buildbot/test/unit/worker/test_manager.py
@@ -22,7 +22,7 @@ from zope.interface import implementer
 from buildbot import interfaces
 from buildbot.process import botmaster
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import service
 from buildbot.worker import manager as workermanager
 

--- a/master/buildbot/test/unit/worker/test_manager.py
+++ b/master/buildbot/test/unit/worker/test_manager.py
@@ -49,7 +49,7 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.workers = workermanager.WorkerManager(self.master)

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -23,7 +23,7 @@ from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.fakeprotocol import FakeTrivialConnection as FakeBot
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.worker.marathon import MarathonLatentWorker
 
 

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -29,7 +29,7 @@ from buildbot.worker.marathon import MarathonLatentWorker
 
 class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.build = Properties(
             image="busybox:latest", builder="docker_worker")
         self.worker = None

--- a/master/buildbot/test/unit/worker/test_openstack.py
+++ b/master/buildbot/test/unit/worker/test_openstack.py
@@ -27,7 +27,7 @@ from buildbot import interfaces
 from buildbot.process.properties import Interpolate
 from buildbot.process.properties import Properties
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.worker import openstack
 
 

--- a/master/buildbot/test/unit/worker/test_openstack.py
+++ b/master/buildbot/test/unit/worker/test_openstack.py
@@ -49,7 +49,7 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
         **os_auth)
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.patch(openstack, "client", novaclient)
         self.patch(openstack, "loading", novaclient)
         self.patch(openstack, "session", novaclient)

--- a/master/buildbot/test/unit/worker/test_protocols_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_base.py
@@ -27,7 +27,7 @@ class TestFakeConnection(protocols.ConnectionInterfaceTest,
                          TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.worker = mock.Mock()
         self.conn = fakeprotocol.FakeConnection(self.worker)
 
@@ -36,7 +36,7 @@ class TestConnection(protocols.ConnectionInterfaceTest,
                      TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.worker = mock.Mock()
         self.conn = base.Connection(self.worker.workername)
 

--- a/master/buildbot/test/unit/worker/test_protocols_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_base.py
@@ -18,8 +18,8 @@ import mock
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakeprotocol
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import protocols
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker.protocols import base
 
 

--- a/master/buildbot/test/unit/worker/test_protocols_pb.py
+++ b/master/buildbot/test/unit/worker/test_protocols_pb.py
@@ -20,8 +20,8 @@ from twisted.spread import pb as twisted_pb
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import protocols as util_protocols
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker.protocols import base
 from buildbot.worker.protocols import pb
 

--- a/master/buildbot/test/unit/worker/test_protocols_pb.py
+++ b/master/buildbot/test/unit/worker/test_protocols_pb.py
@@ -29,7 +29,7 @@ from buildbot.worker.protocols import pb
 class TestListener(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
 
     def makeListener(self):
@@ -89,7 +89,7 @@ class TestConnectionApi(util_protocols.ConnectionInterfaceTest,
                         TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.conn = pb.Connection(self.master, mock.Mock(), mock.Mock())
 
@@ -97,7 +97,7 @@ class TestConnectionApi(util_protocols.ConnectionInterfaceTest,
 class TestConnection(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
         self.mind = mock.Mock()
         self.worker = mock.Mock()

--- a/master/buildbot/test/unit/worker/test_upcloud.py
+++ b/master/buildbot/test/unit/worker/test_upcloud.py
@@ -81,7 +81,7 @@ class TestUpcloudWorker(TestReactorMixin, unittest.TestCase):
     worker = None
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):

--- a/master/buildbot/test/unit/worker/test_upcloud.py
+++ b/master/buildbot/test/unit/worker/test_upcloud.py
@@ -25,7 +25,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.fakebuild import FakeBuildForRendering as FakeBuild
 from buildbot.test.fake.fakeprotocol import FakeTrivialConnection as FakeBot
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.worker import upcloud
 
 # Please see https://developers.upcloud.com/ for details

--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -43,7 +43,7 @@ class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
                        unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpAuthResource()
         self.rsrc = auth.AuthRootResource(self.master)
 
@@ -63,7 +63,7 @@ class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
 class AuthBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.auth = auth.AuthBase()
         self.master = self.make_master(url='h:/a/b/')
         self.auth.master = self.master
@@ -109,7 +109,7 @@ class NoAuth(unittest.TestCase):
 class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         self.make_master()
         self.request = self.make_request(b'/')
@@ -146,7 +146,7 @@ class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         self.auth = auth.NoAuth()
         self.make_master()
@@ -162,7 +162,7 @@ class TwistedICredAuthBase(TestReactorMixin, www.WwwTestMixin,
                            unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     # twisted.web makes it difficult to simulate the authentication process, so
     # this only tests the mechanics of the getLoginResource method.
@@ -201,7 +201,7 @@ class CustomAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             return us == 'fellow' and ps == 'correct'
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_callable(self):
@@ -218,7 +218,7 @@ class LoginResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
                     unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpAuthResource()
 
     @defer.inlineCallbacks
@@ -235,7 +235,7 @@ class PreAuthenticatedLoginResource(TestReactorMixin, www.WwwTestMixin,
                                     AuthResourceMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpAuthResource()
         self.rsrc = auth.PreAuthenticatedLoginResource(self.master, 'him')
 
@@ -262,7 +262,7 @@ class LogoutResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
                      unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setUpAuthResource()
         self.rsrc = auth.LogoutResource(self.master)
 

--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -25,8 +25,8 @@ from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
 from twisted.web.resource import IResource
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
 
 

--- a/master/buildbot/test/unit/www/test_authz.py
+++ b/master/buildbot/test/unit/www/test_authz.py
@@ -17,8 +17,8 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import authz
 from buildbot.www.authz.endpointmatchers import AnyEndpointMatcher
 from buildbot.www.authz.endpointmatchers import BranchEndpointMatcher

--- a/master/buildbot/test/unit/www/test_authz.py
+++ b/master/buildbot/test/unit/www/test_authz.py
@@ -35,7 +35,7 @@ from buildbot.www.authz.roles import RolesFromOwner
 class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         authzcfg = authz.Authz(
             # simple matcher with '*' glob character
             stringsMatcher=authz.fnmatchStrMatcher,

--- a/master/buildbot/test/unit/www/test_avatar.py
+++ b/master/buildbot/test/unit/www/test_avatar.py
@@ -18,8 +18,8 @@ from twisted.trial import unittest
 
 from buildbot import config
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
 from buildbot.www import avatar
 

--- a/master/buildbot/test/unit/www/test_avatar.py
+++ b/master/buildbot/test/unit/www/test_avatar.py
@@ -34,7 +34,7 @@ class TestAvatar(avatar.AvatarBase):
 class AvatarResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_default(self):
@@ -533,7 +533,7 @@ class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         master = self.make_master(
             url='http://a/b/', auth=auth.NoAuth(),
@@ -670,7 +670,7 @@ class GitHubAvatarBasicAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         avatar_method = avatar.AvatarGitHub(client_id="oauth_id",
                                             client_secret="oauth_secret")

--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -22,8 +22,8 @@ from twisted.internet import defer
 from twisted.python import log
 from twisted.trial import unittest
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.www import auth
 from buildbot.www import config

--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -32,7 +32,7 @@ from buildbot.www import config
 class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):

--- a/master/buildbot/test/unit/www/test_endpointmatchers.py
+++ b/master/buildbot/test/unit/www/test_endpointmatchers.py
@@ -27,7 +27,7 @@ from buildbot.www.authz import endpointmatchers
 class EndpointBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url='h:/a/b/')
         self.db = self.master.db
         self.matcher = self.makeMatcher()

--- a/master/buildbot/test/unit/www/test_endpointmatchers.py
+++ b/master/buildbot/test/unit/www/test_endpointmatchers.py
@@ -19,8 +19,8 @@ from twisted.trial import unittest
 
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.test import fakedb
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www.authz import endpointmatchers
 
 

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -21,8 +21,8 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.data import connector
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www import graphql
 

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -38,7 +38,7 @@ class V3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
         self.patch(connector.DataConnector, 'submodules', [])
-        self.setUpTestReactor(use_asyncio=True)
+        self.setup_test_reactor(use_asyncio=True)
         self.master = self.make_master(url="http://server/path/", wantGraphql=True)
         self.master.config.www["graphql"] = {"debug": True}
         self.rsrc = graphql.V3RootResource(self.master)
@@ -236,7 +236,7 @@ class DisabledV3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCa
         skip = "graphql is required for V3RootResource tests"
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url="http://server/path/")
         self.rsrc = graphql.V3RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)

--- a/master/buildbot/test/unit/www/test_hooks_base.py
+++ b/master/buildbot/test/unit/www/test_hooks_base.py
@@ -40,7 +40,7 @@ def _prepare_request(payload, headers=None):
 
 class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = _prepare_base_change_hook(self)
 
     @defer.inlineCallbacks
@@ -102,7 +102,7 @@ class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCustomBase(unittest.TestCase,
                                              TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         class CustomBase(BaseHookHandler):
             def getChanges(self, request):

--- a/master/buildbot/test/unit/www/test_hooks_base.py
+++ b/master/buildbot/test/unit/www/test_hooks_base.py
@@ -5,7 +5,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.base import BaseHookHandler

--- a/master/buildbot/test/unit/www/test_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucket.py
@@ -19,7 +19,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.www import change_hook
 from buildbot.www.hooks.bitbucket import _HEADER_EVENT
 

--- a/master/buildbot/test/unit/www/test_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucket.py
@@ -141,7 +141,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase,
     """
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucket': True}, master=fakeMasterForHooks(self))
 

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
@@ -21,7 +21,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www import change_hook
 from buildbot.www.hooks.bitbucketcloud import _HEADER_EVENT

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
@@ -687,7 +687,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
                                             TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucketcloud': {
                     'bitbucket_property_whitelist': ["bitbucket.*"],

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
@@ -21,7 +21,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www import change_hook
 from buildbot.www.hooks.bitbucketserver import _HEADER_EVENT

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
@@ -710,7 +710,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
                                             TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucketserver': {
                     'bitbucket_property_whitelist': ["bitbucket.*"],

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -620,7 +620,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
@@ -911,7 +911,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"],
             pullrequest_ref="head")
@@ -947,7 +947,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"],
@@ -989,7 +989,7 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.changeHook = \
             _prepare_github_change_hook(self, strict=False, github_property_whitelist=["github.*"],
@@ -1036,7 +1036,7 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, skips=[r'\[ *bb *skip *\]'], token=_token)
@@ -1123,7 +1123,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
@@ -1245,7 +1245,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_api_endpoint='https://black.magic.io')
         self.master = self.changeHook.master
@@ -1279,7 +1279,7 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
@@ -1319,7 +1319,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
     _SECRET = 'somethingreallysecret'
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"secret_key": self._SECRET})
@@ -1433,7 +1433,7 @@ class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase,
                                                 TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = _prepare_github_change_hook(self, codebase='foobar')
 
     @defer.inlineCallbacks
@@ -1459,7 +1459,7 @@ class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase,
                                                    TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = _prepare_github_change_hook(
             self, codebase=_codebase_function)
 
@@ -1482,7 +1482,7 @@ class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase,
                                                      TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         class CustomGitHubEventHandler(GitHubEventHandler):
             def handle_ping(self, _, __):

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -28,7 +28,7 @@ from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.github import _HEADER_EVENT

--- a/master/buildbot/test/unit/www/test_hooks_gitlab.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitlab.py
@@ -23,7 +23,7 @@ from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.www import change_hook
 from buildbot.www.hooks.gitlab import _HEADER_EVENT
 from buildbot.www.hooks.gitlab import _HEADER_GITLAB_TOKEN

--- a/master/buildbot/test/unit/www/test_hooks_gitlab.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitlab.py
@@ -810,7 +810,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
                                             TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitlab': True}, master=fakeMasterForHooks(self))
 
@@ -1005,7 +1005,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase, TestReactorMixin):
     _SECRET = 'thesecret'
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakeMasterForHooks(self)
 
         fakeStorageService = FakeSecretStorage()

--- a/master/buildbot/test/unit/www/test_hooks_gitorious.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitorious.py
@@ -65,7 +65,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
                                             TestReactorMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         dialects = {'gitorious': True}
         self.changeHook = change_hook.ChangeHookResource(
             dialects=dialects, master=fakeMasterForHooks(self))

--- a/master/buildbot/test/unit/www/test_hooks_gitorious.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitorious.py
@@ -19,7 +19,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.www import change_hook
 
 # Sample Gitorious commit payload

--- a/master/buildbot/test/unit/www/test_hooks_poller.py
+++ b/master/buildbot/test/unit/www/test_hooks_poller.py
@@ -48,7 +48,7 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
             self.called = True
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def setUpRequest(self, args, options=True, activate=True,

--- a/master/buildbot/test/unit/www/test_hooks_poller.py
+++ b/master/buildbot/test/unit/www/test_hooks_poller.py
@@ -22,7 +22,7 @@ from buildbot.changes import base
 from buildbot.changes.manager import ChangeManager
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake.web import FakeRequest
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 from buildbot.www import change_hook

--- a/master/buildbot/test/unit/www/test_ldapuserinfo.py
+++ b/master/buildbot/test/unit/www/test_ldapuserinfo.py
@@ -167,7 +167,7 @@ class LdapAvatar(CommonTestCase, TestReactorMixin, WwwTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
         CommonTestCase.setUp(self)
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         master = self.make_master(
             url='http://a/b/',

--- a/master/buildbot/test/unit/www/test_ldapuserinfo.py
+++ b/master/buildbot/test/unit/www/test_ldapuserinfo.py
@@ -21,7 +21,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.www import WwwTestMixin
 from buildbot.www import avatar
 from buildbot.www import ldapuserinfo

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -62,7 +62,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
 
@@ -525,7 +525,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin,
         return cls(config["CLIENTID"], config["CLIENTSECRET"])
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -32,9 +32,9 @@ import buildbot
 from buildbot.process.properties import Secret
 from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake.secrets import FakeSecretStorage
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 
 try:

--- a/master/buildbot/test/unit/www/test_resource.py
+++ b/master/buildbot/test/unit/www/test_resource.py
@@ -16,8 +16,8 @@
 
 from twisted.trial import unittest
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import resource
 
 

--- a/master/buildbot/test/unit/www/test_resource.py
+++ b/master/buildbot/test/unit/www/test_resource.py
@@ -29,7 +29,7 @@ class ResourceSubclass(resource.Resource):
 class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     def test_base_url(self):
         master = self.make_master(url=b'h:/a/b/')
@@ -45,7 +45,7 @@ class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class RedirectResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
     def test_redirect(self):
         master = self.make_master(url=b'h:/a/b/')

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -38,7 +38,7 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     maxVersion = 3
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         [graphql]  # used for import side effect
 
     @defer.inlineCallbacks
@@ -72,7 +72,7 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class V2RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url='http://server/path/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
@@ -146,7 +146,7 @@ class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin,
                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url='h:/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
@@ -247,7 +247,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
                           unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url='h:/')
         self.master.config.www['debug'] = True
         self.master.data._scanModule(endpoint)
@@ -698,7 +698,7 @@ class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin,
                               unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url='h:/')
 
         def allow(*args, **kw):

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -23,8 +23,8 @@ from twisted.trial import unittest
 
 from buildbot.data.exceptions import InvalidQueryParameter
 from buildbot.test.fake import endpoint
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import authz

--- a/master/buildbot/test/unit/www/test_service.py
+++ b/master/buildbot/test/unit/www/test_service.py
@@ -27,9 +27,9 @@ from twisted.trial import unittest
 from twisted.web._auth.wrapper import HTTPAuthSessionWrapper
 from twisted.web.server import Request
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.unit.www import test_hooks_base
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
 from buildbot.www import change_hook
 from buildbot.www import resource

--- a/master/buildbot/test/unit/www/test_service.py
+++ b/master/buildbot/test/unit/www/test_service.py
@@ -63,7 +63,7 @@ class Test(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = self.make_master(url='h:/a/b/')
         self.svc = self.master.www = service.WWWService()
         yield self.svc.setServiceParent(self.master)

--- a/master/buildbot/test/unit/www/test_sse.py
+++ b/master/buildbot/test/unit/www/test_sse.py
@@ -19,9 +19,9 @@ import json
 
 from twisted.trial import unittest
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.unit.data import test_changes
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import unicode2bytes

--- a/master/buildbot/test/unit/www/test_sse.py
+++ b/master/buildbot/test/unit/www/test_sse.py
@@ -31,7 +31,7 @@ from buildbot.www import sse
 class EventResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = master = self.make_master(url=b'h:/a/b/')
         self.sse = sse.EventResource(master)
 

--- a/master/buildbot/test/unit/www/test_ws.py
+++ b/master/buildbot/test/unit/www/test_ws.py
@@ -29,7 +29,7 @@ from buildbot.www import ws
 
 class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setUpTestReactor(use_asyncio=True)
+        self.setup_test_reactor(use_asyncio=True)
         self.master = master = self.make_master(
             url="h:/a/b/", wantMq=True, wantGraphql=True
         )

--- a/master/buildbot/test/unit/www/test_ws.py
+++ b/master/buildbot/test/unit/www/test_ws.py
@@ -21,8 +21,8 @@ from mock import Mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.www import ws
 

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -43,7 +43,7 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
 
     @defer.inlineCallbacks
     def setUpConnectorComponent(self, table_names=None, basedir='basedir', dialect_name='sqlite'):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         """Set up C{self.db}, using the given db_url and basedir."""
         if table_names is None:
@@ -70,7 +70,7 @@ class FakeConnectorComponentMixin(TestReactorMixin):
     # Just like ConnectorComponentMixin, but for working with fake database
 
     def setUpConnectorComponent(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -20,8 +20,8 @@ from twisted.internet import defer
 
 from buildbot.db import model
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import db
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class FakeDBConnector:

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -36,7 +36,7 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
     resourceTypeClass = None
 
     def setUpEndpoint(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.db = self.master.db

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -19,9 +19,9 @@ from twisted.internet import defer
 from buildbot.data import base
 from buildbot.data import resultspec
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import pathmatch
 
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -34,8 +34,8 @@ from buildbot.plugins import worker
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import statusToString
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.misc import DebugIntegrationLogsMixin
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.sandboxed_worker import SandboxedWorker
 from buildbot.worker.local import LocalWorker
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -88,7 +88,7 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
                             DebugIntegrationLogsMixin):
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.setupDebugIntegrationLogs()
 
     def tearDown(self):

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -24,10 +24,10 @@ from twisted.python import log
 
 from buildbot.db import connector
 from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import db
 from buildbot.test.util import dirs
 from buildbot.test.util import querylog
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import sautils
 
 # test_upgrade vs. migration tests

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -41,7 +41,7 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
 
     @defer.inlineCallbacks
     def setUpMigrateTest(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.basedir = os.path.abspath("basedir")
         self.setUpDirs('basedir')
 

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -16,19 +16,19 @@
 
 import mock
 
-from buildbot.test.util import steps
+from buildbot.test.steps import TestBuildStepMixin
 
 
-class SourceStepMixin(steps.BuildStepMixin):
+class SourceStepMixin(TestBuildStepMixin):
 
     """
     Support for testing source steps.  Aside from the capabilities of
-    L{BuildStepMixin}, this adds:
+    L{TestBuildStepMixin}, this adds:
 
      - fake sourcestamps
 
     The following instance variables are available after C{setupSourceStep}, in
-    addition to those made available by L{BuildStepMixin}:
+    addition to those made available by L{TestBuildStepMixin}:
 
     @ivar sourcestamp: fake SourceStamp for the build
     """
@@ -43,7 +43,7 @@ class SourceStepMixin(steps.BuildStepMixin):
 
     def setup_step(self, step, args=None, patch=None, **kwargs):
         """
-        Set up C{step} for testing.  This calls L{BuildStepMixin}'s C{setup_step}
+        Set up C{step} for testing.  This calls L{TestBuildStepMixin}'s C{setup_step}
         and then does setup specific to a Source step.
         """
         step = super().setup_step(step, **kwargs)

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -34,10 +34,10 @@ class SourceStepMixin(TestBuildStepMixin):
     """
 
     def setUpSourceStep(self):
-        return super().setup_build_step()
+        return super().setup_test_build_step()
 
     def tearDownSourceStep(self):
-        return super().tear_down_build_step()
+        return super().tear_down_test_build_step()
 
     # utilities
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -191,11 +191,11 @@ setup_args = {
         "buildbot.www",
         "buildbot.www.hooks",
         "buildbot.www.authz",
-    ] + ([] if BUILDING_WHEEL else [  # skip tests for wheels (save 50% of the archive)
         "buildbot.test",
         "buildbot.test.util",
         "buildbot.test.fake",
         "buildbot.test.fakedb",
+    ] + ([] if BUILDING_WHEEL else [  # skip tests for wheels (save 50% of the archive)
         "buildbot.test.fuzz",
         "buildbot.test.integration",
         "buildbot.test.integration.interop",


### PR DESCRIPTION
This PR prepares testing API for testing user Buildbot configurations. This is not documented yet, so not really exposed. This PR contains noisy renaming and code movement.

The exposed test API will live in `buildbot.test` package. This PR moves some functionality out of `buildbot.test.util` to `buildbot.test`, because from the perspective of outside user we will expose only few things in `buildbot.test` anyway, so there's no point in putting them into `util`.