### PR TITLE
Discontinue use of deprecated teams API in Bitbucket OAuth client

### DIFF
--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -442,10 +442,10 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
                 values=[
                     {'email': 'buzz@bar', 'is_primary': False},
                     {'email': 'bar@foo', 'is_primary': True}]),
-            dict(  # /teams?role=member
+            dict(  # /workspaces?role=member
                 values=[
-                    {'username': 'hello'},
-                    {'username': 'grp'}])
+                    {'slug': 'hello'},
+                    {'slug': 'grp'}])
         ])
         res = yield self.bitbucketAuth.verifyCode("code!")
         self.assertEqual({'email': 'bar@foo',

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -395,8 +395,8 @@ class BitbucketAuth(OAuth2Auth):
             if email.get('is_primary', False):
                 user['email'] = email['email']
                 break
-        orgs = self.get(c, '/teams?role=member')
+        orgs = self.get(c, '/workspaces?role=member')
         return dict(full_name=user['display_name'],
                     email=user['email'],
                     username=user['username'],
-                    groups=[org['username'] for org in orgs["values"]])
+                    groups=[org['slug'] for org in orgs["values"]])

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -992,6 +992,7 @@ workdirs
 WorkerForBuilder
 workername
 workflow
+workspaces
 wouldn
 www
 xda

--- a/newsfragments/update-bitbucket-oauth-api.bugfix
+++ b/newsfragments/update-bitbucket-oauth-api.bugfix
@@ -1,0 +1,1 @@
+Switched Bitbucket OAuth client from the deprecated 'teams' APIs to the new 'workspaces' APIs


### PR DESCRIPTION
Atlassian has deprecated the 'teams' APIs in favor of new
'workspaces' APIs and will soon discontinue support for 'teams'
endpoints. This change produces equivalent functionality using
the recommended 'workspaces' endpoints.

See:
https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/