### PR TITLE
Fix error in documentation build

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -39,7 +39,7 @@ except pkg_resources.ResolutionError as e:
                        "Please install documentation dependencies with `pip "
                        "install buildbot[docs]`") from e
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.0'
+needs_sphinx = '4.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -49,7 +49,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'bbdocs.ext',
     'bbdocs.api_index',
-    'sphinxcontrib.jinja',
+    'sphinx_jinja',
     'sphinx_rtd_theme',
 ]
 todo_include_todos = True

--- a/newsfragments/documentation-build.bugfix
+++ b/newsfragments/documentation-build.bugfix
@@ -1,0 +1,1 @@
+Fix documentation build for ReadTheDocs.


### PR DESCRIPTION
Also update minimum Sphinx version to 4.

ReadTheDocs builds have been failing for a while ([latest error log](https://readthedocs.org/projects/buildbot/builds/16864586/) as of this PR, for 2022-05-09).  Root cause appears to be an outdated reference to a Sphinx extension.  Correct library is installed, but referenced with the wrong name.

## Contributor Checklist:

* [N/A ] I have updated the unit tests
* [ Y] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ Y] I have updated the appropriate documentation
