### PR TITLE
wamp: Remove unused config attribute to fix compat with new autobahn

### DIFF
--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -37,7 +37,6 @@ class MasterService(ApplicationSession, service.AsyncMultiService):
         # We must explicitly call both parent constructors.
         ApplicationSession.__init__(self)
         service.AsyncMultiService.__init__(self)
-        self.config = config
         self.leaving = False
         self.setServiceParent(config.extra['parent'])
 

--- a/newsfragments/autobahn-compat.bugfix
+++ b/newsfragments/autobahn-compat.bugfix
@@ -1,0 +1,1 @@
+Fix compatibility with Autobahn 22.4.x.


### PR DESCRIPTION
This fixes compatibility with autobahn 22.4.x.