### PR TITLE
Allow auto-update of base docker images

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -48,8 +48,10 @@ class Client:
     def wait(self, id):
         return 0
 
-    def build(self, fileobj, tag):
+    def build(self, fileobj, pull, tag):
         if fileobj.read() == b'BUG':
+            pass
+        elif pull != bool(pull):
             pass
         else:
             logs = []

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -273,10 +273,12 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
                     lines = docker_client.build(fileobj=fin,
                                                 custom_context=custom_context,
                                                 encoding=encoding, tag=image,
+                                                pull=self.alwaysPull,
                                                 buildargs=buildargs)
             else:
                 lines = docker_client.build(
                     fileobj=BytesIO(dockerfile.encode('utf-8')),
+                    pull=self.alwaysPull,
                     tag=image,
                 )
 

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -242,7 +242,8 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
 
 ``alwaysPull``
     (optional, defaults to false)
-    Always pulls image if autopull is set to true.
+    Always pulls (update) image if autopull is set to true.
+    Also affects the base image specified by `FROM ....` if using a dockerfile, autopull is not needed then.
 
 ``custom_context``
     (renderable boolean, optional)

--- a/newsfragments/autopull-base-image.feature
+++ b/newsfragments/autopull-base-image.feature
@@ -1,0 +1,1 @@
+Added ``alwaysPull`` support when using ``dockerfile`` parameter of ``DockerLatentWorker``.


### PR DESCRIPTION
- alwaysPull in docker latent worker will now not only apply when using `image`, but also when using a `dockerfile`. In that case it will try to update the base image. E.g. if your `dockerfile` contains `FROM ubuntu:focal ...`, it will always try to update the `ubuntu:focal` image, instead of just pulling only if it's missing

- I'm soliciting feedback, I tried to use a minimalistic approach and not sure what all else I have to do for such a small change

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
