### PR TITLE
gerritchangesource: Strip refs/heads from branch names

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -204,6 +204,11 @@ class GerritChangeSourceBase(base.ChangeSource, PullRequestMixin):
             return event["patchSet"]["ref"]
         return event["change"]["branch"]
 
+    def strip_refs_heads_from_branch(self, branch):
+        if branch.startswith('refs/heads/'):
+            branch = branch[len('refs/heads/'):]
+        return branch
+
     @defer.inlineCallbacks
     def addChangeFromEvent(self, properties, event):
         if "change" not in event:
@@ -259,7 +264,7 @@ class GerritChangeSourceBase(base.ChangeSource, PullRequestMixin):
             author=author,
             project=ref["project"],
             repository="{}/{}".format(self.gitBaseURL, ref["project"]),
-            branch=ref["refName"],
+            branch=self.strip_refs_heads_from_branch(ref["refName"]),
             revision=ref["newRev"],
             comments="Gerrit: commit(s) pushed.",
             files=["unknown"],

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -354,7 +354,7 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
             'committer': None,
             'revision': '56785678',
             'when_timestamp': None,
-            'branch': 'refs/heads/master',
+            'branch': 'master',
             'category': 'ref-updated',
             'revlink': '',
             'properties': {

--- a/newsfragments/gerrit-branch-name.bugfix
+++ b/newsfragments/gerrit-branch-name.bugfix
@@ -1,0 +1,1 @@
+Fixed Gerrit change sources to emit changes with proper branch name instead of one containing "refs/heads/" as the prefix.


### PR DESCRIPTION
Changes should have correct branch name and not e.g. refs/heads/master because this is expected by other components of Buildbot. For example before this commit Nightly schedulers didn't work on the changes emitted by Gerrit change sources.
