### PR TITLE
Expose internal testing framework for writing unit tests for steps

### DIFF
--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -89,16 +89,6 @@ def _describe_cmd_difference(exp_command, exp_args, got_command, got_args):
 class TestBuildStepMixin:
 
     """
-    Support for testing build steps.  This class adds two capabilities:
-
-     - patch out RemoteCommand with fake versions that check expected
-       commands and produce the appropriate results
-
-     - surround a step with the mock objects that it needs to execute
-
-    The following instance variables are available after C{setup_step}:
-
-    @ivar step: the step under test
     @ivar build: the fake build containing the step
     @ivar progress: mock progress object
     @ivar worker: mock worker object
@@ -106,17 +96,6 @@ class TestBuildStepMixin:
     """
 
     def setup_test_build_step(self, want_data=True, want_db=False, want_mq=False):
-        """
-        @param want_data(bool): Set to True to add data API connector to master.
-            Default value: True.
-
-        @param want_db(bool): Set to True to add database connector to master.
-            Default value: False.
-
-        @param want_mq(bool): Set to True to add mq connector to master.
-            Default value: False.
-        """
-
         if not hasattr(self, 'reactor'):
             raise Exception('Reactor has not yet been setup for step')
 
@@ -152,21 +131,7 @@ class TestBuildStepMixin:
 
     def setup_step(self, step, worker_version=None, worker_env=None,
                    build_files=None, want_default_work_dir=True):
-        """
-        Set up C{step} for testing.  This begins by using C{step} as a factory
-        to create a I{new} step instance, thereby testing that the factory
-        arguments are handled correctly.  It then creates a comfortable
-        environment for the worker to run in, replete with a fake build and a
-        fake worker.
 
-        As a convenience, it can set the step's workdir with C{'wkdir'}.
-
-        @param worker_version: worker version to present, as a dictionary mapping
-            command name to version.  A command name of '*' will apply for all
-            commands.
-
-        @param worker_env: environment from the worker at worker startup
-        """
         if worker_version is None:
             worker_version = {
                 '*': '99.99'
@@ -287,37 +252,20 @@ class TestBuildStepMixin:
         return step
 
     def expect_commands(self, *exp):
-        """
-        Add to the expected remote commands, along with their results.  Each
-        argument should be an instance of L{Expect}.
-        """
         self.expected_remote_commands.extend(exp)
 
     def expect_outcome(self, result, state_string=None):
-        """
-        Expect the given result (from L{buildbot.process.results}) and status
-        text (a list).
-        """
         self.exp_result = result
         if state_string:
             self.exp_state_string = state_string
 
     def expect_property(self, property, value, source=None):
-        """
-        Expect the given property to be set when the step is complete.
-        """
         self.exp_properties[property] = (value, source)
 
     def expect_no_property(self, property):
-        """
-        Expect the given property is *not* set when the step is complete
-        """
         self.exp_missing_properties.append(property)
 
     def expect_log_file(self, logfile, contents):
-        """
-        Expect a logfile with the given contents
-        """
         self.exp_logfiles[logfile] = contents
 
     def expect_log_file_stderr(self, logfile, contents):
@@ -327,15 +275,9 @@ class TestBuildStepMixin:
         self._exp_build_data[name] = (value, source)
 
     def expect_hidden(self, hidden=True):
-        """
-        Set whether the step is expected to be hidden.
-        """
         self.exp_hidden = hidden
 
     def expect_exception(self, exception_class):
-        """
-        Set whether the step is expected to raise an exception.
-        """
         self.exp_exception = exception_class
         self.expect_outcome(EXCEPTION)
 

--- a/master/docs/manual/configuration/index.rst
+++ b/master/docs/manual/configuration/index.rst
@@ -34,3 +34,4 @@ The next section, :doc:`../customization`, describes this approach, with frequen
     multimaster
     multicodebase
     misc/index
+    tests/index

--- a/master/docs/manual/configuration/tests/expect.rst
+++ b/master/docs/manual/configuration/tests/expect.rst
@@ -1,0 +1,247 @@
+Worker command expectations
++++++++++++++++++++++++++++
+
+:class:`TestBuildStepMixin` is used to test steps and accepts command expectations to its ``expect_commands`` method.
+These command expectations are instances of classes listed in this page.
+
+In all cases the arguments used to construct the expectation is what is expected to receive from the step under test.
+The methods called on the command are used to build a list of effects that the step will observe.
+
+
+.. py:class:: buildbot.test.expect.Expect
+
+    This class is the base class of all command expectation classes.
+    It must not be instantiated by the user.
+    It provides methods that are common to all command expectations.
+
+    .. py:method:: exit(code)
+
+        :param int code: Exit code
+
+        Specifies command exit code sent to the step.
+        In most cases ``0`` signify success, other values signify failure.
+
+    .. py:method:: stdout(output)
+
+        :param output: stdout output to send to the step. Must be an instance of ``bytes`` or ``str``.
+
+        Specifies ``stdout`` stream in the ``stdio`` log that is sent by the command to the step.
+
+    .. py:method:: stderr(output)
+
+        :param output: stderr output to send to the step. Must be an instance of ``bytes`` or ``str``.
+
+        Specifies ``stderr`` stream in the ``stdio`` log that is sent by the command to the step.
+
+    .. py:method:: log(name, **streams)
+
+        :param str name: The name of the log.
+        :param kwargs streams: The log streams of the log streams.
+                               The most common are ``stdout`` and ``stderr``.
+                               The values must be instances of ``bytes`` or ``str``.
+
+        Specifies logs sent by the command to the step.
+
+        For ``stdio`` log and ``stdout`` stream use the ``stdout()`` function.
+
+        For ``stdio`` log and ``stderr`` stream use the ``stderr()`` function.
+
+    .. py:method:: error(error)
+
+        :param error: An instance of an exception to throw when running the command.
+
+        Throws an exception when running the command.
+        This is often used to simulate broken connection by throwing in an instance of ``twisted.internet.error.ConnectionLost``.
+
+
+.. _Test-ExpectShell:
+
+ExpectShell
+~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectShell(Expect)
+
+    This class represents a ``shell`` command sent to the worker.
+
+    Usually the stdout log produced by the command is specified by the ``.stdout`` method, the stderr log is specified by the ``.stderr`` method and the exit code is specified by the ``.exit`` method.
+
+    .. code-block:: python
+
+        ExpectShell(workdir='myworkdir', command=["my-test-command", "arg1", "arg2"])
+        .stdout(b'my sample output')
+        .exit(0)
+
+    .. py:method:: __init__(workdir, command, env=None, want_stdout=1, want_stderr=1, initial_stdin=None, timeout=20 * 60, max_time=None, logfiles=None, use_pty=None, log_environ=True, interrupt_signal=None)
+
+        Initializes the expectation.
+
+
+.. _Test-ExpectStat:
+
+ExpectStat
+~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectStat(Expect)
+
+    This class represents a ``stat`` command sent to the worker.
+
+    Tests usually indicate the existence of the file by calling the ``.exit`` method.
+
+    .. py:method:: __init__(file, workdir=None, log_environ=None)
+
+        Initializes the expectation.
+
+    .. py:method:: stat(mode, inode=99, dev=99, nlink=1, uid=0, gid=0, size=99, atime=0, mtime=0, ctime=0)
+
+        Specifies ``os.stat`` result that is sent back to the step.
+
+        In most cases it's more convenient to use ``stat_file`` or ``stat_dir``.
+
+    .. py:method:: stat_file(mode=0, size=99, atime=0, mtime=0, ctime=0)
+
+        :param int mode: Additional mode bits to set
+
+        Specifies ``os.stat`` result of a regular file.
+
+    .. py:method:: stat_dir(mode=0, size=99, atime=0, mtime=0, ctime=0)
+
+        :param int mode: Additional mode bits to set
+
+        Specifies ``os.stat`` result of a directory.
+
+
+.. _Test-ExpectUploadFile:
+
+ExpectUploadFile
+~~~~~~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectUploadFile(Expect)
+
+    This class represents a ``uploadFile`` command sent to the worker.
+
+    .. py:method:: __init__(blocksize=None, maxsize=None, workersrc=None, workdir=None, writer=None, keepstamp=None, slavesrc=None, interrupted=False)
+
+        Initializes the expectation.
+
+    .. py:method:: upload_string(string, error=None)
+
+        :param str string: The data of the file to sent to the step.
+        :param object error: An optional instance of an exception to raise to simulate failure to transfer data.
+
+        Specifies the data to send to the step.
+
+
+.. _Test-ExpectDownloadFile:
+
+ExpectDownloadFile
+~~~~~~~~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectDownloadFile(Expect)
+
+    This class represents a ``downloadFile`` command sent to the worker.
+    Tests usually check what the step attempts to send to the worker by calling ``.download_string`` and checking what data the supplied callable receives.
+
+    .. py:method:: __init__(blocksize=None, maxsize=None, workerdest=None, workdir=None, reader=None, mode=None, interrupted=False, slavesrc=None, slavedest=None)
+
+        Initializes the expectation.
+
+    .. py:method:: download_string(dest_callable, size=1000)
+
+        :param callable dest_callable: A callable to call with the data that is being sent from the step.
+        :param int size: The size of the data to read
+
+        Specifies the callable to store the data that the step wants the worker to download.
+
+
+.. _Test-ExpectMkdir:
+
+ExpectMkdir
+~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectMkdir(Expect)
+
+    This class represents a ``mkdir`` command sent to the worker.
+
+    .. py:method:: __init__(dir=None, log_environ=None))
+
+        Initializes the expectation.
+
+
+.. _Test-ExpectRmdir:
+
+ExpectRmdir
+~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectRmdir(Expect)
+
+    This class represents a ``rmdir`` command sent to the worker.
+
+    .. py:method:: __init__(dir=None, log_environ=None, timeout=None, path=None)
+
+        Initializes the expectation.
+
+
+.. _Test-ExpectCpdir:
+
+ExpectCpdir
+~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectCpdir(Expect)
+
+    This class represents a ``cpdir`` command sent to the worker.
+
+    .. py:method:: __init__(fromdir=None, todir=None, log_environ=None, timeout=None, max_time=None)
+
+        Initializes the expectation.
+
+
+.. _Test-ExpectRmfile:
+
+ExpectRmfile
+~~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectRmfile(Expect)
+
+    This class represents a ``rmfile`` command sent to the worker.
+
+    .. py:method:: __init__(path=None, log_environ=None)
+
+        Initializes the expectation.
+
+.. _Test-ExpectGlob:
+
+ExpectGlob
+~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectGlob(Expect)
+
+    This class represents a ``mkdir`` command sent to the worker.
+
+    .. py:method:: __init__(path=None, log_environ=None)
+
+        Initializes the expectation.
+
+    .. py:method:: files(files=None)
+
+        :param list files: An optional list of returned files.
+
+        Specifies the list of files returned to the step.
+
+.. _Test-ExpectListdir:
+
+ExpectListdir
+~~~~~~~~~~~~~
+
+.. py:class:: buildbot.test.expect.ExpectListdir(Expect)
+
+    This class represents a ``mkdir`` command sent to the worker.
+
+    .. py:method:: __init__(dir=None):
+
+        Initializes the expectation.
+
+    .. py:method:: files(files=None)
+
+        :param list files: An optional list of returned files.
+
+        Specifies the list of files returned to the step.

--- a/master/docs/manual/configuration/tests/index.rst
+++ b/master/docs/manual/configuration/tests/index.rst
@@ -8,7 +8,9 @@ Testing Utilities
     :maxdepth: 2
 
     reactor
+    steps
 
 This section outlives various utilities that are useful when testing configuration written for Buildbot.
 
+* :ref:`Test-TestBuildStepMixin` - provides a framework for testing steps
 * :ref:`Test-TestReactorMixin` - sets up test case with mock time

--- a/master/docs/manual/configuration/tests/index.rst
+++ b/master/docs/manual/configuration/tests/index.rst
@@ -7,10 +7,27 @@ Testing Utilities
     :hidden:
     :maxdepth: 2
 
+    expect
     reactor
     steps
 
 This section outlives various utilities that are useful when testing configuration written for Buildbot.
 
+.. note::
+    At this moment the APIs outlined here are experimental and subject to change.
+
 * :ref:`Test-TestBuildStepMixin` - provides a framework for testing steps
 * :ref:`Test-TestReactorMixin` - sets up test case with mock time
+
+Command expectations:
+
+* :ref:`Test-ExpectShell` - expects ``shell`` command
+* :ref:`Test-ExpectStat` - expects ``stat`` command
+* :ref:`Test-ExpectUploadFile` - expects ``uploadFile`` command
+* :ref:`Test-ExpectDownloadFile` - expects ``downloadFile`` command
+* :ref:`Test-ExpectMkdir` - expects ``mkdir`` command
+* :ref:`Test-ExpectRmdir` - expects ``rmdir`` command
+* :ref:`Test-ExpectCpdir` - expects ``cpdir`` command
+* :ref:`Test-ExpectRmfile` - expects ``rmfile`` command
+* :ref:`Test-ExpectGlob` - expects ``glob`` command
+* :ref:`Test-ExpectListdir` - expects ``listdir`` command

--- a/master/docs/manual/configuration/tests/index.rst
+++ b/master/docs/manual/configuration/tests/index.rst
@@ -1,0 +1,14 @@
+.. _Testing-Utilities:
+
+Testing Utilities
+=================
+
+.. toctree::
+    :hidden:
+    :maxdepth: 2
+
+    reactor
+
+This section outlives various utilities that are useful when testing configuration written for Buildbot.
+
+* :ref:`Test-TestReactorMixin` - sets up test case with mock time

--- a/master/docs/manual/configuration/tests/reactor.rst
+++ b/master/docs/manual/configuration/tests/reactor.rst
@@ -1,0 +1,22 @@
+.. _Test-TestReactorMixin:
+
+TestReactorMixin
+++++++++++++++++
+
+.. py:class:: buildbot.test.reactor.TestReactorMixin
+
+    The class ``TestReactorMixin`` is used to create a fake ``twisted.internet.reactor`` in tests.
+    This allows to mock the flow of time in tests.
+    The fake reactor becomes available as ``self.reactor`` in the test case that mixes in ``TestReactorMixin``.
+
+    Call ``self.reactor.advance(seconds)`` to advance the mocked time by the specified number of seconds.
+
+    Call ``self.reactor.pump(seconds_list)`` to advance the mocked time multiple times as if by calling ``advance``.
+
+    For more information see the documentation of `twisted.internet.task.Clock <https://twistedmatrix.com/documents/current/api/twisted.internet.task.Clock.html>`_.
+
+    .. py:method:: setup_test_reactor(use_asyncio=False)
+
+        :param bool use_asyncio Whether to enable asyncio integration.
+
+        Call this function in the ``setUp()`` of the test case to setup fake reactor.

--- a/master/docs/manual/configuration/tests/steps.rst
+++ b/master/docs/manual/configuration/tests/steps.rst
@@ -1,0 +1,149 @@
+.. _Test-TestBuildStepMixin:
+
+TestBuildStepMixin
+++++++++++++++++++
+
+.. py:class:: buildbot.test.steps.TestBuildStepMixin
+
+    The class :class:`TestBuildStepMixin` allows to test build steps.
+    It mocks the connection to the worker.
+    The commands sent to the worker can be verified and command results can be injected back into the step under test.
+    Additionally, the step under test is modified to allow checking how the step runs and what results it produces.
+
+    The following is an example of a basic step test:
+
+    .. code-block:: python
+
+        class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
+
+            def setUp(self):
+                self.setup_test_reactor()
+                return self.setup_test_build_step()
+
+            def tearDown(self):
+                return self.tear_down_test_build_step()
+
+            @defer.inlineCallbacks
+            def test_run_ok(self):
+                self.setup_step(python_twisted.RemovePYCs())
+                self.expect_commands(
+                    ExpectShell(workdir='wkdir',
+                                command=['find', '.', '-name', '\'*.pyc\'', '-exec', 'rm', '{}', ';'])
+                    .exit(0)
+                )
+                self.expect_outcome(result=SUCCESS, state_string='remove .pycs')
+                return self.run_step()
+
+    Basic workflow is as follows:
+
+     * The test case must derive from ``TestReactorMixin`` and properly setup it.
+
+     * In ``setUp()`` of test case call ``self.setup_test_build_step()``.
+
+     * In unit test call ``self.setup_step(step)`` which will setup the step for testing.
+
+     * Call ``self.expect_commands(commands)`` to specify commands that the step is expected to run and the results of these commands.
+
+     * Call various other ``expect_*`` member functions to define other expectations.
+
+     * Call ``self.run_step()`` to actually run the step.
+
+    All expectations are verified once the step has completed running.
+
+    .. py:method:: setup_test_build_step()
+
+        Call this function in the ``setUp()`` method of the test case to setup step testing machinery.
+
+    .. py:method:: tear_down_test_build_step()
+
+        Call this function in the ``tearDown()`` of the test case to destroy step testing machinery.
+
+    .. py:method:: setup_step(step, worker_env=None, build_files=None)
+
+        :param dict worker_env: An optional dictionary of environment variables on the mock worker.
+        :param list build_files: An optional list of source files that were changed in the build.
+        :returns: An instance of prepared step (not the same as the ``step`` argument).
+
+        Prepares the given step for testing.
+        The method mimics how Buildbot instantiates steps in reality and thus the ``step`` parameter is used only as a factory for creating the real step.
+
+    .. py:attribute:: step
+
+        The step under test.
+        This attribute is available after ``setup_step()`` is run.
+
+    ..
+        TODO: build, progress, worker, properties attributes
+
+    .. py:method:: expect_commands(*commands)
+
+        :param commands: A list of commands that are expected to be run (a subclass of :class:`buildbot.test.expect.Expect`).
+
+        Sets up an expectation of step sending the given commands to worker.
+
+    .. py:method:: expect_outcome(result, state_string=None)
+
+        :param result: A result from `buildbot.process.results`.
+        :param str state_string: An optional status text.
+
+        Sets up an expectation of the step result.
+
+    .. py:method:: expect_property(property, value, source=None)
+
+        :param str property: The name of the property
+        :param str value: The value of the property
+        :param str source: An optional source of the property
+
+        Sets up an expectation of a property set by the step
+
+    .. py:method:: expect_no_property(self, property)
+
+        :param str property: The name of the property
+
+        Sets up an expectation of an absence of a property set by the step.
+
+    .. py:method:: expect_log_file(self, logfile, contents)
+
+        :param str logfile: The name of the log file
+        :param str contents: The contents of the log file
+
+        Sets up an expectation of a log file being produced by the step.
+        Only the ``stdout`` associated with the log file is checked.
+        To check the ``stderr`` see ``expect_log_file_stderr()``
+
+    .. py:method:: expect_log_file_stderr(self, logfile, contents)
+
+        :param str logfile: The name of the log file
+        :param str contents: The contents of the log file
+
+        Sets up an expectation of a ``stderr`` output in log file being produced by the step.
+
+    .. py:method:: expect_build_data(name, value, source)
+
+        :param str name: The name of the build data.
+        :param str value: The value of the build data.
+        :param str source: The source of the build data.
+
+        Sets up an expectation of build data produced by the step.
+
+    .. py:method:: expect_hidden(hidden=True)
+
+        :param bool hidden: Whether the step should be hidden.
+
+        Sets up an expectation of step being hidden on completion.
+
+    .. py:method:: expect_exception(expection_class)
+
+        :param expection_class: The type of the class to expect.
+
+        Sets up an expectation of an exception being raised during the runtime of the step.
+        The expected result of the step is automatically set to ``EXCEPTION``.
+
+    ..
+        TODO: expect_test_result_sets(), expect_test_results()
+
+        These are not documented yet as there's no UI to view them.
+
+    .. py:method:: run_step()
+
+        Runs the step and validates the expectations setup before this function.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -32,6 +32,7 @@ AssertionFailed
 asymmetrics
 async
 Async
+asyncio
 Atlassian
 attrs
 auth

--- a/newsfragments/testing-api.feature
+++ b/newsfragments/testing-api.feature
@@ -1,0 +1,2 @@
+Buildbot now exposes its internal framework for writing tests of custom build steps.
+Currently the API is experimental and subject to change.


### PR DESCRIPTION
This PR exposes part of our internal test framework and enables the users to write unit tests for steps.

We currently mark the API as experimental because we may still discover improvements of how to expose this.

I'm not completely sure if buildbot.test.expect is the best place for command expectations. Maybe they should be moved to buildbot.test.steps.

cc @tardyp

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
