### PR TITLE
schedulers: Run a build the first time onlyIfChanged is set to True

### DIFF
--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -148,12 +148,18 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
         scheds = self.master.db.schedulers
         classifications = yield scheds.getChangeClassifications(self.serviceid)
 
-        # if onlyIfChanged is True, then we will skip this build if no
-        # important changes have occurred since the last invocation
-        if self.onlyIfChanged and not any(classifications.values()):
+        # if onlyIfChanged is True, then we will skip this build if no important changes have
+        # occurred since the last invocation. Note that when the scheduler has just been started
+        # there may not be any important changes yet and we should start the build for the
+        # current state of the code whatever it is.
+        last_only_if_changed = yield self.getState('last_only_if_changed', False)
+        if last_only_if_changed and self.onlyIfChanged and not any(classifications.values()):
             log.msg(("{} scheduler <{}>: skipping build " +
                      "- No important changes").format(self.__class__.__name__, self.name))
             return
+
+        if last_only_if_changed != self.onlyIfChanged:
+            yield self.setState('last_only_if_changed', self.onlyIfChanged)
 
         changeids = sorted(classifications.keys())
 

--- a/master/docs/manual/configuration/schedulers.rst
+++ b/master/docs/manual/configuration/schedulers.rst
@@ -644,9 +644,8 @@ The arguments to this scheduler are:
 
 ``onlyIfChanged`` (optional)
 
-    If this is ``True``, then builds will not be scheduled at the designated time
-    *unless* the specified branch has seen an important change since
-    the previous build.
+    If this is ``True``, then builds will be scheduled at the designated time only if the specified branch has seen an important change since the previous build.
+    If there is no previous build or the previous build was made when this option was ``False`` then the build will be scheduled even if there are no new changes.
     By default this setting is ``False``.
 
 ``periodicBuildTimer``

--- a/newsfragments/scheduler_only_if_changed_run_first.bugfix
+++ b/newsfragments/scheduler_only_if_changed_run_first.bugfix
@@ -1,0 +1,2 @@
+Fixed timed schedulers not scheduling builds the first time they are enabled with ``onlyIfChanged=True`` when there are no important changes.
+In such case the state of the code is not known, so a build must be run to establish the baseline.


### PR DESCRIPTION
`onlyIfChanged` parameter of timed schedulers is there to avoid duplicate builds if there are no changes that could affect the build outcome. Currently timed builds will only run if there were important changes after `onlyIfChanged` has been enabled. This means that if there are no important changes then the baseline is not established and pre-existing breakage of code could be unnoticed.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* (not needed, bugfix) I have updated the appropriate documentation
