### PR TITLE
fix race condition in build wait timers for substantiated workers

### DIFF
--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -236,7 +236,6 @@ class AbstractLatentWorker(AbstractWorker):
             return defer.succeed(False)
 
         if self.state == States.SUBSTANTIATED and self.conn is not None:
-            self._setBuildWaitTimer()
             return defer.succeed(True)
 
         if self.state in [States.SUBSTANTIATING,

--- a/newsfragments/latent-worker-build-wait-timer.bugfix
+++ b/newsfragments/latent-worker-build-wait-timer.bugfix
@@ -1,0 +1,1 @@
+Fixed handling of ``build_wait_timeout`` on latent workers which previously could result in latent worker being shut down while a build is running in certain scenarios (:issue:`5988`).


### PR DESCRIPTION
Patched an issue where latent workers that have already been substantiated will start a `build_wait_timer` during substantiation of a new build. This timer starts after the `build_wait_timer` is cleared from a new build arriving, disconnecting the worker `build_wait_timeout` seconds later, mid-build or not.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
  - added a nice comment
