### PR TITLE
Implement rendering support for more Docker parameters

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -23,6 +23,7 @@ class Client:
 
     def __init__(self, base_url):
         Client.latest = self
+        self.base_url = base_url
         self.call_args_create_container = []
         self.call_args_create_host_config = []
         self.called_class_name = None

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -170,6 +170,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
                         hostname=None, **kwargs):
 
         yield super().reconfigService(name, password, image, masterFQDN, **kwargs)
+        self.docker_host = docker_host
         self.volumes = volumes or []
         self.followStartupLogs = followStartupLogs
 
@@ -181,8 +182,9 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         self.custom_context = custom_context
         self.encoding = encoding
         self.buildargs = buildargs
-        # Prepare the parameters for the Docker Client object.
-        self.client_args = {'base_url': docker_host}
+        # Prepare the parameters for the Docker Client object (except docker_host which is
+        # renderable and will be available only when starting containers).
+        self.client_args = {}
         if version is not None:
             self.client_args['version'] = version
         if tls is not None:
@@ -205,15 +207,15 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
             volume_list.append(volume)
         return volume_list, volumes
 
-    def _getDockerClient(self):
+    def _getDockerClient(self, client_args):
         if docker.version[0] == '1':
-            docker_client = client.Client(**self.client_args)
+            docker_client = client.Client(**client_args)
         else:
-            docker_client = client.APIClient(**self.client_args)
+            docker_client = client.APIClient(**client_args)
         return docker_client
 
     def renderWorkerProps(self, build):
-        return build.render((self.image, self.dockerfile,
+        return build.render((self.docker_host, self.image, self.dockerfile,
                              self.volumes, self.hostconfig, self.custom_context,
                              self.encoding, self.buildargs, self.hostname))
 
@@ -221,10 +223,10 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
     def start_instance(self, build):
         if self.instance is not None:
             raise ValueError('instance active')
-        image, dockerfile, volumes, hostconfig, custom_context, encoding, buildargs, hostname = \
-            yield self.renderWorkerPropsOnStart(build)
+        docker_host, image, dockerfile, volumes, hostconfig, custom_context, encoding, buildargs, \
+            hostname = yield self.renderWorkerPropsOnStart(build)
 
-        res = yield threads.deferToThread(self._thd_start_instance, image,
+        res = yield threads.deferToThread(self._thd_start_instance, docker_host, image,
                                           dockerfile, volumes, hostconfig, custom_context,
                                           encoding, buildargs, hostname)
         return res
@@ -239,9 +241,12 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
                     return True
         return False
 
-    def _thd_start_instance(self, image, dockerfile, volumes, host_config,
+    def _thd_start_instance(self, docker_host, image, dockerfile, volumes, host_config,
                             custom_context, encoding, buildargs, hostname):
-        docker_client = self._getDockerClient()
+        curr_client_args = self.client_args.copy()
+        curr_client_args['base_url'] = docker_host
+
+        docker_client = self._getDockerClient(curr_client_args)
         container_name = self.getContainerName()
         # cleanup the old instances
         instances = docker_client.containers(
@@ -315,6 +320,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         log.msg('Container created, Id: {}...'.format(shortid))
         instance['image'] = image
         self.instance = instance
+        self._curr_client_args = curr_client_args
         docker_client.start(instance)
         log.msg('Container started')
         if self.followStartupLogs:
@@ -335,11 +341,14 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
             return defer.succeed(None)
         instance = self.instance
         self.instance = None
-        self.resetWorkerPropsOnStop()
-        return threads.deferToThread(self._thd_stop_instance, instance, fast)
+        curr_client_args = self._curr_client_args
+        self._curr_client_args = None
 
-    def _thd_stop_instance(self, instance, fast):
-        docker_client = self._getDockerClient()
+        self.resetWorkerPropsOnStop()
+        return threads.deferToThread(self._thd_stop_instance, instance, curr_client_args, fast)
+
+    def _thd_stop_instance(self, instance, curr_client_args, fast):
+        docker_client = self._getDockerClient(curr_client_args)
         log.msg('Stopping container {}...'.format(instance['Id'][:6]))
         docker_client.stop(instance['Id'])
         if not fast:

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -187,7 +187,7 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     This is the address the master will use to connect with a running Docker instance.
 
 ``image``
-
+    (renderable string, mandatory)
     This is the name of the image that will be started by the build master. It should start a worker.
     This option can be a renderable, like :ref:`Interpolate`, so that it generates from the build request properties.
 
@@ -196,11 +196,17 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     This will override the command setup during image creation.
 
 ``volumes``
-    (optional)
-    See `Setting up Volumes`_
+    (a renderable list of strings, optional)
+    Allows to share directory between containers, or between a container and the host system.
+    Refer to Docker documentation for more information about Volumes.
+
+    Each string within the ``volumes`` array specify a volume in the following format: :samp:`{volumename}:{bindname}`.
+    The volume name has to be appended with ``:ro`` if the volume should be mounted *read-only*.
+
+    .. note:: This is the same format as when specifying volumes on the command line for docker's own ``-v`` option.
 
 ``dockerfile``
-    (optional if ``image`` is given)
+    (renderable string, optional if ``image`` is given)
     This is the content of the Dockerfile that will be used to build the specified image if the image is not found by Docker.
     It should be a multiline string.
 
@@ -238,32 +244,20 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     Always pulls image if autopull is set to true.
 
 ``custom_context``
-	(optional)
+    (renderable boolean, optional)
 	Boolean indicating that the user wants to use custom build arguments for the docker environment. Defaults to False.
 
 ``encoding``
-	(optional)
+    (renderable string, optional)
 	String indicating the compression format for the build context. defaults to 'gzip', but 'bzip' can be used as well.
 
 ``buildargs``
-	(optional if ``custom_context`` is True)
+    (renderable dictionary, optional if ``custom_context`` is True)
 	Dictionary, passes information for the docker to build its environment. Eg. {'DISTRO':'ubuntu', 'RELEASE':'11.11'}. Defaults to None.
 
 ``hostname``
-        (optional)
-        This will set container's hostname.
-
-Setting up Volumes
-..................
-
-The ``volume`` parameter allows to share directory between containers, or between a container and the host system.
-Refer to Docker documentation for more information about Volumes.
-
-The format of that variable has to be an array of string.
-Each string specify a volume in the following format: :samp:`{volumename}:{bindname}`.
-The volume name has to be appended with ``:ro`` if the volume should be mounted *read-only*.
-
-.. note:: This is the same format as when specifying volumes on the command line for docker's own ``-v`` option.
+    (renderable string, optional)
+    This will set container's hostname.
 
 Marathon latent worker
 ======================

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -232,8 +232,9 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     This value is passed to the docker image via environment variable ``BUILDMASTER``
 
 ``hostconfig``
-    (optional)
-    Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config>`_ for all the supported options.
+    (renderable dictionary, optional)
+    Extra host configuration parameters passed as a dictionary used to create HostConfig object.
+    See `docker-py's HostConfig documentation <https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config>`_ for all the supported options.
 
 ``autopull``
     (optional, defaults to false)

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -183,7 +183,7 @@ The following example will add a Docker latent worker for docker running at the 
 In addition to the arguments available for any :ref:`Latent-Workers`, :class:`DockerLatentWorker` will accept the following extra ones:
 
 ``docker_host``
-    (mandatory)
+    (renderable string, mandatory)
     This is the address the master will use to connect with a running Docker instance.
 
 ``image``

--- a/newsfragments/docker-renderable-hostconfig.feature
+++ b/newsfragments/docker-renderable-hostconfig.feature
@@ -1,1 +1,0 @@
-Added rendering support to ``hostconfig`` parameter of ``DockerLatentWorker``.

--- a/newsfragments/docker-renderable-hostconfig.feature
+++ b/newsfragments/docker-renderable-hostconfig.feature
@@ -1,0 +1,1 @@
+Added rendering support to ``hostconfig`` parameter of ``DockerLatentWorker``.

--- a/newsfragments/docker-renderable-parameters.feature
+++ b/newsfragments/docker-renderable-parameters.feature
@@ -1,0 +1,1 @@
+Added rendering support to ``docker_host`` and ``hostconfig`` parameters of ``DockerLatentWorker``.


### PR DESCRIPTION
This improves capabilities of using a single docker worker for arbitrary configurations, e.g. figuring out actual hostconfig parameters just before starting build.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
