### PR TITLE
Message formatter improvements

### DIFF
--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -80,8 +80,8 @@ class BitbucketStatusPush(ReporterBase):
     def _create_default_generators(self):
         return [
             BuildStartEndStatusGenerator(
-                start_formatter=MessageFormatter(subject=""),
-                end_formatter=MessageFormatter(subject="")
+                start_formatter=MessageFormatter(subject="", template=''),
+                end_formatter=MessageFormatter(subject="", template='')
             )
         ]
 

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -20,6 +20,7 @@ from buildbot import interfaces
 from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterRenderable
+from buildbot.warnings import warn_deprecated
 
 from .utils import BuildStatusGeneratorMixin
 
@@ -35,8 +36,14 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
 
     def __init__(self, mode=("failing", "passing", "warnings"),
                  tags=None, builders=None, schedulers=None, branches=None,
-                 subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                 add_logs=False, add_patch=False, report_new=False, message_formatter=None):
+                 subject=None, add_logs=False, add_patch=False, report_new=False,
+                 message_formatter=None):
+        if subject is not None:
+            warn_deprecated('3.5.0', 'BuildStatusGenerator subject parameter has been ' +
+                            'deprecated: please configure subject in the message formatter')
+        else:
+            subject = "Buildbot %(result)s in %(title)s on %(builder)s"
+
         super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch)
         self.formatter = message_formatter
         if self.formatter is None:

--- a/master/buildbot/reporters/generators/buildrequest.py
+++ b/master/buildbot/reporters/generators/buildrequest.py
@@ -73,8 +73,8 @@ class BuildRequestGenerator(BuildStatusGeneratorMixin):
     def buildrequest_message(self, master, build):
         patches = self._get_patches_for_build(build)
         users = []
-        buildmsg = yield self.formatter.format_message_for_build(master, build, mode=self.mode,
-                                                                 users=users)
+        buildmsg = yield self.formatter.format_message_for_build(master, build, is_buildset=True,
+                                                                 mode=self.mode, users=users)
 
         return {
             'body': buildmsg['body'],

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -84,8 +84,8 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
             blamelist = yield reporter.getResponsibleUsersForBuild(master, build['buildid'])
             users.update(set(blamelist))
 
-            buildmsg = yield formatter.format_message_for_build(master, build, mode=self.mode,
-                                                                users=blamelist)
+            buildmsg = yield formatter.format_message_for_build(master, build, is_buildset=True,
+                                                                mode=self.mode, users=blamelist)
 
             msgtype, ok = self._merge_msgtype(msgtype, buildmsg['type'])
             if not ok:

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -20,6 +20,7 @@ from buildbot import interfaces
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatter
+from buildbot.warnings import warn_deprecated
 
 from .utils import BuildStatusGeneratorMixin
 
@@ -35,8 +36,13 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
 
     def __init__(self, mode=("failing", "passing", "warnings"),
                  tags=None, builders=None, schedulers=None, branches=None,
-                 subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                 add_logs=False, add_patch=False, message_formatter=None):
+                 subject=None, add_logs=False, add_patch=False, message_formatter=None):
+        if subject is not None:
+            warn_deprecated('3.5.0', 'BuildSetStatusGenerator subject parameter has been ' +
+                            'deprecated: please configure subject in the message formatter')
+        else:
+            subject = "Buildbot %(result)s in %(title)s on %(builder)s"
+
         super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch)
         self.formatter = message_formatter
         if self.formatter is None:

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -179,8 +179,8 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
 
         users = yield reporter.getResponsibleUsersForBuild(master, build['buildid'])
 
-        buildmsg = yield formatter.format_message_for_build(master, build, mode=self.mode,
-                                                            users=users)
+        buildmsg = yield formatter.format_message_for_build(master, build, is_buildset=False,
+                                                            mode=self.mode, users=users)
 
         results = build['results']
 

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -37,6 +37,8 @@ from buildbot.reporters.base import ENCODING
 from buildbot.reporters.base import ReporterBase
 from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.reporters.generators.worker import WorkerMissingGenerator
+from buildbot.reporters.message import MessageFormatter
+from buildbot.reporters.message import MessageFormatterMissingWorker
 from buildbot.util import ssl
 from buildbot.util import unicode2bytes
 
@@ -154,8 +156,12 @@ class MailNotifier(ReporterBase):
 
     def _create_default_generators(self):
         return [
-            BuildStatusGenerator(add_patch=True),
-            WorkerMissingGenerator(workers='all'),
+            BuildStatusGenerator(
+                add_patch=True,
+                message_formatter=MessageFormatter(template_type='html')),
+            WorkerMissingGenerator(
+                workers='all',
+                message_formatter=MessageFormatterMissingWorker(template_type='html')),
         ]
 
     def patch_to_attachment(self, patch, index):

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -363,8 +363,6 @@ Sincerely,
 
 
 class MessageFormatterMissingWorker(MessageFormatterBaseJinja):
-    template_filename = 'missing_mail.txt'
-
     def __init__(self, template=None, **kwargs):
         if template is None:
             template = default_missing_template

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -111,7 +111,7 @@ def get_projects_text(source_stamps, master):
     return ', '.join(list(projects))
 
 
-def create_context_for_build(mode, build, master, blamelist):
+def create_context_for_build(mode, build, is_buildset, master, blamelist):
     buildset = build['buildset']
     ss_list = buildset['sourcestamps']
     results = build['results']
@@ -129,6 +129,7 @@ def create_context_for_build(mode, build, master, blamelist):
         'workername': build['properties'].get('workername', ["<unknown>"])[0],
         'buildset': buildset,
         'build': build,
+        'is_buildset': is_buildset,
         'projects': get_projects_text(ss_list, master),
         'previous_results': previous_results,
         'status_detected': get_detected_status_text(mode, results, previous_results),
@@ -230,7 +231,7 @@ class MessageFormatterBase(util.ComparableMixin):
         return None
 
     def format_message_for_build(self, master, build, **kwargs):
-        # Known kwargs keys: mode, users
+        # Known kwargs keys: mode, users, is_buildset
         raise NotImplementedError
 
 
@@ -345,8 +346,8 @@ class MessageFormatterBaseJinja(MessageFormatterBase):
 
 class MessageFormatter(MessageFormatterBaseJinja):
     @defer.inlineCallbacks
-    def format_message_for_build(self, master, build, users=None, mode=None):
-        ctx = create_context_for_build(mode, build, master, users)
+    def format_message_for_build(self, master, build, is_buildset=False, users=None, mode=None):
+        ctx = create_context_for_build(mode, build, is_buildset, master, users)
         msgdict = yield self.render_message_dict(master, ctx)
         return msgdict
 

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -313,6 +313,9 @@ Sincerely,
 '''  # noqa pylint: disable=line-too-long
 
 
+default_subject_template = "Buildbot {{ result_names[results] }} in {{ buildbot_title }} on {{ 'whole buildset' if is_buildset else buildername }}"  # noqa pylint: disable=line-too-long
+
+
 class MessageFormatterBaseJinja(MessageFormatterBase):
     compare_attrs = ['body_template', 'subject_template', 'template_type']
     subject_template = None
@@ -321,11 +324,11 @@ class MessageFormatterBaseJinja(MessageFormatterBase):
     def __init__(self, template=None, subject=None, template_type=None, **kwargs):
         if template is None:
             template = default_body_template
+        if subject is None:
+            subject = default_subject_template
 
         self.body_template = jinja2.Template(template)
-
-        if subject is not None:
-            self.subject_template = jinja2.Template(subject)
+        self.subject_template = jinja2.Template(subject)
 
         if template_type is not None:
             self.template_type = template_type
@@ -339,8 +342,6 @@ class MessageFormatterBaseJinja(MessageFormatterBase):
         return self.body_template.render(context)
 
     def render_message_subject(self, context):
-        if self.subject_template is None:
-            return None
         return self.subject_template.render(context)
 
 
@@ -366,11 +367,16 @@ Sincerely,
 '''  # noqa pylint: disable=line-too-long
 
 
+default_missing_worker_subject_template = 'Buildbot worker {{ worker.name }} missing'
+
+
 class MessageFormatterMissingWorker(MessageFormatterBaseJinja):
-    def __init__(self, template=None, **kwargs):
+    def __init__(self, template=None, subject=None, **kwargs):
         if template is None:
             template = default_missing_template
-        super().__init__(template=template, **kwargs)
+        if subject is None:
+            subject = default_missing_worker_subject_template
+        super().__init__(template=template, subject=subject, **kwargs)
 
     @defer.inlineCallbacks
     def formatMessageForMissingWorker(self, master, worker):

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -25,6 +25,7 @@ from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
+from buildbot.process.results import Results
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
 from buildbot.warnings import warn_deprecated
@@ -122,6 +123,7 @@ def create_context_for_build(mode, build, master, blamelist):
 
     return {
         'results': build['results'],
+        'result_names': Results,
         'mode': mode,
         'buildername': build['builder']['name'],
         'workername': build['properties'].get('workername', ["<unknown>"])[0],

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -18,11 +18,14 @@ import jinja2
 
 from twisted.internet import defer
 
+from buildbot import config
 from buildbot import util
 from buildbot.process.properties import Properties
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
+from buildbot.process.results import RETRY
+from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
@@ -294,49 +297,107 @@ class MessageFormatterRenderable(MessageFormatterBase):
         return body
 
 
-default_body_template = '''\
-The Buildbot has detected a {{ status_detected }} on builder {{ buildername }} while building {{ projects }}.
+default_body_template_plain = '''\
+A {{ status_detected }} has been detected on builder {{ buildername }} while building {{ projects }}.
+
 Full details are available at:
     {{ build_url }}
 
-Buildbot URL: {{ buildbot_url }}
-
-Worker for this Build: {{ workername }}
-
-Build Reason: {{ build['properties'].get('reason', ["<unknown>"])[0] }}
+Build state: {{ build['state_string'] }}
+Revision: {{ build['properties'].get('got_revision', ['(unknown)'])[0] }}
+Worker: {{ workername }}
+Build Reason: {{ build['properties'].get('reason', ["(unknown)"])[0] }}
 Blamelist: {{ ", ".join(blamelist) }}
 
-{{ summary }}
-
-Sincerely,
- -The Buildbot
+Steps:
+{% if build['steps'] %}{% for step in build['steps'] %}
+- {{ step['number'] }}: {{ step['name'] }} ( {{ result_names[step['results']] }} )
+{% if step['logs'] %}    Logs:{% for log in step['logs'] %}
+        - {{ log.name }}: {{ log.url }}{% endfor %}
+{% endif %}{% endfor %}
+{% else %}
+- (no steps)
+{% endif %}
 '''  # noqa pylint: disable=line-too-long
 
 
-default_subject_template = "Buildbot {{ result_names[results] }} in {{ buildbot_title }} on {{ 'whole buildset' if is_buildset else buildername }}"  # noqa pylint: disable=line-too-long
+default_body_template_html = '''\
+<p>A {{ status_detected }} has been detected on builder
+<a href="{{ build_url }}">{{ buildername }}</a>
+while building {{ projects }}.</p>
+<p>Information:</p>
+<ul>
+    <li>Build state: {{ build['state_string'] }}</li>
+    <li>Revision: {{ build['properties'].get('got_revision', ['(unknown)'])[0] }}</li>
+    <li>Worker: {{ workername }}</li>
+    <li>Build Reason: {{ build['properties'].get('reason', ["(unknown)"])[0] }}</li>
+    <li>Blamelist: {{ ", ".join(blamelist) }}</li>
+</ul>
+<p>Steps:</p>
+<ul>
+{% if build['steps'] %}{% for step in build['steps'] %}
+    <li style="{{ results_style[step['results']] }}">
+    {{ step['number'] }}: {{ step['name'] }} ( {{ result_names[step['results']] }} )
+    {% if step['logs'] %}({% for log in step['logs'] %}
+        <a href="{{ log.url }}">&lt;{{ log.name }}&gt;</a>{% endfor %}
+    )
+    {% endif %}</li>
+{% endfor %}{% else %}
+    <li>No steps</li>
+{% endif %}
+</ul>
+'''  # noqa pylint: disable=line-too-long
+
+default_subject_template = '''\
+{{ '☠' if result_names[results] == 'failure' else '☺' if result_names[results] == 'success' else '☝' }} \
+Buildbot ({{ buildbot_title }}): {{ build['properties'].get('project', ['whole buildset'])[0] if is_buildset else buildername }} \
+- \
+{{ build['state_string'] }} \
+{{ '(%s)' % (build['properties']['branch'][0] if (build['properties']['branch'] and build['properties']['branch'][0]) else build['properties'].get('got_revision', ['(unknown revision)'])[0]) }}'''  # # noqa pylint: disable=line-too-long
 
 
 class MessageFormatterBaseJinja(MessageFormatterBase):
     compare_attrs = ['body_template', 'subject_template', 'template_type']
     subject_template = None
     template_type = 'plain'
+    uses_default_body_template = False
 
     def __init__(self, template=None, subject=None, template_type=None, **kwargs):
+        if template_type is not None:
+            self.template_type = template_type
+
         if template is None:
-            template = default_body_template
+            self.uses_default_body_template = True
+            if self.template_type == 'plain':
+                template = default_body_template_plain
+            elif self.template_type == 'html':
+                template = default_body_template_html
+            else:
+                config.error(f'{self.__class__.__name__}: template type {self.template_type} '
+                             'is not known to pick default template')
+
+            kwargs['want_steps'] = True
+            kwargs['want_logs'] = True
+
         if subject is None:
             subject = default_subject_template
 
         self.body_template = jinja2.Template(template)
         self.subject_template = jinja2.Template(subject)
 
-        if template_type is not None:
-            self.template_type = template_type
-
         super().__init__(**kwargs)
 
     def buildAdditionalContext(self, master, ctx):
-        pass
+        if self.uses_default_body_template:
+            ctx['results_style'] = {
+                SUCCESS: '',
+                EXCEPTION: 'color: #f0f; font-weight: bold;',
+                FAILURE: 'color: #f00; font-weight: bold;',
+                RETRY: 'color: #4af;',
+                SKIPPED: 'color: #4af;',
+                WARNINGS: 'color: #f80;',
+                CANCELLED: 'color: #4af;',
+            }
 
     def render_message_body(self, context):
         return self.body_template.render(context)
@@ -353,30 +414,47 @@ class MessageFormatter(MessageFormatterBaseJinja):
         return msgdict
 
 
-default_missing_template = '''\
-The Buildbot working for '{{buildbot_title}}' has noticed that the worker named {{worker.name}} went away.
+default_missing_template_plain = '''\
+The Buildbot worker named {{worker.name}} went away.
 
 It last disconnected at {{worker.last_connection}}.
 
 {% if 'admin' in worker['workerinfo'] %}
 The admin on record (as reported by WORKER:info/admin) was {{worker.workerinfo.admin}}.
 {% endif %}
+'''  # noqa pylint: disable=line-too-long
 
-Sincerely,
- -The Buildbot
+default_missing_template_html = '''\
+<p>The Buildbot worker named {{worker.name}} went away.</p>
+<p>It last disconnected at {{worker.last_connection}}.</p>
+
+{% if 'admin' in worker['workerinfo'] %}
+<p>The admin on record (as reported by WORKER:info/admin) was {{worker.workerinfo.admin}}.</p>
+{% endif %}
 '''  # noqa pylint: disable=line-too-long
 
 
-default_missing_worker_subject_template = 'Buildbot worker {{ worker.name }} missing'
+default_missing_worker_subject_template = \
+    'Buildbot {{ buildbot_title }} worker {{ worker.name }} missing'
 
 
 class MessageFormatterMissingWorker(MessageFormatterBaseJinja):
-    def __init__(self, template=None, subject=None, **kwargs):
+    def __init__(self, template=None, subject=None, template_type=None, **kwargs):
+        if template_type is None:
+            template_type = 'plain'
+
         if template is None:
-            template = default_missing_template
+            if template_type == 'plain':
+                template = default_missing_template_plain
+            elif template_type == 'html':
+                template = default_missing_template_html
+            else:
+                config.error(f'{self.__class__.__name__}: template type {self.template_type} '
+                             'is not known to pick default template')
+
         if subject is None:
             subject = default_missing_worker_subject_template
-        super().__init__(template=template, subject=subject, **kwargs)
+        super().__init__(template=template, subject=subject, template_type=template_type, **kwargs)
 
     @defer.inlineCallbacks
     def formatMessageForMissingWorker(self, master, worker):

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -131,6 +131,7 @@ def create_context_for_build(mode, build, master, blamelist):
         'previous_results': previous_results,
         'status_detected': get_detected_status_text(mode, results, previous_results),
         'build_url': utils.getURLForBuild(master, build['builder']['builderid'], build['number']),
+        'buildbot_title': master.config.title,
         'buildbot_url': master.config.buildbotURL,
         'blamelist': blamelist,
         'summary': get_message_summary_text(build, results),

--- a/master/buildbot/test/integration/test_notifier.py
+++ b/master/buildbot/test/integration/test_notifier.py
@@ -64,19 +64,22 @@ class NotifierMaster(RunMasterBase):
                       committer="me@foo.com",
                       comments="good stuff",
                       revision="HEAD",
-                      project="none"
+                      project="projectname"
                       )
         build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         mail, recipients = yield self.mailDeferred
         self.assertEqual(recipients, ["author@foo.com"])
         self.assertIn("From: bot@foo.com", mail)
-        self.assertIn("Subject: Buildbot success in Buildbot", mail)
-        self.assertEncodedIn("The Buildbot has detected a passing build", mail)
+        self.assertIn(f"Subject: =?utf-8?q?=E2=98=BA_Buildbot_=28Buildbot=29=3A_{what}_-_build_successful_=28master=29?=\n",  # noqa pylint: disable=line-too-long
+                      mail)
+        self.assertEncodedIn("A passing build has been detected on builder testy while", mail)
         params = yield self.notification
         self.assertEqual(build['buildid'], 1)
-        self.assertEqual(params, {'title': "Buildbot success in Buildbot on {}".format(what),
-                                  'message': "This is a message."})
+        self.assertEqual(params, {
+            'title': f"☺ Buildbot (Buildbot): {what} - build successful (master)",
+            'message': "This is a message."
+        })
 
     def assertEncodedIn(self, text, mail):
         # python 2.6 default transfer in base64 for utf-8
@@ -95,7 +98,7 @@ class NotifierMaster(RunMasterBase):
     @defer.inlineCallbacks
     def test_notifiy_for_buildset(self):
         yield self.create_master_config(build_set_summary=True)
-        yield self.doTest('whole buildset')
+        yield self.doTest('projectname')
 
     @defer.inlineCallbacks
     def test_missing_worker(self):
@@ -109,11 +112,11 @@ class NotifierMaster(RunMasterBase):
         mail, recipients = yield self.mailDeferred
         self.assertIn("From: bot@foo.com", mail)
         self.assertEqual(recipients, ['admin@worker.org'])
-        self.assertIn("Subject: Buildbot worker local1 missing", mail)
+        self.assertIn("Subject: Buildbot Buildbot worker local1 missing", mail)
         self.assertIn("disconnected at long time ago", mail)
         self.assertEncodedIn("worker named local1 went away", mail)
         params = yield self.notification
-        self.assertEqual(params, {'title': "Buildbot worker local1 missing",
+        self.assertEqual(params, {'title': "Buildbot Buildbot worker local1 missing",
                                   'message': b"No worker."})
 
 

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -90,8 +90,8 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
     def test_buildMessage_nominal(self):
         mn, build, formatter = yield self.setupBuildMessage(mode=("failing",))
 
-        formatter.format_message_for_build.assert_called_with(self.master, build, mode=('failing',),
-                                                              users=['me@foo'])
+        formatter.format_message_for_build.assert_called_with(self.master, build, is_buildset=False,
+                                                              mode=('failing',), users=['me@foo'])
 
         report = {
             'body': 'body',

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -88,6 +88,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, build)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                is_buildset=False,
                                                                 mode=('change',), users=[])
 
         self.assertEqual(report, {
@@ -107,6 +108,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, build, results=None)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                is_buildset=False,
                                                                 mode=('change',), users=[])
 
         self.assertEqual(report, {
@@ -134,6 +136,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, build, results=None)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                is_buildset=False,
                                                                 mode=('change',), users=[])
 
         self.assertEqual(report, {
@@ -305,6 +308,7 @@ class TestBuildStartEndGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, build)
 
         g.start_formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                      is_buildset=False,
                                                                       mode=self.all_messages,
                                                                       users=[])
 
@@ -326,6 +330,7 @@ class TestBuildStartEndGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, build, results=None)
 
         g.start_formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                      is_buildset=False,
                                                                       mode=self.all_messages,
                                                                       users=[])
 

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -29,6 +29,8 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.reporter import ReporterTestMixin
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
@@ -123,16 +125,19 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         })
 
     @defer.inlineCallbacks
-    def test_build_message_no_result_default_subject(self):
-        subject = 'result: %(result)s builder: %(builder)s title: %(title)s'
+    def test_build_subject_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning, "subject parameter"):
+            yield self.setup_generator(subject='subject')
+
+    @defer.inlineCallbacks
+    def test_build_message_no_result_formatter_no_subject(self):
         message = {
             "body": "body",
             "type": "text",
-            "subject": None,
+            "subject": None,  # deprecated unspecified subject
         }
 
-        g, build = yield self.setup_generator(results=None, subject=subject,
-                                              message=message, mode=("change",))
+        g, build = yield self.setup_generator(results=None, message=message, mode=("change",))
         report = yield self.build_message(g, build, results=None)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
@@ -141,7 +146,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
 
         self.assertEqual(report, {
             'body': 'body',
-            'subject': 'result: not finished builder: Builder0 title: Buildbot',
+            'subject': 'Buildbot not finished in Buildbot on Builder0',
             'type': 'text',
             'results': None,
             'builds': [build],

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -83,6 +83,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield g.buildrequest_message(self.master, build)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                is_buildset=True,
                                                                 mode=self.all_messages,
                                                                 users=[])
 

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -25,6 +25,8 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.reporter import ReporterTestMixin
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMixin,
@@ -125,16 +127,19 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
         })
 
     @defer.inlineCallbacks
-    def test_buildset_message_no_result_default_subject(self):
-        subject = 'result: %(result)s builder: %(builder)s title: %(title)s'
+    def test_buildset_subject_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning, "subject parameter"):
+            yield self.setup_generator(subject='subject')
+
+    @defer.inlineCallbacks
+    def test_buildset_message_no_result_formatter_no_subject(self):
         message = {
             "body": "body",
             "type": "text",
-            "subject": None,
+            "subject": None,  # deprecated unspecified subject
         }
 
-        g, build, _ = yield self.setup_generator(results=None, subject=subject,
-                                                 message=message, mode=("change",))
+        g, build, _ = yield self.setup_generator(results=None, message=message, mode=("change",))
         report = yield self.buildset_message(g, [build], results=None)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
@@ -143,7 +148,7 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
 
         self.assertEqual(report, {
             'body': 'body',
-            'subject': 'result: not finished builder: whole buildset title: Buildbot',
+            'subject': 'Buildbot not finished in Buildbot on whole buildset',
             'type': 'text',
             'results': None,
             'builds': [build],

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -90,7 +90,8 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
         report = yield self.buildset_message(g, [build])
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
-                                                                mode=('change',), users=[])
+                                                                is_buildset=True, mode=('change',),
+                                                                users=[])
 
         self.assertEqual(report, {
             'body': 'body',
@@ -109,6 +110,7 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
         report = yield self.buildset_message(g, [build], results=None)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                is_buildset=True,
                                                                 mode=('change',), users=[])
 
         self.assertEqual(report, {
@@ -136,6 +138,7 @@ class TestBuildSetGenerator(ConfigErrorsMixin, TestReactorMixin, ReporterTestMix
         report = yield self.buildset_message(g, [build], results=None)
 
         g.formatter.format_message_for_build.assert_called_with(self.master, build,
+                                                                is_buildset=True,
                                                                 mode=('change',), users=[])
 
         self.assertEqual(report, {

--- a/master/buildbot/test/unit/reporters/test_generators_worker.py
+++ b/master/buildbot/test/unit/reporters/test_generators_worker.py
@@ -52,7 +52,7 @@ class TestWorkerMissingGenerator(ConfigErrorsMixin, TestReactorMixin,
                                   self._get_worker_dict('myworker'))
 
         self.assertEqual(report['users'], ['workeradmin@example.org'])
-        self.assertIn(b"has noticed that the worker named myworker went away", report['body'])
+        self.assertIn(b"worker named myworker went away", report['body'])
 
     @defer.inlineCallbacks
     def test_report_not_matched_worker(self):

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -216,8 +216,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
     def test_buildMessage(self):
         mn, build, formatter = yield self.setupBuildMessage(mode=("passing",))
 
-        formatter.format_message_for_build.assert_called_with(self.master, build, mode=('passing',),
-                                                              users=['me@foo'])
+        formatter.format_message_for_build.assert_called_with(self.master, build, is_buildset=False,
+                                                              mode=('passing',), users=['me@foo'])
 
         mn.findInterrestedUsersEmails.assert_called_with(['me@foo'])
         mn.processRecipients.assert_called_with('<recipients>', '<email>')

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -210,7 +210,7 @@ class TestMessageFormatter(MessageFormatterTestBase):
 
             Sincerely,
              -The Buildbot'''))
-        self.assertIsNone(res['subject'])
+        self.assertIsNotNone(res['subject'], 'Buildbot 0 in  on Builder1')
 
     @defer.inlineCallbacks
     def test_inline_template(self):

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -163,9 +163,9 @@ class BuildDictLookAlike:
 
     def __eq__(self, b):
         if sorted(b.keys()) != self.keys:
-            print(set(b.keys()) - set(self.keys))
-            print(set(self.keys) - set(b.keys()))
-            return False
+            raise AssertionError('BuildDictLookAlike is not equal to build: '
+                                 f'Extra keys: {set(b.keys()) - set(self.keys)} '
+                                 f'Missing keys: {set(self.keys) - set(b.keys())}')
         for k, v in self.assertions.items():
             if b[k] != v:
                 return False

--- a/master/docs/manual/configuration/report_generators/build.rst
+++ b/master/docs/manual/configuration/report_generators/build.rst
@@ -14,6 +14,10 @@ The following parameters are supported:
 
 ``subject``
     (string, optional).
+
+    Deprecated since Buildbot 3.5.
+    Please use the ``subject`` argument of the ``message_formatter`` passed to the generator.
+
     A string to be used as the subject line of the message.
     ``%(builder)s`` will be replaced with the name of the builder which provoked the message.
     ``%(result)s`` will be replaced with the name of the result of the build.

--- a/master/docs/manual/configuration/report_generators/buildset.rst
+++ b/master/docs/manual/configuration/report_generators/buildset.rst
@@ -14,6 +14,10 @@ The following parameters are supported:
 
 ``subject``
     (string, optional).
+
+    Deprecated since Buildbot 3.5.
+    Please use the ``subject`` argument of the ``message_formatter`` passed to the generator.
+
     A string to be used as the subject line of the message.
     ``%(builder)s`` will be replaced with the name of the builder which provoked the message.
     ``%(result)s`` will be replaced with the name of the result of the build.

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -7,7 +7,7 @@ MessageFormatter
 
 This formatter is used to format messages in :ref:`Reportgen-BuildStatusGenerator` and :ref:`Reportgen-BuildSetStatusGenerator`.
 
-It formats a message using the Jinja2_ templating language and picks the template either from a string or from a file.
+It formats a message using the Jinja2_ templating language and picks the template either from a string.
 
 The constructor of the class takes the following arguments:
 

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -128,6 +128,10 @@ The context that is given to the template consists of the following data:
 
         Additionally, if ``want_logs_content`` is set to ``True`` then the log dictionaries will contain ``contents`` key with full contents of the log.
 
+``is_buildset``
+    A boolean identifying whether the current message will form a larger message that describes multiple builds in a buildset.
+    This mostly concerns generation of the subject as the message bodies will be merged.
+
 ``projects``
     A string identifying the projects that the build was built for.
 

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -11,15 +11,19 @@ It formats a message using the Jinja2_ templating language and picks the templat
 
 The constructor of the class takes the following arguments:
 
-``template``
-    If set, this parameter indicates the content of the template used to generate the body of the mail as string.
-
 ``template_type``
     This indicates the type of the generated template.
     Use either 'plain' (the default) or 'html'.
 
+``template``
+    If set, specifies the template used to generate the message body.
+    If not set, a default template will be used.
+    The default template is selected according to ``template_type`` so it may make sense to specify appropriate ``template_type`` even if the default template is used.
+
 ``subject``
-    The content of the subject of the mail as string.
+    If set, specifies the template used to generate the message subject.
+    In case of messages generated for multiple builds within a buildset (e.g. from within ``BuildSetStatusGenerator``), the subject of the first message will be used.
+    The ``is_buildset`` key of the context can be used to detect such case and adjust the message appropriately.
 
 ``ctx``
     This is an extension of the standard context that will be given to the templates.

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -134,8 +134,11 @@ The context that is given to the template consists of the following data:
 ``build_url``
     URL to the build in the Buildbot UI.
 
+``buildbot_title``
+    The title of the Buildbot instance as per ``c['title']`` from the ``master.cfg``
+
 ``buildbot_url``
-    URL to the Buildbot instance.
+    The URL of the Buildbot instance as per ``c['buildbotURL']`` from the ``master.cfg``
 
 ``blamelist``
     The list of users responsible for the build.

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -68,8 +68,14 @@ Context
 The context that is given to the template consists of the following data:
 
 ``results``
-    The results of the build.
+    The results of the build as an integer.
     Equivalent to ``build['results']``.
+
+``result_names``
+    A collection that allows accessing a textual identifier of build result.
+    The intended usage is ``result_names[results]``.
+
+    The following are possible values: ``success``, ``warnings``, ``failure``, ``skipped``, ``exception``, ``retry``, ``cancelled``.
 
 ``buildername``
     The name of the builder.

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -41,7 +41,7 @@ The constructor to that class takes the same arguments as MessageFormatter, minu
 The default ``ctx`` for the missing worker email is made of:
 
 ``buildbot_title``
-    The Buildbot title as per ``c['title']`` from the ``master.cfg``
+    The title of the Buildbot instance as per ``c['title']`` from the ``master.cfg``
 
 ``buildbot_url``
     The URL of the Buildbot instance as per ``c['buildbotURL']`` from the ``master.cfg``

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -44,7 +44,7 @@ The default ``ctx`` for the missing worker email is made of:
     The Buildbot title as per ``c['title']`` from the ``master.cfg``
 
 ``buildbot_url``
-    The Buildbot title as per ``c['title']`` from the ``master.cfg``
+    The URL of the Buildbot instance as per ``c['buildbotURL']`` from the ``master.cfg``
 
 ``worker``
     The worker object as defined in the REST api plus two attributes:

--- a/master/docs/manual/upgrading/4.0-upgrade.rst
+++ b/master/docs/manual/upgrading/4.0-upgrade.rst
@@ -19,6 +19,12 @@ The recommended upgrade procedure is as follows:
   - (Optional) Upgrade to newest Buildbot 4.x.
     The newest point release will contain bug fixes and functionality improvements.
 
+Build status generators
+-----------------------
+
+The ``subject`` argument of ``BuildStatusGenerator`` and ``BuildSetStatusGenerator`` has been removed.
+The equivalent is setting the ``subject`` argument of the message formatter.
+
 Message formatters
 ------------------
 

--- a/newsfragments/mail-notifier-html-messages.feature
+++ b/newsfragments/mail-notifier-html-messages.feature
@@ -1,0 +1,1 @@
+``MailNotifier`` reporter now sends HTML messages by default.

--- a/newsfragments/message-formatter-buildbot-title.feature
+++ b/newsfragments/message-formatter-buildbot-title.feature
@@ -1,0 +1,1 @@
+Added ``buildbot_title`` key to the data passed to ``MessageFormatter`` instances for message rendering.

--- a/newsfragments/message-formatter-buildbot-title.feature
+++ b/newsfragments/message-formatter-buildbot-title.feature
@@ -1,1 +1,0 @@
-Added ``buildbot_title`` key to the data passed to ``MessageFormatter`` instances for message rendering.

--- a/newsfragments/message-formatter-default-subject.feature
+++ b/newsfragments/message-formatter-default-subject.feature
@@ -1,0 +1,1 @@
+``MessageFormatter`` will now use a default subject value if one is not specified.

--- a/newsfragments/message-formatter-default-template-improvements.feature
+++ b/newsfragments/message-formatter-default-template-improvements.feature
@@ -1,0 +1,2 @@
+The default templates used in message formatters have been improved to supply more information.
+Separate default templates for html messages have been provided.

--- a/newsfragments/message-formatter-keys.feature
+++ b/newsfragments/message-formatter-keys.feature
@@ -1,1 +1,1 @@
-Added ``buildbot_title`` and ``result_names`` keys to the data passed to ``MessageFormatter`` instances for message rendering.
+Added ``buildbot_title``, ``result_names`` and ``is_buildset`` keys to the data passed to ``MessageFormatter`` instances for message rendering.

--- a/newsfragments/message-formatter-keys.feature
+++ b/newsfragments/message-formatter-keys.feature
@@ -1,0 +1,1 @@
+Added ``buildbot_title`` and ``result_names`` keys to the data passed to ``MessageFormatter`` instances for message rendering.

--- a/newsfragments/status-generator-subject.removal
+++ b/newsfragments/status-generator-subject.removal
@@ -1,0 +1,2 @@
+Deprecated ``subject`` argument of ``BuildStatusGenerator`` and ``BuildSetStatusGenerator`` status generators.
+Use ``subject`` argument of corresponding message formatters.


### PR DESCRIPTION
This implements several improvements into the reporter infrastructure:

 - Deprecated ``subject`` argument of ``BuildStatusGenerator`` and ``BuildSetStatusGenerator`` status generators.
Use ``subject`` argument of corresponding message formatters.

 - Added ``buildbot_title``, ``result_names`` and ``is_buildset`` keys to the data passed to ``MessageFormatter`` instances for message rendering.
 
 - The default templates used in message formatters have been improved to supply more information. Separate default templates for html messages have been provided.

 - ``MessageFormatter`` will now use a default subject value if one is not specified.
 
 - ``MailNotifier`` reporter now sends HTML messages by default.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
