### PR TITLE
util: Improve error messages when services fail to be reconfigured

### DIFF
--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -529,3 +529,8 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
                 yield svc.disownServiceParent()
                 config_sibling.objectid = svc.objectid
                 yield config_sibling.setServiceParent(self)
+            except Exception as e:  # pragma: no cover
+                log.err(e, f'Got exception while reconfiguring {self} child service {svc.name}:\n'
+                        'current config dict:\n{svc.getConfigDict()}\n'
+                        'new config dict:\n{config_sibling.getConfigDict()}')
+                raise


### PR DESCRIPTION
This will make issues like https://github.com/buildbot/buildbot/issues/6341 easier to debug.