### PR TITLE
Revert accidentally left debugging line

### DIFF
--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -251,7 +251,6 @@ class PullRequestListRest():
         if m:
             return self.src_by_url[f'{m.group("src_owner")}/{m.group("src_slug")}'].repo_request()
 
-        print('ZZZ:', url)
         raise Error(code=404)
 
 


### PR DESCRIPTION
This PR removes a line for debugging which was left accidentally.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
