### PR TITLE
Use HTTP Basic authentication for worker in MsgPack protocol

### DIFF
--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -202,7 +202,7 @@ class RunMasterBase(unittest.TestCase):
                 proto = {"pb": {"port": "tcp:0:interface=127.0.0.1"}}
                 workerclass = worker.Worker
             if self.proto == 'msgpack':
-                proto = {"msgpack_experimental_v1": {"port": 0}}
+                proto = {"msgpack_experimental_v2": {"port": 0}}
                 workerclass = worker.Worker
             elif self.proto == 'null':
                 proto = {"null": {}}
@@ -226,7 +226,7 @@ class RunMasterBase(unittest.TestCase):
                 protocol = 'pb'
                 dispatcher = list(m.pbmanager.dispatchers.values())[0]
             else:
-                protocol = 'msgpack_experimental_v1'
+                protocol = 'msgpack_experimental_v2'
                 dispatcher = list(m.msgmanager.dispatchers.values())[0]
 
                 if sandboxed_worker_path is not None and worker_python_version == '2.7':

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -57,10 +57,10 @@ class WorkerRegistration:
                 worker_config.workername, worker_config.password,
                 global_config.protocols['pb']['port'])
 
-        if 'msgpack_experimental_v1' in global_config.protocols:
+        if 'msgpack_experimental_v2' in global_config.protocols:
             self.msgpack_reg = yield self.master.workers.msgpack.updateRegistration(
                 worker_config.workername, worker_config.password,
-                global_config.protocols['msgpack_experimental_v1']['port'])
+                global_config.protocols['msgpack_experimental_v2']['port'])
 
     def getPBPort(self):
         return self.pbReg.getPort()

--- a/master/docs/developer/master-worker-msgpack.rst
+++ b/master/docs/developer/master-worker-msgpack.rst
@@ -10,7 +10,11 @@ Messages between master and worker are sent using WebSocket protocol in both dir
 Data to be sent conceptually is a dictionary and is encoded using MessagePack.
 One such encoded dictionary corresponds to one WebSocket message.
 
-A message can be either a request or a response.
+Authentication happens during opening WebSocket handshake using standard HTTP Basic authentication.
+Worker credentials are sent in the value of the HTTP "Authorization" header.
+Master checks if the credentials match and if not - the connection is terminated.
+
+A WebSocket message can be either a request or a response.
 Request message is sent when one side wants another one to perform an action.
 Once the action is performed, the other side sends the response message back.
 A response message is mandatory for every request message.
@@ -397,50 +401,6 @@ Worker returns ``result``: ``None`` without waiting for completion of shutdown.
 
 Messages from worker to master
 ------------------------------
-
-auth
-~~~~
-
-Request
-+++++++
-
-The authentication message requests master to authenticate username and password given by the worker.
-This message must be the first message sent by worker.
-
-``seq_number``
-    Described in section :ref:`MsgPack_Request_Message`.
-
-``op``
-    Value is a string ``auth``.
-
-``username``
-    Value is a string.
-    It represents a username of a connecting worker.
-
-``password``
-    Value is a string.
-    It represents a password of a connecting worker.
-
-
-Response
-++++++++
-
-Master returns ``result``: ``True`` if authentication was successful and worker has logged to master.
-
-``op``
-    Value is a string ``response``.
-
-``seq_number``
-    Described in section :ref:`MsgPack_Response_Message`.
-
-``result``
-    Value is ``True`` when authentication succeeded, ``False`` if authentication failed.
-    If request itself failed due to reason not related to authentication, value contains the message of exception.
-
-``is_exception``
-    This key-value pair is optional.
-    If request succeeded this key-value pair is absent.
-    Otherwise, its value is a boolean ``True`` and the message of exception is specified in the value of ``result``.
 
 .. _MsgPack_Update_Message:
 

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -244,7 +244,7 @@ class Worker(WorkerBase):
 
         if protocol == 'pb':
             bot_class = BotPb
-        elif protocol == 'msgpack_experimental_v1':
+        elif protocol == 'msgpack_experimental_v2':
             if sys.version_info.major < 3:
                 raise NotImplementedError('Msgpack protocol is not supported in Python2')
             bot_class = BotMsgpack
@@ -258,6 +258,7 @@ class Worker(WorkerBase):
             keepalive = None
 
         name = unicode2bytes(name, self.bot.unicode_encoding)
+        passwd = unicode2bytes(passwd, self.bot.unicode_encoding)
 
         self.numcpus = numcpus
         self.shutdown_loop = None
@@ -272,16 +273,13 @@ class Worker(WorkerBase):
         self.allow_shutdown = allow_shutdown
 
         if protocol == 'pb':
-            passwd = unicode2bytes(passwd, self.bot.unicode_encoding)
-
             bf = self.bf = BotFactory(buildmaster_host, port, keepalive, maxdelay)
             bf.startLogin(credentials.UsernamePassword(name, passwd), client=self.bot)
-        elif protocol == 'msgpack_experimental_v1':
+        elif protocol == 'msgpack_experimental_v2':
             if connection_string is None:
                 ws_conn_string = "ws://{}:{}".format(buildmaster_host, port)
             else:
                 from urllib.parse import urlparse
-
                 parsed_url = urlparse(connection_string)
                 ws_conn_string = "ws://{}:{}".format(parsed_url.hostname, parsed_url.port)
 


### PR DESCRIPTION
This PR introduces authentication with HTTP Basic "Authorization" header.

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
