### PR TITLE
Fix python2/python3 inconsistency in documentation firstrun

### DIFF
--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -66,17 +66,14 @@ Creating a master
 -----------------
 
 The first necessary step is to create a virtualenv for our master.
-We will also use a separate directory to demonstrate the distinction between a master and worker:
-
-On Python 2:
+We first create a separate directory to demonstrate the distinction between a master and worker:
 
 .. code-block:: bash
 
   mkdir -p ~/buildbot-test/master
   cd ~/buildbot-test/master
 
-
-On Python 3:
+Then we create the virtual environment. On Python 3:
 
 .. code-block:: bash
 
@@ -156,21 +153,15 @@ As a consequence of this, your worker will need access to the git_ command in or
 Be sure that it is installed, or the builds will fail.
 
 Same as we did for our master, we will create a virtualenv for our worker next to the other one.
-It would however be completely ok to do this on another computer - as long as the *worker* computer is able to connect to the *master* one:
+It would however be completely ok to do this on another computer - as long as the *worker* computer is able to connect to the *master* one.
+We first create a new directory for the worker:
 
 .. code-block:: bash
 
   mkdir -p ~/buildbot-test/worker
   cd ~/buildbot-test/worker
 
-On Python 2:
-
-.. code-block:: bash
-
-  virtualenv sandbox
-  source sandbox/bin/activate
-
-On Python 3:
+Again, we create a virtual environment. On Python 3:
 
 .. code-block:: bash
 


### PR DESCRIPTION
There are 2 issues in the firstrun documentation:
- There are two paragraphs about how to create virtual environments. The first instance contains code for (only) python 3, the second instance contains code for python 2 and python 3. That should be consistent
- The first instance mentions python 2 but says that the directory creation is only relevant for python 2. This seems to be wrongly attributed, the directory creation should be relevant for python 2 and python 3.

That issues were caused by:
- https://github.com/buildbot/buildbot/commit/3ffe6013a8e9681ac0fe3ad1137436de9e5d8c82#diff-d6d51cdf93e59b4b0a40f1b11683e27a7697ed312c03d36d43882958654e6922
  - Removes one python 2 block (but does not change the second)
- https://github.com/buildbot/buildbot/commit/53511e29c8bba9491c71078e56c393254ba29ed0#diff-d6d51cdf93e59b4b0a40f1b11683e27a7697ed312c03d36d43882958654e6922
  - Introduces the python 2 text again, but not the code

There are 2 alternative ways to fix the issues:
1. Add all relevant information for both paragraphs about python 2 and python 3
2. Remove python 2 from both paragraphs

I have chosen the first option given that python 2 support seems to be dropped according to https://buildbot.net/

In addition, I have clarified some sentences around the code blocks.



## Contributor Checklist:

* [ ] I have updated the unit tests
  * Not relevant
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
  * Not relevant
* [x] I have updated the appropriate documentation
