### PR TITLE
Some code cleanups

### DIFF
--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -15,7 +15,6 @@
 
 import os
 import unittest
-from builtins import int
 
 from twisted.python import util
 
@@ -54,26 +53,6 @@ def patch_servicechecks():
 
 
 @onlyOnce
-def patch_mysqlclient_warnings():
-    try:
-        from _mysql_exceptions import Warning
-        # MySQLdb.compat is only present in mysqlclient
-        import MySQLdb.compat  # noqa pylint: disable=unused-import,import-outside-toplevel
-    except ImportError:
-        return
-    # workaround for https://twistedmatrix.com/trac/ticket/9005
-    # mysqlclient is easier to patch than twisted
-    # we swap _mysql_exceptions.Warning arguments so that the code is in second place
-
-    def patched_init(self, *args):
-        if isinstance(args[0], int):
-            super().__init__(f"{args[0]} {args[1]}")
-        else:
-            super().__init__(*args)
-    Warning.__init__ = patched_init
-
-
-@onlyOnce
 def patch_decorators():
     from buildbot.monkeypatches import decorators
     decorators.patch()
@@ -107,6 +86,5 @@ def patch_all(for_tests=False):
         patch_servicechecks()
         patch_testcase_timeout()
         patch_decorators()
-        patch_mysqlclient_warnings()
         patch_config_for_unit_tests()
         patch_unittest_testcase()

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -66,25 +66,9 @@ def patch_config_for_unit_tests():
     set_is_in_unit_tests(True)
 
 
-@onlyOnce
-def patch_unittest_testcase():
-    from twisted.trial.unittest import TestCase
-
-    # In Python 3.2,
-    # - assertRaisesRegexp() was renamed to assertRaisesRegex(),
-    #   and assertRaisesRegexp() was deprecated.
-    # - assertRegexpMatches() was renamed to assertRegex()
-    #   and assertRegexpMatches() was deprecated.
-    if not getattr(TestCase, "assertRaisesRegex", None):
-        TestCase.assertRaisesRegex = TestCase.assertRaisesRegexp
-    if not getattr(TestCase, "assertRegex", None):
-        TestCase.assertRegex = TestCase.assertRegexpMatches
-
-
 def patch_all(for_tests=False):
     if for_tests:
         patch_servicechecks()
         patch_testcase_timeout()
         patch_decorators()
         patch_config_for_unit_tests()
-        patch_unittest_testcase()

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -13,11 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-# We cannot use the builtins module here from Python-Future.
-# We need to use the native __builtin__ module on Python 2,
-# and builtins module on Python 3, because we need to override
-# the actual native open method.
-
+import builtins
 import os
 import re
 import textwrap
@@ -50,13 +46,6 @@ from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import service
 from buildbot.warnings import ConfigWarning
 from buildbot.warnings import DeprecatedApiWarning
-
-try:
-    # Python 2
-    import __builtin__ as builtins
-except ImportError:
-    # Python 3
-    import builtins
 
 global_defaults = dict(
     title='Buildbot',

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -22,12 +22,6 @@ from buildbot.schedulers import timed
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
 
-try:
-    from multiprocessing import Process
-    assert Process
-except ImportError:
-    Process = None
-
 
 class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin,
                   unittest.TestCase):

--- a/master/buildbot/util/logger.py
+++ b/master/buildbot/util/logger.py
@@ -14,24 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-try:
-    from twisted.logger import Logger
-except ImportError:
-    from twisted.python import log
+from twisted.logger import Logger
 
-    class Logger:
-        """A simplistic backporting of the new logger system for old versions of twisted"""
-        def _log(self, format, *args, **kwargs):
-            log.msg(format.format(args, **kwargs))
-
-        # legacy logging system do not support log level.
-        # We don't bother inventing something. If needed, user can upgrade
-        debug = _log
-        info = _log
-        warn = _log
-        error = _log
-        critical = _log
-
-        def failure(self, format, failure, *args, **kwargs):
-            log.error(failure, format.format(args, **kwargs))
 __all__ = ["Logger"]

--- a/master/buildbot/util/raml.py
+++ b/master/buildbot/util/raml.py
@@ -16,13 +16,9 @@
 import copy
 import json
 import os
+from collections import OrderedDict
 
 import yaml
-
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
 
 
 # minimalistic raml loader. Support !include tags, and mapping as OrderedDict

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -120,13 +120,7 @@ class GitHubEventHandler(PullRequestMixin):
                            digestmod=sha1)
 
             def _cmp(a, b):
-                try:
-                    # try the more secure compare_digest() first
-                    from hmac import compare_digest
-                    return compare_digest(a, b)
-                except ImportError:  # pragma: no cover
-                    # and fallback to the insecure simple comparison otherwise
-                    return a == b
+                return hmac.compare_digest(a, b)
 
             if not _cmp(bytes2unicode(mac.hexdigest()), hexdigest):
                 raise ValueError('Hash mismatch')


### PR DESCRIPTION
* Remove import tricks for Python 2.x
* Remove a unittest trick for Python < 3.2. Buildbot master already
  requires Python >= 3.6.
* Remove a trick for hmac.compare_digest(), which is available since
  Python 3.3 [1]
* Remove an unused multiprocessing.Process import
* Remove tricks for older Twisted - buildbot master requires Twisted
  17.9.0 or newer
    * The mentioned bug in buildbot.monkeypatches is fixed in Twisted
      17.1 [2]
    * The compatibility class for twisted.logger.Logger is not needed as
      the latter is available since Twisted 15.2.0 [3]

[1] https://docs.python.org/3/library/hmac.html
[2] https://github.com/twisted/twisted/commit/76ca7457621bdbd58f7220ac038bff84f9ef9a1d
[3] https://github.com/twisted/twisted/commit/30eab9904f289f3d85cfaf7a66dc37379da0ea23

(All of them are trivial changes, so I put them all in one commit. Please tell me if multiple commits are better, thanks!)

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory) - not needed in my opinion
* [ ] I have updated the appropriate documentation - not needed
