### PR TITLE
codecov: Add configuration to wait until all reports are uploaded

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    # 1 ci/coverage build from Buildbot
+    # 3 Appveyor builds
+    # 6 Github Actions DB builds
+    after_n_builds: 10
+    wait_for_ci: yes


### PR DESCRIPTION
Unstable codecov reports are very annoying because it makes unclear what are the actual coverage changes. Then we waste a lot of time figuring out whether coverage failure was real or not. Adding codecov.yml with additional settings will probably fix the issue.