### PR TITLE
codecov: Re-add default parts of the config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,21 @@ codecov:
     # 6 Github Actions DB builds
     after_n_builds: 10
     wait_for_ci: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Turns out codecov.yml overrides default config instead of merging with it.

Fixes https://github.com/buildbot/buildbot/pull/6358.