### PR TITLE
Split config module into several

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -80,6 +80,15 @@ def error(error, always_raise=False):
 _in_unit_tests = False
 
 
+def set_is_in_unit_tests(in_tests):
+    global _in_unit_tests
+    _in_unit_tests = in_tests
+
+
+def get_is_in_unit_tests():
+    return _in_unit_tests
+
+
 def loadConfigDict(basedir, configFileName):
     if not os.path.isdir(basedir):
         raise ConfigErrors([f"basedir '{basedir}' does not exist"])
@@ -374,7 +383,7 @@ class MasterConfig(util.ComparableMixin):
                        can_be_callable=True)
 
         if "buildbotNetUsageData" not in config_dict:
-            if _in_unit_tests:
+            if get_is_in_unit_tests():
                 self.buildbotNetUsageData = None
             else:
                 warnings.warn(

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -16,7 +16,6 @@
 
 from .builder import BuilderConfig  # noqa pylint: disable=unused-import
 from .errors import ConfigErrors  # noqa pylint: disable=unused-import
-from .errors import capture_config_errors  # noqa pylint: disable=unused-import
 from .errors import error  # noqa pylint: disable=unused-import
 from .master import FileLoader  # noqa pylint: disable=unused-import
 from .master import MasterConfig  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -17,6 +17,5 @@
 from .builder import BuilderConfig  # noqa pylint: disable=unused-import
 from .errors import ConfigErrors  # noqa pylint: disable=unused-import
 from .errors import error  # noqa pylint: disable=unused-import
-from .master import MasterConfig  # noqa pylint: disable=unused-import
 from .master import get_is_in_unit_tests  # noqa pylint: disable=unused-import
 from .master import loadConfigDict  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -21,4 +21,3 @@ from .master import FileLoader  # noqa pylint: disable=unused-import
 from .master import MasterConfig  # noqa pylint: disable=unused-import
 from .master import get_is_in_unit_tests  # noqa pylint: disable=unused-import
 from .master import loadConfigDict  # noqa pylint: disable=unused-import
-from .master import set_is_in_unit_tests  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -18,4 +18,3 @@ from .builder import BuilderConfig  # noqa pylint: disable=unused-import
 from .errors import ConfigErrors  # noqa pylint: disable=unused-import
 from .errors import error  # noqa pylint: disable=unused-import
 from .master import get_is_in_unit_tests  # noqa pylint: disable=unused-import
-from .master import loadConfigDict  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -17,7 +17,6 @@
 from .builder import BuilderConfig  # noqa pylint: disable=unused-import
 from .errors import ConfigErrors  # noqa pylint: disable=unused-import
 from .errors import error  # noqa pylint: disable=unused-import
-from .master import FileLoader  # noqa pylint: disable=unused-import
 from .master import MasterConfig  # noqa pylint: disable=unused-import
 from .master import get_is_in_unit_tests  # noqa pylint: disable=unused-import
 from .master import loadConfigDict  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -17,4 +17,3 @@
 from .builder import BuilderConfig  # noqa pylint: disable=unused-import
 from .errors import ConfigErrors  # noqa pylint: disable=unused-import
 from .errors import error  # noqa pylint: disable=unused-import
-from .master import get_is_in_unit_tests  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/__init__.py
+++ b/master/buildbot/config/__init__.py
@@ -1,0 +1,25 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from .builder import BuilderConfig  # noqa pylint: disable=unused-import
+from .errors import ConfigErrors  # noqa pylint: disable=unused-import
+from .errors import capture_config_errors  # noqa pylint: disable=unused-import
+from .errors import error  # noqa pylint: disable=unused-import
+from .master import FileLoader  # noqa pylint: disable=unused-import
+from .master import MasterConfig  # noqa pylint: disable=unused-import
+from .master import get_is_in_unit_tests  # noqa pylint: disable=unused-import
+from .master import loadConfigDict  # noqa pylint: disable=unused-import
+from .master import set_is_in_unit_tests  # noqa pylint: disable=unused-import

--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -1,0 +1,147 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from buildbot.config.errors import error
+from buildbot.util import bytes2unicode
+from buildbot.util import config as util_config
+from buildbot.util import safeTranslate
+
+RESERVED_UNDERSCORE_NAMES = ["__Janitor"]
+
+
+class BuilderConfig(util_config.ConfiguredMixin):
+
+    def __init__(self, name=None, workername=None, workernames=None,
+                 builddir=None, workerbuilddir=None, factory=None,
+                 tags=None,
+                 nextWorker=None, nextBuild=None, locks=None, env=None,
+                 properties=None, collapseRequests=None, description=None,
+                 canStartBuild=None, defaultProperties=None
+                 ):
+        # name is required, and can't start with '_'
+        if not name or type(name) not in (bytes, str):
+            error("builder's name is required")
+            name = '<unknown>'
+        elif name[0] == '_' and name not in RESERVED_UNDERSCORE_NAMES:
+            error(f"builder names must not start with an underscore: '{name}'")
+        try:
+            self.name = bytes2unicode(name, encoding="ascii")
+        except UnicodeDecodeError:
+            error("builder names must be unicode or ASCII")
+
+        # factory is required
+        if factory is None:
+            error(f"builder '{name}' has no factory")
+        from buildbot.process.factory import BuildFactory
+        if factory is not None and not isinstance(factory, BuildFactory):
+            error(f"builder '{name}'s factory is not a BuildFactory instance")
+        self.factory = factory
+
+        # workernames can be a single worker name or a list, and should also
+        # include workername, if given
+        if isinstance(workernames, str):
+            workernames = [workernames]
+        if workernames:
+            if not isinstance(workernames, list):
+                error(f"builder '{name}': workernames must be a list or a string")
+        else:
+            workernames = []
+
+        if workername:
+            if not isinstance(workername, str):
+                error(f"builder '{name}': workername must be a string but it is {repr(workername)}")
+            workernames = workernames + [workername]
+        if not workernames:
+            error(f"builder '{name}': at least one workername is required")
+
+        self.workernames = workernames
+
+        # builddir defaults to name
+        if builddir is None:
+            builddir = safeTranslate(name)
+            builddir = bytes2unicode(builddir)
+        self.builddir = builddir
+
+        # workerbuilddir defaults to builddir
+        if workerbuilddir is None:
+            workerbuilddir = builddir
+        self.workerbuilddir = workerbuilddir
+
+        # remainder are optional
+        if tags:
+            if not isinstance(tags, list):
+                error(f"builder '{name}': tags must be a list")
+            bad_tags = any((tag for tag in tags if not isinstance(tag, str)))
+            if bad_tags:
+                error(f"builder '{name}': tags list contains something that is not a string")
+
+            if len(tags) != len(set(tags)):
+                dupes = " ".join({x for x in tags if tags.count(x) > 1})
+                error(f"builder '{name}': tags list contains duplicate tags: {dupes}")
+        else:
+            tags = []
+
+        self.tags = tags
+
+        self.nextWorker = nextWorker
+        if nextWorker and not callable(nextWorker):
+            error('nextWorker must be a callable')
+        self.nextBuild = nextBuild
+        if nextBuild and not callable(nextBuild):
+            error('nextBuild must be a callable')
+        self.canStartBuild = canStartBuild
+        if canStartBuild and not callable(canStartBuild):
+            error('canStartBuild must be a callable')
+
+        self.locks = locks or []
+        self.env = env or {}
+        if not isinstance(self.env, dict):
+            error("builder's env must be a dictionary")
+        self.properties = properties or {}
+        self.defaultProperties = defaultProperties or {}
+        self.collapseRequests = collapseRequests
+
+        self.description = description
+
+    def getConfigDict(self):
+        # note: this method will disappear eventually - put your smarts in the
+        # constructor!
+        rv = {
+            'name': self.name,
+            'workernames': self.workernames,
+            'factory': self.factory,
+            'builddir': self.builddir,
+            'workerbuilddir': self.workerbuilddir,
+        }
+        if self.tags:
+            rv['tags'] = self.tags
+        if self.nextWorker:
+            rv['nextWorker'] = self.nextWorker
+        if self.nextBuild:
+            rv['nextBuild'] = self.nextBuild
+        if self.locks:
+            rv['locks'] = self.locks
+        if self.env:
+            rv['env'] = self.env
+        if self.properties:
+            rv['properties'] = self.properties
+        if self.defaultProperties:
+            rv['defaultProperties'] = self.defaultProperties
+        if self.collapseRequests is not None:
+            rv['collapseRequests'] = self.collapseRequests
+        if self.description:
+            rv['description'] = self.description
+        return rv

--- a/master/buildbot/config/errors.py
+++ b/master/buildbot/config/errors.py
@@ -1,0 +1,63 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import contextlib
+
+
+class ConfigErrors(Exception):
+
+    def __init__(self, errors=None):
+        if errors is None:
+            errors = []
+        self.errors = errors[:]
+
+    def __str__(self):
+        return "\n".join(self.errors)
+
+    def addError(self, msg):
+        self.errors.append(msg)
+
+    def merge(self, errors):
+        self.errors.extend(errors.errors)
+
+    def __bool__(self):
+        return bool(len(self.errors))
+
+
+_errors = None
+
+
+def error(error, always_raise=False):
+    if _errors is not None and not always_raise:
+        _errors.addError(error)
+    else:
+        raise ConfigErrors([error])
+
+
+@contextlib.contextmanager
+def capture_config_errors(raise_on_error=False):
+    global _errors
+    prev_errors = _errors
+    _errors = errors = ConfigErrors()
+    try:
+        yield errors
+    except ConfigErrors as e:
+        errors.merge(e)
+    finally:
+        _errors = prev_errors
+
+    if raise_on_error and errors:
+        raise errors

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import contextlib
 import datetime
 import os
 import re
@@ -29,70 +28,21 @@ from zope.interface import implementer
 from buildbot import interfaces
 from buildbot import locks
 from buildbot import util
+from buildbot.config.builder import BuilderConfig
+from buildbot.config.errors import ConfigErrors
+from buildbot.config.errors import capture_config_errors
+from buildbot.config.errors import error
 from buildbot.interfaces import IRenderable
 from buildbot.revlinks import default_revlink_matcher
 from buildbot.util import ComparableMixin
-from buildbot.util import bytes2unicode
-from buildbot.util import config as util_config
 from buildbot.util import identifiers as util_identifiers
-from buildbot.util import safeTranslate
 from buildbot.util import service as util_service
 from buildbot.warnings import ConfigWarning
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www.authz import authz
 
-
-class ConfigErrors(Exception):
-
-    def __init__(self, errors=None):
-        if errors is None:
-            errors = []
-        self.errors = errors[:]
-
-    def __str__(self):
-        return "\n".join(self.errors)
-
-    def addError(self, msg):
-        self.errors.append(msg)
-
-    def merge(self, errors):
-        self.errors.extend(errors.errors)
-
-    def __bool__(self):
-        return bool(len(self.errors))
-
-
-_errors = None
-
-
 DEFAULT_DB_URL = 'sqlite:///state.sqlite'
-
-RESERVED_UNDERSCORE_NAMES = ["__Janitor"]
-
-
-def error(error, always_raise=False):
-    if _errors is not None and not always_raise:
-        _errors.addError(error)
-    else:
-        raise ConfigErrors([error])
-
-
-@contextlib.contextmanager
-def capture_config_errors(raise_on_error=False):
-    global _errors
-    prev_errors = _errors
-    _errors = errors = ConfigErrors()
-    try:
-        yield errors
-    except ConfigErrors as e:
-        errors.merge(e)
-    finally:
-        _errors = prev_errors
-
-    if raise_on_error and errors:
-        raise errors
-
 
 _in_unit_tests = False
 
@@ -902,128 +852,3 @@ class MasterConfig(util.ComparableMixin):
         for w in self.workers:
             if w.machine_name is not None and w.machine_name not in seen_names:
                 error(f"worker '{w.name}' uses unknown machine '{w.machine_name}'")
-
-
-class BuilderConfig(util_config.ConfiguredMixin):
-
-    def __init__(self, name=None, workername=None, workernames=None,
-                 builddir=None, workerbuilddir=None, factory=None,
-                 tags=None,
-                 nextWorker=None, nextBuild=None, locks=None, env=None,
-                 properties=None, collapseRequests=None, description=None,
-                 canStartBuild=None, defaultProperties=None
-                 ):
-        # name is required, and can't start with '_'
-        if not name or type(name) not in (bytes, str):
-            error("builder's name is required")
-            name = '<unknown>'
-        elif name[0] == '_' and name not in RESERVED_UNDERSCORE_NAMES:
-            error(f"builder names must not start with an underscore: '{name}'")
-        try:
-            self.name = util.bytes2unicode(name, encoding="ascii")
-        except UnicodeDecodeError:
-            error("builder names must be unicode or ASCII")
-
-        # factory is required
-        if factory is None:
-            error(f"builder '{name}' has no factory")
-        from buildbot.process.factory import BuildFactory
-        if factory is not None and not isinstance(factory, BuildFactory):
-            error(f"builder '{name}'s factory is not a BuildFactory instance")
-        self.factory = factory
-
-        # workernames can be a single worker name or a list, and should also
-        # include workername, if given
-        if isinstance(workernames, str):
-            workernames = [workernames]
-        if workernames:
-            if not isinstance(workernames, list):
-                error(f"builder '{name}': workernames must be a list or a string")
-        else:
-            workernames = []
-
-        if workername:
-            if not isinstance(workername, str):
-                error(f"builder '{name}': workername must be a string but it is {repr(workername)}")
-            workernames = workernames + [workername]
-        if not workernames:
-            error(f"builder '{name}': at least one workername is required")
-
-        self.workernames = workernames
-
-        # builddir defaults to name
-        if builddir is None:
-            builddir = safeTranslate(name)
-            builddir = bytes2unicode(builddir)
-        self.builddir = builddir
-
-        # workerbuilddir defaults to builddir
-        if workerbuilddir is None:
-            workerbuilddir = builddir
-        self.workerbuilddir = workerbuilddir
-
-        # remainder are optional
-        if tags:
-            if not isinstance(tags, list):
-                error(f"builder '{name}': tags must be a list")
-            bad_tags = any((tag for tag in tags if not isinstance(tag, str)))
-            if bad_tags:
-                error(f"builder '{name}': tags list contains something that is not a string")
-
-            if len(tags) != len(set(tags)):
-                dupes = " ".join({x for x in tags if tags.count(x) > 1})
-                error(f"builder '{name}': tags list contains duplicate tags: {dupes}")
-        else:
-            tags = []
-
-        self.tags = tags
-
-        self.nextWorker = nextWorker
-        if nextWorker and not callable(nextWorker):
-            error('nextWorker must be a callable')
-        self.nextBuild = nextBuild
-        if nextBuild and not callable(nextBuild):
-            error('nextBuild must be a callable')
-        self.canStartBuild = canStartBuild
-        if canStartBuild and not callable(canStartBuild):
-            error('canStartBuild must be a callable')
-
-        self.locks = locks or []
-        self.env = env or {}
-        if not isinstance(self.env, dict):
-            error("builder's env must be a dictionary")
-        self.properties = properties or {}
-        self.defaultProperties = defaultProperties or {}
-        self.collapseRequests = collapseRequests
-
-        self.description = description
-
-    def getConfigDict(self):
-        # note: this method will disappear eventually - put your smarts in the
-        # constructor!
-        rv = {
-            'name': self.name,
-            'workernames': self.workernames,
-            'factory': self.factory,
-            'builddir': self.builddir,
-            'workerbuilddir': self.workerbuilddir,
-        }
-        if self.tags:
-            rv['tags'] = self.tags
-        if self.nextWorker:
-            rv['nextWorker'] = self.nextWorker
-        if self.nextBuild:
-            rv['nextBuild'] = self.nextBuild
-        if self.locks:
-            rv['locks'] = self.locks
-        if self.env:
-            rv['env'] = self.env
-        if self.properties:
-            rv['properties'] = self.properties
-        if self.defaultProperties:
-            rv['defaultProperties'] = self.defaultProperties
-        if self.collapseRequests is not None:
-            rv['collapseRequests'] = self.collapseRequests
-        if self.description:
-            rv['description'] = self.description
-        return rv

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -17,7 +17,7 @@
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import ProgrammingError
 
-from buildbot.config import MasterConfig
+from buildbot.config.master import MasterConfig
 from buildbot.db import enginestrategy
 from buildbot.db import model
 from buildbot.db import state

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -31,6 +31,7 @@ from buildbot import monkeypatches
 from buildbot.buildbot_net_usage_data import sendBuildbotNetUsageData
 from buildbot.changes.manager import ChangeManager
 from buildbot.config.master import FileLoader
+from buildbot.config.master import MasterConfig
 from buildbot.data import connector as dataconnector
 from buildbot.data import graphql
 from buildbot.db import connector as dbconnector
@@ -104,7 +105,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         self.configured_db_url = None
 
         # configuration / reconfiguration handling
-        self.config = config.MasterConfig()
+        self.config = MasterConfig()
         self.config_version = 0  # increased by one on each reconfig
         self.reconfig_active = False
         self.reconfig_requested = False

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -30,6 +30,7 @@ from buildbot import config
 from buildbot import monkeypatches
 from buildbot.buildbot_net_usage_data import sendBuildbotNetUsageData
 from buildbot.changes.manager import ChangeManager
+from buildbot.config.master import FileLoader
 from buildbot.data import connector as dataconnector
 from buildbot.data import graphql
 from buildbot.db import connector as dbconnector
@@ -88,7 +89,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         if config_loader is None:
             if configFileName is None:
                 configFileName = 'master.cfg'
-            config_loader = config.FileLoader(self.basedir, configFileName)
+            config_loader = FileLoader(self.basedir, configFileName)
         self.config_loader = config_loader
         self.configFileName = configFileName
 

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -81,10 +81,10 @@ def patch_decorators():
 
 @onlyOnce
 def patch_config_for_unit_tests():
-    from buildbot import config
+    from buildbot.config.master import set_is_in_unit_tests
     # by default, buildbot.config warns about not configured buildbotNetUsageData.
     # its important for users to not leak information, but unneeded and painful for tests
-    config.set_is_in_unit_tests(True)
+    set_is_in_unit_tests(True)
 
 
 @onlyOnce

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -84,7 +84,7 @@ def patch_config_for_unit_tests():
     from buildbot import config
     # by default, buildbot.config warns about not configured buildbotNetUsageData.
     # its important for users to not leak information, but unneeded and painful for tests
-    config._in_unit_tests = True
+    config.set_is_in_unit_tests(True)
 
 
 @onlyOnce

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -24,7 +24,8 @@ from contextlib import contextmanager
 from twisted.python import runtime
 from twisted.python import usage
 
-from buildbot import config as config_module
+from buildbot.config.errors import ConfigErrors
+from buildbot.config.master import FileLoader
 
 
 @contextmanager
@@ -108,9 +109,8 @@ def loadConfig(config, configFileName='master.cfg'):
         print(f"checking {configFileName}")
 
     try:
-        master_cfg = config_module.FileLoader(
-            config['basedir'], configFileName).loadConfig()
-    except config_module.ConfigErrors as e:
+        master_cfg = FileLoader(config['basedir'], configFileName).loadConfig()
+    except ConfigErrors as e:
         print("Errors loading configuration:")
 
         for msg in e.errors:

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -17,15 +17,16 @@
 import os
 import sys
 
-from buildbot import config
+from buildbot.config.errors import ConfigErrors
+from buildbot.config.master import FileLoader
 from buildbot.scripts.base import getConfigFileFromTac
 from buildbot.util import in_reactor
 
 
 def _loadConfig(basedir, configFile, quiet):
     try:
-        config.FileLoader(basedir, configFile).loadConfig()
-    except config.ConfigErrors as e:
+        FileLoader(basedir, configFile).loadConfig()
+    except ConfigErrors as e:
         if not quiet:
             print("Configuration Errors:", file=sys.stderr)
             for e in e.errors:

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -20,8 +20,8 @@ import jinja2
 from twisted.internet import defer
 from twisted.python import util
 
-from buildbot import config as config_module
 from buildbot import monkeypatches
+from buildbot.config import master as config_master
 from buildbot.master import BuildMaster
 from buildbot.util import in_reactor
 
@@ -84,7 +84,7 @@ def createDB(config, _noMonkey=False):
 
     # create a master with the default configuration, but with db_url
     # overridden
-    master_cfg = config_module.MasterConfig()
+    master_cfg = config_master.MasterConfig()
     master_cfg.db['db_url'] = config['db']
     master = BuildMaster(config['basedir'])
     master.config = master_cfg

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -93,7 +93,7 @@ class FakeMaster(service.MasterService):
         self._master_id = master_id
         self.reactor = reactor
         self.objectids = {}
-        self.config = config.MasterConfig()
+        self.config = config.master.MasterConfig()
         self.caches = FakeCaches()
         self.pbmanager = pbmanager.FakePBManager()
         self.initLock = defer.DeferredLock()

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -19,7 +19,7 @@ import os
 from twisted.python import util
 from twisted.trial import unittest
 
-from buildbot import config
+from buildbot.config.master import FileLoader
 from buildbot.scripts import runner
 from buildbot.test.util import dirs
 from buildbot.test.util.warnings import assertNotProducesWarnings
@@ -39,13 +39,13 @@ class RealConfigs(dirs.DirsMixin, unittest.TestCase):
     def test_sample_config(self):
         filename = util.sibpath(runner.__file__, 'sample.cfg')
         with assertNotProducesWarnings(DeprecatedApiWarning):
-            config.FileLoader(self.basedir, filename).loadConfig()
+            FileLoader(self.basedir, filename).loadConfig()
 
     def test_0_9_0b5_api_renamed_config(self):
         with open(self.filename, "w", encoding='utf-8') as f:
             f.write(sample_0_9_0b5_api_renamed)
         with assertNotProducesWarnings(DeprecatedApiWarning):
-            config.FileLoader(self.basedir, self.filename).loadConfig()
+            FileLoader(self.basedir, self.filename).loadConfig()
 
 
 # sample.cfg from various versions, with comments stripped.  Adjustments made

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -20,7 +20,7 @@ from twisted.python.failure import Failure
 from twisted.spread import pb
 
 from buildbot.config import BuilderConfig
-from buildbot.config import MasterConfig
+from buildbot.config.master import MasterConfig
 from buildbot.interfaces import LatentWorkerCannotSubstantiate
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled

--- a/master/buildbot/test/unit/config/test_builder.py
+++ b/master/buildbot/test/unit/config/test_builder.py
@@ -1,0 +1,220 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.trial import unittest
+
+from buildbot.config.builder import BuilderConfig
+from buildbot.process import factory
+from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.warnings import assertNotProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
+
+
+class BuilderConfigTests(ConfigErrorsMixin, unittest.TestCase):
+
+    factory = factory.BuildFactory()
+
+    # utils
+
+    def assertAttributes(self, cfg, **expected):
+        got = {
+            attr: getattr(cfg, attr)
+            for attr, exp in expected.items()}
+        self.assertEqual(got, expected)
+
+    # tests
+
+    def test_no_name(self):
+        with self.assertRaisesConfigError("builder's name is required"):
+            BuilderConfig(factory=self.factory, workernames=['a'])
+
+    def test_reserved_name(self):
+        with self.assertRaisesConfigError(
+                "builder names must not start with an underscore: '_a'"):
+            BuilderConfig(name='_a', factory=self.factory, workernames=['a'])
+
+    def test_utf8_name(self):
+        with self.assertRaisesConfigError(
+                "builder names must be unicode or ASCII"):
+            BuilderConfig(name="\N{SNOWMAN}".encode('utf-8'),
+                          factory=self.factory, workernames=['a'])
+
+    def test_no_factory(self):
+        with self.assertRaisesConfigError("builder 'a' has no factory"):
+            BuilderConfig(name='a', workernames=['a'])
+
+    def test_wrong_type_factory(self):
+        with self.assertRaisesConfigError("builder 'a's factory is not"):
+            BuilderConfig(factory=[], name='a', workernames=['a'])
+
+    def test_no_workernames(self):
+        with self.assertRaisesConfigError(
+                "builder 'a': at least one workername is required"):
+            BuilderConfig(name='a', factory=self.factory)
+
+    def test_bogus_workernames(self):
+        with self.assertRaisesConfigError(
+                "workernames must be a list or a string"):
+            BuilderConfig(name='a', workernames={1: 2}, factory=self.factory)
+
+    def test_bogus_workername(self):
+        with self.assertRaisesConfigError("workername must be a string"):
+            BuilderConfig(name='a', workername=1, factory=self.factory)
+
+    def test_tags_must_be_list(self):
+        with self.assertRaisesConfigError("tags must be a list"):
+            BuilderConfig(tags='abc', name='a', workernames=['a'], factory=self.factory)
+
+    def test_tags_must_be_list_of_str(self):
+        with self.assertRaisesConfigError(
+                "tags list contains something that is not a string"):
+            BuilderConfig(tags=['abc', 13], name='a', workernames=['a'], factory=self.factory)
+
+    def test_tags_no_tag_dupes(self):
+        with self.assertRaisesConfigError(
+                "builder 'a': tags list contains duplicate tags: abc"):
+            BuilderConfig(tags=['abc', 'bca', 'abc'], name='a', workernames=['a'],
+                          factory=self.factory)
+
+    def test_inv_nextWorker(self):
+        with self.assertRaisesConfigError("nextWorker must be a callable"):
+            BuilderConfig(nextWorker="foo", name="a", workernames=['a'], factory=self.factory)
+
+    def test_inv_nextBuild(self):
+        with self.assertRaisesConfigError("nextBuild must be a callable"):
+            BuilderConfig(nextBuild="foo", name="a", workernames=['a'], factory=self.factory)
+
+    def test_inv_canStartBuild(self):
+        with self.assertRaisesConfigError("canStartBuild must be a callable"):
+            BuilderConfig(canStartBuild="foo", name="a", workernames=['a'], factory=self.factory)
+
+    def test_inv_env(self):
+        with self.assertRaisesConfigError("builder's env must be a dictionary"):
+            BuilderConfig(env="foo", name="a", workernames=['a'], factory=self.factory)
+
+    def test_defaults(self):
+        cfg = BuilderConfig(name='a b c', workername='a', factory=self.factory)
+        self.assertIdentical(cfg.factory, self.factory)
+        self.assertAttributes(cfg,
+                              name='a b c',
+                              workernames=['a'],
+                              builddir='a_b_c',
+                              workerbuilddir='a_b_c',
+                              tags=[],
+                              nextWorker=None,
+                              locks=[],
+                              env={},
+                              properties={},
+                              collapseRequests=None,
+                              description=None)
+
+    def test_unicode_name(self):
+        cfg = BuilderConfig(name='a \N{SNOWMAN} c', workername='a', factory=self.factory)
+        self.assertIdentical(cfg.factory, self.factory)
+        self.assertAttributes(cfg,
+                              name='a \N{SNOWMAN} c')
+
+    def test_args(self):
+        cfg = BuilderConfig(name='b', workername='s1', workernames='s2', builddir='bd',
+                            workerbuilddir='wbd', factory=self.factory, tags=['c'],
+                            nextWorker=lambda: 'ns', nextBuild=lambda: 'nb', locks=['l'],
+                            env=dict(x=10), properties=dict(y=20), collapseRequests='cr',
+                            description='buzz')
+        self.assertIdentical(cfg.factory, self.factory)
+        self.assertAttributes(cfg,
+                              name='b',
+                              workernames=['s2', 's1'],
+                              builddir='bd',
+                              workerbuilddir='wbd',
+                              tags=['c'],
+                              locks=['l'],
+                              env={'x': 10},
+                              properties={'y': 20},
+                              collapseRequests='cr',
+                              description='buzz')
+
+    def test_getConfigDict(self):
+        ns = lambda: 'ns'
+        nb = lambda: 'nb'
+        cfg = BuilderConfig(name='b', workername='s1', workernames='s2', builddir='bd',
+                            workerbuilddir='wbd', factory=self.factory, tags=['c'],
+                            nextWorker=ns, nextBuild=nb, locks=['l'],
+                            env=dict(x=10), properties=dict(y=20), collapseRequests='cr',
+                            description='buzz')
+        self.assertEqual(cfg.getConfigDict(), {'builddir': 'bd',
+                                               'tags': ['c'],
+                                               'description': 'buzz',
+                                               'env': {'x': 10},
+                                               'factory': self.factory,
+                                               'locks': ['l'],
+                                               'collapseRequests': 'cr',
+                                               'name': 'b',
+                                               'nextBuild': nb,
+                                               'nextWorker': ns,
+                                               'properties': {'y': 20},
+                                               'workerbuilddir': 'wbd',
+                                               'workernames': ['s2', 's1'],
+                                               })
+
+    def test_getConfigDict_collapseRequests(self):
+        for cr in (False, lambda a, b, c: False):
+            cfg = BuilderConfig(name='b', collapseRequests=cr,
+                                factory=self.factory, workername='s1')
+            self.assertEqual(cfg.getConfigDict(), {'builddir': 'b',
+                                                   'collapseRequests': cr,
+                                                   'name': 'b',
+                                                   'workerbuilddir': 'b',
+                                                   'factory': self.factory,
+                                                   'workernames': ['s1'],
+                                                   })
+
+    def test_init_workername_keyword(self):
+        cfg = BuilderConfig(name='a b c', workername='a', factory=self.factory)
+        self.assertEqual(cfg.workernames, ['a'])
+
+    def test_init_workername_positional(self):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
+            cfg = BuilderConfig('a b c', 'a', factory=self.factory)
+
+        self.assertEqual(cfg.workernames, ['a'])
+
+    def test_init_workernames_keyword(self):
+        cfg = BuilderConfig(name='a b c', workernames=['a'], factory=self.factory)
+
+        self.assertEqual(cfg.workernames, ['a'])
+
+    def test_init_workernames_positional(self):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
+            cfg = BuilderConfig('a b c', None, ['a'], factory=self.factory)
+
+        self.assertEqual(cfg.workernames, ['a'])
+
+    def test_init_workerbuilddir_keyword(self):
+        cfg = BuilderConfig(name='a b c', workername='a', factory=self.factory,
+                            workerbuilddir="dir")
+
+        self.assertEqual(cfg.workerbuilddir, 'dir')
+
+    def test_init_workerbuilddir_positional(self):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
+            cfg = BuilderConfig('a b c', 'a', None, None, 'dir', factory=self.factory)
+
+        self.assertEqual(cfg.workerbuilddir, 'dir')
+
+    def test_init_next_worker_keyword(self):
+        f = lambda: None
+        cfg = BuilderConfig(name='a b c', workername='a', factory=self.factory, nextWorker=f)
+        self.assertEqual(cfg.nextWorker, f)

--- a/master/buildbot/test/unit/config/test_errors.py
+++ b/master/buildbot/test/unit/config/test_errors.py
@@ -1,0 +1,63 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.trial import unittest
+
+from buildbot.config.errors import ConfigErrors
+from buildbot.config.errors import capture_config_errors
+from buildbot.config.errors import error
+
+
+class ConfigErrorsTest(unittest.TestCase):
+
+    def test_constr(self):
+        ex = ConfigErrors(['a', 'b'])
+        self.assertEqual(ex.errors, ['a', 'b'])
+
+    def test_addError(self):
+        ex = ConfigErrors(['a'])
+        ex.addError('c')
+        self.assertEqual(ex.errors, ['a', 'c'])
+
+    def test_nonempty(self):
+        empty = ConfigErrors()
+        full = ConfigErrors(['a'])
+        self.assertTrue(not empty)
+        self.assertFalse(not full)
+
+    def test_error_raises(self):
+        with self.assertRaises(ConfigErrors) as e:
+            error("message")
+        self.assertEqual(e.exception.errors, ["message"])
+
+    def test_error_no_raise(self):
+        with capture_config_errors() as errors:
+            error("message")
+        self.assertEqual(errors.errors, ["message"])
+
+    def test_str(self):
+        ex = ConfigErrors()
+        self.assertEqual(str(ex), "")
+
+        ex = ConfigErrors(["a"])
+        self.assertEqual(str(ex), "a")
+
+        ex = ConfigErrors(["a", "b"])
+        self.assertEqual(str(ex), "a\nb")
+
+        ex = ConfigErrors(["a"])
+        ex.addError('c')
+        self.assertEqual(str(ex), "a\nc")

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -38,6 +38,7 @@ from buildbot import revlinks
 from buildbot import worker
 from buildbot.changes import base as changes_base
 from buildbot.config.errors import capture_config_errors
+from buildbot.config.master import FileLoader
 from buildbot.process import factory
 from buildbot.process import properties
 from buildbot.schedulers import base as schedulers_base
@@ -293,7 +294,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
                 config.error('noes too!')""")
 
         with capture_config_errors() as errors:
-            config.FileLoader(self.basedir, self.filename).loadConfig()
+            FileLoader(self.basedir, self.filename).loadConfig()
 
         self.assertEqual(errors.errors, ['oh noes!', 'noes too!',
                                          'no workers are configured',
@@ -305,7 +306,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
                 BuildmasterConfig = dict(foo=10)
                 """)
         with self.assertRaisesConfigError("Unknown BuildmasterConfig key foo"):
-            config.FileLoader(self.basedir, self.filename).loadConfig()
+            FileLoader(self.basedir, self.filename).loadConfig()
 
     def test_loadConfig_unknown_keys(self):
         self.patch_load_helpers()
@@ -314,14 +315,14 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
                 """)
         with self.assertRaisesConfigError(
                 "Unknown BuildmasterConfig keys bar, foo"):
-            config.FileLoader(self.basedir, self.filename).loadConfig()
+            FileLoader(self.basedir, self.filename).loadConfig()
 
     def test_loadConfig_success(self):
         self.patch_load_helpers()
         self.install_config_file("""\
                 BuildmasterConfig = dict()
                 """)
-        rv = config.FileLoader(self.basedir, self.filename).loadConfig()
+        rv = FileLoader(self.basedir, self.filename).loadConfig()
         self.assertIsInstance(rv, config.MasterConfig)
 
         # make sure all of the loaders and checkers are called

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -37,6 +37,7 @@ from buildbot import locks
 from buildbot import revlinks
 from buildbot import worker
 from buildbot.changes import base as changes_base
+from buildbot.config.errors import capture_config_errors
 from buildbot.process import factory
 from buildbot.process import properties
 from buildbot.schedulers import base as schedulers_base
@@ -291,7 +292,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
                 config.error('oh noes!')
                 config.error('noes too!')""")
 
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             config.FileLoader(self.basedir, self.filename).loadConfig()
 
         self.assertEqual(errors.errors, ['oh noes!', 'noes too!',
@@ -387,29 +388,29 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(**global_defaults)
 
     def test_load_global_string_param_not_string(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {"title": 10})
         self.assertConfigError(errors, 'must be a string')
 
     def test_load_global_int_param_not_int(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'changeHorizon': 'yes'})
 
         self.assertConfigError(errors, 'must be an int')
 
     def test_load_global_protocols_not_dict(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'protocols': "test"})
         self.assertConfigError(errors, "c['protocols'] must be dict")
 
     def test_load_global_protocols_key_int(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'protocols': {321: {"port": 123}}})
 
         self.assertConfigError(errors, "c['protocols'] keys must be strings")
 
     def test_load_global_protocols_value_not_dict(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'protocols': {"pb": 123}})
 
         self.assertConfigError(errors, "c['protocols']['pb'] must be a dict")
@@ -457,7 +458,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  logCompressionMethod='bz2')
 
     def test_load_global_logCompressionMethod_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'logCompressionMethod': 'foo'})
 
         self.assertConfigError(
@@ -469,7 +470,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  codebaseGenerator=func)
 
     def test_load_global_codebaseGenerator_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'codebaseGenerator': 'dummy'})
 
         self.assertConfigError(errors,
@@ -492,7 +493,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(properties=dict(x=10)), properties=exp)
 
     def test_load_global_properties_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'properties': 'yes'})
 
         self.assertConfigError(errors, "must be a dictionary")
@@ -507,7 +508,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  collapseRequests=callable)
 
     def test_load_global_collapseRequests_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'collapseRequests': 'yes'})
 
         self.assertConfigError(errors,
@@ -519,7 +520,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  prioritizeBuilders=callable)
 
     def test_load_global_prioritizeBuilders_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'prioritizeBuilders': 'yes'})
 
         self.assertConfigError(errors, "must be a callable")
@@ -541,7 +542,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  revlink=callable)
 
     def test_load_global_revlink_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'revlink': ''})
 
         self.assertConfigError(errors, "must be a callable")
@@ -554,13 +555,13 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                          ]))
 
     def test_load_validation_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_validation(self.filename, {'validation': 'plz'})
 
         self.assertConfigError(errors, "must be a dictionary")
 
     def test_load_validation_unk_keys(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_validation(self.filename, {'validation': {'users': '.*'}})
 
         self.assertConfigError(errors, "unrecognized validation key(s)")
@@ -587,7 +588,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(db=dict(db_url='abcd'))
 
     def test_load_db_unk_keys(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_db(self.filename, {'db': {'db_url': 'abcd', 'bar': 'bar'}})
 
         self.assertConfigError(errors, "unrecognized keys in")
@@ -602,13 +603,13 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(mq=dict(type='simple'))
 
     def test_load_mq_unk_type(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_mq(self.filename, {'mq': {'type': 'foo'}})
 
         self.assertConfigError(errors, "mq type 'foo' is not known")
 
     def test_load_mq_unk_keys(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_mq(self.filename, {'mq': {'bar': 'bar'}})
 
         self.assertConfigError(errors, "unrecognized keys in")
@@ -618,7 +619,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(metrics=None)
 
     def test_load_metrics_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_metrics(self.filename, {'metrics': 13})
 
         self.assertConfigError(errors, "must be a dictionary")
@@ -633,7 +634,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(caches=dict(Changes=10, Builds=15))
 
     def test_load_caches_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_caches(self.filename, {'caches': 13})
 
         self.assertConfigError(errors, "must be a dictionary")
@@ -644,7 +645,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(caches=dict(Builds=13, Changes=10))
 
     def test_load_caches_buildCacheSize_and_caches(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_caches(self.filename, {'buildCacheSize': 13, 'caches': {'builds': 11}})
 
         self.assertConfigError(errors, "cannot specify")
@@ -655,7 +656,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(caches=dict(Changes=13, Builds=15))
 
     def test_load_caches_changeCacheSize_and_caches(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_caches(self.filename, {'changeCacheSize': 13, 'caches': {'changes': 11}})
 
         self.assertConfigError(errors, "cannot specify")
@@ -669,7 +670,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         """
         Test that non-integer cache sizes are not allowed.
         """
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_caches(self.filename, {'caches': {'foo': "1"}})
 
         self.assertConfigError(errors, "value for cache size 'foo' must be an integer")
@@ -678,7 +679,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         """
         Test that cache sizes less then 1 are not allowed.
         """
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_caches(self.filename, {'caches': {'Changes': -12}})
 
         self.assertConfigError(errors, "'Changes' cache size must be at least 1, got '-12'")
@@ -688,19 +689,19 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(schedulers={})
 
     def test_load_schedulers_not_list(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_schedulers(self.filename, {'schedulers': {}})
 
         self.assertConfigError(errors, "must be a list of")
 
     def test_load_schedulers_not_instance(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_schedulers(self.filename, {'schedulers': [mock.Mock()]})
 
         self.assertConfigError(errors, "must be a list of")
 
     def test_load_schedulers_dupe(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             sch1 = FakeScheduler(name='sch')
             sch2 = FakeScheduler(name='sch')
             self.cfg.load_schedulers(self.filename, {'schedulers': [sch1, sch2]})
@@ -717,13 +718,13 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(builders=[])
 
     def test_load_builders_not_list(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_builders(self.filename, {'builders': {}})
 
         self.assertConfigError(errors, "must be a list")
 
     def test_load_builders_not_instance(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_builders(self.filename, {'builders': [mock.Mock()]})
         self.assertConfigError(errors, "is not a builder config (in c['builders']")
 
@@ -755,12 +756,12 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(workers=[])
 
     def test_load_workers_not_list(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_workers(self.filename, {'workers': {}})
         self.assertConfigError(errors, "must be a list")
 
     def test_load_workers_not_instance(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_workers(self.filename, {'workers': [mock.Mock()]})
 
         self.assertConfigError(errors, "must be a list of")
@@ -769,7 +770,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         'debug', 'change', 'status'
     ])
     def test_load_workers_reserved_names(self, worker_name):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_workers(self.filename, {'workers': [worker.Worker(worker_name, 'x')]})
 
         self.assertConfigError(errors, "is reserved")
@@ -781,20 +782,20 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         ("dot", "a.b"),
     ])
     def test_load_workers_not_identifiers(self, name, worker_name):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_workers(self.filename, {'workers': [worker.Worker(worker_name, 'x')]})
 
         self.assertConfigError(errors, "is not an identifier")
 
     def test_load_workers_too_long(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             name = "a" * 51
             self.cfg.load_workers(self.filename, {'workers': [worker.Worker(name, 'x')]})
 
         self.assertConfigError(errors, "is longer than")
 
     def test_load_workers_empty(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             name = ""
             self.cfg.load_workers(self.filename, {'workers': [worker.Worker(name, 'x')]})
             errors.errors[:] = errors.errors[1:2]  # only get necessary error
@@ -812,7 +813,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(change_sources=[])
 
     def test_load_change_sources_not_instance(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_change_sources(self.filename, {'change_source': [mock.Mock()]})
 
         self.assertConfigError(errors, "must be a list of")
@@ -834,13 +835,13 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(machines=[])
 
     def test_load_machines_not_instance(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_machines(self.filename, {'machines': [mock.Mock()]})
 
         self.assertConfigError(errors, "must be a list of")
 
     def test_load_machines_single(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             mm = FakeMachine(name='a')
             self.cfg.load_machines(self.filename, {'machines': mm})
 
@@ -857,7 +858,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(user_managers=[])
 
     def test_load_user_managers_not_list(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_user_managers(self.filename, {'user_managers': 'foo'})
 
         self.assertConfigError(errors, "must be a list")
@@ -929,7 +930,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     logfileName='http.log'))
 
     def test_load_www_versions_not_list(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             custom_versions = {
                 'Test Custom Component': '0.0.1',
                 'Test Custom Component 2': '0.0.2',
@@ -938,20 +939,20 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, 'Invalid www configuration value of versions')
 
     def test_load_www_versions_value_invalid(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             custom_versions = [('a', '1'), 'abc', ('b',)]
             self.cfg.load_www(self.filename, {'www': {'versions': custom_versions}})
 
         self.assertConfigError(errors, 'Invalid www configuration value of versions')
 
     def test_load_www_cookie_expiration_time_not_timedelta(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_www(self.filename, {'www': {"cookie_expiration_time": 1}})
 
         self.assertConfigError(errors, 'Invalid www["cookie_expiration_time"]')
 
     def test_load_www_unknown(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.load_www(self.filename, {"www": {"foo": "bar"}})
 
         self.assertConfigError(errors, "unknown www configuration parameter(s) foo")
@@ -975,7 +976,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         class MyService:
             pass
 
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             myService = MyService()
             self.cfg.load_services(self.filename, {'services': [myService]})
 
@@ -986,7 +987,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, errMsg)
 
     def test_load_services_duplicate(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             class MyService(service.BuildbotService):
                 name = 'myservice'
 
@@ -1073,14 +1074,14 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
     # tests
 
     def test_check_single_master_multimaster(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.multiMaster = True
             self.cfg.check_single_master()
 
         self.assertNoConfigErrors(errors)
 
     def test_check_single_master_no_builders(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             self.cfg.builders = []
             self.cfg.check_single_master()
@@ -1088,7 +1089,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "no builders are configured")
 
     def test_check_single_master_no_workers(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             self.cfg.workers = []
             self.cfg.check_single_master()
@@ -1096,7 +1097,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "no workers are configured")
 
     def test_check_single_master_unsch_builder(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             b3 = mock.Mock()
             b3.name = 'b3'
@@ -1106,7 +1107,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "have no schedulers to drive them")
 
     def test_check_single_master_renderable_builderNames(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             b3 = mock.Mock()
             b3.name = 'b3'
@@ -1119,7 +1120,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertNoConfigErrors(errors)
 
     def test_check_schedulers_unknown_builder(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             del self.cfg.builders[1]  # remove b2, leaving b1
 
@@ -1128,7 +1129,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "Unknown builder 'b2'")
 
     def test_check_schedulers_ignored_in_multiMaster(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             del self.cfg.builders[1]  # remove b2, leaving b1
             self.cfg.multiMaster = True
@@ -1137,7 +1138,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertNoConfigErrors(errors)
 
     def test_check_schedulers_renderable_builderNames(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             sch2 = mock.Mock()
             sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
@@ -1148,21 +1149,21 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertNoConfigErrors(errors)
 
     def test_check_schedulers(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_basic_attrs()
             self.cfg.check_schedulers()
 
         self.assertNoConfigErrors(errors)
 
     def test_check_locks_dup_builder_lock(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_builder_locks(builder_lock='l', dup_builder_lock=True)
             self.cfg.check_locks()
 
         self.assertConfigError(errors, "Two locks share")
 
     def test_check_locks(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_builder_locks(builder_lock='bl')
             self.cfg.check_locks()
 
@@ -1170,7 +1171,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
 
     def test_check_locks_none(self):
         # no locks in the whole config, should be fine
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_builder_locks()
             self.cfg.check_locks()
 
@@ -1180,14 +1181,14 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         # check_locks() should be able to handle bare lock object,
         # lock objects that are not wrapped into LockAccess() object
 
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.setup_builder_locks(builder_lock='oldlock', bare_builder_lock=True)
             self.cfg.check_locks()
 
         self.assertNoConfigErrors(errors)
 
     def test_check_builders_unknown_worker(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             wrk = mock.Mock()
             wrk.workername = 'xyz'
             self.cfg.workers = [wrk]
@@ -1199,7 +1200,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "builder 'b1' uses unknown workers 'abc'")
 
     def test_check_builders_duplicate_name(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             b1 = FakeBuilder(workernames=[], name='b1', builddir='1')
             b2 = FakeBuilder(workernames=[], name='b1', builddir='2')
             self.cfg.builders = [b1, b2]
@@ -1209,7 +1210,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "duplicate builder name 'b1'")
 
     def test_check_builders_duplicate_builddir(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             b1 = FakeBuilder(workernames=[], name='b1', builddir='dir')
             b2 = FakeBuilder(workernames=[], name='b2', builddir='dir')
             self.cfg.builders = [b1, b2]
@@ -1219,7 +1220,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "duplicate builder builddir 'dir'")
 
     def test_check_builders(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             wrk = mock.Mock()
             wrk.workername = 'a'
             self.cfg.workers = [wrk]
@@ -1233,28 +1234,28 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertNoConfigErrors(errors)
 
     def test_check_ports_protocols_set(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.protocols = {"pb": {"port": 10}}
             self.cfg.check_ports()
 
         self.assertNoConfigErrors(errors)
 
     def test_check_ports_protocols_not_set_workers(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.workers = [mock.Mock()]
             self.cfg.check_ports()
 
         self.assertConfigError(errors, "workers are configured, but c['protocols'] not")
 
     def test_check_ports_protocols_port_duplication(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.protocols = {"pb": {"port": 123}, "amp": {"port": 123}}
             self.cfg.check_ports()
 
         self.assertConfigError(errors, "Some of ports in c['protocols'] duplicated")
 
     def test_check_machines_unknown_name(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.workers = [
                 FakeWorker(name='wa', machine_name='unk')
             ]
@@ -1266,7 +1267,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, 'uses unknown machine')
 
     def test_check_machines_duplicate_name(self):
-        with config.capture_config_errors() as errors:
+        with capture_config_errors() as errors:
             self.cfg.machines = [
                 FakeMachine(name='a'),
                 FakeMachine(name='a')

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -39,6 +39,7 @@ from buildbot import worker
 from buildbot.changes import base as changes_base
 from buildbot.config.errors import capture_config_errors
 from buildbot.config.master import FileLoader
+from buildbot.config.master import loadConfigDict
 from buildbot.process import factory
 from buildbot.process import properties
 from buildbot.schedulers import base as schedulers_base
@@ -137,12 +138,12 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
     def test_loadConfig_missing_file(self):
         with self.assertRaisesConfigError(
                 re.compile("configuration file .* does not exist")):
-            config.loadConfigDict(self.basedir, self.filename)
+            loadConfigDict(self.basedir, self.filename)
 
     def test_loadConfig_missing_basedir(self):
         with self.assertRaisesConfigError(
                 re.compile("basedir .* does not exist")):
-            config.loadConfigDict(os.path.join(self.basedir, 'NO'), 'test.cfg')
+            loadConfigDict(os.path.join(self.basedir, 'NO'), 'test.cfg')
 
     def test_loadConfig_open_error(self):
         """
@@ -161,13 +162,13 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
         # check that we got the expected ConfigError exception
         with self.assertRaisesConfigError(
                 re.compile("unable to open configuration file .*: error_msg")):
-            config.loadConfigDict(self.basedir, self.filename)
+            loadConfigDict(self.basedir, self.filename)
 
     def test_loadConfig_parse_error(self):
         self.install_config_file('def x:\nbar')
         with self.assertRaisesConfigError(re.compile(
                 "encountered a SyntaxError while parsing config file:")):
-            config.loadConfigDict(self.basedir, self.filename)
+            loadConfigDict(self.basedir, self.filename)
 
     def test_loadConfig_eval_ConfigError(self):
         self.install_config_file("""\
@@ -175,7 +176,7 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
                 BuildmasterConfig = { 'multiMaster': True }
                 config.error('oh noes!')""")
         with self.assertRaisesConfigError("oh noes"):
-            config.loadConfigDict(self.basedir, self.filename)
+            loadConfigDict(self.basedir, self.filename)
 
     def test_loadConfig_eval_otherError(self):
         self.install_config_file("""\
@@ -184,7 +185,7 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
                 raise ValueError('oh noes')""")
         with self.assertRaisesConfigError(
                 "error while parsing config file: oh noes (traceback in logfile)"):
-            config.loadConfigDict(self.basedir, self.filename)
+            loadConfigDict(self.basedir, self.filename)
 
         [error] = self.flushLoggedErrors(ValueError)
         self.assertEqual(error.value.args, ("oh noes",))
@@ -193,7 +194,7 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
         self.install_config_file('x=10')
         with self.assertRaisesConfigError(
                 "does not define 'BuildmasterConfig'"):
-            config.loadConfigDict(self.basedir, self.filename)
+            loadConfigDict(self.basedir, self.filename)
 
     def test_loadConfig_with_local_import(self):
         self.install_config_file("""\
@@ -201,7 +202,7 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
                 BuildmasterConfig = dict(x=x)
                 """,
                                  {'basedir/subsidiary_module.py': "x = 10"})
-        _, rv = config.loadConfigDict(self.basedir, self.filename)
+        _, rv = loadConfigDict(self.basedir, self.filename)
         self.assertEqual(rv, {'x': 10})
 
 

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -205,7 +205,7 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
         self.assertEqual(rv, {'x': 10})
 
 
-class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
+class MasterConfigTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
@@ -220,7 +220,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
 
     def patch_load_helpers(self):
         # patch out all of the "helpers" for loadConfig with null functions
-        for n in dir(config.MasterConfig):
+        for n in dir(config.master.MasterConfig):
             if n.startswith('load_'):
                 typ = 'loader'
             elif n.startswith('check_'):
@@ -228,14 +228,14 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
             else:
                 continue
 
-            v = getattr(config.MasterConfig, n)
+            v = getattr(config.master.MasterConfig, n)
             if callable(v):
                 if typ == 'loader':
-                    self.patch(config.MasterConfig, n,
+                    self.patch(config.master.MasterConfig, n,
                                mock.Mock(side_effect=lambda filename,
                                          config_dict: None))
                 else:
-                    self.patch(config.MasterConfig, n,
+                    self.patch(config.master.MasterConfig, n,
                                mock.Mock(side_effect=lambda: None))
 
     def install_config_file(self, config_file, other_files=None):
@@ -250,7 +250,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
     # tests
 
     def test_defaults(self):
-        cfg = config.MasterConfig()
+        cfg = config.master.MasterConfig()
         expected = dict(
             # validation,
             db=dict(
@@ -277,7 +277,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
 
     def test_defaults_validation(self):
         # re's aren't comparable, but we can make sure the keys match
-        cfg = config.MasterConfig()
+        cfg = config.master.MasterConfig()
         self.assertEqual(sorted(cfg.validation.keys()),
                          sorted([
                              'branch', 'revision', 'property_name', 'property_value',
@@ -323,7 +323,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
                 BuildmasterConfig = dict()
                 """)
         rv = FileLoader(self.basedir, self.filename).loadConfig()
-        self.assertIsInstance(rv, config.MasterConfig)
+        self.assertIsInstance(rv, config.master.MasterConfig)
 
         # make sure all of the loaders and checkers are called
         self.assertTrue(rv.load_global.called)
@@ -346,7 +346,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         self.assertTrue(rv.check_machines.called)
 
     def test_preChangeGenerator(self):
-        cfg = config.MasterConfig()
+        cfg = config.master.MasterConfig()
         self.assertEqual({
             'author': None,
             'files': None,
@@ -368,7 +368,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     filename = 'test.cfg'
 
     def setUp(self):
-        self.cfg = config.MasterConfig()
+        self.cfg = config.master.MasterConfig()
 
     # utils
 
@@ -1014,7 +1014,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
 
     def setUp(self):
-        self.cfg = config.MasterConfig()
+        self.cfg = config.master.MasterConfig()
 
     # utils
 
@@ -1283,7 +1283,7 @@ class MasterConfig_old_worker_api(unittest.TestCase):
     filename = "test.cfg"
 
     def setUp(self):
-        self.cfg = config.MasterConfig()
+        self.cfg = config.master.MasterConfig()
 
     def test_workers_new_api(self):
         with assertNotProducesWarnings(DeprecatedApiWarning):

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -20,7 +20,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
+from buildbot.config.master import MasterConfig
 from buildbot.db import connector
 from buildbot.db import exceptions
 from buildbot.test.fake import fakemaster
@@ -45,7 +45,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin,
             'buildrequests', 'workers'])
 
         self.master = fakemaster.make_master(self)
-        self.master.config = config.MasterConfig()
+        self.master.config = MasterConfig()
         self.db = connector.DBConnector(os.path.abspath('basedir'))
         yield self.db.setServiceParent(self.master)
 

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -23,6 +23,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
+from buildbot.config.master import MasterConfig
 from buildbot.process import builder
 from buildbot.process import factory
 from buildbot.process.properties import Properties
@@ -79,7 +80,7 @@ class BuilderMixin:
 
         self.bldr.startService()
 
-        mastercfg = config.MasterConfig()
+        mastercfg = MasterConfig()
         mastercfg.builders = [self.builder_config]
         if not noReconfig:
             return self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
@@ -610,7 +611,7 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
         new_builder_config.description = "New"
         new_builder_config.tags = ["NewTag"]
 
-        mastercfg = config.MasterConfig()
+        mastercfg = MasterConfig()
         mastercfg.builders = [new_builder_config]
         yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
 
@@ -634,7 +635,7 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
         new_builder_config.description = new_desc
         new_builder_config.tags = new_tags
 
-        mastercfg = config.MasterConfig()
+        mastercfg = MasterConfig()
         mastercfg.builders = [new_builder_config]
 
         builder_updates = []
@@ -649,7 +650,7 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
         yield self.makeBuilder(description="Old", tags=["OldTag"])
         new_builder_config = config.BuilderConfig(**self.config_args)
 
-        mastercfg = config.MasterConfig()
+        mastercfg = MasterConfig()
         mastercfg.builders = [new_builder_config]
 
         builder_updates = []

--- a/master/buildbot/test/unit/process/test_debug.py
+++ b/master/buildbot/test/unit/process/test_debug.py
@@ -19,7 +19,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
+from buildbot.config.master import MasterConfig
 from buildbot.process import debug
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
@@ -35,7 +35,7 @@ class TestDebugServices(TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()
         self.master = mock.Mock(name='master')
-        self.config = config.MasterConfig()
+        self.config = MasterConfig()
 
     @defer.inlineCallbacks
     def test_reconfigService_manhole(self):

--- a/master/buildbot/test/unit/process/test_users_manager.py
+++ b/master/buildbot/test/unit/process/test_users_manager.py
@@ -18,7 +18,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
+from buildbot.config.master import MasterConfig
 from buildbot.process.users import manager
 from buildbot.util import service
 
@@ -34,7 +34,7 @@ class TestUserManager(unittest.TestCase):
         self.umm = manager.UserManagerManager(self.master)
         self.umm.startService()
 
-        self.config = config.MasterConfig()
+        self.config = MasterConfig()
 
     def tearDown(self):
         self.umm.stopService()

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -18,7 +18,7 @@ import json
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
+from buildbot.config.master import MasterConfig
 from buildbot.schedulers.forcesched import AnyPropertyParameter
 from buildbot.schedulers.forcesched import BaseParameter
 from buildbot.schedulers.forcesched import BooleanParameter
@@ -62,7 +62,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
             self.OBJECTID, self.SCHEDULERID,
             overrideBuildsetMethods=True,
             createBuilderDB=True)
-        sched.master.config = config.MasterConfig()
+        sched.master.config = MasterConfig()
 
         self.assertEqual(sched.name, name)
 

--- a/master/buildbot/test/unit/scripts/test_base.py
+++ b/master/buildbot/test/unit/scripts/test_base.py
@@ -23,7 +23,7 @@ from twisted.python import runtime
 from twisted.python import usage
 from twisted.trial import unittest
 
-from buildbot import config as config_module
+from buildbot.config import master as config_master
 from buildbot.scripts import base
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
@@ -394,17 +394,17 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin,
     def test_loadConfig(self):
         @classmethod
         def loadConfig(cls):
-            return config_module.MasterConfig()
-        self.patch(config_module.FileLoader, 'loadConfig', loadConfig)
+            return config_master.MasterConfig()
+        self.patch(config_master.FileLoader, 'loadConfig', loadConfig)
         cfg = base.loadConfig(mkconfig())
-        self.assertIsInstance(cfg, config_module.MasterConfig)
+        self.assertIsInstance(cfg, config_master.MasterConfig)
         self.assertInStdout('checking')
 
     def test_loadConfig_ConfigErrors(self):
         @classmethod
         def loadConfig(cls):
-            raise config_module.ConfigErrors(['oh noes'])
-        self.patch(config_module.FileLoader, 'loadConfig', loadConfig)
+            raise config_master.ConfigErrors(['oh noes'])
+        self.patch(config_master.FileLoader, 'loadConfig', loadConfig)
         cfg = base.loadConfig(mkconfig())
         self.assertIdentical(cfg, None)
         self.assertInStdout('oh noes')
@@ -413,7 +413,7 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin,
         @classmethod
         def loadConfig(cls):
             raise RuntimeError()
-        self.patch(config_module.FileLoader, 'loadConfig', loadConfig)
+        self.patch(config_master.FileLoader, 'loadConfig', loadConfig)
         cfg = base.loadConfig(mkconfig())
         self.assertIdentical(cfg, None)
         self.assertInStdout('RuntimeError')

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -22,7 +22,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config as config_module
+from buildbot.config import master as config_master
 from buildbot.db import connector
 from buildbot.db import masters
 from buildbot.db import model
@@ -61,7 +61,7 @@ class TestUpgradeMaster(dirs.DirsMixin, misc.StdoutAssertionsMixin,
 
         def loadConfig(config, configFileName='master.cfg'):
             self.calls.append('loadConfig')
-            return config_module.MasterConfig() if configOk else False
+            return config_master.MasterConfig() if configOk else False
         self.patch(base, 'loadConfig', loadConfig)
 
         def upgradeFiles(config):
@@ -69,7 +69,7 @@ class TestUpgradeMaster(dirs.DirsMixin, misc.StdoutAssertionsMixin,
         self.patch(upgrade_master, 'upgradeFiles', upgradeFiles)
 
         def upgradeDatabase(config, master_cfg):
-            self.assertIsInstance(master_cfg, config_module.MasterConfig)
+            self.assertIsInstance(master_cfg, config_master.MasterConfig)
             self.calls.append('upgradeDatabase')
         self.patch(upgrade_master, 'upgradeDatabase', upgradeDatabase)
 
@@ -193,7 +193,7 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
                    'setAllMastersActiveLongTimeAgo', setAllMastersActiveLongTimeAgo)
         yield upgrade_master.upgradeDatabase(
             mkconfig(basedir='test', quiet=True),
-            config_module.MasterConfig())
+            config_master.MasterConfig())
         setup.asset_called_with(check_version=False, verbose=False)
         upgrade.assert_called_with()
         self.assertWasQuiet()
@@ -208,7 +208,7 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
         self.patch(model.Model, 'upgrade', upgrade)
         ret = yield upgrade_master._upgradeMaster(
             mkconfig(basedir='test', quiet=True),
-            config_module.MasterConfig())
+            config_master.MasterConfig())
         self.assertEqual(ret, 1)
         self.assertIn("problem while upgrading!:\nTraceback (most recent call last):\n",
                       sys.stderr.getvalue())

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -69,7 +69,7 @@ class Tests(unittest.TestCase):
         }
 
     def test_basic(self):
-        self.patch(config, "_in_unit_tests", False)
+        self.patch(config, "get_is_in_unit_tests", lambda: False)
         with assertProducesWarning(
                 ConfigWarning,
                 message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic."):

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -69,7 +69,7 @@ class Tests(unittest.TestCase):
         }
 
     def test_basic(self):
-        self.patch(config, "get_is_in_unit_tests", lambda: False)
+        self.patch(config.master, "get_is_in_unit_tests", lambda: False)
         with assertProducesWarning(
                 ConfigWarning,
                 message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic."):
@@ -81,7 +81,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(data['plugins']['buildbot/worker/base/Worker'], 3)
         self.assertEqual(sorted(data['plugins'].keys()), sorted(
             ['buildbot/schedulers/forcesched/ForceScheduler', 'buildbot/worker/base/Worker',
-             'buildbot/steps/shell/ShellCommand', 'buildbot/config/BuilderConfig']))
+             'buildbot/steps/shell/ShellCommand', 'buildbot/config/builder/BuilderConfig']))
 
     def test_full(self):
         c = self.getBaseConfig()

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -22,6 +22,8 @@ import os
 import re
 import textwrap
 
+from parameterized import parameterized
+
 import mock
 
 from twisted.internet import defer
@@ -126,14 +128,14 @@ class ConfigErrors(unittest.TestCase):
         self.assertFalse(not full)
 
     def test_error_raises(self):
-        e = self.assertRaises(config.ConfigErrors, config.error, "message")
-        self.assertEqual(e.errors, ["message"])
+        with self.assertRaises(config.ConfigErrors) as e:
+            config.error("message")
+        self.assertEqual(e.exception.errors, ["message"])
 
     def test_error_no_raise(self):
-        e = config.ConfigErrors()
-        self.patch(config, "_errors", e)
-        config.error("message")
-        self.assertEqual(e.errors, ["message"])
+        with config.capture_config_errors() as errors:
+            config.error("message")
+        self.assertEqual(errors.errors, ["message"])
 
     def test_str(self):
         ex = config.ConfigErrors()
@@ -330,11 +332,13 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
                 BuildmasterConfig = {}
                 config.error('oh noes!')
                 config.error('noes too!')""")
-        e = self.assertRaises(config.ConfigErrors,
-                              config.FileLoader(self.basedir, self.filename).loadConfig)
-        self.assertEqual(e.errors, ['oh noes!', 'noes too!',
-                                    'no workers are configured',
-                                    'no builders are configured'])
+
+        with config.capture_config_errors() as errors:
+            config.FileLoader(self.basedir, self.filename).loadConfig()
+
+        self.assertEqual(errors.errors, ['oh noes!', 'noes too!',
+                                         'no workers are configured',
+                                         'no builders are configured'])
 
     def test_loadConfig_unknown_key(self):
         self.patch_load_helpers()
@@ -405,13 +409,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 
     def setUp(self):
         self.cfg = config.MasterConfig()
-        self.errors = config.ConfigErrors()
-        self.patch(config, '_errors', self.errors)
 
     # utils
 
     def assertResults(self, **expected):
-        self.assertFalse(self.errors, self.errors.errors)
         got = {
             attr: getattr(self.cfg, attr)
             for attr, exp in expected.items()}
@@ -428,31 +429,32 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(**global_defaults)
 
     def test_load_global_string_param_not_string(self):
-        self.cfg.load_global(self.filename,
-                             dict(title=10))
-        self.assertConfigError(self.errors, 'must be a string')
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {"title": 10})
+        self.assertConfigError(errors, 'must be a string')
 
     def test_load_global_int_param_not_int(self):
-        self.cfg.load_global(self.filename,
-                             dict(changeHorizon='yes'))
-        self.assertConfigError(self.errors, 'must be an int')
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'changeHorizon': 'yes'})
+
+        self.assertConfigError(errors, 'must be an int')
 
     def test_load_global_protocols_not_dict(self):
-        self.cfg.load_global(self.filename,
-                             dict(protocols="test"))
-        self.assertConfigError(self.errors, "c['protocols'] must be dict")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'protocols': "test"})
+        self.assertConfigError(errors, "c['protocols'] must be dict")
 
     def test_load_global_protocols_key_int(self):
-        self.cfg.load_global(self.filename,
-                             dict(protocols={321: {"port": 123}}))
-        self.assertConfigError(
-            self.errors, "c['protocols'] keys must be strings")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'protocols': {321: {"port": 123}}})
+
+        self.assertConfigError(errors, "c['protocols'] keys must be strings")
 
     def test_load_global_protocols_value_not_dict(self):
-        self.cfg.load_global(self.filename,
-                             dict(protocols={"pb": 123}))
-        self.assertConfigError(
-            self.errors, "c['protocols']['pb'] must be a dict")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'protocols': {"pb": 123}})
+
+        self.assertConfigError(errors, "c['protocols']['pb'] must be a dict")
 
     def do_test_load_global(self, config_dict, **expected):
         self.cfg.load_global(self.filename, config_dict)
@@ -497,10 +499,11 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  logCompressionMethod='bz2')
 
     def test_load_global_logCompressionMethod_invalid(self):
-        self.cfg.load_global(self.filename,
-                             dict(logCompressionMethod='foo'))
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'logCompressionMethod': 'foo'})
+
         self.assertConfigError(
-            self.errors, "c['logCompressionMethod'] must be 'raw', 'bz2', 'gz' or 'lz4'")
+            errors, "c['logCompressionMethod'] must be 'raw', 'bz2', 'gz' or 'lz4'")
 
     def test_load_global_codebaseGenerator(self):
         func = lambda _: "dummy"
@@ -508,9 +511,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  codebaseGenerator=func)
 
     def test_load_global_codebaseGenerator_invalid(self):
-        self.cfg.load_global(self.filename,
-                             dict(codebaseGenerator='dummy'))
-        self.assertConfigError(self.errors,
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'codebaseGenerator': 'dummy'})
+
+        self.assertConfigError(errors,
                                "codebaseGenerator must be a callable "
                                "accepting a dict and returning a str")
 
@@ -530,9 +534,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(properties=dict(x=10)), properties=exp)
 
     def test_load_global_properties_invalid(self):
-        self.cfg.load_global(self.filename,
-                             dict(properties='yes'))
-        self.assertConfigError(self.errors, "must be a dictionary")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'properties': 'yes'})
+
+        self.assertConfigError(errors, "must be a dictionary")
 
     def test_load_global_collapseRequests_bool(self):
         self.do_test_load_global(dict(collapseRequests=False),
@@ -544,9 +549,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  collapseRequests=callable)
 
     def test_load_global_collapseRequests_invalid(self):
-        self.cfg.load_global(self.filename,
-                             dict(collapseRequests='yes'))
-        self.assertConfigError(self.errors,
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'collapseRequests': 'yes'})
+
+        self.assertConfigError(errors,
                                "must be a callable, True, or False")
 
     def test_load_global_prioritizeBuilders_callable(self):
@@ -555,9 +561,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  prioritizeBuilders=callable)
 
     def test_load_global_prioritizeBuilders_invalid(self):
-        self.cfg.load_global(self.filename,
-                             dict(prioritizeBuilders='yes'))
-        self.assertConfigError(self.errors, "must be a callable")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'prioritizeBuilders': 'yes'})
+
+        self.assertConfigError(errors, "must be a callable")
 
     def test_load_global_protocols_str(self):
         self.do_test_load_global(dict(protocols={'pb': {'port': 'udp:123'}}),
@@ -576,8 +583,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                  revlink=callable)
 
     def test_load_global_revlink_invalid(self):
-        self.cfg.load_global(self.filename, dict(revlink=''))
-        self.assertConfigError(self.errors, "must be a callable")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {'revlink': ''})
+
+        self.assertConfigError(errors, "must be a callable")
 
     def test_load_validation_defaults(self):
         self.cfg.load_validation(self.filename, {})
@@ -587,14 +596,16 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                          ]))
 
     def test_load_validation_invalid(self):
-        self.cfg.load_validation(self.filename,
-                                 dict(validation='plz'))
-        self.assertConfigError(self.errors, "must be a dictionary")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_validation(self.filename, {'validation': 'plz'})
+
+        self.assertConfigError(errors, "must be a dictionary")
 
     def test_load_validation_unk_keys(self):
-        self.cfg.load_validation(self.filename,
-                                 dict(validation=dict(users='.*')))
-        self.assertConfigError(self.errors, "unrecognized validation key(s)")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_validation(self.filename, {'validation': {'users': '.*'}})
+
+        self.assertConfigError(errors, "unrecognized validation key(s)")
 
     def test_load_validation(self):
         r = re.compile('.*')
@@ -618,8 +629,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(db=dict(db_url='abcd'))
 
     def test_load_db_unk_keys(self):
-        self.cfg.load_db(self.filename, {'db': {'db_url': 'abcd', 'bar': 'bar'}})
-        self.assertConfigError(self.errors, "unrecognized keys in")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_db(self.filename, {'db': {'db_url': 'abcd', 'bar': 'bar'}})
+
+        self.assertConfigError(errors, "unrecognized keys in")
 
     def test_load_mq_defaults(self):
         self.cfg.load_mq(self.filename, {})
@@ -631,21 +644,26 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(mq=dict(type='simple'))
 
     def test_load_mq_unk_type(self):
-        self.cfg.load_mq(self.filename, dict(mq=dict(type='foo')))
-        self.assertConfigError(self.errors, "mq type 'foo' is not known")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_mq(self.filename, {'mq': {'type': 'foo'}})
+
+        self.assertConfigError(errors, "mq type 'foo' is not known")
 
     def test_load_mq_unk_keys(self):
-        self.cfg.load_mq(self.filename,
-                         dict(mq=dict(bar='bar')))
-        self.assertConfigError(self.errors, "unrecognized keys in")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_mq(self.filename, {'mq': {'bar': 'bar'}})
+
+        self.assertConfigError(errors, "unrecognized keys in")
 
     def test_load_metrics_defaults(self):
         self.cfg.load_metrics(self.filename, {})
         self.assertResults(metrics=None)
 
     def test_load_metrics_invalid(self):
-        self.cfg.load_metrics(self.filename, dict(metrics=13))
-        self.assertConfigError(self.errors, "must be a dictionary")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_metrics(self.filename, {'metrics': 13})
+
+        self.assertConfigError(errors, "must be a dictionary")
 
     def test_load_metrics(self):
         self.cfg.load_metrics(self.filename,
@@ -657,8 +675,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(caches=dict(Changes=10, Builds=15))
 
     def test_load_caches_invalid(self):
-        self.cfg.load_caches(self.filename, dict(caches=13))
-        self.assertConfigError(self.errors, "must be a dictionary")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_caches(self.filename, {'caches': 13})
+
+        self.assertConfigError(errors, "must be a dictionary")
 
     def test_load_caches_buildCacheSize(self):
         self.cfg.load_caches(self.filename,
@@ -666,9 +686,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(caches=dict(Builds=13, Changes=10))
 
     def test_load_caches_buildCacheSize_and_caches(self):
-        self.cfg.load_caches(self.filename,
-                             dict(buildCacheSize=13, caches=dict(builds=11)))
-        self.assertConfigError(self.errors, "cannot specify")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_caches(self.filename, {'buildCacheSize': 13, 'caches': {'builds': 11}})
+
+        self.assertConfigError(errors, "cannot specify")
 
     def test_load_caches_changeCacheSize(self):
         self.cfg.load_caches(self.filename,
@@ -676,9 +697,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(caches=dict(Changes=13, Builds=15))
 
     def test_load_caches_changeCacheSize_and_caches(self):
-        self.cfg.load_caches(self.filename,
-                             dict(changeCacheSize=13, caches=dict(changes=11)))
-        self.assertConfigError(self.errors, "cannot specify")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_caches(self.filename, {'changeCacheSize': 13, 'caches': {'changes': 11}})
+
+        self.assertConfigError(errors, "cannot specify")
 
     def test_load_caches(self):
         self.cfg.load_caches(self.filename,
@@ -689,40 +711,42 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         """
         Test that non-integer cache sizes are not allowed.
         """
-        self.cfg.load_caches(self.filename,
-                             dict(caches=dict(foo="1")))
-        self.assertConfigError(self.errors,
-                               "value for cache size 'foo' must be an integer")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_caches(self.filename, {'caches': {'foo': "1"}})
+
+        self.assertConfigError(errors, "value for cache size 'foo' must be an integer")
 
     def test_load_caches_to_small_err(self):
         """
         Test that cache sizes less then 1 are not allowed.
         """
-        self.cfg.load_caches(self.filename, dict(caches=dict(Changes=-12)))
-        self.assertConfigError(self.errors,
-                               "'Changes' cache size must be at least 1, got '-12'")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_caches(self.filename, {'caches': {'Changes': -12}})
+
+        self.assertConfigError(errors, "'Changes' cache size must be at least 1, got '-12'")
 
     def test_load_schedulers_defaults(self):
         self.cfg.load_schedulers(self.filename, {})
         self.assertResults(schedulers={})
 
     def test_load_schedulers_not_list(self):
-        self.cfg.load_schedulers(self.filename,
-                                 dict(schedulers={}))
-        self.assertConfigError(self.errors, "must be a list of")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_schedulers(self.filename, {'schedulers': {}})
+
+        self.assertConfigError(errors, "must be a list of")
 
     def test_load_schedulers_not_instance(self):
-        self.cfg.load_schedulers(self.filename,
-                                 dict(schedulers=[mock.Mock()]))
-        self.assertConfigError(self.errors, "must be a list of")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_schedulers(self.filename, {'schedulers': [mock.Mock()]})
+
+        self.assertConfigError(errors, "must be a list of")
 
     def test_load_schedulers_dupe(self):
-        sch1 = FakeScheduler(name='sch')
-        sch2 = FakeScheduler(name='sch')
-        self.cfg.load_schedulers(self.filename,
-                                 dict(schedulers=[sch1, sch2]))
-        self.assertConfigError(self.errors,
-                               "scheduler name 'sch' used multiple times")
+        with config.capture_config_errors() as errors:
+            sch1 = FakeScheduler(name='sch')
+            sch2 = FakeScheduler(name='sch')
+            self.cfg.load_schedulers(self.filename, {'schedulers': [sch1, sch2]})
+        self.assertConfigError(errors, "scheduler name 'sch' used multiple times")
 
     def test_load_schedulers(self):
         sch = schedulers_base.BaseScheduler('sch', [""])
@@ -735,15 +759,15 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(builders=[])
 
     def test_load_builders_not_list(self):
-        self.cfg.load_builders(self.filename,
-                               dict(builders={}))
-        self.assertConfigError(self.errors, "must be a list")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_builders(self.filename, {'builders': {}})
+
+        self.assertConfigError(errors, "must be a list")
 
     def test_load_builders_not_instance(self):
-        self.cfg.load_builders(self.filename,
-                               dict(builders=[mock.Mock()]))
-        self.assertConfigError(
-            self.errors, "is not a builder config (in c['builders']")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_builders(self.filename, {'builders': [mock.Mock()]})
+        self.assertConfigError(errors, "is not a builder config (in c['builders']")
 
     def test_load_builders(self):
         bldr = config.BuilderConfig(name='x',
@@ -773,45 +797,51 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(workers=[])
 
     def test_load_workers_not_list(self):
-        self.cfg.load_workers(self.filename,
-                              dict(workers={}))
-        self.assertConfigError(self.errors, "must be a list")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_workers(self.filename, {'workers': {}})
+        self.assertConfigError(errors, "must be a list")
 
     def test_load_workers_not_instance(self):
-        self.cfg.load_workers(self.filename,
-                              dict(workers=[mock.Mock()]))
-        self.assertConfigError(self.errors, "must be a list of")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_workers(self.filename, {'workers': [mock.Mock()]})
 
-    def test_load_workers_reserved_names(self):
-        for name in 'debug', 'change', 'status':
-            self.cfg.load_workers(self.filename,
-                                  dict(workers=[worker.Worker(name, 'x')]))
-            self.assertConfigError(self.errors, "is reserved")
-            self.errors.errors[:] = []  # clear out the errors
+        self.assertConfigError(errors, "must be a list of")
 
-    def test_load_workers_not_identifiers(self):
-        for name in ("123 no initial digits", "spaces not allowed",
-                     'a/b', "a.b.c.d", "a-b_c.d9",):
-            self.cfg.load_workers(self.filename,
-                                  dict(workers=[worker.Worker(name, 'x')]))
-            self.assertConfigError(self.errors, "is not an identifier")
-            self.errors.errors[:] = []  # clear out the errors
+    @parameterized.expand([
+        'debug', 'change', 'status'
+    ])
+    def test_load_workers_reserved_names(self, worker_name):
+        with config.capture_config_errors() as errors:
+            self.cfg.load_workers(self.filename, {'workers': [worker.Worker(worker_name, 'x')]})
+
+        self.assertConfigError(errors, "is reserved")
+
+    @parameterized.expand([
+        ('initial_digits', "123_text_text"),
+        ("spaces", "text text"),
+        ("slash", "a/b"),
+        ("dot", "a.b"),
+    ])
+    def test_load_workers_not_identifiers(self, name, worker_name):
+        with config.capture_config_errors() as errors:
+            self.cfg.load_workers(self.filename, {'workers': [worker.Worker(worker_name, 'x')]})
+
+        self.assertConfigError(errors, "is not an identifier")
 
     def test_load_workers_too_long(self):
-        name = "a" * 51
-        self.cfg.load_workers(self.filename,
-                              dict(workers=[worker.Worker(name, 'x')]))
-        self.assertConfigError(self.errors, "is longer than")
-        self.errors.errors[:] = []  # clear out the errors
+        with config.capture_config_errors() as errors:
+            name = "a" * 51
+            self.cfg.load_workers(self.filename, {'workers': [worker.Worker(name, 'x')]})
+
+        self.assertConfigError(errors, "is longer than")
 
     def test_load_workers_empty(self):
-        name = ""
-        self.cfg.load_workers(self.filename,
-                              dict(workers=[worker.Worker(name, 'x')]))
-        self.errors.errors[:] = self.errors.errors[
-            1:2]  # only get necessary error
-        self.assertConfigError(self.errors, "cannot be an empty string")
-        self.errors.errors[:] = []  # clear out the errors
+        with config.capture_config_errors() as errors:
+            name = ""
+            self.cfg.load_workers(self.filename, {'workers': [worker.Worker(name, 'x')]})
+            errors.errors[:] = errors.errors[1:2]  # only get necessary error
+
+        self.assertConfigError(errors, "cannot be an empty string")
 
     def test_load_workers(self):
         wrk = worker.Worker('foo', 'x')
@@ -824,9 +854,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(change_sources=[])
 
     def test_load_change_sources_not_instance(self):
-        self.cfg.load_change_sources(self.filename,
-                                     dict(change_source=[mock.Mock()]))
-        self.assertConfigError(self.errors, "must be a list of")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_change_sources(self.filename, {'change_source': [mock.Mock()]})
+
+        self.assertConfigError(errors, "must be a list of")
 
     def test_load_change_sources_single(self):
         chsrc = FakeChangeSource()
@@ -845,15 +876,17 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(machines=[])
 
     def test_load_machines_not_instance(self):
-        self.cfg.load_machines(self.filename,
-                               dict(machines=[mock.Mock()]))
-        self.assertConfigError(self.errors, "must be a list of")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_machines(self.filename, {'machines': [mock.Mock()]})
+
+        self.assertConfigError(errors, "must be a list of")
 
     def test_load_machines_single(self):
-        mm = FakeMachine(name='a')
-        self.cfg.load_machines(self.filename,
-                               dict(machines=mm))
-        self.assertConfigError(self.errors, "must be a list of")
+        with config.capture_config_errors() as errors:
+            mm = FakeMachine(name='a')
+            self.cfg.load_machines(self.filename, {'machines': mm})
+
+        self.assertConfigError(errors, "must be a list of")
 
     def test_load_machines_list(self):
         mm = FakeMachine()
@@ -866,9 +899,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(user_managers=[])
 
     def test_load_user_managers_not_list(self):
-        self.cfg.load_user_managers(self.filename,
-                                    dict(user_managers='foo'))
-        self.assertConfigError(self.errors, "must be a list")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_user_managers(self.filename, {'user_managers': 'foo'})
+
+        self.assertConfigError(errors, "must be a list")
 
     def test_load_user_managers(self):
         um = mock.Mock()
@@ -937,33 +971,32 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     logfileName='http.log'))
 
     def test_load_www_versions_not_list(self):
-        custom_versions = {
-            'Test Custom Component': '0.0.1',
-            'Test Custom Component 2': '0.0.2',
-        }
-        self.cfg.load_www(
-            self.filename, {'www': dict(versions=custom_versions)})
-        self.assertConfigError(
-            self.errors, 'Invalid www configuration value of versions')
+        with config.capture_config_errors() as errors:
+            custom_versions = {
+                'Test Custom Component': '0.0.1',
+                'Test Custom Component 2': '0.0.2',
+            }
+            self.cfg.load_www(self.filename, {'www': {'versions': custom_versions}})
+        self.assertConfigError(errors, 'Invalid www configuration value of versions')
 
     def test_load_www_versions_value_invalid(self):
-        custom_versions = [('a', '1'), 'abc', ('b',)]
-        self.cfg.load_www(
-            self.filename, {'www': dict(versions=custom_versions)})
-        self.assertConfigError(
-            self.errors, 'Invalid www configuration value of versions')
+        with config.capture_config_errors() as errors:
+            custom_versions = [('a', '1'), 'abc', ('b',)]
+            self.cfg.load_www(self.filename, {'www': {'versions': custom_versions}})
+
+        self.assertConfigError(errors, 'Invalid www configuration value of versions')
 
     def test_load_www_cookie_expiration_time_not_timedelta(self):
-        self.cfg.load_www(
-            self.filename, {'www': dict(cookie_expiration_time=1)})
-        self.assertConfigError(
-            self.errors, 'Invalid www["cookie_expiration_time"]')
+        with config.capture_config_errors() as errors:
+            self.cfg.load_www(self.filename, {'www': {"cookie_expiration_time": 1}})
+
+        self.assertConfigError(errors, 'Invalid www["cookie_expiration_time"]')
 
     def test_load_www_unknown(self):
-        self.cfg.load_www(self.filename,
-                          dict(www=dict(foo="bar")))
-        self.assertConfigError(self.errors,
-                               "unknown www configuration parameter(s) foo")
+        with config.capture_config_errors() as errors:
+            self.cfg.load_www(self.filename, {"www": {"foo": "bar"}})
+
+        self.assertConfigError(errors, "unknown www configuration parameter(s) foo")
 
     def test_load_services_nominal(self):
         testcase = self
@@ -983,28 +1016,29 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 
         class MyService:
             pass
-        myService = MyService()
-        self.cfg.load_services(self.filename, dict(
-            services=[myService]))
+
+        with config.capture_config_errors() as errors:
+            myService = MyService()
+            self.cfg.load_services(self.filename, {'services': [myService]})
+
         errMsg = ("<class 'buildbot.test.unit.test_config."
                   "MasterConfig_loaders.test_load_services_badservice."
                   "<locals>.MyService'> ")
         errMsg += "object should be an instance of buildbot.util.service.BuildbotService"
-        self.assertConfigError(self.errors, errMsg)
+        self.assertConfigError(errors, errMsg)
 
     def test_load_services_duplicate(self):
+        with config.capture_config_errors() as errors:
+            class MyService(service.BuildbotService):
+                name = 'myservice'
 
-        class MyService(service.BuildbotService):
-            name = 'myservice'
+                def reconfigService(self, x=None):
+                    self.x = x
 
-            def reconfigService(self, x=None):
-                self.x = x
+            self.cfg.load_services(self.filename, dict(
+                services=[MyService(x='a'), MyService(x='b')]))
 
-        self.cfg.load_services(self.filename, dict(
-            services=[MyService(x='a'), MyService(x='b')]))
-
-        self.assertConfigError(
-            self.errors, f'Duplicate service name {repr(MyService.name)}')
+        self.assertConfigError(errors, f'Duplicate service name {repr(MyService.name)}')
 
     def test_load_configurators_norminal(self):
 
@@ -1021,8 +1055,6 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
 
     def setUp(self):
         self.cfg = config.MasterConfig()
-        self.errors = config.ConfigErrors()
-        self.patch(config, '_errors', self.errors)
 
     # utils
 
@@ -1083,170 +1115,207 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
     # tests
 
     def test_check_single_master_multimaster(self):
-        self.cfg.multiMaster = True
-        self.cfg.check_single_master()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.cfg.multiMaster = True
+            self.cfg.check_single_master()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_single_master_no_builders(self):
-        self.setup_basic_attrs()
-        self.cfg.builders = []
-        self.cfg.check_single_master()
-        self.assertConfigError(self.errors, "no builders are configured")
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            self.cfg.builders = []
+            self.cfg.check_single_master()
+
+        self.assertConfigError(errors, "no builders are configured")
 
     def test_check_single_master_no_workers(self):
-        self.setup_basic_attrs()
-        self.cfg.workers = []
-        self.cfg.check_single_master()
-        self.assertConfigError(self.errors, "no workers are configured")
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            self.cfg.workers = []
+            self.cfg.check_single_master()
+
+        self.assertConfigError(errors, "no workers are configured")
 
     def test_check_single_master_unsch_builder(self):
-        self.setup_basic_attrs()
-        b3 = mock.Mock()
-        b3.name = 'b3'
-        self.cfg.builders.append(b3)
-        self.cfg.check_single_master()
-        self.assertConfigError(self.errors, "have no schedulers to drive them")
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            b3 = mock.Mock()
+            b3.name = 'b3'
+            self.cfg.builders.append(b3)
+            self.cfg.check_single_master()
+
+        self.assertConfigError(errors, "have no schedulers to drive them")
 
     def test_check_single_master_renderable_builderNames(self):
-        self.setup_basic_attrs()
-        b3 = mock.Mock()
-        b3.name = 'b3'
-        self.cfg.builders.append(b3)
-        sch2 = mock.Mock()
-        sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
-        self.cfg.schedulers['sch2'] = sch2
-        self.cfg.check_single_master()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            b3 = mock.Mock()
+            b3.name = 'b3'
+            self.cfg.builders.append(b3)
+            sch2 = mock.Mock()
+            sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
+            self.cfg.schedulers['sch2'] = sch2
+            self.cfg.check_single_master()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_schedulers_unknown_builder(self):
-        self.setup_basic_attrs()
-        del self.cfg.builders[1]  # remove b2, leaving b1
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            del self.cfg.builders[1]  # remove b2, leaving b1
 
-        self.cfg.check_schedulers()
-        self.assertConfigError(self.errors, "Unknown builder 'b2'")
+            self.cfg.check_schedulers()
+
+        self.assertConfigError(errors, "Unknown builder 'b2'")
 
     def test_check_schedulers_ignored_in_multiMaster(self):
-        self.setup_basic_attrs()
-        del self.cfg.builders[1]  # remove b2, leaving b1
-        self.cfg.multiMaster = True
-        self.cfg.check_schedulers()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            del self.cfg.builders[1]  # remove b2, leaving b1
+            self.cfg.multiMaster = True
+            self.cfg.check_schedulers()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_schedulers_renderable_builderNames(self):
-        self.setup_basic_attrs()
-        sch2 = mock.Mock()
-        sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
-        self.cfg.schedulers['sch2'] = sch2
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            sch2 = mock.Mock()
+            sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
+            self.cfg.schedulers['sch2'] = sch2
 
-        self.cfg.check_schedulers()
-        self.assertNoConfigErrors(self.errors)
+            self.cfg.check_schedulers()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_schedulers(self):
-        self.setup_basic_attrs()
-        self.cfg.check_schedulers()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.setup_basic_attrs()
+            self.cfg.check_schedulers()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_locks_dup_builder_lock(self):
-        self.setup_builder_locks(builder_lock='l', dup_builder_lock=True)
-        self.cfg.check_locks()
-        self.assertConfigError(self.errors, "Two locks share")
+        with config.capture_config_errors() as errors:
+            self.setup_builder_locks(builder_lock='l', dup_builder_lock=True)
+            self.cfg.check_locks()
+
+        self.assertConfigError(errors, "Two locks share")
 
     def test_check_locks(self):
-        self.setup_builder_locks(builder_lock='bl')
-        self.cfg.check_locks()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.setup_builder_locks(builder_lock='bl')
+            self.cfg.check_locks()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_locks_none(self):
         # no locks in the whole config, should be fine
-        self.setup_builder_locks()
-        self.cfg.check_locks()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.setup_builder_locks()
+            self.cfg.check_locks()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_locks_bare(self):
         # check_locks() should be able to handle bare lock object,
         # lock objects that are not wrapped into LockAccess() object
-        self.setup_builder_locks(builder_lock='oldlock',
-                                 bare_builder_lock=True)
-        self.cfg.check_locks()
-        self.assertNoConfigErrors(self.errors)
+
+        with config.capture_config_errors() as errors:
+            self.setup_builder_locks(builder_lock='oldlock', bare_builder_lock=True)
+            self.cfg.check_locks()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_builders_unknown_worker(self):
-        wrk = mock.Mock()
-        wrk.workername = 'xyz'
-        self.cfg.workers = [wrk]
+        with config.capture_config_errors() as errors:
+            wrk = mock.Mock()
+            wrk.workername = 'xyz'
+            self.cfg.workers = [wrk]
 
-        b1 = FakeBuilder(workernames=['xyz', 'abc'], builddir='x', name='b1')
-        self.cfg.builders = [b1]
+            b1 = FakeBuilder(workernames=['xyz', 'abc'], builddir='x', name='b1')
+            self.cfg.builders = [b1]
 
-        self.cfg.check_builders()
-        self.assertConfigError(self.errors,
-                               "builder 'b1' uses unknown workers 'abc'")
+            self.cfg.check_builders()
+        self.assertConfigError(errors, "builder 'b1' uses unknown workers 'abc'")
 
     def test_check_builders_duplicate_name(self):
-        b1 = FakeBuilder(workernames=[], name='b1', builddir='1')
-        b2 = FakeBuilder(workernames=[], name='b1', builddir='2')
-        self.cfg.builders = [b1, b2]
+        with config.capture_config_errors() as errors:
+            b1 = FakeBuilder(workernames=[], name='b1', builddir='1')
+            b2 = FakeBuilder(workernames=[], name='b1', builddir='2')
+            self.cfg.builders = [b1, b2]
 
-        self.cfg.check_builders()
-        self.assertConfigError(self.errors,
-                               "duplicate builder name 'b1'")
+            self.cfg.check_builders()
+
+        self.assertConfigError(errors, "duplicate builder name 'b1'")
 
     def test_check_builders_duplicate_builddir(self):
-        b1 = FakeBuilder(workernames=[], name='b1', builddir='dir')
-        b2 = FakeBuilder(workernames=[], name='b2', builddir='dir')
-        self.cfg.builders = [b1, b2]
+        with config.capture_config_errors() as errors:
+            b1 = FakeBuilder(workernames=[], name='b1', builddir='dir')
+            b2 = FakeBuilder(workernames=[], name='b2', builddir='dir')
+            self.cfg.builders = [b1, b2]
 
-        self.cfg.check_builders()
-        self.assertConfigError(self.errors,
-                               "duplicate builder builddir 'dir'")
+            self.cfg.check_builders()
+
+        self.assertConfigError(errors, "duplicate builder builddir 'dir'")
 
     def test_check_builders(self):
-        wrk = mock.Mock()
-        wrk.workername = 'a'
-        self.cfg.workers = [wrk]
+        with config.capture_config_errors() as errors:
+            wrk = mock.Mock()
+            wrk.workername = 'a'
+            self.cfg.workers = [wrk]
 
-        b1 = FakeBuilder(workernames=['a'], name='b1', builddir='dir1')
-        b2 = FakeBuilder(workernames=['a'], name='b2', builddir='dir2')
-        self.cfg.builders = [b1, b2]
+            b1 = FakeBuilder(workernames=['a'], name='b1', builddir='dir1')
+            b2 = FakeBuilder(workernames=['a'], name='b2', builddir='dir2')
+            self.cfg.builders = [b1, b2]
 
-        self.cfg.check_builders()
-        self.assertNoConfigErrors(self.errors)
+            self.cfg.check_builders()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_ports_protocols_set(self):
-        self.cfg.protocols = {"pb": {"port": 10}}
-        self.cfg.check_ports()
-        self.assertNoConfigErrors(self.errors)
+        with config.capture_config_errors() as errors:
+            self.cfg.protocols = {"pb": {"port": 10}}
+            self.cfg.check_ports()
+
+        self.assertNoConfigErrors(errors)
 
     def test_check_ports_protocols_not_set_workers(self):
-        self.cfg.workers = [mock.Mock()]
-        self.cfg.check_ports()
-        self.assertConfigError(self.errors,
-                               "workers are configured, but c['protocols'] not")
+        with config.capture_config_errors() as errors:
+            self.cfg.workers = [mock.Mock()]
+            self.cfg.check_ports()
+
+        self.assertConfigError(errors, "workers are configured, but c['protocols'] not")
 
     def test_check_ports_protocols_port_duplication(self):
-        self.cfg.protocols = {"pb": {"port": 123}, "amp": {"port": 123}}
-        self.cfg.check_ports()
-        self.assertConfigError(self.errors,
-                               "Some of ports in c['protocols'] duplicated")
+        with config.capture_config_errors() as errors:
+            self.cfg.protocols = {"pb": {"port": 123}, "amp": {"port": 123}}
+            self.cfg.check_ports()
+
+        self.assertConfigError(errors, "Some of ports in c['protocols'] duplicated")
 
     def test_check_machines_unknown_name(self):
-        self.cfg.workers = [
-            FakeWorker(name='wa', machine_name='unk')
-        ]
-        self.cfg.machines = [
-            FakeMachine(name='a')
-        ]
-        self.cfg.check_machines()
-        self.assertConfigError(self.errors, 'uses unknown machine')
+        with config.capture_config_errors() as errors:
+            self.cfg.workers = [
+                FakeWorker(name='wa', machine_name='unk')
+            ]
+            self.cfg.machines = [
+                FakeMachine(name='a')
+            ]
+            self.cfg.check_machines()
+
+        self.assertConfigError(errors, 'uses unknown machine')
 
     def test_check_machines_duplicate_name(self):
-        self.cfg.machines = [
-            FakeMachine(name='a'),
-            FakeMachine(name='a')
-        ]
-        self.cfg.check_machines()
-        self.assertConfigError(self.errors,
-                               'duplicate machine name')
+        with config.capture_config_errors() as errors:
+            self.cfg.machines = [
+                FakeMachine(name='a'),
+                FakeMachine(name='a')
+            ]
+            self.cfg.check_machines()
+
+        self.assertConfigError(errors, 'duplicate machine name')
 
 
 class MasterConfig_old_worker_api(unittest.TestCase):

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -155,7 +155,7 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
     def setUp(self):
         self.basedir = os.path.abspath('basedir')
         self.filename = os.path.join(self.basedir, 'test.cfg')
-        self.patch(config, "_in_unit_tests", False)
+        self.patch(config, "get_is_in_unit_tests", lambda: False)
 
         return self.setUpDirs('basedir')
 
@@ -481,7 +481,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(changeHorizon=None), changeHorizon=None)
 
     def test_load_global_buildbotNetUsageData(self):
-        self.patch(config, "_in_unit_tests", False)
+        self.patch(config, "get_is_in_unit_tests", lambda: False)
         with assertProducesWarning(
                 ConfigWarning,
                 message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic."):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -29,6 +29,7 @@ from buildbot import config
 from buildbot import master
 from buildbot import monkeypatches
 from buildbot.config.master import FileLoader
+from buildbot.config.master import MasterConfig
 from buildbot.db import exceptions
 from buildbot.interfaces import IConfigLoader
 from buildbot.test import fakedb
@@ -51,7 +52,7 @@ class FailingLoader:
 class DefaultLoader:
 
     def loadConfig(self):
-        return config.MasterConfig()
+        return MasterConfig()
 
 
 class InitTests(unittest.SynchronousTestCase):
@@ -212,11 +213,11 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,
 
     @defer.inlineCallbacks
     def test_reconfigService_db_url_changed(self):
-        old = self.master.config = config.MasterConfig()
+        old = self.master.config = MasterConfig()
         old.db['db_url'] = 'aaaa'
         yield self.master.reconfigServiceWithBuildbotConfig(old)
 
-        new = config.MasterConfig()
+        new = MasterConfig()
         new.db['db_url'] = 'bbbb'
 
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -28,6 +28,7 @@ from zope.interface import implementer
 from buildbot import config
 from buildbot import master
 from buildbot import monkeypatches
+from buildbot.config.master import FileLoader
 from buildbot.db import exceptions
 from buildbot.interfaces import IConfigLoader
 from buildbot.test import fakedb
@@ -70,7 +71,7 @@ class InitTests(unittest.SynchronousTestCase):
         `FileLoader` pointing at `"master.cfg"`.
         """
         m = master.BuildMaster(".", reactor=reactor)
-        self.assertEqual(m.config_loader, config.FileLoader(".", "master.cfg"))
+        self.assertEqual(m.config_loader, FileLoader(".", "master.cfg"))
 
 
 class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,

--- a/master/buildbot/test/unit/util/test_ssl.py
+++ b/master/buildbot/test/unit/util/test_ssl.py
@@ -14,15 +14,14 @@
 # Copyright Buildbot Team Members
 
 
-import mock
-
 from twisted.trial import unittest
 
 from buildbot import config
+from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.util import ssl
 
 
-class Tests(unittest.TestCase):
+class Tests(unittest.TestCase, ConfigErrorsMixin):
 
     @ssl.skipUnless
     def test_ClientContextFactory(self):
@@ -36,9 +35,9 @@ class Tests(unittest.TestCase):
         try:
             ssl.ssl_import_error = "lib xxx do not exist"
             ssl.has_ssl = False
-            self.patch(config, "_errors", mock.Mock())
-            ssl.ensureHasSSL("myplugin")
-            config._errors.addError.assert_called_with(
+            with config.capture_config_errors() as errors:
+                ssl.ensureHasSSL("myplugin")
+            self.assertConfigError(errors,
                 "TLS dependencies required for myplugin are not installed : "
                 "lib xxx do not exist\n pip install 'buildbot[tls]'")
         finally:

--- a/master/buildbot/test/unit/util/test_ssl.py
+++ b/master/buildbot/test/unit/util/test_ssl.py
@@ -16,7 +16,7 @@
 
 from twisted.trial import unittest
 
-from buildbot import config
+from buildbot.config.errors import capture_config_errors
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.util import ssl
 
@@ -35,7 +35,7 @@ class Tests(unittest.TestCase, ConfigErrorsMixin):
         try:
             ssl.ssl_import_error = "lib xxx do not exist"
             ssl.has_ssl = False
-            with config.capture_config_errors() as errors:
+            with capture_config_errors() as errors:
                 ssl.ensureHasSSL("myplugin")
             self.assertConfigError(errors,
                 "TLS dependencies required for myplugin are not installed : "

--- a/master/buildbot/test/util/configurators.py
+++ b/master/buildbot/test/util/configurators.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-from buildbot.config import MasterConfig
+from buildbot.config.master import MasterConfig
 
 
 class ConfiguratorMixin:

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -27,7 +27,7 @@ from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 from zope.interface import implementer
 
-from buildbot.config import MasterConfig
+from buildbot.config.master import MasterConfig
 from buildbot.data import resultspec
 from buildbot.interfaces import IConfigLoader
 from buildbot.master import BuildMaster

--- a/master/setup.py
+++ b/master/setup.py
@@ -165,6 +165,7 @@ setup_args = {
         "buildbot.worker.protocols.manager",
         "buildbot.changes",
         "buildbot.clients",
+        "buildbot.config",
         "buildbot.data",
         "buildbot.db",
         "buildbot.db.migrations.versions",
@@ -371,7 +372,7 @@ setup_args = {
                 ('svn.split_file_branches', 'split_file_branches'),
                 ('svn.split_file_alwaystrunk', 'split_file_alwaystrunk')]),
             ('buildbot.configurators.janitor', ['JanitorConfigurator']),
-            ('buildbot.config', ['BuilderConfig']),
+            ('buildbot.config.builder', ['BuilderConfig']),
             ('buildbot.locks', [
                 'MasterLock',
                 'WorkerLock',


### PR DESCRIPTION
This PR splits the internal `buildbot.config` module into multiple submodules at `buildbot.config.***`. Previously exposed import paths have not been changed.

The reason for the change is that it will become easier to import error-related functions from `buildbot.config.errors` without introducing a circular import.