### PR TITLE
test: Ignore distutils version class deprecation in tests (used by moto)

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -99,6 +99,8 @@ warnings.filterwarnings('ignore', ".*Using or importing the ABCs from 'collectio
 # more 3.7 warning from moto
 warnings.filterwarnings('ignore', r".*Use 'list\(elem\)' or iteration over elem instead.*",
                         DeprecationWarning)
+warnings.filterwarnings('ignore', r".*distutils Version classes are deprecated.*",
+                        DeprecationWarning)
 
 # ignore ResourceWarnings for unclosed sockets for the pg8000 driver on Python 3+ (tech debt: #4508)
 if sys.version_info[0] >= 3 and "pg8000" in os.getenv("BUILDBOT_TEST_DB_URL", ""):


### PR DESCRIPTION
This deprecation warning started being issued recently in Windows tests.