### PR TITLE
Create transfer related tempfiles with prefix 'buildbot-transfer-'

### DIFF
--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -42,7 +42,7 @@ class FileWriter(base.FileWriterImpl):
 
         self.destfile = destfile
         self.mode = mode
-        fd, self.tmpname = tempfile.mkstemp(dir=dirname)
+        fd, self.tmpname = tempfile.mkstemp(dir=dirname, prefix='buildbot-transfer-')
         self.fp = os.fdopen(fd, 'wb')
         self.remaining = maxsize
 
@@ -104,7 +104,7 @@ class DirectoryWriter(FileWriter):
         self.destroot = destroot
         self.compress = compress
 
-        self.fd, self.tarname = tempfile.mkstemp()
+        self.fd, self.tarname = tempfile.mkstemp(prefix='buildbot-transfer-')
         os.close(self.fd)
 
         super().__init__(self.tarname, maxsize, mode)

--- a/master/buildbot/test/unit/process/test_remotetransfer.py
+++ b/master/buildbot/test/unit/process/test_remotetransfer.py
@@ -63,7 +63,7 @@ class TestFileWriter(unittest.TestCase):
         absdir = os.path.dirname(os.path.abspath(os.path.join("dir", "file")))
         mockedExists.assert_called_once_with(absdir)
         mockedMakedirs.assert_called_once_with(absdir)
-        mockedMkstemp.assert_called_once_with(dir=absdir)
+        mockedMkstemp.assert_called_once_with(dir=absdir, prefix='buildbot-transfer-')
         mockedFdopen.assert_called_once_with(7, 'wb')
 
 

--- a/newsfragments/tempfile.feature
+++ b/newsfragments/tempfile.feature
@@ -1,0 +1,1 @@
+Prefix transfer related temporary files with ``buildbot-transfer-``.

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -208,7 +208,7 @@ class WorkerDirectoryUploadCommand(WorkerFileUploadCommand):
             log.msg("path: {0!r}".format(self.path))
 
         # Create temporary archive
-        fd, self.tarname = tempfile.mkstemp()
+        fd, self.tarname = tempfile.mkstemp(prefix='buildbot-transfer-')
         self.fp = os.fdopen(fd, "rb+")
 
         if self.compress == 'bz2':


### PR DESCRIPTION
Right now `mkstemp()` is used to create temporary files for transfers (both on worker and controller). Our IDS sometimes noticed a new file in `/tmp` while running which I didn't knew where it came from, and it took me a bit to figure out that it came from a buildbot job uploading a directory to the controller. Having buildbot's name in the filename would made identifying this a lot easier.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
