### PR TITLE
appveyor: Run tests in parallel on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
 build: false
 
 test_script:
-  - "coverage run --rcfile=common/coveragerc -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
+  - "coverage run --rcfile=common/coveragerc -m twisted.trial -j2 --reporter=text --rterrors buildbot.test buildbot_worker.test"
   - ps: |
           echo $ENV:PYTHON
           if ($env:PYTHON -imatch 'C:\\Python27') {


### PR DESCRIPTION
Appveyor free job runners support 2 threads, so it makes sense to use them as test running is frequently bound by Appveyor latency.
