### PR TITLE
requirements: Fix incorrect requirement on astroid

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 appdirs==1.4.4
 asn1crypto==1.4.0
-astroid==2.9.3;
+astroid==2.9.3
 attrs==21.2.0
 autobahn==20.12.3;  python_version < "3.7"  # pyup: ignore
 autobahn==21.3.1;  python_version >= "3.7"


### PR DESCRIPTION
Looks like having a trailing semicolon confuses pip sometimes.