### PR TITLE
util: Allow full URLs for HTTPClientService methods

### DIFF
--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -118,7 +118,11 @@ class HTTPClientService(service.SharedService):
 
     def _doRequest(self, method, ep, params=None, headers=None, data=None, json=None, files=None,
             timeout=None):
-        assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep
+        if ep.startswith('http://') or ep.startswith('https://'):
+            pass
+        else:
+            assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep
+
         if not self.quiet:
             log.debug("{method} {ep} {params!r} <- {data!r}",
                       method=method, ep=ep, params=params, data=data or json)

--- a/master/buildbot/test/unit/util/test_httpclientservice.py
+++ b/master/buildbot/test/unit/util/test_httpclientservice.py
@@ -72,6 +72,11 @@ class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
         self._http._session.request.assert_called_once_with('get', 'http://foo/bar', headers={},
                                                             background_callback=mock.ANY)
 
+    def test_get_full_url(self):
+        self._http.get('http://other/bar')
+        self._http._session.request.assert_called_once_with('get', 'http://other/bar', headers={},
+                                                            background_callback=mock.ANY)
+
     def test_put(self):
         self._http.put('/bar', json={'foo': 'bar'})
         jsonStr = json.dumps(dict(foo='bar'))

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -147,8 +147,11 @@ class HTTPClientService(service.SharedService):
         yield super().stopService()
 
     def _prepareRequest(self, ep, kwargs):
-        assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep
-        url = self._base_url + ep
+        if ep.startswith('http://') or ep.startswith('https://'):
+            url = ep
+        else:
+            assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep
+            url = self._base_url + ep
         if self._auth is not None and 'auth' not in kwargs:
             kwargs['auth'] = self._auth
         headers = kwargs.get('headers', {})

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -1194,7 +1194,7 @@ For example, a particular daily scheduler could be configured on multiple master
 
     .. py:method:: get(endpoint, params=None)
 
-        :param endpoint: endpoint relative to the base_url (starts with ``/``)
+        :param endpoint: endpoint. It must either be a full URL (starts with ``http://`` or ``https://``) or relative to the base_url (starts with ``/``)
         :param params: optional dictionary that will be encoded in the query part of the url (e.g. ``?param1=foo``)
         :returns: implementation of :`IHTTPResponse` via deferred
 
@@ -1202,7 +1202,7 @@ For example, a particular daily scheduler could be configured on multiple master
 
     .. py:method:: delete(endpoint, params=None)
 
-        :param endpoint: endpoint relative to the base_url (starts with ``/``)
+        :param endpoint: endpoint. It must either be a full URL (starts with ``http://`` or ``https://``) or relative to the base_url (starts with ``/``)
         :param params: optional dictionary that will be encoded in the query part of the url (e.g. ``?param1=foo``)
         :returns: implementation of :`IHTTPResponse` via deferred
 
@@ -1210,7 +1210,7 @@ For example, a particular daily scheduler could be configured on multiple master
 
     .. py:method:: post(endpoint, data=None, json=None, params=None)
 
-        :param endpoint: endpoint relative to the base_url (starts with ``/``)
+        :param endpoint: endpoint. It must either be a full URL (starts with ``http://`` or ``https://``) or relative to the base_url (starts with ``/``)
         :param data: optional dictionary that will be encoded in the body of the http requests as ``application/x-www-form-urlencoded``
         :param json: optional dictionary that will be encoded in the body of the http requests as ``application/json``
         :param params: optional dictionary that will be encoded in the query part of the url (e.g. ``?param1=foo``)
@@ -1224,7 +1224,7 @@ For example, a particular daily scheduler could be configured on multiple master
 
     .. py:method:: put(endpoint, data=None, json=None, params=None)
 
-        :param endpoint: endpoint relative to the base_url (starts with ``/``)
+        :param endpoint: endpoint. It must either be a full URL (starts with ``http://`` or ``https://``) or relative to the base_url (starts with ``/``)
         :param data: optional dictionary that will be encoded in the body of the http requests as ``application/x-www-form-urlencoded``
         :param json: optional dictionary that will be encoded in the body of the http requests as ``application/json``
         :param params: optional dictionary that will be encoded in the query part of the url (e.g. ``?param1=foo``)

--- a/newsfragments/httpclientservice-full-url.feature
+++ b/newsfragments/httpclientservice-full-url.feature
@@ -1,0 +1,2 @@
+``HTTPClientService`` now accepts full URL in its methods.
+Previously only a relative URL was supported.


### PR DESCRIPTION
HTTPClientService currently only supports URLs that are relative to base URL. This is a serious limitation in case of REST APIs that return paths to other resources in the API responses. If the paths are full URLs then it would be simplest if we could just pass the URLs to HTTPClientService unmodified.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
