### PR TITLE
worker/protocols/manager: Extract common functionality for users hand…

### DIFF
--- a/master/buildbot/test/unit/worker/test_protocols_manager_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_base.py
@@ -1,0 +1,264 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+Test clean shutdown functionality of the master
+"""
+
+import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.worker.protocols.manager.base import BaseDispatcher
+from buildbot.worker.protocols.manager.base import BaseManager
+
+
+class FakeMaster:
+    initLock = defer.DeferredLock()
+
+    def addService(self, svc):
+        pass
+
+    @property
+    def master(self):
+        return self
+
+
+class TestDispatcher(BaseDispatcher):
+    def __init__(self, portstr):
+        super().__init__(portstr)
+        self.start_listening_count = 0
+        self.stop_listening_count = 0
+
+    def start_listening_port(self):
+        def stopListening():
+            self.stop_listening_count += 1
+
+        self.start_listening_count += 1
+        port = mock.Mock()
+        port.stopListening = stopListening
+        return port
+
+
+class TestPort():
+    def __init__(self, test):
+        self.test = test
+
+    def stopListening(self):
+        self.test.stop_listening_count += 1
+
+
+class TestManagerClass(BaseManager):
+    dispatcher_class = TestDispatcher
+
+
+class TestBaseManager(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.manager = TestManagerClass('test_base_manager')
+        yield self.manager.setServiceParent(FakeMaster())
+
+    def assert_equal_registration(self, result, expected):
+        result_users = {key: result[key].users for key in result}
+        self.assertEqual(result_users, expected)
+
+    def assert_start_stop_listening_counts(self, disp, start_count, stop_count):
+        self.assertEqual(disp.start_listening_count, start_count)
+        self.assertEqual(disp.stop_listening_count, stop_count)
+
+    @defer.inlineCallbacks
+    def test_repr(self):
+        reg = yield self.manager.register('tcp:port', 'x', 'y', 'pf')
+        self.assertEqual(repr(self.manager.dispatchers['tcp:port']),
+                         '<base.BaseDispatcher for x on tcp:port>')
+        self.assertEqual(repr(reg), '<base.Registration for x on tcp:port>')
+
+    @defer.inlineCallbacks
+    def test_register_before_start_service(self):
+        yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+
+        self.assert_equal_registration(self.manager.dispatchers,
+                                       {'tcp:port': {'user': ('pass', 'pf')}})
+
+        disp = self.manager.dispatchers['tcp:port']
+        self.assert_start_stop_listening_counts(disp, 0, 0)
+        self.assertEqual(len(self.manager.services), 1)
+
+        yield self.manager.startService()
+        self.assert_start_stop_listening_counts(disp, 1, 0)
+
+        yield self.manager.stopService()
+        self.assert_start_stop_listening_counts(disp, 1, 1)
+
+    @defer.inlineCallbacks
+    def test_same_registration_two_times(self):
+        yield self.manager.startService()
+        yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+
+        # one registration is ok
+        self.assert_equal_registration(self.manager.dispatchers,
+                                       {'tcp:port': {'user': ('pass', 'pf')}})
+        self.assertEqual(len(self.manager.services), 1)
+
+        disp = self.manager.dispatchers['tcp:port']
+        self.assert_start_stop_listening_counts(disp, 1, 0)
+
+        # same user is not allowed to register
+        with self.assertRaises(KeyError):
+            yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+
+        yield self.manager.stopService()
+        self.assert_start_stop_listening_counts(disp, 1, 1)
+
+    @defer.inlineCallbacks
+    def test_register_unregister_register(self):
+        yield self.manager.startService()
+        reg = yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+        self.assert_equal_registration(self.manager.dispatchers,
+                                       {'tcp:port': {'user': ('pass', 'pf')}})
+
+        disp = self.manager.dispatchers['tcp:port']
+        self.assert_start_stop_listening_counts(disp, 1, 0)
+
+        reg.unregister()
+        self.assert_equal_registration(self.manager.dispatchers, {})
+
+        # allow registering same user again
+        yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+
+        self.assert_equal_registration(self.manager.dispatchers,
+                                       {'tcp:port': {'user': ('pass', 'pf')}})
+
+        yield self.manager.stopService()
+        self.assert_start_stop_listening_counts(disp, 1, 1)
+
+    @defer.inlineCallbacks
+    def test_register_unregister_empty_disp_users(self):
+        yield self.manager.startService()
+        reg = yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+        self.assertEqual(len(self.manager.services), 1)
+
+        expected = {'tcp:port': {'user': ('pass', 'pf')}}
+        self.assert_equal_registration(self.manager.dispatchers, expected)
+
+        disp = self.manager.dispatchers['tcp:port']
+
+        reg.unregister()
+        self.assert_equal_registration(self.manager.dispatchers, {})
+        self.assertEqual(reg.username, None)
+        self.assertEqual(len(self.manager.services), 0)
+
+        yield self.manager.stopService()
+        self.assert_start_stop_listening_counts(disp, 1, 1)
+
+    @defer.inlineCallbacks
+    def test_different_ports_same_users(self):
+        yield self.manager.startService()
+        # same registrations on different ports is ok
+        reg1 = yield self.manager.register('tcp:port1', "user", "pass", 'pf')
+        reg2 = yield self.manager.register('tcp:port2', "user", "pass", 'pf')
+        reg3 = yield self.manager.register('tcp:port3', "user", "pass", 'pf')
+
+        disp1 = self.manager.dispatchers['tcp:port1']
+        self.assert_start_stop_listening_counts(disp1, 1, 0)
+
+        disp2 = self.manager.dispatchers['tcp:port2']
+        self.assert_start_stop_listening_counts(disp2, 1, 0)
+
+        disp3 = self.manager.dispatchers['tcp:port3']
+        self.assert_start_stop_listening_counts(disp3, 1, 0)
+
+        self.assert_equal_registration(self.manager.dispatchers, {
+            'tcp:port1': {'user': ('pass', 'pf')},
+            'tcp:port2': {'user': ('pass', 'pf')},
+            'tcp:port3': {'user': ('pass', 'pf')}
+        })
+        self.assertEqual(len(self.manager.services), 3)
+
+        yield reg1.unregister()
+        self.assert_equal_registration(self.manager.dispatchers, {
+            'tcp:port2': {'user': ('pass', 'pf')},
+            'tcp:port3': {'user': ('pass', 'pf')}
+        })
+        self.assertEqual(reg1.username, None)
+        self.assertEqual(len(self.manager.services), 2)
+        self.assert_start_stop_listening_counts(disp1, 1, 1)
+
+        yield reg2.unregister()
+        self.assert_equal_registration(self.manager.dispatchers, {
+            'tcp:port3': {'user': ('pass', 'pf')}
+        })
+        self.assertEqual(reg2.username, None)
+        self.assertEqual(len(self.manager.services), 1)
+        self.assert_start_stop_listening_counts(disp2, 1, 1)
+
+        yield reg3.unregister()
+        expected = {}
+        self.assert_equal_registration(self.manager.dispatchers, expected)
+        self.assertEqual(reg3.username, None)
+        self.assertEqual(len(self.manager.services), 0)
+        self.assert_start_stop_listening_counts(disp3, 1, 1)
+
+        yield self.manager.stopService()
+        self.assert_start_stop_listening_counts(disp1, 1, 1)
+        self.assert_start_stop_listening_counts(disp2, 1, 1)
+        self.assert_start_stop_listening_counts(disp3, 1, 1)
+
+    @defer.inlineCallbacks
+    def test_same_port_different_users(self):
+        yield self.manager.startService()
+        reg1 = yield self.manager.register('tcp:port', 'user1', 'pass1', 'pf1')
+        reg2 = yield self.manager.register('tcp:port', 'user2', 'pass2', 'pf2')
+        reg3 = yield self.manager.register('tcp:port', 'user3', 'pass3', 'pf3')
+        disp = self.manager.dispatchers['tcp:port']
+
+        self.assertEqual(len(self.manager.services), 1)
+        self.assert_equal_registration(self.manager.dispatchers, {
+            'tcp:port': {
+                'user1': ('pass1', 'pf1'),
+                'user2': ('pass2', 'pf2'),
+                'user3': ('pass3', 'pf3')
+            }
+        })
+        self.assertEqual(len(self.manager.services), 1)
+
+        yield reg1.unregister()
+        self.assert_equal_registration(self.manager.dispatchers, {
+            'tcp:port': {
+                'user2': ('pass2', 'pf2'),
+                'user3': ('pass3', 'pf3')
+            }
+        })
+        self.assertEqual(reg1.username, None)
+        self.assertEqual(len(self.manager.services), 1)
+
+        yield reg2.unregister()
+        self.assert_equal_registration(self.manager.dispatchers, {
+            'tcp:port': {
+                'user3': ('pass3', 'pf3')
+            }
+        })
+        self.assertEqual(reg2.username, None)
+        self.assertEqual(len(self.manager.services), 1)
+
+        yield reg3.unregister()
+        expected = {}
+        self.assert_equal_registration(self.manager.dispatchers, expected)
+        self.assertEqual(reg3.username, None)
+        self.assertEqual(len(self.manager.services), 0)
+
+        yield self.manager.stopService()
+        self.assert_start_stop_listening_counts(disp, 1, 1)

--- a/master/buildbot/test/unit/worker/test_protocols_manager_pbmanager.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_pbmanager.py
@@ -57,15 +57,6 @@ class TestPBManager(unittest.TestCase):
         return defer.succeed(persp)
 
     @defer.inlineCallbacks
-    def test_repr(self):
-        reg = yield self.pbm.register(
-            'tcp:0:interface=127.0.0.1', "x", "y", self.perspectiveFactory)
-        self.assertEqual(repr(self.pbm.dispatchers['tcp:0:interface=127.0.0.1']),
-                         '<pbmanager.Dispatcher for x on tcp:0:interface=127.0.0.1>')
-        self.assertEqual(
-            repr(reg), '<pbmanager.Registration for x on tcp:0:interface=127.0.0.1>')
-
-    @defer.inlineCallbacks
     def test_register_unregister(self):
         portstr = "tcp:0:interface=127.0.0.1"
         reg = yield self.pbm.register(portstr, "boris", "pass", self.perspectiveFactory)
@@ -113,30 +104,6 @@ class TestPBManager(unittest.TestCase):
         self.assertNotIn('boris', self.connections)
 
         yield reg.unregister()
-
-    @defer.inlineCallbacks
-    def test_double_register_unregister(self):
-        portstr = "tcp:0:interface=127.0.0.1"
-        reg1 = yield self.pbm.register(portstr, "boris", "pass", None)
-        reg2 = yield self.pbm.register(portstr, "ivona", "pass", None)
-
-        # make sure things look right
-        self.assertEqual(len(self.pbm.dispatchers), 1)
-        self.assertIn(portstr, self.pbm.dispatchers)
-        disp = self.pbm.dispatchers[portstr]
-        self.assertIn('boris', disp.users)
-        self.assertIn('ivona', disp.users)
-
-        yield reg1.unregister()
-
-        self.assertEqual(len(self.pbm.dispatchers), 1)
-        self.assertIn(portstr, self.pbm.dispatchers)
-        disp = self.pbm.dispatchers[portstr]
-        self.assertNotIn('boris', disp.users)
-        self.assertIn('ivona', disp.users)
-        yield reg2.unregister()
-
-        self.assertEqual(len(self.pbm.dispatchers), 0)
 
     @defer.inlineCallbacks
     def test_requestAvatarId_noinitLock(self):

--- a/master/buildbot/worker/protocols/manager/base.py
+++ b/master/buildbot/worker/protocols/manager/base.py
@@ -1,0 +1,138 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.application import strports
+from twisted.internet import defer
+from twisted.python import log
+
+from buildbot.util import service
+
+
+class BaseManager(service.AsyncMultiService):
+    """
+    A centralized manager for connection ports and authentication on them.
+    Allows various pieces of code to request a (port, username) combo, along
+    with a password and a connection factory.
+    """
+    def __init__(self, name):
+        super().__init__()
+        self.setName(name)
+        self.dispatchers = {}
+
+    @defer.inlineCallbacks
+    def register(self, portstr, username, password, pfactory):
+        """
+        Register a connection code to be executed after a user with its USERNAME/PASSWORD
+        was authenticated and a valid high level connection can be established on a PORTSTR.
+        Returns a Registration object which can be used to unregister later.
+        """
+        # do some basic normalization of portstrs
+        if isinstance(portstr, type(0)) or ':' not in portstr:
+            portstr = "tcp:{}".format(portstr)
+
+        reg = Registration(self, portstr, username)
+
+        if portstr not in self.dispatchers:
+            disp = self.dispatchers[portstr] = self.dispatcher_class(portstr)
+            yield disp.setServiceParent(self)
+        else:
+            disp = self.dispatchers[portstr]
+
+        disp.register(username, password, pfactory)
+
+        return reg
+
+    @defer.inlineCallbacks
+    def _unregister(self, registration):
+        disp = self.dispatchers[registration.portstr]
+        disp.unregister(registration.username)
+        registration.username = None
+        if not disp.users:
+            del self.dispatchers[registration.portstr]
+            yield disp.disownServiceParent()
+
+
+class Registration:
+
+    def __init__(self, manager, portstr, username):
+        self.portstr = portstr
+        "portstr this registration is active on"
+        self.username = username
+        "username of this registration"
+        self.manager = manager
+
+    def __repr__(self):
+        return "<base.Registration for {} on {}>".format(self.username, self.portstr)
+
+    def unregister(self):
+        """
+        Unregister this registration, removing the username from the port, and
+        closing the port if there are no more users left.  Returns a Deferred.
+        """
+        return self.manager._unregister(self)
+
+    def getPort(self):
+        """
+        Helper method for testing; returns the TCP port used for this
+        registration, even if it was specified as 0 and thus allocated by the
+        OS.
+        """
+        disp = self.manager.dispatchers[self.portstr]
+        return disp.port.getHost().port
+
+
+class BaseDispatcher(service.AsyncService):
+    debug = False
+
+    def __init__(self, portstr):
+        self.portstr = portstr
+        self.users = {}
+        self.port = None
+
+    def __repr__(self):
+        return "<base.BaseDispatcher for {} on {}>".format(", ".join(list(self.users)),
+                                                           self.portstr)
+
+    def start_listening_port(self):
+        return strports.listen(self.portstr, self.serverFactory)
+
+    def startService(self):
+        assert not self.port
+        self.port = self.start_listening_port()
+
+        return super().startService()
+
+    @defer.inlineCallbacks
+    def stopService(self):
+        # stop listening on the port when shut down
+        assert self.port
+        port, self.port = self.port, None
+        yield port.stopListening()
+        yield super().stopService()
+
+    def register(self, username, password, pfactory):
+        if self.debug:
+            log.msg("registering username '{}' on port {}: {}".format(username, self.portstr,
+                                                                      pfactory))
+        if username in self.users:
+            raise KeyError("username '{}' is already registered on port {}".format(username,
+                                                                                   self.portstr))
+        self.users[username] = (password, pfactory)
+
+    def unregister(self, username):
+        if self.debug:
+            log.msg("unregistering username '{}' on port {}".format(username, self.portstr))
+        del self.users[username]

--- a/master/buildbot/worker/protocols/manager/pb.py
+++ b/master/buildbot/worker/protocols/manager/pb.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-from twisted.application import strports
 from twisted.cred import checkers
 from twisted.cred import credentials
 from twisted.cred import error
@@ -26,137 +25,25 @@ from zope.interface import implementer
 
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
-from buildbot.util import service
 from buildbot.util import unicode2bytes
 from buildbot.util.eventual import eventually
-
-debug = False
-
-
-class PBManager(service.AsyncMultiService):
-
-    """
-    A centralized manager for PB ports and authentication on them.
-
-    Allows various pieces of code to request a (port, username) combo, along
-    with a password and a perspective factory.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.setName('pbmanager')
-        self.dispatchers = {}
-
-    @defer.inlineCallbacks
-    def register(self, portstr, username, password, pfactory):
-        """
-        Register a perspective factory PFACTORY to be executed when a PB
-        connection arrives on PORTSTR with USERNAME/PASSWORD.  Returns a
-        Registration object which can be used to unregister later.
-        """
-        # do some basic normalization of portstrs
-        if isinstance(portstr, type(0)) or ':' not in portstr:
-            portstr = "tcp:{}".format(portstr)
-
-        reg = Registration(self, portstr, username)
-
-        if portstr not in self.dispatchers:
-            disp = self.dispatchers[portstr] = Dispatcher(portstr)
-            yield disp.setServiceParent(self)
-        else:
-            disp = self.dispatchers[portstr]
-
-        disp.register(username, password, pfactory)
-
-        return reg
-
-    @defer.inlineCallbacks
-    def _unregister(self, registration):
-        disp = self.dispatchers[registration.portstr]
-        disp.unregister(registration.username)
-        registration.username = None
-        if not disp.users:
-            del self.dispatchers[registration.portstr]
-            yield disp.disownServiceParent()
-
-
-class Registration:
-
-    def __init__(self, pbmanager, portstr, username):
-        self.portstr = portstr
-        "portstr this registration is active on"
-        self.username = username
-        "username of this registration"
-
-        self.pbmanager = pbmanager
-
-    def __repr__(self):
-        return "<pbmanager.Registration for {} on {}>".format(self.username, self.portstr)
-
-    def unregister(self):
-        """
-        Unregister this registration, removing the username from the port, and
-        closing the port if there are no more users left.  Returns a Deferred.
-        """
-        return self.pbmanager._unregister(self)
-
-    def getPort(self):
-        """
-        Helper method for testing; returns the TCP port used for this
-        registration, even if it was specified as 0 and thus allocated by the
-        OS.
-        """
-        disp = self.pbmanager.dispatchers[self.portstr]
-        return disp.port.getHost().port
+from buildbot.worker.protocols.manager.base import BaseDispatcher
+from buildbot.worker.protocols.manager.base import BaseManager
 
 
 @implementer(portal.IRealm, checkers.ICredentialsChecker)
-class Dispatcher(service.AsyncService):
+class Dispatcher(BaseDispatcher):
 
     credentialInterfaces = [credentials.IUsernamePassword,
                             credentials.IUsernameHashedPassword]
 
     def __init__(self, portstr):
-        self.portstr = portstr
-        self.users = {}
-
+        super().__init__(portstr)
         # there's lots of stuff to set up for a PB connection!
         self.portal = portal.Portal(self)
         self.portal.registerChecker(self)
         self.serverFactory = pb.PBServerFactory(self.portal)
         self.serverFactory.unsafeTracebacks = True
-        self.port = None
-
-    def __repr__(self):
-        return "<pbmanager.Dispatcher for {} on {}>".format(", ".join(list(self.users)),
-                                                            self.portstr)
-
-    def startService(self):
-        assert not self.port
-        self.port = strports.listen(self.portstr, self.serverFactory)
-        return super().startService()
-
-    @defer.inlineCallbacks
-    def stopService(self):
-        # stop listening on the port when shut down
-        assert self.port
-        port, self.port = self.port, None
-        yield port.stopListening()
-        yield super().stopService()
-
-    def register(self, username, password, pfactory):
-        if debug:
-            log.msg("registering username '{}' on pb port {}: {}".format(username, self.portstr,
-                                                                         pfactory))
-        if username in self.users:
-            raise KeyError("username '{}' is already registered on PB port {}".format(username,
-                                                                                      self.portstr))
-        self.users[username] = (password, pfactory)
-
-    def unregister(self, username):
-        if debug:
-            log.msg("unregistering username '{}' on pb port {}".format(username, self.portstr))
-        del self.users[username]
 
     # IRealm
 
@@ -200,3 +87,10 @@ class Dispatcher(service.AsyncService):
             # brake the callback stack by returning to the reactor
             # before waking up other waiters
             eventually(self.master.initLock.release)
+
+
+class PBManager(BaseManager):
+    def __init__(self):
+        super().__init__('pbmanager')
+
+    dispatcher_class = Dispatcher


### PR DESCRIPTION
Extract common functionality for users handling: their registration and listening to appropriate ports. This will be useful when implementing other protocols, such as message pack.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
