### PR TITLE
Fix occasional stuck builds on Windows

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1430,6 +1430,7 @@ tac
 taichino
 tarball
 targetname
+taskkill
 tbl
 tcp
 tcpdump

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -137,7 +137,12 @@ class RemoteCommand(base.RemoteCommandImpl):
 
     @defer.inlineCallbacks
     def _finished(self, failure=None):
+        # Finished may be called concurrently by a message from worker and interruption due to
+        # lost connection.
+        if not self.active:
+            return
         self.active = False
+
         # the rc is send asynchronously and there is a chance it is still in the callback queue
         # when finished is received, we have to workaround in the master because worker might be
         # older

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -157,16 +157,19 @@ class RemoteCommand(base.RemoteCommandImpl):
     @defer.inlineCallbacks
     def interrupt(self, why):
         log.msg("RemoteCommand.interrupt", self, why)
+
+        if self.conn and isinstance(why, Failure) and why.check(error.ConnectionLost):
+            # Note that we may be in the process of interruption and waiting for the worker to
+            # return the final results when the connection is disconnected.
+            log.msg("RemoteCommand.interrupt: lost worker")
+            self.conn = None
+            self._finished(why)
+            return
         if not self.active or self.interrupted:
             log.msg(" but this RemoteCommand is already inactive")
             return
         if not self.conn:
             log.msg(" but our .conn went away")
-            return
-        if isinstance(why, Failure) and why.check(error.ConnectionLost):
-            log.msg("RemoteCommand.disconnect: lost worker")
-            self.conn = None
-            self._finished(why)
             return
 
         self.interrupted = True

--- a/master/buildbot/test/expect.py
+++ b/master/buildbot/test/expect.py
@@ -71,6 +71,7 @@ class Expect:
         self.args = args
         self.result = None
         self.interrupted = interrupted
+        self.connection_broken = False
         self.behaviors = []
 
     def behavior(self, callable):
@@ -99,6 +100,10 @@ class Expect:
 
     def exit(self, code):
         self.behaviors.append(('rc', code))
+        return self
+
+    def break_connection(self):
+        self.connection_broken = True
         return self
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -428,7 +428,8 @@ class TestBuildStepMixin:
                 self.expected_remote_commands.pop(0)
                 self._expected_remote_commands_popped += 1
 
-        command.remote_complete()
+        if not exp.connection_broken:
+            command.remote_complete()
 
     def change_worker_system(self, system):
         self.worker.worker_system = system

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -40,14 +40,6 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import TestBuildStepMixin
 
 
-def uploadString(string):
-    def behavior(command):
-        writer = command.args['writer']
-        writer.remote_write(string)
-        writer.remote_close()
-    return behavior
-
-
 class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin,
                                unittest.TestCase):
 

--- a/newsfragments/errors_lost_worker_connection.bugfix
+++ b/newsfragments/errors_lost_worker_connection.bugfix
@@ -1,0 +1,1 @@
+Fixed rare `AlreadyCalledError` exceptions in the logs when worker worker connection is lost at the same time it is delivering final outcome of a command.

--- a/newsfragments/fix_error_interruption_loses_connection.bugfix
+++ b/newsfragments/fix_error_interruption_loses_connection.bugfix
@@ -1,0 +1,1 @@
+Fixed error that caused builds to become stuck in building state until next master restart if builds that were in the process of being interrupted lost connection to the worker.

--- a/newsfragments/worker-fix-windows-terminate.bugfix
+++ b/newsfragments/worker-fix-windows-terminate.bugfix
@@ -1,0 +1,1 @@
+Fixed errors when killing a process on a worker fails due to any reason (e.g. permission error or process being already exited) (#6140).

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -49,6 +49,7 @@ pathlib2==2.3.6
 pbr==5.6.0
 pep8==1.7.1
 Pillow==8.3.2
+psutil==5.9.0
 pyaml==20.4.0
 ruamel.yaml==0.17.16
 pyasn1==0.4.8

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -11,6 +11,7 @@ mock==3.0.5  # pyup: ignore
 pbr==5.6.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
+psutil==5.9.0
 six==1.16.0
 Twisted==21.2.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.0"  # pyup: ignore

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -898,18 +898,10 @@ class RunProcess(object):
                 log.msg("interruptSignal==None, only pretending to kill child")
             elif self.process.pid is not None:
                 if interruptSignal == "TERM":
-                    log.msg("using TASKKILL PID /T to kill pid {0}".format(
-                            self.process.pid))
-                    subprocess.check_call(
-                        "TASKKILL /PID {0} /T".format(self.process.pid))
-                    log.msg("taskkill'd pid {0}".format(self.process.pid))
+                    self._taskkill(self.process.pid, force=False)
                     hit = 1
                 elif interruptSignal == "KILL":
-                    log.msg("using TASKKILL PID /F /T to kill pid {0}".format(
-                            self.process.pid))
-                    subprocess.check_call(
-                        "TASKKILL /F /PID {0} /T".format(self.process.pid))
-                    log.msg("taskkill'd pid {0}".format(self.process.pid))
+                    self._taskkill(self.process.pid, force=True)
                     hit = 1
 
         # try signalling the process itself (works on Windows too, sorta)
@@ -929,6 +921,16 @@ class RunProcess(object):
                 # been called already or will be called shortly
 
         return hit
+
+    def _taskkill(self, pid, force):
+        if force:
+            cmd = "TASKKILL /F /PID {0} /T".format(pid)
+        else:
+            cmd = "TASKKILL /PID {0} /T".format(pid)
+
+        log.msg("using {0} to kill pid {1}".format(cmd, pid))
+        subprocess.check_call(cmd)
+        log.msg("taskkill'd pid {0}".format(pid))
 
     def kill(self, msg):
         # This may be called by the timeout, or when the user has decided to

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -160,6 +160,7 @@ if setuptools is not None:
     # Unit test hard dependencies.
     test_deps = [
         'mock',
+        'psutil',
     ]
 
     setup_args['tests_require'] = test_deps


### PR DESCRIPTION
This PR fixes several issues that ultimately caused finished or cancelled builds to become stuck on Windows workers until master restart.

Fixes #6140.


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
