### PR TITLE
Prepare test API for making it externally usable (part 2)

### DIFF
--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -222,20 +222,29 @@ class ExpectShell(Expect):
     """
 
     def __init__(self, workdir, command, env=None,
-                 want_stdout=1, want_stderr=1, initialStdin=None,
-                 timeout=20 * 60, maxTime=None, logfiles=None,
-                 usePTY=None, logEnviron=True, interruptSignal=None):
+                 want_stdout=1, want_stderr=1, initial_stdin=None,
+                 timeout=20 * 60, max_time=None, logfiles=None,
+                 use_pty=None, log_environ=True, interrupt_signal=None):
         if env is None:
             env = {}
         if logfiles is None:
             logfiles = {}
-        args = dict(workdir=workdir, command=command, env=env,
-                    want_stdout=want_stdout, want_stderr=want_stderr,
-                    initial_stdin=initialStdin,
-                    timeout=timeout, maxTime=maxTime, logfiles=logfiles,
-                    usePTY=usePTY, logEnviron=logEnviron)
-        if interruptSignal is not None:
-            args['interruptSignal'] = interruptSignal
+        args = {
+            'workdir': workdir,
+            'command': command,
+            'env': env,
+            'want_stdout': want_stdout,
+            'want_stderr': want_stderr,
+            'initial_stdin': initial_stdin,
+            'timeout': timeout,
+            'maxTime': max_time,
+            'logfiles': logfiles,
+            'usePTY': use_pty,
+            'logEnviron': log_environ
+        }
+
+        if interrupt_signal is not None:
+            args['interruptSignal'] = interrupt_signal
         super().__init__("shell", args)
 
     def __repr__(self):
@@ -244,12 +253,12 @@ class ExpectShell(Expect):
 
 class ExpectStat(Expect):
 
-    def __init__(self, file, workdir=None, logEnviron=None):
+    def __init__(self, file, workdir=None, log_environ=None):
         args = {'file': file}
         if workdir is not None:
             args['workdir'] = workdir
-        if logEnviron is not None:
-            args['logEnviron'] = logEnviron
+        if log_environ is not None:
+            args['logEnviron'] = log_environ
 
         super().__init__('stat', args)
 
@@ -387,10 +396,10 @@ class ExpectDownloadFile(Expect):
 
 class ExpectMkdir(Expect):
 
-    def __init__(self, dir=None, logEnviron=None):
+    def __init__(self, dir=None, log_environ=None):
         args = {'dir': dir}
-        if logEnviron is not None:
-            args['logEnviron'] = logEnviron
+        if log_environ is not None:
+            args['logEnviron'] = log_environ
 
         super().__init__('mkdir', args)
 
@@ -400,10 +409,10 @@ class ExpectMkdir(Expect):
 
 class ExpectRmdir(Expect):
 
-    def __init__(self, dir=None, logEnviron=None, timeout=None, path=None):
+    def __init__(self, dir=None, log_environ=None, timeout=None, path=None):
         args = {'dir': dir}
-        if logEnviron is not None:
-            args['logEnviron'] = logEnviron
+        if log_environ is not None:
+            args['logEnviron'] = log_environ
         if timeout is not None:
             args['timeout'] = timeout
         if path is not None:
@@ -417,14 +426,14 @@ class ExpectRmdir(Expect):
 
 class ExpectCpdir(Expect):
 
-    def __init__(self, fromdir=None, todir=None, logEnviron=None, timeout=None, maxTime=None):
+    def __init__(self, fromdir=None, todir=None, log_environ=None, timeout=None, max_time=None):
         args = {'fromdir': fromdir, 'todir': todir}
-        if logEnviron is not None:
-            args['logEnviron'] = logEnviron
+        if log_environ is not None:
+            args['logEnviron'] = log_environ
         if timeout is not None:
             args['timeout'] = timeout
-        if maxTime is not None:
-            args['maxTime'] = maxTime
+        if max_time is not None:
+            args['maxTime'] = max_time
 
         super().__init__('cpdir', args)
 
@@ -434,10 +443,10 @@ class ExpectCpdir(Expect):
 
 class ExpectGlob(Expect):
 
-    def __init__(self, path=None, logEnviron=None):
+    def __init__(self, path=None, log_environ=None):
         args = {'path': path}
-        if logEnviron is not None:
-            args['logEnviron'] = logEnviron
+        if log_environ is not None:
+            args['logEnviron'] = log_environ
 
         super().__init__('glob', args)
 
@@ -470,10 +479,10 @@ class ExpectListdir(Expect):
 
 class ExpectRmfile(Expect):
 
-    def __init__(self, path=None, logEnviron=None):
+    def __init__(self, path=None, log_environ=None):
         args = {'path': path}
-        if logEnviron is not None:
-            args['logEnviron'] = logEnviron
+        if log_environ is not None:
+            args['logEnviron'] = log_environ
 
         super().__init__('rmfile', args)
 

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -365,6 +365,21 @@ class ExpectDownloadFile(Expect):
 
         super().__init__('downloadFile', args, interrupted=interrupted)
 
+    def download_string(self, dest_callable, size=1000, timestamp=None):
+        def behavior(command):
+            reader = command.args['reader']
+            read = reader.remote_read(size)
+
+            dest_callable(read)
+
+            reader.remote_close()
+            if timestamp:
+                reader.remote_utime(timestamp)
+            return read
+
+        self.behavior(behavior)
+        return self
+
     def __repr__(self):
         return "ExpectUploadDirectory({}, {})".format(repr(self.args['workdir']),
                                                       repr(self.args['workerdest']))

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import functools
+import stat
 import tarfile
 from io import BytesIO
 
@@ -291,6 +292,19 @@ class ExpectStat(Expect):
             args['logEnviron'] = logEnviron
 
         super().__init__('stat', args)
+
+    def stat(self, mode, inode=99, dev=99, nlink=1, uid=0, gid=0, size=99,
+             atime=0, mtime=0, ctime=0):
+        self.update('stat', [mode, inode, dev, nlink, uid, gid, size, atime, mtime, ctime])
+        return self
+
+    def stat_file(self, mode=0, size=99, atime=0, mtime=0, ctime=0):
+        self.stat(stat.S_IFREG, size=size, atime=atime, mtime=mtime, ctime=ctime)
+        return self
+
+    def stat_dir(self, mode=0, size=99, atime=0, mtime=0, ctime=0):
+        self.stat(stat.S_IFDIR, size=size, atime=atime, mtime=mtime, ctime=ctime)
+        return self
 
     def __repr__(self):
         return "ExpectStat(" + repr(self.args['file']) + ")"

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -426,6 +426,12 @@ class ExpectGlob(Expect):
 
         super().__init__('glob', args)
 
+    def files(self, files=None):
+        if files is None:
+            files = []
+        self.update('files', files)
+        return self
+
     def __repr__(self):
         return "ExpectGlob({})".format(repr(self.args['path']))
 

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -79,8 +79,8 @@ class Expect:
         self.behaviors.append(('callable', callable))
         return self
 
-    def error(self, callable):
-        self.behaviors.append(('err', callable))
+    def error(self, error):
+        self.behaviors.append(('err', error))
         return self
 
     def log(self, name, **streams):

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -84,10 +84,6 @@ class Expect:
         return self
 
     def log(self, name, **streams):
-        if name == 'stdio' and 'stdout' in streams:
-            raise NotImplementedError()
-        if name == 'stdio' and 'sterr' in streams:
-            raise NotImplementedError()
         self.behaviors.append(('log', name, streams))
         return self
 

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -437,6 +437,12 @@ class ExpectListdir(Expect):
 
         super().__init__('listdir', args)
 
+    def files(self, files=None):
+        if files is None:
+            files = []
+        self.update('files', files)
+        return self
+
     def __repr__(self):
         return "ExpectListdir({})".format(repr(self.args['dir']))
 

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1024,7 +1024,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
         self.step.testMethod = testFunc
         self.expect_commands(
             ExpectGlob(path='*.pyc', logEnviron=False)
-            .update('files', ["one.pyc", "two.pyc"])
+            .files(["one.pyc", "two.pyc"])
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -1034,7 +1034,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
         self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expect_commands(
             ExpectGlob(path='*.pyc', logEnviron=False)
-            .update('files', [])
+            .files()
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -940,7 +940,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_runRmdir(self):
         self.step.testMethod = lambda: self.step.runRmdir('/some/path')
         self.expect_commands(
-            ExpectRmdir(dir='/some/path', logEnviron=False)
+            ExpectRmdir(dir='/some/path', log_environ=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -951,7 +951,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_runMkdir(self):
         self.step.testMethod = lambda: self.step.runMkdir('/some/path')
         self.expect_commands(
-            ExpectMkdir(dir='/some/path', logEnviron=False)
+            ExpectMkdir(dir='/some/path', log_environ=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -962,7 +962,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_runMkdir_fails(self):
         self.step.testMethod = lambda: self.step.runMkdir('/some/path')
         self.expect_commands(
-            ExpectMkdir(dir='/some/path', logEnviron=False)
+            ExpectMkdir(dir='/some/path', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -973,7 +973,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
         self.step.testMethod = lambda: self.step.runMkdir(
             '/some/path', abandonOnFailure=False)
         self.expect_commands(
-            ExpectMkdir(dir='/some/path', logEnviron=False)
+            ExpectMkdir(dir='/some/path', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=SUCCESS)
@@ -984,7 +984,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_pathExists(self):
         self.step.testMethod = lambda: self.step.pathExists('/some/path')
         self.expect_commands(
-            ExpectStat(file='/some/path', logEnviron=False)
+            ExpectStat(file='/some/path', log_environ=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -995,7 +995,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_pathExists_doesnt(self):
         self.step.testMethod = lambda: self.step.pathExists('/some/path')
         self.expect_commands(
-            ExpectStat(file='/some/path', logEnviron=False)
+            ExpectStat(file='/some/path', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=SUCCESS)
@@ -1006,7 +1006,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_pathExists_logging(self):
         self.step.testMethod = lambda: self.step.pathExists('/some/path')
         self.expect_commands(
-            ExpectStat(file='/some/path', logEnviron=False)
+            ExpectStat(file='/some/path', log_environ=False)
             .log('stdio', header='NOTE: never mind\n')
             .exit(1)
         )
@@ -1023,7 +1023,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
             self.assertEqual(res, ["one.pyc", "two.pyc"])
         self.step.testMethod = testFunc
         self.expect_commands(
-            ExpectGlob(path='*.pyc', logEnviron=False)
+            ExpectGlob(path='*.pyc', log_environ=False)
             .files(["one.pyc", "two.pyc"])
             .exit(0)
         )
@@ -1033,7 +1033,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_glob_empty(self):
         self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expect_commands(
-            ExpectGlob(path='*.pyc', logEnviron=False)
+            ExpectGlob(path='*.pyc', log_environ=False)
             .files()
             .exit(0)
         )
@@ -1043,7 +1043,7 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin,
     def test_glob_fail(self):
         self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expect_commands(
-            ExpectGlob(path='*.pyc', logEnviron=False)
+            ExpectGlob(path='*.pyc', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -1306,7 +1306,7 @@ class TestShellMixin(TestBuildStepMixin,
                                           interruptSignal='DIE'),
                        worker_version={'*': "3.0"})
         self.expect_commands(
-            ExpectShell(workdir='wkdir', usePTY=False, interruptSignal='DIE',
+            ExpectShell(workdir='wkdir', use_pty=False, interrupt_signal='DIE',
                         command=['cmd', 'arg'])
             .exit(0)
         )

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import stat
 import time
 
 from twisted.trial import unittest
@@ -62,7 +61,7 @@ class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(pbuilder.DebPbuilder())
         self.expect_commands(
             ExpectStat(file='/var/cache/pbuilder/stable-local-buildbot.tgz')
-            .update('stat', [stat.S_IFREG, 99, 99, 1, 0, 0, 99, 0, 0, 0])
+            .stat_file()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['sudo', '/usr/sbin/pbuilder', '--update',
@@ -80,7 +79,7 @@ class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(pbuilder.DebPbuilder())
         self.expect_commands(
             ExpectStat(file='/var/cache/pbuilder/stable-local-buildbot.tgz')
-            .update('stat', [stat.S_IFREG, 99, 99, 1, 0, 0, 99, 0, int(time.time()), 0])
+            .stat_file(mtime=int(time.time()))
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['pdebuild', '--buildresult', '.',
@@ -308,7 +307,7 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(pbuilder.DebCowbuilder())
         self.expect_commands(
             ExpectStat(file='/var/cache/pbuilder/stable-local-buildbot.cow/')
-            .update('stat', [stat.S_IFDIR, 99, 99, 1, 0, 0, 99, 0, 0, 0])
+            .stat_dir()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['sudo', '/usr/sbin/cowbuilder', '--update',
@@ -326,7 +325,7 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(pbuilder.DebCowbuilder())
         self.expect_commands(
             ExpectStat(file='/var/cache/pbuilder/stable-local-buildbot.cow/')
-            .update('stat', [stat.S_IFDIR, 99, 99, 1, 0, 0, 99, 0, int(time.time()), 0])
+            .stat_dir(mtime=int(time.time()))
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['pdebuild', '--buildresult', '.',
@@ -341,7 +340,7 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin,
             basetgz='/var/cache/pbuilder/stable-local-buildbot.cow'))
         self.expect_commands(
             ExpectStat(file='/var/cache/pbuilder/stable-local-buildbot.cow')
-            .update('stat', [stat.S_IFREG, 99, 99, 1, 0, 0, 99, 0, 0, 0])
+            .stat_file()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['sudo', '/usr/sbin/cowbuilder', '--update',
@@ -355,7 +354,7 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin,
             basetgz='/var/cache/pbuilder/stable-local-buildbot.cow'))
         self.expect_commands(
             ExpectStat(file='/var/cache/pbuilder/stable-local-buildbot.cow')
-            .update('stat', [stat.S_IFREG, 99, 99, 1, 0, 0, 99, 0, int(time.time()), 0])
+            .stat_file(mtime=int(time.time()))
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['pdebuild', '--buildresult', '.',

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -46,7 +46,7 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.setup_step(mock.Mock(root='TESTROOT'))
         self.expect_commands(
             ExpectRmdir(dir=['build/build.log', 'build/root.log', 'build/state.log'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mock', '--root', 'TESTROOT'],
@@ -63,7 +63,7 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectRmdir(dir=['build/RESULT/build.log',
                              'build/RESULT/root.log',
                              'build/RESULT/state.log'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mock', '--root', 'TESTROOT',
@@ -83,7 +83,7 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectRmdir(dir=['build/RESULT/build.log',
                              'build/RESULT/root.log',
                              'build/RESULT/state.log'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mock', '--root', 'TESTROOT',
@@ -114,7 +114,7 @@ class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(mock.MockBuildSRPM(root='TESTROOT', spec="foo.spec"))
         self.expect_commands(
             ExpectRmdir(dir=['build/build.log', 'build/root.log', 'build/state.log'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mock', '--root', 'TESTROOT',
@@ -146,7 +146,7 @@ class TestMockRebuild(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(mock.MockRebuild(root='TESTROOT', srpm="foo.src.rpm"))
         self.expect_commands(
             ExpectRmdir(dir=['build/build.log', 'build/root.log', 'build/state.log'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mock', '--root', 'TESTROOT',

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -159,8 +159,7 @@ class TestShellCommandExecution(TestBuildStepMixin,
     def test_run_usePTY(self):
         self.setup_step(shell.ShellCommand(workdir='build', command="echo hello", usePTY=False))
         self.expect_commands(
-            ExpectShell(workdir='build', command='echo hello',
-                        usePTY=False)
+            ExpectShell(workdir='build', command='echo hello', use_pty=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -665,22 +665,14 @@ class WarningCountingShellCommand(TestBuildStepMixin,
             for key in props:
                 self.build.setProperty(key, props[key], "")
 
-        # Invoke the expected callbacks for the suppression file upload.  Note
-        # that this assumes all of the remote_* are synchronous, but can be
-        # easily adapted to suit if that changes (using inlineCallbacks)
-        def upload_behavior(command):
-            writer = command.args['writer']
-            writer.remote_write(supps_file)
-            writer.remote_close()
-            command.rc = 0
-
         if supps_file is not None:
             self.expect_commands(
                 # step will first get the remote suppressions file
                 ExpectUploadFile(blocksize=32768, maxsize=None,
                                  workersrc='supps', workdir='wkdir',
                                  writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
-                .behavior(upload_behavior),
+                .upload_string(supps_file)
+                .exit(0),
                 # and then run the command
                 ExpectShell(workdir='wkdir',
                             command=["make"])

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -53,9 +53,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--force'])
@@ -81,9 +81,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file=r'wkdir\.buildbot-patched', logEnviron=True)
+            ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file=r'wkdir\.bzr', logEnviron=True)
+            ExpectStat(file=r'wkdir\.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--force'])
@@ -108,9 +108,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
                         timeout=1,
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         timeout=1,
@@ -139,9 +139,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--force'])
@@ -166,9 +166,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--ignored', '--force'])
@@ -193,13 +193,13 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             # clean up the applied patch
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--ignored', '--force'])
             .exit(0),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             # this clean is from 'mode=clean'
             ExpectShell(workdir='wkdir',
@@ -225,9 +225,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--ignored', '--force'])
@@ -247,7 +247,7 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'version-info', '--custom', "--template='{revno}"])
@@ -267,9 +267,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--ignored', '--force'])
@@ -289,7 +289,7 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'version-info', '--custom', "--template='{revno}"])
@@ -309,9 +309,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--ignored', '--force'])
@@ -336,9 +336,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'clean-tree', '--force'])
@@ -363,9 +363,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -388,21 +388,21 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
                                  'http://bzr.squid-cache.org/bzr/squid3/trunk', '.'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
                                  'http://bzr.squid-cache.org/bzr/squid3/trunk', '.'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -426,9 +426,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -452,9 +452,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -479,9 +479,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -505,16 +505,16 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='build', logEnviron=True)
+            ExpectRmdir(dir='build', log_environ=True)
             .exit(0),
-            ExpectStat(file='source/.bzr', logEnviron=True)
+            ExpectStat(file='source/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['bzr', 'update'])
             .exit(0),
-            ExpectCpdir(fromdir='source', logEnviron=True, todir='build')
+            ExpectCpdir(fromdir='source', log_environ=True, todir='build')
             .exit(0),
             ExpectShell(workdir='source',
                         command=['bzr', 'version-info', '--custom', "--template='{revno}"])
@@ -533,9 +533,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'update'])
@@ -558,9 +558,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'update', '-r', '9384'])
@@ -582,9 +582,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -607,15 +607,15 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
                                  'http://bzr.squid-cache.org/bzr/squid3/trunk', '.'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -638,9 +638,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',
@@ -662,9 +662,9 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['bzr', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.bzr', logEnviron=True)
+            ExpectStat(file='wkdir/.bzr', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['bzr', 'checkout',

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -95,9 +95,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                                  '-d',
                                  ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
                                  'login'],
-                        initialStdin="a password\n")
+                        initial_stdin="a password\n")
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -142,9 +142,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                                  '-d',
                                  ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
                                  'login'],
-                        initialStdin="a password\n")
+                        initial_stdin="a password\n")
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              slavesrc='Root', workdir='wkdir/CVS',
@@ -182,7 +182,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['cvsdiscard'])
@@ -220,7 +220,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -237,7 +237,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['cvsdiscard'])
@@ -275,7 +275,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -292,7 +292,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                         timeout=1,
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -332,7 +332,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -370,7 +370,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -407,7 +407,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -444,9 +444,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -469,9 +469,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -479,7 +479,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                                  ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
                                  '-z3', 'checkout', '-d', 'wkdir', 'mozilla/browser/'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -487,7 +487,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                                  ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
                                  '-z3', 'checkout', '-d', 'wkdir', 'mozilla/browser/'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -509,9 +509,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='source/CVS',
@@ -531,7 +531,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='source',
                         command=['cvs', '-z3', 'update', '-dP'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0)
         )
 
@@ -547,16 +547,16 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='source/CVS',
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .upload_string('the-end-of-the-universe\n')
             .exit(0),
-            ExpectRmdir(dir='source', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='source', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -564,7 +564,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                                  ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
                                  '-z3', 'checkout', '-d', 'source', 'mozilla/browser/'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0)
         )
 
@@ -580,7 +580,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -614,7 +614,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -631,7 +631,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .upload_string('/file/1.1/Fri May 17 23:20:00//D2013.10.08.11.20.33\nD\n')
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -653,7 +653,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -689,7 +689,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -725,7 +725,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -762,7 +762,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -796,7 +796,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -830,13 +830,13 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -858,13 +858,13 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -872,7 +872,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                                  ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
                                  '-z3', 'checkout', '-d', 'wkdir', 'mozilla/browser/'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -893,14 +893,14 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .upload_string('the-end-of-the-universe\n')
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -921,7 +921,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -933,7 +933,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .upload_string('the-end-of-the-universe\n')
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs',
@@ -954,7 +954,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -979,7 +979,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -1005,7 +1005,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -1043,13 +1043,13 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
                              writer=ExpectRemoteRef(remotetransfer.StringFileWriter))
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=step.timeout)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=step.timeout)
             .exit(0),
             ExpectShell(workdir='',
                         command=['cvs', '-q', '-d',
@@ -1061,7 +1061,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
         self.expect_property('got_revision', '2012-09-09 12:00:39 +0000', 'CVS')
         return self.run_step()
 
-    def test_mode_incremental_with_env_logEnviron(self):
+    def test_mode_incremental_with_env_log_environ(self):
         self.setup_step(
             cvs.CVS(cvsroot=":pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot",
                     cvsmodule="mozilla/browser/", mode='incremental',
@@ -1070,9 +1070,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'],
                         env={'abc': '123'},
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=False)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=False)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',
@@ -1092,7 +1092,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '-z3', 'update', '-dP'],
                         env={'abc': '123'},
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0)
         )
 
@@ -1121,7 +1121,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['cvs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectUploadFile(blocksize=32768, maxsize=None,
                              workersrc='Root', workdir='wkdir/CVS',

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -67,9 +67,9 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['darcs', 'get', '--verbose', '--lazy',
@@ -93,16 +93,16 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/_darcs', logEnviron=True)
+            ExpectStat(file='source/_darcs', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['darcs', 'pull', '--all', '--verbose'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='build', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='build', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='build',
                         command=['darcs', 'changes', '--max-count=1'])
@@ -122,16 +122,16 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/_darcs', logEnviron=True)
+            ExpectStat(file='source/_darcs', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['darcs', 'pull', '--all', '--verbose'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='build', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='build', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='build',
                         command=['darcs', 'changes', '--max-count=1'])
@@ -151,9 +151,9 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_darcs', logEnviron=True)
+            ExpectStat(file='wkdir/_darcs', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['darcs', 'pull', '--all', '--verbose'])
@@ -176,18 +176,18 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/_darcs', logEnviron=True)
+            ExpectStat(file='source/_darcs', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['darcs', 'pull', '--all', '--verbose'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='build', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='build', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='build/_darcs', logEnviron=True)
+            ExpectStat(file='build/_darcs', log_environ=True)
             .exit(0),
             ExpectShell(workdir='build',
                         command=['darcs', 'pull', '--all', '--verbose'])
@@ -211,9 +211,9 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_darcs', logEnviron=True)
+            ExpectStat(file='wkdir/_darcs', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['darcs', 'pull', '--all', '--verbose'])
@@ -230,7 +230,7 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['darcs', 'changes', '--max-count=1'])
@@ -250,21 +250,21 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['darcs', 'get', '--verbose', '--lazy',
                                  '--repo-name', 'wkdir', 'http://localhost/darcs'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['darcs', 'get', '--verbose', '--lazy',
                                  '--repo-name', 'wkdir', 'http://localhost/darcs'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['darcs', 'get', '--verbose', '--lazy',
@@ -289,9 +289,9 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -322,9 +322,9 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -353,9 +353,9 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['darcs', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_darcs', logEnviron=True)
+            ExpectStat(file='wkdir/_darcs', log_environ=True)
             .exit(1),
             ExpectShell(workdir='.',
                         command=['darcs', 'get', '--verbose', '--lazy',

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -48,7 +48,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -90,7 +90,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -132,7 +132,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -174,7 +174,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -51,7 +51,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -93,7 +93,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -135,7 +135,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -177,7 +177,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -70,7 +70,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -96,7 +96,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--filter', 'tree:0',
@@ -122,7 +122,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -157,7 +157,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -204,7 +204,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_key_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -253,7 +253,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_key_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -311,7 +311,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             .behavior(downloadString(read.append))
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -375,7 +375,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_known_hosts_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -433,7 +433,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_known_hosts_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -497,7 +497,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             .behavior(downloadString(read.append))
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -562,7 +562,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_wrapper_path, workdir='wkdir', mode=0o700)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -623,7 +623,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_known_hosts_path, workdir=workdir, mode=0o400)
             .exit(0),
             ExpectListdir(dir=workdir)
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir=workdir,
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -662,7 +662,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file=r'wkdir\.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -709,7 +709,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_key_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -759,7 +759,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_key_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -813,7 +813,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_wrapper_path, workdir='wkdir', mode=0o700)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -853,7 +853,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         timeout=1,
@@ -897,7 +897,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         logEnviron=True)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -955,7 +955,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         logEnviron=True)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1008,7 +1008,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1053,7 +1053,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1091,7 +1091,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['file1', 'file2'])
+            .files(['file1', 'file2'])
             .exit(0),
             ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
             .exit(0),
@@ -1121,7 +1121,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1153,7 +1153,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1179,7 +1179,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--reference', 'path/to/reference/repo',
@@ -1205,7 +1205,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1232,7 +1232,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--origin', 'foo',
@@ -1258,7 +1258,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1307,7 +1307,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1542,7 +1542,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -1574,7 +1574,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -1606,7 +1606,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1642,7 +1642,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -1690,7 +1690,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                workerdest=ssh_key_path, workdir='wkdir', mode=0o400)
             .exit(0),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', '-c', ssh_command_config,
@@ -1728,7 +1728,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -1763,7 +1763,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -1799,7 +1799,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'cat-file', '-e', 'abcdef01'])
@@ -1831,7 +1831,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'cat-file', '-e', 'abcdef01'])
@@ -1866,7 +1866,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -1914,7 +1914,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -1964,7 +1964,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -2101,7 +2101,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -2142,7 +2142,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -2186,7 +2186,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -2226,7 +2226,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -2268,7 +2268,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             .exit(1),
             ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200),
             ExpectListdir(dir='source')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='source',
                         command=['git', 'fetch', '-f', '-t',
@@ -2315,7 +2315,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             .exit(0),
             ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200),
             ExpectListdir(dir='source')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='source',
                         command=['git', '-c', ssh_command_config,
@@ -2358,7 +2358,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2519,7 +2519,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2551,7 +2551,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2595,7 +2595,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', [])
+            .files()
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2631,7 +2631,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -2667,7 +2667,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'],
@@ -2707,7 +2707,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=False)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'],
@@ -2779,7 +2779,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -2826,7 +2826,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
@@ -3147,7 +3147,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=prefix + ['clean', '-f', '-f', '-d'])

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -37,7 +37,6 @@ from buildbot.test.expect import ExpectShell
 from buildbot.test.expect import ExpectStat
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import TestBuildStepMixin
-from buildbot.test.unit.steps.test_transfer import downloadString
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
 from buildbot.util import unicode2bytes
@@ -308,7 +307,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                workerdest=ssh_wrapper_path, workdir='wkdir', mode=0o700)
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -494,7 +493,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                workerdest=ssh_wrapper_path, workdir='wkdir', mode=0o700)
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0),
             ExpectListdir(dir='wkdir')
             .files(['.git'])

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -66,7 +66,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.26.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -92,7 +92,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.27.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -118,7 +118,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -153,7 +153,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -194,9 +194,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -221,7 +221,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -243,9 +243,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.3.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -270,7 +270,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -296,9 +296,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -328,7 +328,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -361,9 +361,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -392,7 +392,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -419,9 +419,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.3.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -450,7 +450,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -478,9 +478,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -514,7 +514,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -544,9 +544,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -579,7 +579,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -609,9 +609,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectStat(file='/myworkdir/workdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='/myworkdir/workdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -640,7 +640,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -658,7 +658,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file=r'wkdir\.buildbot-patched', logEnviron=True)
+            ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -699,9 +699,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectStat(file='wkdir\\.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir\\.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -726,7 +726,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -749,9 +749,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.3.0')
             .exit(0),
-            ExpectStat(file='wkdir\\.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir\\.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -776,7 +776,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -799,9 +799,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.0')
             .exit(0),
-            ExpectStat(file='wkdir\\.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir\\.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -830,7 +830,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -849,7 +849,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -889,11 +889,11 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'],
-                        logEnviron=True)
+                        log_environ=True)
             .exit(0),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -922,9 +922,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'apply', '--index', '-p', '1'],
-                        initialStdin='patch')
+                        initial_stdin='patch')
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -947,11 +947,11 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'],
-                        logEnviron=True)
+                        log_environ=True)
             .exit(0),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -980,9 +980,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'apply', '--index', '-p', '1'],
-                        initialStdin='patch')
+                        initial_stdin='patch')
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -1004,7 +1004,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1033,7 +1033,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'apply', '--index', '-p', '1'],
-                        initialStdin='patch')
+                        initial_stdin='patch')
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -1049,7 +1049,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1087,12 +1087,12 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['file1', 'file2'])
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--branch', 'test-branch',
@@ -1117,7 +1117,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1149,7 +1149,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -1175,7 +1175,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -1201,7 +1201,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -1228,7 +1228,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -1254,7 +1254,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1303,7 +1303,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1352,9 +1352,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1384,9 +1384,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1413,9 +1413,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1437,9 +1437,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1467,9 +1467,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.5.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1503,23 +1503,23 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='incremental', progress=True))
         self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expect_commands(
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.git', logEnviron=True)
+            ExpectStat(file='wkdir/.git', log_environ=True)
             .exit(0),
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             .exit(0),
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', 'checkout', '-f', 'FETCH_HEAD'])
             .exit(0),
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0)
@@ -1538,7 +1538,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1570,7 +1570,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5.1')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1602,7 +1602,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -1612,7 +1612,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                  'http://github.com/buildbot/buildbot.git',
                                  '.', '--progress'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1638,7 +1638,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1680,9 +1680,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -1707,7 +1707,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -1724,7 +1724,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1759,7 +1759,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1767,7 +1767,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
             .exit(1),  # clean fails -> clobber
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -1795,7 +1795,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1827,7 +1827,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1862,7 +1862,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1910,7 +1910,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.6')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -1960,7 +1960,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.8')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2010,9 +2010,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--depth', '1',
@@ -2039,9 +2039,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--depth', '100',
@@ -2068,9 +2068,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2097,7 +2097,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2138,7 +2138,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2182,7 +2182,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2195,7 +2195,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'checkout', '-f', 'FETCH_HEAD'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2222,7 +2222,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2235,7 +2235,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'checkout', '-f', 'FETCH_HEAD'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2263,9 +2263,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
             ExpectListdir(dir='source')
             .files(['.git'])
             .exit(0),
@@ -2277,7 +2277,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='source',
                         command=['git', 'checkout', '-f', 'FETCH_HEAD'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='wkdir', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -2304,15 +2304,15 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                workerdest=ssh_key_path, workdir='source', mode=0o400)
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
             ExpectListdir(dir='source')
             .files(['.git'])
             .exit(0),
@@ -2325,13 +2325,13 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='source',
                         command=['git', 'checkout', '-f', 'FETCH_HEAD'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='wkdir', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -2354,7 +2354,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -2380,20 +2380,20 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='incremental'))
         self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expect_commands(
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.git', logEnviron=True)
+            ExpectStat(file='wkdir/.git', log_environ=True)
             .exit(1),
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', 'clone',
                                  'http://github.com/buildbot/buildbot.git',
                                  '.', '--progress'])
             .exit(0),
-            ExpectShell(workdir='wkdir', interruptSignal='TERM',
+            ExpectShell(workdir='wkdir', interrupt_signal='TERM',
                         command=['git', 'rev-parse', 'HEAD'])
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0)
@@ -2414,9 +2414,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2447,9 +2447,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2478,9 +2478,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2515,7 +2515,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -2547,7 +2547,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -2557,14 +2557,14 @@ class TestGit(sourcesteps.SourceStepMixin,
                                  'http://github.com/buildbot/buildbot.git',
                                  '.', '--progress'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
                                  'http://github.com/buildbot/buildbot.git',
                                  '.', '--progress'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2591,7 +2591,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files()
@@ -2601,7 +2601,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                  'http://github.com/buildbot/buildbot.git',
                                  '.', '--progress'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -2627,7 +2627,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2663,7 +2663,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         env={'abc': '123'})
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2693,38 +2693,38 @@ class TestGit(sourcesteps.SourceStepMixin,
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.run_step()
 
-    def test_mode_full_logEnviron(self):
+    def test_mode_full_log_environ(self):
         self.setup_step(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', logEnviron=False))
         self.expect_commands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'],
-                        logEnviron=False)
+                        log_environ=False)
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=False)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=False)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'checkout', '-f', 'FETCH_HEAD'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'],
-                        logEnviron=False)
+                        log_environ=False)
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0)
         )
@@ -2742,7 +2742,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .exit(1),
@@ -2775,7 +2775,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2822,7 +2822,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -2873,9 +2873,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
@@ -3143,7 +3143,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=prefix + ['--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -3316,7 +3316,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -3326,7 +3326,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '-c', ssh_command_config,
                                  'push', url, 'testbranch'])
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -3348,7 +3348,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 2.3.0')
             .exit(0),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -3358,7 +3358,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH_COMMAND': ssh_command})
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -3380,7 +3380,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.0')
             .exit(0),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -3394,7 +3394,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH': ssh_wrapper_path})
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -3420,7 +3420,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 2.10.0')
             .exit(0),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -3434,7 +3434,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '-c', ssh_command_config,
                                  'push', url, 'testbranch'])
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -3460,7 +3460,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 2.3.0')
             .exit(0),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -3474,7 +3474,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH_COMMAND': ssh_command})
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -3497,7 +3497,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.0')
             .exit(0),
-            ExpectMkdir(dir=ssh_workdir, logEnviron=True)
+            ExpectMkdir(dir=ssh_workdir, log_environ=True)
             .exit(0),
             ExpectDownloadFile(blocksize=32768, maxsize=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader),
@@ -3515,7 +3515,7 @@ class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH': ssh_wrapper_path})
             .exit(0),
-            ExpectRmdir(dir=ssh_workdir, logEnviron=True)
+            ExpectRmdir(dir=ssh_workdir, log_environ=True)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)

--- a/master/buildbot/test/unit/steps/test_source_github.py
+++ b/master/buildbot/test/unit/steps/test_source_github.py
@@ -36,7 +36,7 @@ class TestGitHub(test_source_git.TestGit):
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])
@@ -77,7 +77,7 @@ class TestGitHub(test_source_git.TestGit):
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])

--- a/master/buildbot/test/unit/steps/test_source_github.py
+++ b/master/buildbot/test/unit/steps/test_source_github.py
@@ -39,7 +39,7 @@ class TestGitHub(test_source_git.TestGit):
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -80,7 +80,7 @@ class TestGitHub(test_source_git.TestGit):
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -63,7 +63,7 @@ class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
             .files(['.git'])

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -66,7 +66,7 @@ class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
             .exit(1),
             ExpectListdir(dir='wkdir')
-            .update('files', ['.git'])
+            .files(['.git'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -72,9 +72,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -114,9 +114,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file=r'wkdir\.buildbot-patched', logEnviron=True)
+            ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file=r'wkdir\.hg', logEnviron=True)
+            ExpectStat(file=r'wkdir\.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -157,9 +157,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
                         timeout=1,
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         timeout=1,
@@ -205,9 +205,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -239,9 +239,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=[
                             'hg', '--verbose', 'import', '--no-commit', '-p', '1', '-'],
-                        initialStdin='patch')
+                        initial_stdin='patch')
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'parents',
@@ -263,9 +263,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -297,9 +297,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=[
                             'hg', '--verbose', 'import', '--no-commit', '-p', '1', '-'],
-                        initialStdin='patch')
+                        initial_stdin='patch')
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'parents',
@@ -320,9 +320,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -354,7 +354,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=[
                             'hg', '--verbose', 'import', '--no-commit', '-p', '1', '-'],
-                        initialStdin='patch')
+                        initial_stdin='patch')
             .exit(1)
         )
         self.expect_outcome(result=FAILURE, state_string="update (failure)")
@@ -368,9 +368,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -379,7 +379,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'update',
                                  '--clean', '--rev', 'default'],
-                        logEnviron=True)
+                        log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'parents',
@@ -399,9 +399,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -428,9 +428,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -469,9 +469,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -480,7 +480,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'update',
                                  '--clean', '--rev', 'default'],
-                        logEnviron=True)
+                        log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'parents',
@@ -501,21 +501,21 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
                                  'http://hg.mozilla.org', '.'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
                                  'http://hg.mozilla.org', '.'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -524,7 +524,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'update',
                                  '--clean', '--rev', 'default'],
-                        logEnviron=True)
+                        log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'parents',
@@ -545,9 +545,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(1),  # does not exist
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -578,15 +578,15 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(1),  # does not exist
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
                                  'http://hg.mozilla.org', '.'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -618,15 +618,15 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
                                  'http://hg.mozilla.org/stable'])
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -654,9 +654,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(1),  # does not exist
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -691,9 +691,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),  # directory exists
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
@@ -728,9 +728,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),  # directory exists
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
@@ -744,7 +744,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['hg', '--verbose', 'locate', 'set:added()'])
             .stdout('foo\nbar/baz\n')
             .exit(1),
-            ExpectRmdir(dir=['wkdir/foo', 'wkdir/bar/baz'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/foo', 'wkdir/bar/baz'], log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'update', '--clean',
@@ -769,9 +769,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),  # directory exists
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
@@ -785,9 +785,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['hg', '--verbose', 'locate', 'set:added()'])
             .stdout('foo\nbar/baz\n')
             .exit(1),
-            ExpectRmdir(dir='wkdir/foo', logEnviron=True)
+            ExpectRmdir(dir='wkdir/foo', log_environ=True)
             .exit(0),
-            ExpectRmdir(dir='wkdir/bar/baz', logEnviron=True)
+            ExpectRmdir(dir='wkdir/bar/baz', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'update', '--clean',
@@ -814,9 +814,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
@@ -853,9 +853,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
@@ -865,7 +865,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
                         command=['hg', '--verbose', 'identify', '--branch'])
             .stdout('default')
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'clone', '--noupdate',
@@ -896,9 +896,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
@@ -934,9 +934,9 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'], env={'abc': '123'})
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=True)
+            ExpectStat(file='wkdir/.hg', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
@@ -969,7 +969,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
-    def test_mode_full_clean_logEnviron(self):
+    def test_mode_full_clean_log_environ(self):
         self.setup_step(
             mercurial.Mercurial(repourl='http://hg.mozilla.org',
                                 mode='full', method='clean',
@@ -978,40 +978,40 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
         self.expect_commands(
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--version'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=False)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=False)
             .exit(1),
-            ExpectStat(file='wkdir/.hg', logEnviron=False)
+            ExpectStat(file='wkdir/.hg', log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', '--config',
                                  'extensions.purge=', 'purge'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'pull',
                                  'http://hg.mozilla.org', '--rev', 'default'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'identify', '--branch'],
-                        logEnviron=False)
+                        log_environ=False)
             .stdout('default')
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'locate', 'set:added()'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(1),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'update',
                                  '--clean', '--rev', 'default'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['hg', '--verbose', 'parents',
                                  '--template', '{node}\\n'],
-                        logEnviron=False)
+                        log_environ=False)
             .stdout('\n')
             .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
             .exit(0)

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -58,7 +58,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -69,15 +69,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
             .stdout('file1\nfile2')
             .exit(0),
-            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -103,7 +103,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -114,15 +114,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
             .stdout('file1\nfile2')
             .exit(0),
-            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -140,7 +140,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
@@ -163,7 +163,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -174,15 +174,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
             .stdout('file1\nfile2')
             .exit(0),
-            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -200,7 +200,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
@@ -222,7 +222,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -233,15 +233,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
             .stdout('file1\nfile2')
             .exit(0),
-            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -259,7 +259,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE, state_string="update (failure)")
@@ -275,7 +275,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(1),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -285,15 +285,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
             .stdout('file1\nfile2')
             .exit(0),
-            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -318,7 +318,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -329,11 +329,11 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
@@ -358,7 +358,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(1),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -368,11 +368,11 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
@@ -397,7 +397,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -408,7 +408,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
@@ -433,7 +433,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(1),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -443,7 +443,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
@@ -468,7 +468,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(1),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -478,9 +478,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -505,7 +505,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -516,11 +516,11 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
@@ -545,7 +545,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(1),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -555,11 +555,11 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True)
+            ExpectRmdir(dir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
@@ -584,7 +584,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -595,9 +595,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -622,7 +622,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -638,9 +638,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -665,7 +665,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -676,9 +676,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
@@ -689,7 +689,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             .stdout('file3\nfile4')
             .exit(0),
             ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2', 'wkdir/file3', 'wkdir/file4'],
-                        logEnviron=True)
+                        log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -715,7 +715,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -726,9 +726,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'abcdef01',
@@ -754,7 +754,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -765,15 +765,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/_MTN', logEnviron=True)
+            ExpectStat(file='source/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['mtn', 'update', '--revision', 'h:master',
                                  '--branch', 'master'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='build', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='build', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='build',
                         command=['mtn', 'automate', 'select', 'w:'])
@@ -794,7 +794,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -805,15 +805,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/_MTN', logEnviron=True)
+            ExpectStat(file='source/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['mtn', 'update', '--revision', 'h:master',
                                  '--branch', 'master'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='build', logEnviron=True, timeout=1200)
+            ExpectCpdir(fromdir='source', todir='build', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='build',
                         command=['mtn', 'automate', 'select', 'w:'])
@@ -854,7 +854,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -865,15 +865,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'ls', 'unknown'])
             .stdout('file1\nfile2')
             .exit(0),
-            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], logEnviron=True)
+            ExpectRmdir(dir=['wkdir/file1', 'wkdir/file2'], log_environ=True)
             .exit(0),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -912,7 +912,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -926,9 +926,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -953,7 +953,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
@@ -973,13 +973,13 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             .stdout('too new, cannot use')
             .exit(0),
-            ExpectRmdir(dir='db.mtn', logEnviron=True)
+            ExpectRmdir(dir='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -989,9 +989,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',
@@ -1016,13 +1016,13 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['mtn', '--version'])
             .stdout(self.MTN_VER)
             .exit(0),
-            ExpectStat(file='db.mtn', logEnviron=True)
+            ExpectStat(file='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             .stdout('database has no tables')
             .exit(0),
-            ExpectRmdir(dir='db.mtn', logEnviron=True)
+            ExpectRmdir(dir='db.mtn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
@@ -1032,9 +1032,9 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/_MTN', logEnviron=True)
+            ExpectStat(file='wkdir/_MTN', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'update', '--revision', 'h:master',

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -146,7 +146,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-P', ('obfuscated', 'pass', 'XXXXXX'),
                                  '-c', 'p4_client1', 'client', '-i'],
-                        initialStdin=client_spec)
+                        initial_stdin=client_spec)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
@@ -178,7 +178,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-P', ('obfuscated', 'pass', 'XXXXXX'),
                                  '-c', 'p4_client1', 'client', '-i'],
-                        initialStdin=client_stdin,)
+                        initial_stdin=client_stdin,)
             .exit(0),
             ExpectShell(workdir=workdir,
                         timeout=timeout,
@@ -507,7 +507,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
                         command=['p4', '-p', 'localhost:12000', '-u', p4user,
                                  '-P', expected_pass,
                                  '-c', p4client, 'client', '-i'],
-                        initialStdin=client_stdin)
+                        initial_stdin=client_stdin)
             .exit(0),
             ExpectShell(workdir=workdir,
                         command=['p4', '-p', 'localhost:12000', '-u', p4user,
@@ -516,7 +516,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
                         + ['sync', '#none'])
             .exit(0),
 
-            ExpectRmdir(dir=workdir, logEnviron=True)
+            ExpectRmdir(dir=workdir, log_environ=True)
             .exit(0),
 
             ExpectShell(workdir=workdir,
@@ -1018,13 +1018,13 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-c', 'p4_client1', 'login'],
-                        initialStdin='pass\n')
+                        initial_stdin='pass\n')
             .exit(0),
 
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-c', 'p4_client1', 'client', '-i'],
-                        initialStdin=client_spec)
+                        initial_stdin=client_spec)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=(['p4', '-p', 'localhost:12000', '-u', 'user',

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -77,8 +77,8 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
     def ExpectShell(self, **kw):
         if 'workdir' not in kw:
             kw['workdir'] = 'wkdir'
-        if 'logEnviron' not in kw:
-            kw['logEnviron'] = self.shouldLogEnviron()
+        if 'log_environ' not in kw:
+            kw['log_environ'] = self.shouldLogEnviron()
         return ExpectShell(**kw)
 
     def mySetupStep(self, **kwargs):
@@ -99,18 +99,18 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
     def expectClobber(self):
         # stat return 1 so we clobber
         self.expect_commands(
-            ExpectStat(file='wkdir/.repo', logEnviron=self.logEnviron)
+            ExpectStat(file='wkdir/.repo', log_environ=self.logEnviron)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=self.logEnviron)
+            ExpectRmdir(dir='wkdir', log_environ=self.logEnviron)
             .exit(0),
-            ExpectMkdir(dir='wkdir', logEnviron=self.logEnviron)
+            ExpectMkdir(dir='wkdir', log_environ=self.logEnviron)
             .exit(0)
         )
 
     def expectnoClobber(self):
         # stat return 0, so nothing
         self.expect_commands(
-            ExpectStat(file='wkdir/.repo', logEnviron=self.logEnviron)
+            ExpectStat(file='wkdir/.repo', log_environ=self.logEnviron)
             .exit(0)
         )
 
@@ -189,12 +189,12 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
                          syncAllBranches=True)
         self.expectClobber()
         override_commands = [
-            ExpectStat(file='wkdir/http://u.rl/test.manifest', logEnviron=False),
-            self.ExpectShell(logEnviron=False, command=['wget',
+            ExpectStat(file='wkdir/http://u.rl/test.manifest', log_environ=False),
+            self.ExpectShell(log_environ=False, command=['wget',
                                                         'http://u.rl/test.manifest',
                                                         '-O', 'manifest_override.xml']),
             self.ExpectShell(
-                logEnviron=False, workdir='wkdir/.repo',
+                log_environ=False, workdir='wkdir/.repo',
                 command=['ln', '-sf', '../manifest_override.xml',
                          'manifest.xml'])
         ]
@@ -210,11 +210,11 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
                          syncAllBranches=True)
         self.expectClobber()
         override_commands = [
-            ExpectStat(file='wkdir/test.manifest', logEnviron=False),
-            self.ExpectShell(logEnviron=False,
+            ExpectStat(file='wkdir/test.manifest', log_environ=False),
+            self.ExpectShell(log_environ=False,
                              command=[
                                  'cp', '-f', 'test.manifest', 'manifest_override.xml']),
-            self.ExpectShell(logEnviron=False,
+            self.ExpectShell(log_environ=False,
                              workdir='wkdir/.repo',
                              command=['ln', '-sf', '../manifest_override.xml',
                                       'manifest.xml'])
@@ -251,7 +251,7 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
             .exit(1),
             self.ExpectShell(command=['rm', '-f', '/tarball.tgz'])
             .exit(1),
-            ExpectRmdir(dir='wkdir/.repo', logEnviron=False)
+            ExpectRmdir(dir='wkdir/.repo', log_environ=False)
             .exit(1))
         self.expectRepoSync()
         self.expect_commands(self.ExpectShell(command=['stat', '-c%Y', '/tarball.tgz'])
@@ -318,7 +318,7 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
             self.ExpectShell(
                 command=['rm', '-f', '/tarball.tar'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.repo', logEnviron=False)
+            ExpectRmdir(dir='wkdir/.repo', log_environ=False)
             .exit(0))
         self.expectRepoSync()
         self.expect_commands(self.ExpectShell(command=['stat', '-c%Y', '/tarball.' + suffix])

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -159,9 +159,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -190,9 +190,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -228,9 +228,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -260,9 +260,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -297,9 +297,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         timeout=1,
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         timeout=1,
@@ -334,9 +334,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -366,9 +366,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -397,11 +397,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
@@ -424,17 +424,17 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
                                  '.', '--non-interactive', '--no-auth-cache'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
@@ -457,9 +457,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -468,7 +468,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             # expecting ../trunk/app
             .stdout('<?xml version="1.0"?><url>http://svn.local/branch/foo/app</url>')
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
@@ -493,9 +493,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -527,9 +527,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file=r'wkdir\.buildbot-patched', logEnviron=True)
+            ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file=r'wkdir\.svn', logEnviron=True)
+            ExpectStat(file=r'wkdir\.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -563,9 +563,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -603,9 +603,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -637,9 +637,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout',
@@ -665,9 +665,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout',
@@ -692,9 +692,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -732,23 +732,23 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
                                  '.', '--non-interactive', '--no-auth-cache'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
                                  '.', '--non-interactive', '--no-auth-cache'])
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
@@ -774,9 +774,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -816,9 +816,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -834,7 +834,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             .stdout(self.svn_st_xml)
             .exit(0),
             ExpectRmdir(dir=['wkdir/svn_external_path/unversioned_file2_uniçode'],
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'update',
@@ -857,9 +857,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -897,9 +897,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -935,11 +935,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
@@ -964,11 +964,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
@@ -993,9 +993,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1011,10 +1011,10 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             .stdout(self.svn_st_xml)
             .exit(0),
             ExpectRmdir(dir='wkdir/svn_external_path/unversioned_file1',
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(0),
             ExpectRmdir(dir='wkdir/svn_external_path/unversioned_file2_uniçode',
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'update',
@@ -1039,9 +1039,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1058,7 +1058,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             .exit(0),
             ExpectRmdir(dir=['wkdir/svn_external_path/unversioned_file1',
                              'wkdir/svn_external_path/unversioned_file2_uniçode'],
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'update',
@@ -1082,11 +1082,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/app/.svn', logEnviron=True)
+            ExpectStat(file='source/app/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source/app',
                         command=['svn', 'info', '--xml',
@@ -1099,7 +1099,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['svn', 'update', '--non-interactive',
                                  '--no-auth-cache'])
             .exit(0),
-            ExpectCpdir(fromdir='source/app', todir='wkdir', logEnviron=True)
+            ExpectCpdir(fromdir='source/app', todir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml'])
@@ -1120,11 +1120,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1137,7 +1137,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['svn', 'update', '--revision', '100',
                                  '--non-interactive', '--no-auth-cache'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='wkdir', logEnviron=True)
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml'])
@@ -1156,11 +1156,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1194,7 +1194,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn',
@@ -1204,11 +1204,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             .exit(0),
             ExpectRmdir(dir=['wkdir/svn_external_path/unversioned_file1',
                              'wkdir/svn_external_path/unversioned_file2_uniçode'],
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1236,7 +1236,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml'])
@@ -1257,7 +1257,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn',
@@ -1267,11 +1267,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             .exit(0),
             ExpectRmdir(dir=['wkdir/svn_external_path/unversioned_file1',
                              'wkdir/svn_external_path/unversioned_file2_uniçode'],
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(0),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1299,7 +1299,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['patch', '-p1', '--remove-empty-files',
                                  '--force', '--forward', '-i', '.buildbot-diff'])
             .exit(0),
-            ExpectRmdir(dir='wkdir/.buildbot-diff', logEnviron=True)
+            ExpectRmdir(dir='wkdir/.buildbot-diff', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml'])
@@ -1320,11 +1320,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         timeout=1,
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         timeout=1,
@@ -1363,11 +1363,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1402,11 +1402,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1449,9 +1449,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['svn', '--version'],
                         env={'abc': '123'})
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1478,7 +1478,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_property('got_revision', '100', 'SVN')
         return self.run_step()
 
-    def test_mode_incremental_logEnviron(self):
+    def test_mode_incremental_log_environ(self):
         self.setup_step(
             svn.SVN(repourl='http://svn.local/app/trunk',
                     mode='incremental', username='user',
@@ -1487,18 +1487,18 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_commands(
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=False)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=False)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=False)
+            ExpectStat(file='wkdir/.svn', log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
                                  '--non-interactive',
                                  '--no-auth-cache', '--username', 'user',
                                  '--password', ('obfuscated', 'pass', 'XXXXXX'), '--random'],
-                        logEnviron=False)
+                        log_environ=False)
             .stdout('<?xml version="1.0"?>'
                     '<url>http://svn.local/app/trunk</url>')
             .exit(0),
@@ -1506,11 +1506,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['svn', 'update', '--non-interactive',
                                  '--no-auth-cache', '--username', 'user',
                                  '--password', ('obfuscated', 'pass', 'XXXXXX'), '--random'],
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml'],
-                        logEnviron=False)
+                        log_environ=False)
             .stdout(self.svn_info_stdout_xml)
             .exit(0)
         )
@@ -1527,9 +1527,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1557,9 +1557,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1592,9 +1592,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -1608,9 +1608,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -1624,11 +1624,11 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectRmdir(dir='wkdir', logEnviron=True, timeout=1200)
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200)
             .exit(0),
-            ExpectStat(file='source/.svn', logEnviron=True)
+            ExpectStat(file='source/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--xml',
@@ -1641,7 +1641,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                         command=['svn', 'update', '--non-interactive',
                                  '--no-auth-cache'])
             .exit(0),
-            ExpectCpdir(fromdir='source', todir='wkdir', logEnviron=True)
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -1657,9 +1657,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1675,7 +1675,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             .stdout(self.svn_st_xml)
             .exit(0),
             ExpectRmdir(dir=['wkdir/svn_external_path/unversioned_file2_uniçode'],
-                        logEnviron=True, timeout=1200)
+                        log_environ=True, timeout=1200)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -1703,9 +1703,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',
@@ -1737,9 +1737,9 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
             .exit(0),
-            ExpectStat(file='wkdir/.buildbot-patched', logEnviron=True)
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
             .exit(1),
-            ExpectStat(file='wkdir/.svn', logEnviron=True)
+            ExpectStat(file='wkdir/.svn', log_environ=True)
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['svn', 'info', '--xml',

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -42,19 +42,6 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import TestBuildStepMixin
 
 
-def downloadString(memoizer, timestamp=None):
-    def behavior(command):
-        reader = command.args['reader']
-        read = reader.remote_read(1000)
-        # save what we read so we can check it
-        memoizer(read)
-        reader.remote_close()
-        if timestamp:
-            reader.remote_utime(timestamp)
-        return read
-    return behavior
-
-
 class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
@@ -873,7 +860,7 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
             ExpectDownloadFile(workerdest=self.destfile, workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.FileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append, size=1000)
             .exit(0))
 
         self.expect_outcome(
@@ -884,7 +871,6 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
 
         with open(master_file, "rb") as f:
             contents = f.read()
-        # Only first 1000 bytes transferred in downloadString() helper
         contents = contents[:1000]
         self.assertEqual(b''.join(read), contents)
 
@@ -903,7 +889,7 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
             ExpectDownloadFile(slavedest=self.destfile, workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.FileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append, size=1000)
             .exit(0))
 
         self.expect_outcome(
@@ -915,7 +901,6 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin,
         def checkCalls(res):
             with open(master_file, "rb") as f:
                 contents = f.read()
-            # Only first 1000 bytes transferred in downloadString() helper
             contents = contents[:1000]
             self.assertEqual(b''.join(read), contents)
 
@@ -966,7 +951,7 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin,
             ExpectDownloadFile(workerdest="hello.txt", workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0))
 
         self.expect_outcome(
@@ -992,7 +977,7 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin,
             ExpectDownloadFile(slavedest="hello.txt", workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0))
 
         self.expect_outcome(
@@ -1056,7 +1041,7 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin,
             ExpectDownloadFile(workerdest="hello.json", workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0))
 
         self.expect_outcome(
@@ -1080,7 +1065,7 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin,
             ExpectDownloadFile(workerdest="hello.json", workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0))
 
         self.expect_outcome(
@@ -1138,7 +1123,7 @@ class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.
             ExpectDownloadFile(workerdest="props.json", workdir='wkdir',
                                blocksize=16384, maxsize=None, mode=None,
                                reader=ExpectRemoteRef(remotetransfer.StringFileReader))
-            .behavior(downloadString(read.append))
+            .download_string(read.append)
             .exit(0))
 
         self.expect_outcome(

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -575,7 +575,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
                 workersrcs=["src*"], masterdest=self.destdir, glob=True))
         self.expect_commands(
             ExpectGlob(path=os.path.join('wkdir', 'src*'), logEnviron=False)
-            .update('files', ["srcfile"])
+            .files(["srcfile"])
             .exit(0),
             ExpectStat(file="srcfile", workdir='wkdir')
             .stat_file()
@@ -597,7 +597,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
                 workersrcs=["src*"], masterdest=self.destdir, glob=True))
         self.expect_commands(
             ExpectGlob(path=os.path.join('wkdir', 'src*'), logEnviron=False)
-            .update('files', [])
+            .files()
             .exit(1)
         )
         self.expect_outcome(

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -561,7 +561,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             transfer.MultipleFileUpload(
                 workersrcs=["src*"], masterdest=self.destdir, glob=True))
         self.expect_commands(
-            ExpectGlob(path=os.path.join('wkdir', 'src*'), logEnviron=False)
+            ExpectGlob(path=os.path.join('wkdir', 'src*'), log_environ=False)
             .files(["srcfile"])
             .exit(0),
             ExpectStat(file="srcfile", workdir='wkdir')
@@ -583,7 +583,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             transfer.MultipleFileUpload(
                 workersrcs=["src*"], masterdest=self.destdir, glob=True))
         self.expect_commands(
-            ExpectGlob(path=os.path.join('wkdir', 'src*'), logEnviron=False)
+            ExpectGlob(path=os.path.join('wkdir', 'src*'), log_environ=False)
             .files()
             .exit(1)
         )

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -16,7 +16,6 @@
 import json
 import os
 import shutil
-import stat
 import tempfile
 
 from mock import Mock
@@ -468,7 +467,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -486,7 +485,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcdir", workdir='wkdir')
-            .update('stat', [stat.S_IFDIR, 99, 99])
+            .stat_dir()
             .exit(0),
             ExpectUploadDirectory(workersrc="srcdir", workdir='wkdir',
                                   blocksize=16384, compress=None, maxsize=None,
@@ -518,7 +517,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file='srcdir', workdir='wkdir')
-            .update('stat', [0, 99, 99])
+            .stat(mode=0)
             .exit(0))
 
         self.expect_outcome(result=FAILURE, state_string="uploading 1 file (failure)")
@@ -532,7 +531,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -540,7 +539,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             .upload_string("Hello world!\n")
             .exit(0),
             ExpectStat(file="srcdir", workdir='wkdir')
-            .update('stat', [stat.S_IFDIR, 99, 99])
+            .stat_dir()
             .exit(0),
             ExpectUploadDirectory(workersrc="srcdir", workdir='wkdir',
                                   blocksize=16384, compress=None, maxsize=None,
@@ -558,7 +557,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             transfer.MultipleFileUpload(workersrcs="srcfile", masterdest=self.destdir))
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -579,7 +578,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             .update('files', ["srcfile"])
             .exit(0),
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -614,7 +613,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(slavesrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -634,7 +633,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcdir", workdir='wkdir')
-            .update('stat', [stat.S_IFDIR, 99, 99])
+            .stat_dir()
             .exit(0),
             ExpectUploadDirectory(slavesrc="srcdir", workdir='wkdir',
                                   blocksize=16384, compress=None, maxsize=None,
@@ -654,7 +653,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(slavesrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -662,7 +661,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             .upload_string("Hello world!\n")
             .exit(0),
             ExpectStat(file="srcdir", workdir='wkdir')
-            .update('stat', [stat.S_IFDIR, 99, 99])
+            .stat_dir()
             .exit(0),
             ExpectUploadDirectory(slavesrc="srcdir", workdir='wkdir',
                                   blocksize=16384, compress=None, maxsize=None,
@@ -684,7 +683,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file='srcfile', workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc='srcfile', workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -708,7 +707,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file='srcfile', workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc='srcfile', workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -729,7 +728,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -750,7 +749,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -779,7 +778,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
 
         self.expect_commands(
             ExpectStat(file="srcfile", workdir='wkdir')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0),
             ExpectUploadFile(workersrc="srcfile", workdir='wkdir',
                              blocksize=16384, maxsize=None, keepstamp=False,
@@ -787,7 +786,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin,
             .upload_string("Hello world!\n")
             .exit(0),
             ExpectStat(file="srcdir", workdir='wkdir')
-            .update('stat', [stat.S_IFDIR, 99, 99])
+            .stat_dir()
             .exit(0),
             ExpectUploadDirectory(workersrc="srcdir", workdir='wkdir',
                                   blocksize=16384, compress=None, maxsize=None,

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -107,7 +107,7 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(worker.FileExists(file="x"))
         self.expect_commands(
             ExpectStat(file='x')
-            .update('stat', [stat.S_IFREG, 99, 99])
+            .stat_file()
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="File found.")
@@ -117,7 +117,7 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(worker.FileExists(file="x"))
         self.expect_commands(
             ExpectStat(file='x')
-            .update('stat', [0, 99, 99])
+            .stat(mode=0)
             .exit(0)
         )
         self.expect_outcome(result=FAILURE,

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -403,7 +403,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
         self.setup_step(CompositeUser(testFunc))
         self.expect_commands(
             ExpectGlob(path='*.pyc', logEnviron=False)
-            .update('files', ["one.pyc", "two.pyc"])
+            .files(["one.pyc", "two.pyc"])
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -186,7 +186,7 @@ class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin,
     def test_maxTime(self):
         self.setup_step(worker.CopyDirectory(src="s", dest="d", maxTime=10))
         self.expect_commands(
-            ExpectCpdir(fromdir='s', todir='d', maxTime=10, timeout=120)
+            ExpectCpdir(fromdir='s', todir='d', max_time=10, timeout=120)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="Copied s to d")
@@ -361,7 +361,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
     def test_rmfile(self):
         self.setup_step(CompositeUser(lambda x: x.runRmFile("d")))
         self.expect_commands(
-            ExpectRmfile(path='d', logEnviron=False)
+            ExpectRmfile(path='d', log_environ=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -370,7 +370,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
     def test_mkdir(self):
         self.setup_step(CompositeUser(lambda x: x.runMkdir("d")))
         self.expect_commands(
-            ExpectMkdir(dir='d', logEnviron=False)
+            ExpectMkdir(dir='d', log_environ=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -379,7 +379,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
     def test_rmdir(self):
         self.setup_step(CompositeUser(lambda x: x.runRmdir("d")))
         self.expect_commands(
-            ExpectRmdir(dir='d', logEnviron=False)
+            ExpectRmdir(dir='d', log_environ=False)
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
@@ -388,7 +388,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
     def test_mkdir_fail(self):
         self.setup_step(CompositeUser(lambda x: x.runMkdir("d")))
         self.expect_commands(
-            ExpectMkdir(dir='d', logEnviron=False)
+            ExpectMkdir(dir='d', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -402,7 +402,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
 
         self.setup_step(CompositeUser(testFunc))
         self.expect_commands(
-            ExpectGlob(path='*.pyc', logEnviron=False)
+            ExpectGlob(path='*.pyc', log_environ=False)
             .files(["one.pyc", "two.pyc"])
             .exit(0)
         )
@@ -412,7 +412,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
     def test_glob_fail(self):
         self.setup_step(CompositeUser(lambda x: x.runGlob("*.pyc")))
         self.expect_commands(
-            ExpectGlob(path='*.pyc', logEnviron=False)
+            ExpectGlob(path='*.pyc', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -425,7 +425,7 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
             yield x.runMkdir("d")
         self.setup_step(CompositeUser(testFunc))
         self.expect_commands(
-            ExpectMkdir(dir='d', logEnviron=False)
+            ExpectMkdir(dir='d', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=FAILURE)
@@ -438,9 +438,9 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin,
             yield x.runMkdir("d", abandonOnFailure=False)
         self.setup_step(CompositeUser(testFunc))
         self.expect_commands(
-            ExpectMkdir(dir='d', logEnviron=False)
+            ExpectMkdir(dir='d', log_environ=False)
             .exit(1),
-            ExpectMkdir(dir='d', logEnviron=False)
+            ExpectMkdir(dir='d', log_environ=False)
             .exit(1)
         )
         self.expect_outcome(result=SUCCESS)

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -94,11 +94,11 @@ class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin,
         self.expect_commands(
             ExpectRmdir(path=os.path.join(self.temp_path, "pathA"),
                         dir=os.path.abspath(os.path.join(self.temp_path, "pathA")),
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             ExpectRmdir(path=os.path.join(self.temp_path, "pathB"),
                         dir=os.path.abspath(os.path.join(self.temp_path, "pathB")),
-                        logEnviron=False)
+                        log_environ=False)
             .exit(0),
             )
 
@@ -128,9 +128,9 @@ class TestRemoveFileSecretToWorkerCommand(TestBuildStepMixin,
             RemoveWorkerFileSecret([(os.path.join(self.temp_path, "pathA"), "something"),
                                     (os.path.join(self.temp_path, "pathB"), "somethingmore")]))
         self.expect_commands(
-            ExpectRmfile(path=os.path.join(self.temp_path, "pathA"), logEnviron=False)
+            ExpectRmfile(path=os.path.join(self.temp_path, "pathA"), log_environ=False)
             .exit(0),
-            ExpectRmfile(path=os.path.join(self.temp_path, "pathB"), logEnviron=False)
+            ExpectRmfile(path=os.path.join(self.temp_path, "pathB"), log_environ=False)
             .exit(0),
             )
 


### PR DESCRIPTION
This PR prepares testing API for testing user Buildbot configurations. This is not documented yet, so not really exposed. This PR contains noisy renaming and code movement.