### PR TITLE
docker: Handle invalid image error on Docker on Windows

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -20,6 +20,7 @@ version = "1.10.6"
 class Client:
     latest = None
     containerCreated = False
+    start_exception = None
 
     def __init__(self, base_url):
         Client.latest = self
@@ -40,7 +41,8 @@ class Client:
         return self._images
 
     def start(self, container):
-        pass
+        if self.start_exception is not None:
+            raise self.start_exception  # pylint: disable=raising-bad-type
 
     def stop(self, id):
         pass
@@ -112,3 +114,8 @@ class Client:
 
 class APIClient(Client):
     pass
+
+
+class errors:
+    class APIError(Exception):
+        pass

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -321,7 +321,16 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         instance['image'] = image
         self.instance = instance
         self._curr_client_args = curr_client_args
-        docker_client.start(instance)
+
+        try:
+            docker_client.start(instance)
+        except docker.errors.APIError as e:
+            # The following was noticed in certain usage of Docker on Windows
+            if 'The container operating system does not match the host operating system' in str(e):
+                msg = 'Image used for build is wrong: {}'.format(str(e))
+                raise LatentWorkerCannotSubstantiate(msg) from e
+            raise
+
         log.msg('Container started')
         if self.followStartupLogs:
             logs = docker_client.attach(

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -604,7 +604,11 @@ Overriding these members ensures that builds aren't ran on incompatible workers 
 
         This method is responsible for starting instance that will try to connect with this master.
         A deferred should be returned.
-        Any problems should use an errback.
+
+        Any problems should use an errback or exception.
+        When the error is likely related to infrastructure problem and the worker should be paused in case it produces too many errors, then ``LatentWorkerFailedToSubstantiate`` should be thrown.
+        When the error is related to the properties of the build request, such as renderable Docker image, then ``LatentWorkerCannotSubstantiate`` should be thrown.
+
         The callback value can be ``None``, or can be an iterable of short strings to include in the "substantiate success" status message, such as identifying the instance that started.
         Buildbot will ensure that a single worker will never have its ``start_instance`` called before any previous calls to ``start_instance`` or ``stop_instance`` finish.
         Additionally, for each ``start_instance`` call, exactly one corresponding call to ``stop_instance`` will be done eventually.

--- a/newsfragments/docker-handle-invalid-image-on-windows.bugfix
+++ b/newsfragments/docker-handle-invalid-image-on-windows.bugfix
@@ -1,0 +1,1 @@
+Improved handling of "The container operating system does not match the host operating system" error on Docker on Windows to mark the build as erroneous so that it's not retried.


### PR DESCRIPTION
Starting an invalid image on Docker on Windows will return API error during the container startup. We should handle this the same way as unknown images. Ultimately this is a problem with the build, not the worker infrastructure.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
