### PR TITLE
schedulers: Warn when change filters expect refs/heads/<branch> from Gerrit

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+import copy
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
@@ -24,6 +26,7 @@ from buildbot.changes import changes
 from buildbot.process.properties import Properties
 from buildbot.util.service import ClusteredBuildbotService
 from buildbot.util.state import StateMixin
+from buildbot.warnings import warn_deprecated
 
 
 @implementer(interfaces.IScheduler)
@@ -194,8 +197,36 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         change = yield changes.Change.fromChdict(self.master, chdict)
 
         # filter it
-        if change_filter and not change_filter.filter_change(change):
-            return
+        if change_filter:
+            # There has been a change in how Gerrit handles branches in Buildbot 3.5 - ref-updated
+            # events will now emit proper branch instead of refs/heads/<branch>. Below we detect
+            # whether this breaks change filters.
+            change_filter_may_be_broken = \
+                change.category == 'ref-updated' and not change.branch.startswith('refs/')
+
+            if change_filter_may_be_broken:
+                old_change = copy.deepcopy(change)
+                old_change.branch = f'refs/heads/{old_change.branch}'
+
+                old_filter_result = change_filter.filter_change(old_change)
+                new_filter_result = change_filter.filter_change(change)
+
+                if old_filter_result != new_filter_result and \
+                        'refs/heads/' in repr(change_filter.checks['branch']):
+
+                    warn_deprecated('3.5.0',
+                                    'Change filters must not expect ref-updated events from '
+                                    'Gerrit to include refs/heads prefix for the branch attr.')
+
+                    if not old_filter_result:
+                        return
+                else:
+                    if not new_filter_result:
+                        return
+            else:
+                if not change_filter.filter_change(change):
+                    return
+
         if change.codebase not in self.codebases:
             log.msg(format='change contains codebase %(codebase)s that is '
                     'not processed by scheduler %(name)s',

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -21,12 +21,15 @@ from twisted.trial import unittest
 
 from buildbot import config
 from buildbot.changes import changes
+from buildbot.changes import filter
 from buildbot.process import properties
 from buildbot.process.properties import Interpolate
 from buildbot.schedulers import base
 from buildbot.test import fakedb
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
@@ -145,7 +148,10 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
         self.assertEqual(sched.enabled, expectedValue)
 
     @defer.inlineCallbacks
-    def do_test_change_consumption(self, kwargs, expected_result):
+    def do_test_change_consumption(self, kwargs, expected_result, change_kwargs=None):
+        if change_kwargs is None:
+            change_kwargs = {}
+
         # (expected_result should be True (important), False (unimportant), or
         # None (ignore the change))
         sched = self.makeScheduler()
@@ -163,7 +169,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
             return defer.succeed(chdict)
         self.db.changes.getChange = getChange
 
-        change = self.makeFakeChange()
+        change = self.makeFakeChange(**change_kwargs)
         change.number = 12934
 
         def fromChdict(cls, master, chdict):
@@ -229,6 +235,63 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
         return self.do_test_change_consumption(
             dict(change_filter=cf),
             None)
+
+    def test_change_consumption_change_filter_gerrit_ref_updates(self):
+        cf = mock.Mock()
+        cf.filter_change = lambda c: False
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            None,
+            change_kwargs={'category': 'ref-updated', 'branch': 'master'})
+
+    def test_change_consumption_change_filter_gerrit_ref_updates_with_refs(self):
+        cf = mock.Mock()
+        cf.filter_change = lambda c: False
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            None,
+            change_kwargs={'category': 'ref-updated', 'branch': 'refs/changes/123'})
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning,
+                                   "Change filters must not expect ref-updated events"):
+            cf = filter.ChangeFilter(branch='refs/heads/master')
+            return self.do_test_change_consumption(
+                {'change_filter': cf},
+                True,
+                change_kwargs={'category': 'ref-updated', 'branch': 'master'})
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_re_deprecated(self):
+        with assertProducesWarning(DeprecatedApiWarning,
+                                   "Change filters must not expect ref-updated events"):
+            cf = filter.ChangeFilter(branch_re='refs/heads/master')
+            return self.do_test_change_consumption(
+                {'change_filter': cf},
+                True,
+                change_kwargs={'category': 'ref-updated', 'branch': 'master'})
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_re_deprecated_no_match(self):
+        with assertProducesWarning(DeprecatedApiWarning,
+                                   "Change filters must not expect ref-updated events"):
+            cf = filter.ChangeFilter(branch_re='(refs/heads/other|master)')
+            return self.do_test_change_consumption(
+                {'change_filter': cf},
+                None,
+                change_kwargs={'category': 'ref-updated', 'branch': 'master'})
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_new(self):
+        cf = filter.ChangeFilter(branch='master')
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            True,
+            change_kwargs={'category': 'ref-updated', 'branch': 'master'})
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_new_not_match(self):
+        cf = filter.ChangeFilter(branch='other')
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            None,
+            change_kwargs={'category': 'ref-updated', 'branch': 'master'})
 
     def test_change_consumption_fileIsImportant_False_onlyImportant(self):
         return self.do_test_change_consumption(


### PR DESCRIPTION
This ensures that for most simple cases ded6c4edbf20f8610922cee58dd157dbdd86deb5 will not break user configs.

cc @tardyp This addresses your comment on https://github.com/buildbot/buildbot/pull/6356.
