### PR TITLE
Revert "Only build the Windows Service programs on Windows"

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -446,6 +446,8 @@ setup_args = {
     ]), {
         'console_scripts': [
             'buildbot=buildbot.scripts.runner:run',
+            # this will also be shipped on non windows :-(
+            'buildbot_windows_service=buildbot.scripts.windows_service:HandleCommandLine',
         ]}
     )
 }
@@ -455,9 +457,6 @@ setup_args = {
 # see http://buildbot.net/trac/ticket/907
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
-    setup_args['entry_points']['console_scripts'].append(
-        'buildbot_windows_service=buildbot.scripts.windows_service:HandleCommandLine'
-    )
 
 py_36 = sys.version_info[0] > 3 or (
     sys.version_info[0] == 3 and sys.version_info[1] >= 6)

--- a/newsfragments/fix-installation_as_windows-service.bugfix
+++ b/newsfragments/fix-installation_as_windows-service.bugfix
@@ -1,0 +1,1 @@
+Fix installation of master and worker as Windows service from wheel package. (regression since 3.4.0)  (:issue:`6294`)

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -133,6 +133,8 @@ setup_args = {
     'entry_points': {
         'console_scripts': [
             'buildbot-worker=buildbot_worker.scripts.runner:run',
+            # this will also be shipped on non windows :-(
+            'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',  # noqa pylint: disable=line-too-long
         ]}
 }
 
@@ -141,9 +143,6 @@ setup_args = {
 # see http://buildbot.net/trac/ticket/907
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
-    setup_args['entry_points']['console_scripts'].append(
-        'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',  # noqa pylint: disable=line-too-long
-    )
 
 twisted_ver = ">= 17.9.0"
 


### PR DESCRIPTION
This reverts commit b6c9ecda7fbd11e9db818d5d88e0e0f0bb32bbf4.

Fixes issue #6294

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
