### PR TITLE
Fix an error in passing CMake options and definitions to cmake.

### DIFF
--- a/master/buildbot/steps/cmake.py
+++ b/master/buildbot/steps/cmake.py
@@ -70,15 +70,15 @@ class CMake(ShellMixin, BuildStep):
                 '-G', self.generator
             ])
 
-        if self.path:
-            command.append(self.path)
-
         if self.definitions is not None:
             for item in self.definitions.items():
                 command.append('-D%s=%s' % item)
 
         if self.options is not None:
             command.extend(self.options)
+
+        if self.path:
+            command.append(self.path)
 
         cmd = yield self.makeRemoteShellCommand(command=command)
 

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -154,3 +154,7 @@ class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.setup_step(CMake(path=Property(prop)))
         self.properties.setProperty(prop, value, source='test')
         self.expect_and_run_command(value)
+
+    def test_options_path(self):
+        self.setup_step(CMake(path='some/path', options=('A', 'B')))
+        self.expect_and_run_command('A', 'B', 'some/path')

--- a/newsfragments/fix-cmake-options-and-definitions.bugfix.txt
+++ b/newsfragments/fix-cmake-options-and-definitions.bugfix.txt
@@ -1,0 +1,1 @@
+Fix an error in `CMake` passing options and definitions on the cmake command line.


### PR DESCRIPTION
Fix an error in passing `CMake` options and definitions on the cmake command line.  The cmake usage documentation (see below) dictates that the options shall precede the \<path-to-source> (and also \<path-to-build>).

The new unit test `test_options_path` checks for this.

> cmake --help
> Usage
> 
>   cmake [options] \<path-to-source>
>   cmake [options] \<path-to-existing-build>
>   cmake [options] -S \<path-to-source> -B \<path-to-build>
> 


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
