### PR TITLE
process: Use yield for log finish method

### DIFF
--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -320,7 +320,7 @@ class RemoteCommand(base.RemoteCommandImpl):
                     yield loog.addHeader("\nremoteFailed: {}".format(maybeFailure))
                 else:
                     log.msg("closing log {}".format(loog))
-                loog.finish()
+                yield loog.finish()
         if maybeFailure:
             # workaround http://twistedmatrix.com/trac/ticket/5507
             # CopiedFailure cannot be raised back, this make debug difficult

--- a/newsfragments/log-finish.bugfix
+++ b/newsfragments/log-finish.bugfix
@@ -1,0 +1,1 @@
+Fixed rare "Did you maybe forget to yield the method" errors coming from the log subsystem.


### PR DESCRIPTION
Just a minor fix. Addresses Unhandled Error:
```
    File "/home/user/bbm/sandbox/lib/python3.7/site-packages/buildbot/process/log.py", line 101, in finish
	    assert not self._finishing, "Did you maybe forget to yield the method?"
	builtins.AssertionError: Did you maybe forget to yield the method?
```
