### PR TITLE
Fix reporters issues

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -133,6 +133,8 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
         # references.
         yield self.master.data.updates.completeBuildRequests([brid],
                                                              results.CANCELLED)
+        brdict = yield self.master.db.buildrequests.getBuildRequest(brid)
+        self.master.mq.produce(('buildrequests', str(brid), 'cancel'), brdict)
         return None
 
 

--- a/master/buildbot/reporters/generators/buildrequest.py
+++ b/master/buildbot/reporters/generators/buildrequest.py
@@ -20,6 +20,7 @@ from buildbot import interfaces
 from buildbot.process.build import Build
 from buildbot.process.buildrequest import BuildRequest
 from buildbot.process.properties import Properties
+from buildbot.process.results import CANCELLED
 from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatterRenderable
 
@@ -30,7 +31,8 @@ from .utils import BuildStatusGeneratorMixin
 class BuildRequestGenerator(BuildStatusGeneratorMixin):
 
     wanted_event_keys = [
-        ('buildrequests', None, 'new')
+        ('buildrequests', None, 'new'),
+        ('buildrequests', None, 'cancel')
     ]
 
     compare_attrs = ['formatter']
@@ -62,6 +64,10 @@ class BuildRequestGenerator(BuildStatusGeneratorMixin):
     @defer.inlineCallbacks
     def generate(self, master, reporter, key, buildrequest):
         build = yield self.partial_build_dict(master, buildrequest)
+        _, _, event = key
+        if event == 'cancel':
+            build['complete'] = True
+            build['results'] = CANCELLED
 
         if not self.is_message_needed_by_props(build):
             return None

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -157,8 +157,10 @@ class GitLabStatusPush(ReporterBase):
                 RETRY: 'pending',
                 CANCELLED: 'canceled'
             }.get(build['results'], 'failed')
-        else:
+        elif build.get('started_at'):
             state = 'running'
+        else:
+            state = 'pending'
 
         context = yield props.render(self.context)
 

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -95,7 +95,7 @@ class GitLabStatusPush(ReporterBase):
         :param branch: Branch name to create the status for.
         :param sha: Full sha to create the status for.
         :param state: one of the following 'pending', 'success', 'failed'
-                      or 'cancelled'.
+                      or 'canceled'.
         :param target_url: Target url to associate with this status.
         :param description: Short description of the status.
         :param context: Context of the result
@@ -155,7 +155,7 @@ class GitLabStatusPush(ReporterBase):
                 SKIPPED: 'success',
                 EXCEPTION: 'failed',
                 RETRY: 'pending',
-                CANCELLED: 'cancelled'
+                CANCELLED: 'canceled'
             }.get(build['results'], 'failed')
         else:
             state = 'running'

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -22,6 +22,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.builder import Builder
+from buildbot.process.results import CANCELLED
 from buildbot.reporters.generators.buildrequest import BuildRequestGenerator
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
@@ -135,6 +136,28 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
             'subject': 'start subject',
             'type': 'plain',
             'results': None,
+            'builds': [build],
+            'users': [],
+            'patches': [],
+            'logs': []
+        })
+
+    @defer.inlineCallbacks
+    def test_generate_cancel(self):
+        self.maxDiff = None
+        g = yield self.setup_generator(add_patch=True)
+        buildrequest = yield self.insert_buildrequest_new(insert_patch=False)
+        build = yield g.partial_build_dict(self.master, buildrequest)
+        report = yield g.generate(self.master, None, ('buildrequests', 11, 'cancel'), buildrequest)
+
+        build['complete'] = True
+        build['results'] = CANCELLED
+
+        self.assertEqual(report, {
+            'body': 'start body',
+            'subject': 'start subject',
+            'type': 'plain',
+            'results': CANCELLED,
             'builds': [build],
             'users': [],
             'patches': [],

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -80,8 +80,16 @@ class TestGitLabStatusPush(TestReactorMixin, ConfigErrorsMixin, unittest.TestCas
                   'target_url': 'http://localhost:8080/#buildrequests/11',
                   'ref': 'master',
                   'description': 'Build pending.', 'name': 'buildbot/Builder0'})
+        self._http.expect(
+            'post',
+            '/api/v4/projects/1/statuses/d34db33fd43db33f',
+            json={'state': 'canceled',
+                  'target_url': 'http://localhost:8080/#buildrequests/11',
+                  'ref': 'master',
+                  'description': 'Build pending.', 'name': 'buildbot/Builder0'})
 
         yield self.sp._got_event(('buildrequests', 11, 'new'), buildrequest)
+        yield self.sp._got_event(('buildrequests', 11, 'cancel'), buildrequest)
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -381,6 +381,9 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
                 expected_productions.append(
                     (('control', 'buildrequests', str(id), 'cancel'),
                      {'reason': 'Build request has been obsoleted by a newer commit'}))
+            elif kind == 'buildrequests':
+                brdict = yield self.master.db.buildrequests.getBuildRequest(id)
+                expected_productions.append((('buildrequests', str(id), 'cancel'), brdict))
             else:
                 raise Exception(f"Unknown cancellation type {kind}")
 

--- a/newsfragments/buildrequest-cancel-report.feature
+++ b/newsfragments/buildrequest-cancel-report.feature
@@ -1,0 +1,1 @@
+Generate build report on canceled buildrequests

--- a/newsfragments/gitlab-build-canceled-status-report.bugfix
+++ b/newsfragments/gitlab-build-canceled-status-report.bugfix
@@ -1,0 +1,1 @@
+GitLab: Fix build canceled status report

--- a/newsfragments/gitlab-report-pending-status.bugfix
+++ b/newsfragments/gitlab-report-pending-status.bugfix
@@ -1,0 +1,1 @@
+GitLab: Properly report build pending status


### PR DESCRIPTION
- Gitlab commit API expects the build state to be one of pending, running, success, failed, canceled (not cancelled) (reference: https://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit)
- That means the gitlab reporter must differentiate started builds from pending builds
- Generate build reports for canceled build requests (otherwise builds are reported as pending indefinitely)

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
