### PR TITLE
Check name lengths during reconfig

### DIFF
--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -14,7 +14,9 @@
 # Copyright Buildbot Team Members
 
 
+from buildbot.config.checks import check_param_length
 from buildbot.config.errors import error
+from buildbot.db.model import Model
 from buildbot.util import bytes2unicode
 from buildbot.util import config as util_config
 from buildbot.util import safeTranslate
@@ -110,8 +112,17 @@ class BuilderConfig(util_config.ConfiguredMixin):
         self.env = env or {}
         if not isinstance(self.env, dict):
             error("builder's env must be a dictionary")
+
         self.properties = properties or {}
+        for property_name in self.properties:
+            check_param_length(property_name, f'Builder {self.name} property',
+                               Model.property_name_length)
+
         self.defaultProperties = defaultProperties or {}
+        for property_name in self.defaultProperties:
+            check_param_length(property_name, f'Builder {self.name} default property',
+                               Model.property_name_length)
+
         self.collapseRequests = collapseRequests
 
         self.description = description

--- a/master/buildbot/config/checks.py
+++ b/master/buildbot/config/checks.py
@@ -1,0 +1,32 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.config.errors import error
+from buildbot.process.properties import Interpolate
+
+
+def check_param_length(value, name, max_length):
+    if isinstance(value, str) and len(value) > max_length:
+        error(f"{name} '{value}' exceeds maximum length of {max_length}")
+
+    if isinstance(value, Interpolate):
+        if value.args:
+            interpolations = tuple([''] * len(value.args))
+        else:
+            interpolations = {k: '' for k in value.interpolations}
+        shortest_value = value.fmtstring % interpolations
+        if len(shortest_value) > max_length:
+            error(f"{name} '{value}' (shortest interpolation) exceeds maximum length of "
+                  f"{max_length}")

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -49,6 +49,11 @@ class UpgradeFromBefore3p0Error(Exception):
 
 
 class Model(base.DBConnectorComponent):
+
+    property_name_length = 256
+    property_source_length = 256
+    hash_length = 40
+
     #
     # schema
     #
@@ -131,10 +136,10 @@ class Model(base.DBConnectorComponent):
         sa.Column('buildid', sa.Integer,
                   sa.ForeignKey('builds.id', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('name', sa.String(256), nullable=False),
+        sa.Column('name', sa.String(property_name_length), nullable=False),
         # JSON encoded value
         sa.Column('value', sa.Text, nullable=False),
-        sa.Column('source', sa.String(256), nullable=False),
+        sa.Column('source', sa.String(property_source_length), nullable=False),
     )
 
     # This table contains transient build state.
@@ -246,7 +251,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('buildsetid', sa.Integer,
                   sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('property_name', sa.String(256), nullable=False),
+        sa.Column('property_name', sa.String(property_name_length), nullable=False),
         # JSON-encoded tuple of (value, source)
         sa.Column('property_value', sa.Text, nullable=False),
     )
@@ -298,7 +303,7 @@ class Model(base.DBConnectorComponent):
         # name for this changesource, as given in the configuration, plus a hash
         # of that name used for a unique index
         sa.Column('name', sa.Text, nullable=False),
-        sa.Column('name_hash', sa.String(40), nullable=False),
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
     )
 
     # This links changesources to the master where they are running.  A changesource
@@ -371,7 +376,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('changeid', sa.Integer,
                   sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('property_name', sa.String(256), nullable=False),
+        sa.Column('property_name', sa.String(property_name_length), nullable=False),
         # JSON-encoded tuple of (value, source)
         sa.Column('property_value', sa.Text, nullable=False),
     )
@@ -484,7 +489,7 @@ class Model(base.DBConnectorComponent):
 
         # hash of the branch, revision, patchid, repository, codebase, and
         # project, using hashColumns.
-        sa.Column('ss_hash', sa.String(40), nullable=False),
+        sa.Column('ss_hash', sa.String(hash_length), nullable=False),
 
         # the branch to check out.  When branch is NULL, that means
         # the main branch (trunk, master, etc.)
@@ -540,7 +545,7 @@ class Model(base.DBConnectorComponent):
         # name for this scheduler, as given in the configuration, plus a hash
         # of that name used for a unique index
         sa.Column('name', sa.Text, nullable=False),
-        sa.Column('name_hash', sa.String(40), nullable=False),
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
         sa.Column('enabled', sa.SmallInteger,
                   server_default=sa.DefaultClause("1")),
     )
@@ -589,7 +594,7 @@ class Model(base.DBConnectorComponent):
         # builder's description
         sa.Column('description', sa.Text, nullable=True),
         # sha1 of name; used for a unique index
-        sa.Column('name_hash', sa.String(40), nullable=False),
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
     )
 
     # This links builders to the master where they are running.  A builder
@@ -615,7 +620,7 @@ class Model(base.DBConnectorComponent):
         # tag's name
         sa.Column('name', sa.Text, nullable=False),
         # sha1 of name; used for a unique index
-        sa.Column('name_hash', sa.String(40), nullable=False),
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
     )
 
     # a many-to-may relationship between builders and tags
@@ -821,7 +826,7 @@ class Model(base.DBConnectorComponent):
         # master's name (generally in the form hostname:basedir)
         sa.Column('name', sa.Text, nullable=False),
         # sha1 of name; used for a unique index
-        sa.Column('name_hash', sa.String(40), nullable=False),
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
 
         # true if this master is running
         sa.Column('active', sa.Integer, nullable=False),

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -31,6 +31,8 @@ from zope.interface import implementer
 from buildbot import config
 from buildbot import interfaces
 from buildbot import util
+from buildbot.config.checks import check_param_length
+from buildbot.db.model import Model
 from buildbot.interfaces import IRenderable
 from buildbot.interfaces import WorkerSetupError
 from buildbot.process import log as plog
@@ -247,6 +249,9 @@ class BuildStep(results.ResultComputingConfigMixin,
         if not isinstance(self.name, str) and not IRenderable.providedBy(self.name):
             config.error(f"BuildStep name must be a string or a renderable object: "
                          f"{repr(self.name)}")
+
+        check_param_length(self.name, f'Step {self.__class__.__name__} name',
+                           Model.steps.c.name.type.length)
 
         if isinstance(self.description, str):
             self.description = [self.description]

--- a/master/buildbot/test/unit/config/test_builder.py
+++ b/master/buildbot/test/unit/config/test_builder.py
@@ -146,6 +146,16 @@ class BuilderConfigTests(ConfigErrorsMixin, unittest.TestCase):
                               collapseRequests='cr',
                               description='buzz')
 
+    def test_too_long_property(self):
+        with self.assertRaisesConfigError("exceeds maximum length of"):
+            BuilderConfig(name="a", workernames=['a'], factory=self.factory,
+                          properties={'a' * 257: 'value'})
+
+    def test_too_long_default_property(self):
+        with self.assertRaisesConfigError("exceeds maximum length of"):
+            BuilderConfig(name="a", workernames=['a'], factory=self.factory,
+                          defaultProperties={'a' * 257: 'value'})
+
     def test_getConfigDict(self):
         ns = lambda: 'ns'
         nb = lambda: 'nb'

--- a/master/buildbot/test/unit/config/test_checks.py
+++ b/master/buildbot/test/unit/config/test_checks.py
@@ -1,0 +1,43 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.trial import unittest
+
+from buildbot.config.checks import check_param_length
+from buildbot.process.properties import Interpolate
+from buildbot.test.util import config
+
+
+class TestCheckParamLength(unittest.TestCase, config.ConfigErrorsMixin):
+
+    def test_short_string(self):
+        check_param_length('1234567890', 'Step name', 10)
+
+    def test_long_string(self):
+        with self.assertRaisesConfigError("exceeds maximum length of 10"):
+            check_param_length('12345678901', 'Step name', 10)
+
+    def test_short_interpolate(self):
+        check_param_length(Interpolate('123456%(prop:xy)s7890'), 'Step name', 10)
+
+    def test_short_interpolate_args(self):
+        check_param_length(Interpolate('123456%s7890', 'arg'), 'Step name', 10)
+
+    def test_short_interpolate_kwargs(self):
+        check_param_length(Interpolate('123456%(prop:xy)s7890', kw='arg'), 'Step name', 10)
+
+    def test_long_interpolate(self):
+        with self.assertRaisesConfigError("xceeds maximum length of 10"):
+            check_param_length(Interpolate('123456%(prop:xy)s78901'), 'Step name', 10)

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -127,6 +127,10 @@ class TestBuildStep(TestBuildStepMixin, config.ConfigErrorsMixin,
         with self.assertRaisesConfigError("BuildStep name must be a string"):
             buildstep.BuildStep(name=5)
 
+    def test_name_too_long(self):
+        with self.assertRaisesConfigError("exceeds maximum length of"):
+            buildstep.BuildStep(name="b" * 100)
+
     def test_unexpectedKeywordArgument(self):
         """
         When BuildStep is passed an unknown keyword argument, it reports

--- a/newsfragments/name_length_checks.bugfix
+++ b/newsfragments/name_length_checks.bugfix
@@ -1,0 +1,1 @@
+Implemented maximum-length checks of step names as early as possible to produce readable errors.

--- a/newsfragments/name_length_checks.bugfix
+++ b/newsfragments/name_length_checks.bugfix
@@ -1,1 +1,1 @@
-Implemented maximum-length checks of step names as early as possible to produce readable errors.
+Implemented detection of too long step and builder property names to produce errors at config time if possible.


### PR DESCRIPTION
Currently if a e.g. property name or step name is too long to be stored in the database we will fail at runtime with weird database-related error. Most such problems can be caught at configuration time by checking config. This PR implements this for a subset of names.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* (bugfix, not needed) I have updated the appropriate documentation
