### PR TITLE
Fix descriptionSuffix for rpm Mock build steps

### DIFF
--- a/newsfragments/fix-mock-state-observer.bugfix
+++ b/newsfragments/fix-mock-state-observer.bugfix
@@ -1,0 +1,1 @@
+Fix updating build step summary with mock state changes for MockBuildSRPM and MockRebuild.


### PR DESCRIPTION
This fixes the build step summary so that it updates nicely, for example
"mock buildsrpm [dnf install]" when Mock step is running.
Fix MockStateObserver that looks for progress in "state.log", written by
mock. Since ~2012, mock changed from writing "State Changed:" in the
log. Example of current state.log:

  ```
  2021-12-06 13:40:36,897 - Mock Version: 1.2.17
  2021-12-06 13:40:37,074 - Start: yum install
  2021-12-06 13:43:46,593 - Finish: yum install
  2021-12-06 13:43:48,038 - Start: creating cache
  2021-12-06 13:43:57,480 - Finish: creating cache
  2021-12-06 13:43:57,482 - Finish: chroot init
  2021-12-06 13:43:57,579 - Start: buildsrpm
  2021-12-06 13:43:57,780 - Start: rpmbuild -bs
  2021-12-06 13:43:57,972 - Finish: rpmbuild -bs
  2021-12-06 13:43:57,977 - Finish: buildsrpm
  2021-12-06 13:43:57,978 - Start: clean chroot
  2021-12-06 13:44:03,010 - Finish: clean chroot
  2021-12-06 13:44:03,011 - Finish: run
  ```

So now, look for "Start:" and "Finish:" lines and update the build steps
`descriptionSuffix` accordingly.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
