### PR TITLE
Reuse runprocess module in MasterShellCommand

### DIFF
--- a/master/buildbot/test/integration/test_integration_mastershell.py
+++ b/master/buildbot/test/integration/test_integration_mastershell.py
@@ -14,9 +14,16 @@
 # Copyright Buildbot Team Members
 
 
+import sys
+
 from twisted.internet import defer
 
+from buildbot.config import BuilderConfig
+from buildbot.plugins import schedulers
+from buildbot.plugins import steps
+from buildbot.process.factory import BuildFactory
 from buildbot.test.util.integration import RunMasterBase
+from buildbot.util import asyncSleep
 
 
 # This integration test creates a master and worker environment,
@@ -24,38 +31,84 @@ from buildbot.test.util.integration import RunMasterBase
 # meant to be a template for integration steps
 class ShellMaster(RunMasterBase):
 
+    def config_for_master_command(self, **kwargs):
+        c = {}
+
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(name="sched", builderNames=["testy"])
+        ]
+
+        f = BuildFactory()
+        f.addStep(steps.MasterShellCommand(**kwargs))
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+        return c
+
+    def get_change(self):
+        return {
+            "branch": "master",
+            "files": ["foo.c"],
+            "author": "me@foo.com",
+            "committer": "me@foo.com",
+            "comments": "good stuff",
+            "revision": "HEAD",
+            "project": "none"
+        }
+
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setupConfig(self.config_for_master_command(command='echo hello'))
 
-        change = dict(branch="master",
-                      files=["foo.c"],
-                      author="me@foo.com",
-                      committer="me@foo.com",
-                      comments="good stuff",
-                      revision="HEAD",
-                      project="none"
-                      )
-        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
         self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['steps'][1]['state_string'], 'Ran')
 
+    @defer.inlineCallbacks
+    def test_logs(self):
+        yield self.setupConfig(self.config_for_master_command(command=[
+            sys.executable, '-c', 'print("hello")'
+        ]))
 
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
+        build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        res = yield self.checkBuildStepLogExist(build, "hello")
+        self.assertTrue(res)
+        self.assertEqual(build['steps'][1]['state_string'], 'Ran')
 
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["testy"])]
+    @defer.inlineCallbacks
+    def test_fails(self):
+        yield self.setupConfig(self.config_for_master_command(command=[
+            sys.executable, '-c', 'exit(1)'
+        ]))
 
-    f = BuildFactory()
-    f.addStep(steps.MasterShellCommand(command='echo hello'))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c
+        build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['steps'][1]['state_string'], 'failed (1) (failure)')
+
+    @defer.inlineCallbacks
+    def test_interrupt(self):
+        yield self.setupConfig(self.config_for_master_command(name='sleep', command=[
+            sys.executable, '-c', "while True: pass"
+        ]))
+
+        d = self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
+
+        @defer.inlineCallbacks
+        def on_new_step(_, data):
+            if data['name'] == 'sleep':
+                # wait until the step really starts
+                yield asyncSleep(1)
+                brs = yield self.master.data.get(('buildrequests',))
+                brid = brs[-1]['buildrequestid']
+                self.master.data.control('cancel', {'reason': 'cancelled by test'},
+                                         ('buildrequests', brid))
+
+        yield self.master.mq.startConsuming(on_new_step, ('steps', None, 'new'))
+
+        build = yield d
+        self.assertEqual(build['buildid'], 1)
+        if sys.platform == 'win32':
+            self.assertEqual(build['steps'][1]['state_string'], 'failed (1) (exception)')
+        else:
+            self.assertEqual(build['steps'][1]['state_string'], 'killed (9) (exception)')

--- a/master/buildbot/test/runprocess.py
+++ b/master/buildbot/test/runprocess.py
@@ -33,7 +33,7 @@ class MasterRunProcessMixin:
     def patched_run_process(self, reactor, command, workdir=None, env=None,
                             collect_stdout=True, collect_stderr=True, stderr_is_error=False,
                             io_timeout=300, runtime_timeout=3600, sigterm_timeout=5,
-                            initial_stdin=None):
+                            initial_stdin=None, use_pty=False):
 
         _check_env_is_expected(self, self._master_run_process_expect_env, env)
 

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -77,12 +77,12 @@ def _describe_cmd_difference(exp_command, exp_args, got_command, got_args):
     missing_in_exp, missing_in_cmd, diff = _dict_diff(exp_args, got_args)
     if missing_in_exp:
         missing_dict = {key: got_args[key] for key in missing_in_exp}
-        text += f'Keys in cmd missing from expectation: {missing_dict!r}\n'
+        text += f'Keys in command missing from expectation: {missing_dict!r}\n'
     if missing_in_cmd:
         missing_dict = {key: exp_args[key] for key in missing_in_cmd}
         text += f'Keys in expectation missing from command: {missing_dict!r}\n'
     if diff:
-        formatted_diff = [f'"{d[0]}": expected {d[1]!r}, got {d[2]!r}' for d in diff]
+        formatted_diff = [f'"{d[0]}":\nexpected: {d[1]!r}\ngot:      {d[2]!r}\n' for d in diff]
         text += ('Key differences between expectation and command: {0}\n'.format(
             '\n'.join(formatted_diff)))
     return text

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -239,7 +239,7 @@ class Expect:
         cmd_dif = _describe_cmd_difference(self.remote_command, self.args,
                                            command.remote_command, command.args)
         msg = ("Command contents different from expected (command index: "
-               f"{self._expected_commands_popped}); {cmd_dif}")
+               f"{case._expected_commands_popped}):\n{cmd_dif}")
         raise AssertionError(msg)
 
     def __repr__(self):

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -580,6 +580,19 @@ class ExpectMasterShell:
         return f"<ExpectMasterShell(command={self._command})>"
 
 
+class FakeRunProcess:
+    def __init__(self, start_retval, result_rc):
+        self.start_retval = start_retval
+        self.result_rc = result_rc
+        self.result_signal = None
+
+    def start(self):
+        return defer.succeed(self.start_retval)
+
+    def interrupt(self, signal_name):
+        pass
+
+
 class TestBuildStepMixin:
 
     """
@@ -601,7 +614,7 @@ class TestBuildStepMixin:
         self.master = fakemaster.make_master(self, wantData=want_data, wantDb=want_db,
                                              wantMq=want_mq)
 
-        self.patch(runprocess, "run_process", self._patched_run_process)
+        self.patch(runprocess, "create_process", self._patched_create_process)
         self._master_run_process_expect_env = {}
 
     def tear_down_test_build_step(self):
@@ -889,10 +902,10 @@ class TestBuildStepMixin:
         if not exp.connection_broken:
             command.remote_complete()
 
-    def _patched_run_process(self, reactor, command, workdir=None, env=None,
-                             collect_stdout=True, collect_stderr=True, stderr_is_error=False,
-                             io_timeout=300, runtime_timeout=3600, sigterm_timeout=5,
-                             initial_stdin=None):
+    def _patched_create_process(self, reactor, command, workdir=None, env=None,
+                                collect_stdout=True, collect_stderr=True, stderr_is_error=False,
+                                io_timeout=300, runtime_timeout=3600, sigterm_timeout=5,
+                                initial_stdin=None, use_pty=False):
 
         _check_env_is_expected(self, self._master_run_process_expect_env, env)
 
@@ -908,7 +921,9 @@ class TestBuildStepMixin:
                       f"expectation is not instance of ExpectMasterShell: {exp!r}")
 
         try:
-            rc, stdout, stderr = exp._check(command, workdir, env)
+            rc, stdout, stderr = exp._check(self, command, workdir, env)
+            result_rc = rc
+
         except AssertionError as e:
             # log this error, as the step may swallow the AssertionError or
             # otherwise obscure the failure.  Trial will see the exception in
@@ -917,16 +932,31 @@ class TestBuildStepMixin:
             log.err()
             raise e
 
-        if not collect_stderr and stderr_is_error and stderr:
+        if stderr_is_error and stderr:
             rc = -1
 
-        if collect_stdout and collect_stderr:
-            return (rc, stdout, stderr)
-        if collect_stdout:
-            return (rc, stdout)
-        if collect_stderr:
-            return (rc, stderr)
-        return rc
+        return_stdout = None
+        if collect_stdout is True:
+            return_stdout = stdout
+        elif callable(collect_stdout):
+            collect_stdout(stdout)
+
+        return_stderr = None
+        if collect_stderr is True:
+            return_stderr = stderr
+        elif callable(collect_stderr):
+            collect_stderr(stderr)
+
+        if return_stdout is not None and return_stderr is not None:
+            start_retval = (rc, return_stdout, return_stderr)
+        elif return_stdout is not None:
+            start_retval = (rc, return_stdout)
+        elif return_stderr is not None:
+            start_retval = (rc, return_stderr)
+        else:
+            start_retval = rc
+
+        return FakeRunProcess(start_retval, result_rc)
 
     def change_worker_system(self, system):
         self.worker.worker_system = system

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -45,7 +45,7 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
         self.process = None
         self.reactor.spawnProcess = self.fake_spawn_process
 
-    def fake_spawn_process(self, pp, command, args, env, workdir):
+    def fake_spawn_process(self, pp, command, args, env, workdir, usePTY=False):
         self.assertIsNone(self.process)
         self.pp = pp
         self.pp.transport = mock.Mock()

--- a/master/buildbot/util/runprocess.py
+++ b/master/buildbot/util/runprocess.py
@@ -54,7 +54,8 @@ class RunProcess:
 
     def __init__(self, reactor, command, workdir=None, env=None,
                  collect_stdout=True, collect_stderr=True, stderr_is_error=False,
-                 io_timeout=300, runtime_timeout=3600, sigterm_timeout=5, initial_stdin=None):
+                 io_timeout=300, runtime_timeout=3600, sigterm_timeout=5, initial_stdin=None,
+                 use_pty=False):
 
         self._reactor = reactor
         self.command = command
@@ -81,6 +82,7 @@ class RunProcess:
 
         self.killed = False
         self.kill_timer = None
+        self.use_pty = use_pty
 
     def __repr__(self):
         return f"<{self.__class__.__name__} '{self.command}'>"
@@ -122,7 +124,8 @@ class RunProcess:
             environ['PWD'] = os.path.abspath(self.workdir)
 
         argv = unicode2bytes(self.command)
-        self.process = self._reactor.spawnProcess(self.pp, argv[0], argv, environ, self.workdir)
+        self.process = self._reactor.spawnProcess(self.pp, argv[0], argv, environ, self.workdir,
+                                                  usePTY=self.use_pty)
 
         if self.io_timeout:
             self.io_timer = self._reactor.callLater(self.io_timeout, self.io_timed_out)


### PR DESCRIPTION
There are multiple ways to run shell commands on the master side. This makes testing harder because we need to have testing infrastructure for each of these APIs.

This PR changes MasterShellCommand to use the runprocess API that is used for many master-side shell commands.