### PR TITLE
Correct brackets in manual section `populate secrets in a build`

### DIFF
--- a/master/docs/manual/secretsmanagement.rst
+++ b/master/docs/manual/secretsmanagement.rst
@@ -274,14 +274,14 @@ The files will be automatically deleted at the end of the build.
 .. code-block:: python
 
         f = BuildFactory()
-        f.addSteps([list_of_step_definitions], withSecrets=[secrets_list])
+        f.addSteps([list_of_step_definitions], withSecrets=secrets_list)
 
 In both cases the secrets_list is a list of (secret path, secret value) tuples.
 
 .. code-block:: python
 
         secrets_list = [('/first/path', Interpolate('write something and %(secret:somethingmore)s')),
-                        ('/second/path', Interpolate('%(secret:othersecret)s')]
+                        ('/second/path', Interpolate('%(secret:othersecret)s'))]
 
 The Interpolate class is used to render the value during the build execution.
 

--- a/newsfragments/fix-syntax-errors-in-secret-management.doc
+++ b/newsfragments/fix-syntax-errors-in-secret-management.doc
@@ -1,0 +1,1 @@
+Fixes :issue:`6417`: Correct brackets in section `2.4.2.4 - How to populate secrets in a build`.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
  * unnecessary 
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
  * I hope i got it right, please correct me if there are improvements
* [x] I have updated the appropriate documentation