### PR TITLE
Fix case-sensitivity in the DB layer on MySQL

### DIFF
--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -29,12 +29,13 @@ class MastersConnectorComponent(base.DBConnectorComponent):
 
     def findMasterId(self, name):
         tbl = self.db.model.masters
+        name_hash = self.hashColumns(name)
         return self.findSomethingId(
             tbl=tbl,
-            whereclause=(tbl.c.name == name),
+            whereclause=(tbl.c.name_hash == name_hash),
             insert_values=dict(
                 name=name,
-                name_hash=self.hashColumns(name),
+                name_hash=name_hash,
                 active=0,  # initially inactive
                 last_active=int(self.master.reactor.seconds())
             ))

--- a/master/buildbot/db/tags.py
+++ b/master/buildbot/db/tags.py
@@ -21,10 +21,11 @@ class TagsConnectorComponent(base.DBConnectorComponent):
 
     def findTagId(self, name):
         tbl = self.db.model.tags
+        name_hash = self.hashColumns(name)
         return self.findSomethingId(
             tbl=tbl,
-            whereclause=(tbl.c.name == name),
+            whereclause=(tbl.c.name_hash == name_hash),
             insert_values=dict(
                 name=name,
-                name_hash=self.hashColumns(name),
+                name_hash=name_hash,
             ))

--- a/master/buildbot/test/unit/db/test_builders.py
+++ b/master/buildbot/test/unit/db/test_builders.py
@@ -91,6 +91,24 @@ class Tests(interfaces.InterfaceTests):
                               masterids=[], description='a string which describe the builder'))
 
     @defer.inlineCallbacks
+    def test_update_builder_info_tags_case(self):
+        yield self.insertTestData([
+            fakedb.Builder(id=7, name='some:builder7'),
+        ])
+
+        yield self.db.builders.updateBuilderInfo(7, 'builder_desc', ['Cat', 'cat'])
+        builder_dict = yield self.db.builders.getBuilder(7)
+        validation.verifyDbDict(self, 'builderdict', builder_dict)
+        builder_dict['tags'].sort()  # order is unspecified
+        self.assertEqual(builder_dict, {
+            'id': 7,
+            'name': 'some:builder7',
+            'tags': ['Cat', 'cat'],
+            'masterids': [],
+            'description': 'builder_desc'
+        })
+
+    @defer.inlineCallbacks
     def test_findBuilderId_new(self):
         id = yield self.db.builders.findBuilderId('some:builder')
         builderdict = yield self.db.builders.getBuilder(id)

--- a/master/buildbot/test/unit/db/test_masters.py
+++ b/master/buildbot/test/unit/db/test_masters.py
@@ -69,6 +69,16 @@ class Tests(interfaces.InterfaceTests):
                               last_active=SOMETIME_DT))
 
     @defer.inlineCallbacks
+    def test_findMasterId_new_name_differs_only_by_case(self):
+        yield self.insertTestData([
+            fakedb.Master(id=7, name='some:master'),
+        ])
+        id = yield self.db.masters.findMasterId('some:Master')
+        masterdict = yield self.db.masters.getMaster(id)
+        self.assertEqual(masterdict, {'id': id, 'name': 'some:Master', 'active': False,
+                                      'last_active': SOMETIME_DT})
+
+    @defer.inlineCallbacks
     def test_findMasterId_exists(self):
         yield self.insertTestData([
             fakedb.Master(id=7, name='some:master'),

--- a/newsfragments/builder-tags-case-sensitive.bugfix
+++ b/newsfragments/builder-tags-case-sensitive.bugfix
@@ -1,0 +1,1 @@
+Fixed problem on MySQL when using builder tags that differ only by case.

--- a/newsfragments/master-name-case-sensitive.bugfix
+++ b/newsfragments/master-name-case-sensitive.bugfix
@@ -1,0 +1,1 @@
+Fixed problem on MySQL when using master names that differ only by case.


### PR DESCRIPTION
We have several queries which break on MySQL when using certain values that differ only by case as MySQL uses case-insensitive string matching by default. This PR fixes that.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* (not needed) I have updated the appropriate documentation
