### PR TITLE
Add `target` parameter for docker build

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -50,10 +50,12 @@ class Client:
     def wait(self, id):
         return 0
 
-    def build(self, fileobj, pull, tag):
+    def build(self, fileobj, tag, pull, target):
         if fileobj.read() == b'BUG':
             pass
         elif pull != bool(pull):
+            pass
+        elif target != "":
             pass
         else:
             logs = []

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -245,6 +245,10 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     Always pulls (update) image if autopull is set to true.
     Also affects the base image specified by `FROM ....` if using a dockerfile, autopull is not needed then.
 
+``target``
+    (renderable string, optional)
+    Sets target build stage for multi-stage builds when using a dockerfile.
+
 ``custom_context``
     (renderable boolean, optional)
 	Boolean indicating that the user wants to use custom build arguments for the docker environment. Defaults to False.

--- a/newsfragments/multi-stage-dockerfile.feature
+++ b/newsfragments/multi-stage-dockerfile.feature
@@ -1,0 +1,1 @@
+Added ``target`` support when using ``dockerfile`` parameter of ``DockerLatentWorker``.


### PR DESCRIPTION
- allows to select stage when using multistage build
- it's a renderable so can be set dynamically

Similar to my earlier PR, #6310. I followed the documentation to docker API, which states the default value is `""`.

Should I write a separate test for it? Since the unit tests run against a fake docker library, I'm not sure how useful it would be.

PS. at this time, I haven't tested it in production yet, but I tested #6310 and it seems to be working.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
