### PR TITLE
bitbucket_build_status_reporter: adding basic authentication to Bitbu…

### DIFF
--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -47,7 +47,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
 
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
-            _BASE_URL,
+            _BASE_URL, auth=None,
             debug=None, verify=None)
         self.oauthhttp = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
@@ -229,7 +229,7 @@ class TestBitbucketStatusPushProperties(TestReactorMixin, unittest.TestCase,
 
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
-            _BASE_URL,
+            _BASE_URL, auth=None,
             debug=None, verify=None)
         self.oauthhttp = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
@@ -290,6 +290,13 @@ class TestBitbucketStatusPushProperties(TestReactorMixin, unittest.TestCase,
         build['complete'] = True
         build['results'] = SUCCESS
         yield self.bsp._got_event(('builds', 20, 'finished'), build)
+
+
+class TestBitbucketStatusPushConfig(ConfigErrorsMixin, unittest.TestCase):
+    def test_auth_error(self):
+        with self.assertRaisesConfigError(
+                "Either App Passwords or OAuth can be specified, not both"):
+            BitbucketStatusPush(oauth_key='abc', oauth_secret='abc1', auth=('user', 'pass'))
 
 
 class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):

--- a/master/docs/manual/configuration/reporters/bitbucket_status.rst
+++ b/master/docs/manual/configuration/reporters/bitbucket_status.rst
@@ -24,10 +24,11 @@ Give the new consumer a name, e.g. buildbot, and put in any URL as the callback 
 Give the consumer `Repositories:Write` access.
 After creating the consumer, you will then be able to see the OAuth key and secret.
 
-.. py:class:: BitbucketStatusPush(oauth_key, oauth_secret, base_url='https://api.bitbucket.org/2.0/repositories', oauth_url='https://bitbucket.org/site/oauth2/access_token', status_key=None, status_name=None, generators=None)
+.. py:class:: BitbucketStatusPush(oauth_key=None, oauth_secret=None, auth=None, base_url='https://api.bitbucket.org/2.0/repositories', oauth_url='https://bitbucket.org/site/oauth2/access_token', status_key=None, status_name=None, generators=None)
 
-    :param string oauth_key: The OAuth consumer key. (can be a :ref:`Secret`)
-    :param string oauth_secret: The OAuth consumer secret. (can be a :ref:`Secret`)
+    :param string oauth_key: The OAuth consumer key, when using OAuth to authenticate (can be a :ref:`Secret`)
+    :param string oauth_secret: The OAuth consumer secret, when using OAuth to authenticate (can be a :ref:`Secret`)
+    :param string auth: The ``username,password`` tuple if using App passwords to authenticate (can be a :ref:`Secret`)
     :param string base_url: Bitbucket's Build Status API URL
     :param string oauth_url: Bitbucket's OAuth API URL
     :param string status_key: Key that identifies a build status.

--- a/newsfragments/bitbucket-build-status-auth.feature
+++ b/newsfragments/bitbucket-build-status-auth.feature
@@ -1,0 +1,1 @@
+Implemented support for App password authentication in ``BitbucketStatusPush`` reporter.


### PR DESCRIPTION
…cket reporter

 - the BitbucketStatusPush class only had support for OAuth authentication with the
   Bitbucket API server.  This change adds support for App Passwords using the
   (username,password) tuple.


## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
