### PR TITLE
Use separate pylint configuration for worker

### DIFF
--- a/common/pylintrc_worker
+++ b/common/pylintrc_worker
@@ -1,0 +1,399 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+
+[MESSAGES CONTROL]
+
+# For now disable bunch of checks that does not pass. Some of them should be
+# re-enabled and reported issues fixed, while most are bugs in pylint and could
+# be re-enabled when those are fixed.
+
+# Following are the checks we don't care about, and thus should remain disabled
+#
+# blacklisted-name
+# missing-docstring
+# too-many-lines
+# no-self-use
+# duplicate-code
+# too-many-ancestors
+# too-many-instance-attributes
+# too-few-public-methods
+# too-many-public-methods
+# too-many-return-statements
+# too-many-branches
+# too-many-arguments
+# too-many-locals
+# too-many-statements
+# abstract-class-not-used
+# abstract-class-little-used
+# exec-used
+# star-args
+# deprecated-module
+# fixme
+# global-variable-undefined
+# unused-argument
+# unpacking-non-sequence
+# maybe-no-member
+
+# "bad-continuation" disabled due to conflict with flake8 (and PEP8)
+# See <https://github.com/PyCQA/pylint/issues/747>
+# flake8 wants:
+#     func("..."
+#          )
+# pylint wants:
+#     func("..."
+#         )
+
+disable=
+  blacklisted-name,
+  invalid-name,
+  missing-docstring,
+  too-many-lines,
+  no-self-use,
+  duplicate-code,
+  too-many-ancestors,
+  too-many-instance-attributes,
+  too-few-public-methods,
+  too-many-public-methods,
+  too-many-return-statements,
+  too-many-branches,
+  too-many-arguments,
+  too-many-locals,
+  too-many-statements,
+  abstract-class-not-used,
+  abstract-class-little-used,
+  deprecated-module,
+  fixme,
+  global-variable-undefined,
+  unused-argument,
+  maybe-no-member,
+  locally-disabled,
+  bad-classmethod-argument,
+  method-hidden,
+  no-name-in-module,
+  no-member,
+  not-callable,
+  too-many-function-args,
+  unexpected-keyword-arg,
+  redundant-keyword-arg,
+  import-error,
+  import-outside-toplevel,
+  exec-used,
+  star-args,
+  unreachable,
+  dangerous-default-value,
+  pointless-statement,
+  pointless-string-statement,
+  expression-not-assigned,
+  useless-else-on-loop,
+  bad-builtin,
+  attribute-defined-outside-init,
+  protected-access,
+  arguments-differ,
+  signature-differs,
+  abstract-method,
+  super-init-not-called,
+  no-init,
+  non-parent-init-called,
+  bad-indentation,
+  global-statement,
+  unused-variable,
+  redefined-outer-name,
+  redefined-builtin,
+  unidiomatic-typecheck,
+  undefined-loop-variable,
+  unbalanced-tuple-unpacking,
+  broad-except,
+  bad-open-mode,
+  superfluous-parens,
+  no-self-argument,
+  no-value-for-parameter,
+  interface-not-implemented,
+  bad-continuation,
+  keyword-arg-before-vararg,
+  unsubscriptable-object,
+  useless-object-inheritance,
+  deprecated-method,
+  useless-return,
+  no-else-return,
+  assignment-from-none,
+  comparison-with-callable,
+  comparison-with-itself,
+  assignment-from-no-return,
+  stop-iteration-return,
+  old-style-class,
+  redefined-variable-type,
+  deprecated-lambda,
+  bad-string-format-type, # https://github.com/PyCQA/pylint/issues/2631
+  duplicate-string-formatting-argument,
+  cyclic-import,  # only happens when pylint is ran in non-parallel mode
+  wrong-import-order, # we use isort for import orders
+  raise-missing-from, # TODO: remove when we no longer have Python 2 code
+  super-with-arguments, # TODO: remove when we no longer have Python 2 code
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Change the default error message template.
+msg-template={path}:{line} {msg} [{symbol}]
+
+# Include message's id in output
+include-ids=yes
+
+# Include symbolic ids of messages in output
+symbols=no
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+
+[SPELLING]
+
+# Spelling dictionary name.
+# If this value will be non-empty (e.g. 'en_US') and pyenchant will not be
+# installed, pylint will fail.
+# If this will be left empty pylint will ignore all spelling errors.
+spelling-dict=en_US
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+# Path relative to current working directory.
+spelling-private-dict-file=../common/code_spelling_ignore_words.txt
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[BASIC]
+
+# Will be removed in PyLint 2.0
+# Required attributes for module, separated by a comma
+#required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input
+
+# Regular expression which should only match correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match correct module level names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression which should only match correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match correct function names
+function-rgx=[a-z_][a-zA-Z0-9]{2,30}$
+
+# Regular expression which should only match correct method names
+method-rgx=[_]{0,2}[a-z][a-zA-Z0-9]{2,30}[_]{0,2}$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=[a-z_][a-zA-Z0-9]{2,30}$
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Regular expression which should only match functions or classes name which do
+# not require a docstring
+no-docstring-rgx=__.*__
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the beginning of the name of dummy variables
+# (i.e. not used).
+dummy-variables-rgx=_|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[CLASSES]
+
+# This option will be removed in PyLint 2.0.
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+# ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,string,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branchs=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -1,6 +1,6 @@
 # developer utilities
 pylint:
-	pylint -j4 --rcfile=../common/pylintrc --disable=super-with-arguments,raise-missing-from buildbot_worker setup.py
+	pylint -j4 --rcfile=../common/pylintrc_worker --disable=super-with-arguments,raise-missing-from buildbot_worker setup.py
 
 flake8:
 	flake8 --config=../common/flake8rc buildbot_worker setup.py


### PR DESCRIPTION
Pylint implements warnings which are only compatible with python3. Worker, though, is not able to work with python3 yet, so now it should have its own configuration file with warnings for only python2.
