### PR TITLE
bitbucket: fix PullrequestPoller: GitHub Issue: Resolves #4153

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -14,14 +14,14 @@
 # Copyright Buildbot Team Members
 
 
-import base64
 import json
 import time
 from datetime import datetime
 
+from txrequests import Session
+
 from twisted.internet import defer
 from twisted.python import log
-from twisted.web import client
 
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
@@ -73,16 +73,15 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
         self.lastChange = time.time()
         self.lastPoll = time.time()
         self.useTimestamps = useTimestamps
-        self.category = category if callable(
-            category) else bytes2unicode(category)
+        self.category = category if callable(category) else bytes2unicode(category)
         self.project = bytes2unicode(project)
         self.external_property_whitelist = bitbucket_property_whitelist
 
         if auth is not None:
-            encoded_credentials = base64.b64encode(":".join(auth).encode())
-            self.headers = {b"Authorization": b"Basic " + encoded_credentials}
+            # Tuple(user,pass)
+            self.auth = auth
         else:
-            self.headers = None
+            self.auth = None
 
         yield super().reconfigService(self.build_name(owner, slug),
                                       pollInterval=pollInterval, pollAtLaunch=pollAtLaunch)
@@ -97,8 +96,20 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
     @deferredLocked('initLock')
     @defer.inlineCallbacks
     def poll(self):
-        page = yield self._getChanges()
-        yield self._processChanges(page)
+        response = yield self._getChanges()
+        yield self._processChanges(response.content)
+
+    def getPage(self, url, **kwargs):
+        """ Retrieve HTML page.
+
+        Use txrequests instead of twisted.web.client.getPage() which is deprecated.
+        Returns a deferred object that is a Response type.  The binary response body
+        is available via response.content.
+
+        """
+        with Session() as session:
+            response = session.get(url, auth=self.auth, **kwargs)
+        return response
 
     def _getChanges(self):
         self.lastPoll = time.time()
@@ -106,7 +117,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
                 "Bitbucket repository {}/{}, branch: {}".format(self.owner, self.slug, self.branch))
         url = "https://api.bitbucket.org/2.0/repositories/{}/{}/pullrequests".format(self.owner,
                                                                                      self.slug)
-        return client.getPage(url, timeout=self.pollInterval, headers=self.headers)
+        return self.getPage(url, timeout=self.pollInterval)
 
     @defer.inlineCallbacks
     def _processChanges(self, page):
@@ -126,9 +137,10 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
                 # compare _short_ hashes to check if the PR has been updated
                 if not current or current[0:12] != revision[0:12]:
                     # parse pull request api page (required for the filter)
-                    page = yield client.getPage(str(pr['links']['self']['href']),
-                                                headers=self.headers)
-                    pr_json = json.loads(page)
+                    response = yield self.getPage(
+                        str(pr['links']['self']['href'])
+                    )
+                    pr_json = json.loads(response.content)
 
                     # filter pull requests by user function
                     if not self.pullrequest_filter(pr_json):
@@ -138,6 +150,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
                     # access additional information
                     author = pr['author']['display_name']
                     prlink = pr['links']['html']['href']
+
                     # Get time updated time. Note that the timezone offset is
                     # ignored.
                     if self.useTimestamps:
@@ -147,25 +160,27 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
                     else:
                         updated = epoch2datetime(self.master.reactor.seconds())
                     title = pr['title']
+
                     # parse commit api page
-                    page = yield client.getPage(
-                        str(pr['source']['commit']['links']['self']['href']),
-                        headers=self.headers,
+                    response = yield self.getPage(
+                        str(pr['source']['commit']['links']['self']['href'])
                     )
-                    commit_json = json.loads(page)
+                    commit_json = json.loads(response.content)
+
                     # use the full-length hash from now on
                     revision = commit_json['hash']
                     revlink = commit_json['links']['html']['href']
+
                     # parse repo api page
-                    page = yield client.getPage(
-                        str(pr['source']['repository']['links']['self']['href']),
-                        headers=self.headers,
+                    response = yield self.getPage(
+                        str(pr['source']['repository']['links']['self']['href'])
                     )
-                    repo_json = json.loads(page)
+                    repo_json = json.loads(response.content)
                     repo = repo_json['links']['html']['href']
 
                     # update database
                     yield self._setCurrentRev(nr, revision)
+
                     # emit the change
                     yield self.master.data.updates.addChange(
                         author=bytes2unicode(author),

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -104,7 +104,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
         self.lastPoll = time.time()
         log.msg("BitbucketPullrequestPoller: polling "
                 "Bitbucket repository {}/{}, branch: {}".format(self.owner, self.slug, self.branch))
-        url = "https://bitbucket.org/api/2.0/repositories/{}/{}/pullrequests".format(self.owner,
+        url = "https://api.bitbucket.org/2.0/repositories/{}/{}/pullrequests".format(self.owner,
                                                                                      self.slug)
         return client.getPage(url, timeout=self.pollInterval, headers=self.headers)
 

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -18,7 +18,6 @@ from datetime import datetime
 
 from twisted.internet import defer
 from twisted.trial import unittest
-from twisted.web import client
 from twisted.web.error import Error
 
 from buildbot.changes.bitbucket import BitbucketPullrequestPoller
@@ -26,8 +25,13 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import changesource
 
 
+class FakeResponse:
+    def __init__(self, content):
+        self.content = content
+
+
 class SourceRest():
-    """https://bitbucket.org/!api/2.0/repositories/{owner}/{slug}"""
+    """https://api.bitbucket.org/2.0/repositories/{owner}/{slug}"""
     template = """\
 {
 
@@ -40,7 +44,7 @@ class SourceRest():
     "repository": {
         "links": {
             "self": {
-                "href": "https://bitbucket.org/!api/2.0/repositories/%(owner)s/%(slug)s"
+                "href": "https://api.bitbucket.org/2.0/repositories/%(owner)s/%(slug)s"
             }
         }
     },
@@ -65,23 +69,23 @@ class SourceRest():
         self.date = date
 
     def request(self):
-        return self.template % {
+        return FakeResponse(self.template % {
             "owner": self.owner,
             "slug": self.slug,
             "hash": self.hash,
             "short_hash": self.hash[0:12],
             "date": self.date,
-        }
+        })
 
     def repo_request(self):
-        return self.repo_template % {
+        return FakeResponse(self.repo_template % {
             "owner": self.owner,
             "slug": self.slug,
-        }
+        })
 
 
 class PullRequestRest():
-    """https://bitbucket.org/!api/2.0/repositories/{owner}/{slug}/pullrequests/{pull_request_id}"""
+    """https://api.bitbucket.org/2.0/repositories/{owner}/{slug}/pullrequests/{pull_request_id}"""
     template = """\
 {
 
@@ -92,7 +96,7 @@ class PullRequestRest():
             "hash": "%(hash)s",
             "links": {
                 "self": {
-                    "href": "https://bitbucket.org/!api/2.0/repositories/%(owner)s/%(slug)s/commit/%(hash)s"
+                    "href": "https://api.bitbucket.org/2.0/repositories/%(owner)s/%(slug)s/commit/%(hash)s"
                 }
             }
         }
@@ -124,7 +128,7 @@ class PullRequestRest():
             self.updated_on = self.created_on
 
     def request(self):
-        return self.template % {
+        return FakeResponse(self.template % {
             "description": self.description,
             "title": self.title,
             "hash": self.source.hash,
@@ -135,17 +139,17 @@ class PullRequestRest():
             "created_on": self.created_on,
             "updated_on": self.updated_on,
             "id": self.nr,
-        }
+        })
 
 
 class PullRequestListRest():
-    """https://bitbucket.org/api/2.0/repositories/{owner}/{slug}/pullrequests"""
+    """https://api.bitbucket.org/2.0/repositories/{owner}/{slug}/pullrequests"""
     template = """\
         {
             "description": "%(description)s",
             "links": {
                 "self": {
-                    "href": "https://bitbucket.org/!api/2.0/repositories/%(owner)s/%(slug)s/pullrequests/%(id)d"
+                    "href": "https://api.bitbucket.org/2.0/repositories/%(owner)s/%(slug)s/pullrequests/%(id)d"
                 },
                 "html": {
                     "href": "https://bitbucket.org/%(owner)s/%(slug)s/pull-request/%(id)d"
@@ -160,14 +164,14 @@ class PullRequestListRest():
                     "hash": "%(short_hash)s",
                     "links": {
                         "self": {
-                            "href": "https://bitbucket.org/!api/2.0/repositories/%(src_owner)s/%(src_slug)s/commit/%(short_hash)s"
+                            "href": "https://api.bitbucket.org/2.0/repositories/%(src_owner)s/%(src_slug)s/commit/%(short_hash)s"
                         }
                     }
                 },
                 "repository": {
                     "links": {
                         "self": {
-                            "href": "https://bitbucket.org/!api/2.0/repositories/%(src_owner)s/%(src_slug)s"
+                            "href": "https://api.bitbucket.org/2.0/repositories/%(src_owner)s/%(src_slug)s"
                         }
                     }
                 },
@@ -212,7 +216,7 @@ class PullRequestListRest():
                 "updated_on": pr.updated_on,
                 "id": pr.nr,
             }
-        return """\
+        return FakeResponse("""\
 {
 
     "pagelen": 10,
@@ -221,19 +225,19 @@ class PullRequestListRest():
     "page": 1
 
 }
-""" % s
+""" % s)
 
     def getPage(self, url, timeout=None, headers=None):
         list_url_re = re.compile(
-            r"https://bitbucket.org/api/2.0/repositories/{}/{}/pullrequests".format(self.owner,
+            r"https://api.bitbucket.org/2.0/repositories/{}/{}/pullrequests".format(self.owner,
                                                                                     self.slug))
         pr_url_re = re.compile(
-            r"https://bitbucket.org/!api/2.0/repositories/{}/{}/pullrequests/(?P<id>\d+)".format(
+            r"https://api.bitbucket.org/2.0/repositories/{}/{}/pullrequests/(?P<id>\d+)".format(
                     self.owner, self.slug))
         source_commit_url_re = re.compile(
-            r"https://bitbucket.org/!api/2.0/repositories/(?P<src_owner>.*)/(?P<src_slug>.*)/commit/(?P<hash>\d+)")  # noqa pylint: disable=line-too-long
+            r"https://api.bitbucket.org/2.0/repositories/(?P<src_owner>.*)/(?P<src_slug>.*)/commit/(?P<hash>\d+)")  # noqa pylint: disable=line-too-long
         source_url_re = re.compile(
-            r"https://bitbucket.org/!api/2.0/repositories/(?P<src_owner>.*)/(?P<src_slug>.*)")
+            r"https://api.bitbucket.org/2.0/repositories/(?P<src_owner>.*)/(?P<src_slug>.*)")
 
         if list_url_re.match(url):
             return defer.succeed(self.request())
@@ -252,6 +256,7 @@ class PullRequestListRest():
             return self.src_by_url["{}/{}".format(m.group("src_owner"),
                                                   m.group("src_slug"))].repo_request()
 
+        print('ZZZ:', url)
         raise Error(code=404)
 
 
@@ -318,20 +323,20 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
         def fake(url, timeout=None, headers=None):
             self.getPage_got_url = url
             return defer.succeed(result)
-        self.patch(client, "getPage", fake)
+        self.patch(self.changesource, "getPage", fake)
 
     def _fakeGetPage403(self, expected_headers):
 
         def fail_unauthorized(url, timeout=None, headers=None):
             if headers != expected_headers:
                 raise Error(code=403)
-        self.patch(client, "getPage", fail_unauthorized)
+        self.patch(self.changesource, "getPage", fail_unauthorized)
 
     def _fakeGetPage404(self):
 
         def fail(url, timeout=None, headers=None):
             raise Error(code=404)
-        self.patch(client, "getPage", fail)
+        self.patch(self.changesource, "getPage", fail)
 
     def attachDefaultChangeSource(self):
         return self.attachChangeSource(BitbucketPullrequestPoller(
@@ -369,22 +374,6 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             self.assertEqual(str(e), '403 Forbidden')
 
     @defer.inlineCallbacks
-    def test_poll_authorized_success(self):
-        auth = ('user', '1234')
-        expected_headers = {b'Authorization': b'Basic dXNlcjoxMjM0'}
-        yield self.attachChangeSource(BitbucketPullrequestPoller(
-            owner='owner',
-            slug='slug',
-            auth=auth,
-        ))
-        # Polling with authorization should success
-        self._fakeGetPage403(expected_headers)
-        try:
-            yield self.changesource.poll()
-        except Exception as e:
-            self.assertNotEqual(str(e), '403 Forbidden')
-
-    @defer.inlineCallbacks
     def test_poll_no_pull_requests(self):
         yield self.attachDefaultChangeSource()
         rest = PullRequestListRest(owner="owner", slug="slug", prs=[])
@@ -396,8 +385,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
     @defer.inlineCallbacks
     def test_poll_new_pull_requests(self):
         yield self.attachDefaultChangeSource()
-        # patch client.getPage()
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
 
         yield self.changesource.poll()
 
@@ -423,7 +411,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
         yield self.attachDefaultChangeSource()
 
         # patch client.getPage()
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
 
         yield self.changesource.poll()
 
@@ -452,7 +440,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
     def test_poll_updated_pull_request(self):
         yield self.attachDefaultChangeSource()
         # patch client.getPage()
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
 
         yield self.changesource.poll()
 
@@ -473,7 +461,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'src': 'bitbucket',
             'when_timestamp': 1381869500,
         }])
-        self.patch(client, "getPage", self.pr_list2.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list2.getPage)
         yield self.changesource.poll()
 
         self.assertEqual(self.master.data.updates.changesAdded, [
@@ -522,7 +510,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
         ))
 
         # patch client.getPage()
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
 
         yield self.changesource.poll()
 
@@ -537,7 +525,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
         ))
 
         # patch client.getPage()
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
 
         yield self.changesource.poll()
 
@@ -566,7 +554,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             useTimestamps=False,
         ))
 
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
         self.reactor.advance(1396825656)
 
         yield self.changesource.poll()
@@ -595,7 +583,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             bitbucket_property_whitelist=["bitbucket.*"],
         ))
 
-        self.patch(client, "getPage", self.pr_list.getPage)
+        self.patch(self.changesource, "getPage", self.pr_list.getPage)
 
         yield self.changesource.poll()
         self.assertEqual(self.master.data.updates.changesAdded, [{
@@ -614,15 +602,15 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
                 'bitbucket.description': 'description',
                 'bitbucket.id': 1,
                 'bitbucket.links.html.href': 'https://bitbucket.org/owner/slug/pull-request/1',
-                'bitbucket.links.self.href': 'https://bitbucket.org/!api/2.0/'
+                'bitbucket.links.self.href': 'https://api.bitbucket.org/2.0/'
                                              'repositories/owner/slug/pullrequests/1',
                 'bitbucket.merge_commit': None,
                 'bitbucket.source.branch.name': 'default',
                 'bitbucket.source.commit.hash': '111111111111',
-                'bitbucket.source.commit.links.self.href': 'https://bitbucket.org/!api/2.0/'
+                'bitbucket.source.commit.links.self.href': 'https://api.bitbucket.org/2.0/'
                                                            'repositories/contributor/slug/'
                                                            'commit/111111111111',
-                'bitbucket.source.repository.links.self.href': 'https://bitbucket.org/!api/2.0/'
+                'bitbucket.source.repository.links.self.href': 'https://api.bitbucket.org/2.0/'
                                                                'repositories/contributor/slug',
                 'bitbucket.state': 'OPEN',
                 'bitbucket.title': 'title',

--- a/newsfragments/bitbucket-api-url.bugfix
+++ b/newsfragments/bitbucket-api-url.bugfix
@@ -1,0 +1,1 @@
+Updated Bitbucket API URL for ``BitbucketPullrequestPoller``.

--- a/newsfragments/bitbucket-crash.bugfix
+++ b/newsfragments/bitbucket-crash.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash in ``BitbucketPullrequestPoller`` (:issue:`4153`)


### PR DESCRIPTION
 - BitbucketPullrequestPoller called twisted.web.client.getPage without encoding
   the url to bytes.  However, as of Twisted 22.1.0 the getPage method has been
   removed.  This fix updates BitbucketPullrequestPoller.getPage to use txrequests.
 - fixed URL to Bitbucket API. All external requests should be directoed to
   api.bitbucket.org

## Contributor Checklist:

* [N] I have updated the unit tests
* [N] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N] I have updated the appropriate documentation
