### PR TITLE
Fixed MsBuild141 using incorrect vswhere syntax to retrieve the install location for VS2017

### DIFF
--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -557,9 +557,10 @@ class MsBuild141(VisualStudio):
         self.descriptionDone = 'built ' + self.describe_project()
         yield self.updateSummary()
 
-        command = ('FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\') '
-                   f' do "%%I\\%VCENV_BAT%" x86 && msbuild "{self.projectfile}" '
-                   f'/p:Configuration="{self.config}" /p:Platform="{self.platform}" /maxcpucount')
+        command = (('FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -property  installationPath\') '
+            ' do "%%I\\%VCENV_BAT%" x86 && msbuild "{}" /p:Configuration="{}" '
+            '/p:Platform="{}" /maxcpucount').format(self.projectfile, self.config,
+                                                            self.platform))
 
         command += _msbuild_format_target_parameter(self.mode, self.project)
         command += _msbuild_format_defines_parameter(self.defines)

--- a/newsfragments/msbuild141-incorrect-vswhere-usage.bugfix
+++ b/newsfragments/msbuild141-incorrect-vswhere-usage.bugfix
@@ -1,0 +1,1 @@
+Fixed `MSBuild141` using incorrect vswhere syntax to retrieve the install location for VS2017


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
 * Please provide some proper documentation for your unit test framework, this is just unusable for outsiders, and I tried to use it extensively on one of my plugins.
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
 * Not applicable


The old command caused an error something like `( was unexpected at this time`, indicating an error in the syntax for the batch command.