### PR TITLE
bitbucket: fix PullrequestPoller: GitHub Issue 4153

### DIFF
--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -224,6 +224,10 @@ class PullRequestListRest():
 """ % s
 
     def getPage(self, url, timeout=None, headers=None):
+
+        assert isinstance(url, bytes), "url must be bytes, not unicode"
+        url = url.decode('utf-8')
+
         list_url_re = re.compile(
             r"https://bitbucket.org/api/2.0/repositories/{}/{}/pullrequests".format(self.owner,
                                                                                     self.slug))


### PR DESCRIPTION
 - BitbucketPullrequestPoller calls twisted.web.client.getPage without encoding
   the url to bytes.  This fix copies adds a BitbucketPullrequestPoller.getPage
   method that optionally encodes the url before calling client.getPage.
 - test_bitbucket.py has been updated with the fake client.getPage also checking
   that the url argument is a bytes object rather than string.
 - fixed URL to Bitbucket API. All external requests should be directoed to
   api.bitbucket.org

## Contributor Checklist:

* [Y] I have updated the unit tests
* [N] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N] I have updated the appropriate documentation
