### PR TITLE
Fixed VisualStudio based steps causing an exception in getResultSummary when being skipped.

### DIFF
--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -192,6 +192,10 @@ class VisualStudio(buildstep.ShellMixin, buildstep.BuildStep):
         return self.results
 
     def getResultSummary(self):
+        if self.logobserver is None:
+            # step was skipped or log observer was not created due to another reason
+            return {"step": results.Results[self.results]}
+
         description = (f'compile {self.logobserver.nbProjects} projects {self.logobserver.nbFiles} '
                        'files')
 

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -22,6 +22,7 @@ from buildbot import config
 from buildbot.process import results
 from buildbot.process.properties import Property
 from buildbot.process.results import FAILURE
+from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import vstudio
@@ -226,6 +227,12 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
+        return self.run_step()
+
+    def test_skipped(self):
+        self.setup_step(VCx(doStepIf=False))
+        self.expect_commands()
+        self.expect_outcome(result=SKIPPED, state_string="")
         return self.run_step()
 
     @defer.inlineCallbacks

--- a/newsfragments/vstudio-skipped-exception.bugfix
+++ b/newsfragments/vstudio-skipped-exception.bugfix
@@ -1,0 +1,1 @@
+Fixed `VisualStudio` based steps causing an exception in `getResultSummary` when being skipped.


### PR DESCRIPTION


## Contributor Checklist:

* [ ] I have updated the unit tests
 * Please provide some proper documentation for your unit test framework, this is just unusable for outsiders, and I tried to use it extensively on one of my plugins.
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
 * Not applicable
