### PR TITLE
Dockerfile: Upgrade base Debian image to 11

### DIFF
--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -14,12 +14,12 @@
 # which get installed in the final image.
 # This allows us to avoid installing build tools like gcc in the final image.
 
-FROM        debian:10 AS buildbot-build
+FROM        debian:11 AS buildbot-build
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2021-04-28
+ENV         security_updates_as_of 2022-03-06
 
 RUN \
     apt-get update && \
@@ -53,7 +53,7 @@ RUN virtualenv --python=python3 /buildbot_venv && \
     env CRYPTOGRAPHY_DONT_BUILD_RUST=1 /buildbot_venv/bin/pip3 install /usr/src/buildbot/dist/*.whl
 
 RUN mkdir -p /wheels && \
-    /buildbot_venv/bin/pip3 list --format freeze | grep -v '^buildbot' | grep -v '^pkg_resources' > /wheels/wheels.txt && \
+    /buildbot_venv/bin/pip3 list --format freeze | grep -v '^buildbot' | grep -v '^pkg-resources' > /wheels/wheels.txt && \
     cat /wheels/wheels.txt && \
     cd /wheels && \
     /buildbot_venv/bin/pip3 wheel -r wheels.txt && \
@@ -67,12 +67,12 @@ RUN mkdir -p /wheels && \
 # Note that the UI and worker packages are the latest version published on pypi
 # This is to avoid pulling node inside this container
 
-FROM        debian:10-slim
+FROM        debian:11-slim
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2021-04-28
+ENV         security_updates_as_of 2022-03-06
 
 RUN \
     apt-get update && \

--- a/newsfragments/debian-docker-upgrade.feature
+++ b/newsfragments/debian-docker-upgrade.feature
@@ -1,0 +1,1 @@
+Base Debian image has been upgraded to Debian Bullseye for the Buildbot master.


### PR DESCRIPTION
The purpose of the upgrade is actually to fix docker image build which got broken in db3d26228685e3efd9dccf56408dc6cdc82abd1e. fs-extra now depends on node v12 which is not in Debian 10. So it seems it's a good time to upgrade to Debian 11.

## Contributor Checklist:

* (not needed) I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* (not needed) I have updated the appropriate documentation
