### PR TITLE
Drop support for python 3.6 on master

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -44,12 +44,10 @@ matrix:
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
-    - python: "3.6"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=ci/coverage
     - python: "3.9"
       env: TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
     - python: "3.7"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=ci/coverage
     - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=ci/coverage
     - python: "3.9"

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -4,7 +4,7 @@ language: python
 
 # Available Python versions:
 python:
-  - "3.8"
+  - "3.9"
 label_mapping:
   TWISTED: tw
   SQLALCHEMY: sqla
@@ -25,28 +25,28 @@ matrix:
   fast_finish: true
   include:
     # flake8, isort, pylint, docs first as they're more likely to find issues
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=flake8
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=isort
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=pylint NUM_CPU=2 MEMORY_SIZE=4G
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=docs
 
     # add js tests in separate job. Start it early because it is quite long
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=js_build NUM_CPU=2 MEMORY_SIZE=2G
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=js_unit NUM_CPU=2 MEMORY_SIZE=2G
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=smokes NUM_CPU=4 MEMORY_SIZE=4G
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
     - python: "3.6"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=ci/coverage
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
     - python: "3.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
@@ -59,20 +59,22 @@ matrix:
       env: TWISTED=latest SQLALCHEMY=latest TESTS=minimal_install
 
     # Worker-master interoperability tests
-    - python: "3.8"
+    - python: "3.9"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.9
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.8
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.7
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.6
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=2.7
 
     # Worker tests on python and twisted package combinations.
     # We support worker on Python 2.7, on which Twisted 20.3.0 is the last version that works
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial_worker
     - python: "2.7"
       env: TWISTED=20.3.0 SQLALCHEMY=latest TESTS=trial_worker
@@ -81,12 +83,12 @@ matrix:
     # (by default in other tests in-memory SQLite database is used which is
     # recreated for each test).
     # Helps to detect issues with incorrect database setup/cleanup in tests.
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=sqlite:////tmp/test_db.sqlite DB_TYPE=sqlite
     # Configuration that runs tests with real MySQL database (TODO does not work yet with our docker image)
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest DB_TYPE=mysql
-    - python: "3.8"
+    - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
 
     # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 # AppVeyor CI
 # https://www.appveyor.com/docs
 
+image:
+  - Visual Studio 2019
+
 environment:
   matrix:
     # For Python versions available on AppVeyor, see

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ environment:
   matrix:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python
-    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python39"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault_hvac.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault_hvac.py
@@ -24,12 +24,16 @@ from buildbot.process.properties import Interpolate
 from buildbot.secrets.providers.vault_hvac import HashiCorpVaultKvSecretProvider
 from buildbot.secrets.providers.vault_hvac import VaultAuthenticatorToken
 from buildbot.steps.shell import ShellCommand
+from buildbot.test.util.decorators import skipUnlessPlatformIs
 from buildbot.test.util.integration import RunMasterBase
 
 # This integration test creates a master and worker environment,
 # with one builders and a shellcommand step
 
 
+# Test needs to be explicitly disabled on Windows, as docker may be present there, but not able
+# to properly launch images.
+@skipUnlessPlatformIs('posix')
 class TestVaultHvac(RunMasterBase):
     def setUp(self):
         try:

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import datetime
 import time
 
 import mock
@@ -30,12 +29,6 @@ from buildbot.test.util import scheduler
 
 
 class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
-
-    try:
-        datetime.datetime.fromtimestamp(1)
-    except OSError:
-        skip = ("Python 3.6 bug on Windows: "
-                "https://bugs.python.org/issue29097")
 
     OBJECTID = 132
     SCHEDULERID = 32

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -13,8 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import datetime
-
 from twisted.internet import task
 from twisted.trial import unittest
 
@@ -27,12 +25,6 @@ from buildbot.test.util import scheduler
 
 class NightlyTriggerable(scheduler.SchedulerMixin, TestReactorMixin,
                          unittest.TestCase):
-
-    try:
-        datetime.datetime.fromtimestamp(1)
-    except OSError:
-        skip = ("Python 3.6 bug on Windows: "
-                "https://bugs.python.org/issue29097")
 
     SCHEDULERID = 327
     OBJECTID = 1327

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -68,12 +68,6 @@ class TestHumanReadableDelta(unittest.TestCase):
         """
         It will return a human readable time difference.
         """
-        try:
-            datetime.datetime.fromtimestamp(1)
-        except OSError as e:
-            raise unittest.SkipTest(
-                "Python 3.6 bug on Windows: "
-                "https://bugs.python.org/issue29097") from e
         result = util.human_readable_delta(1, 1)
         self.assertEqual('super fast', result)
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -229,8 +229,10 @@ class RunMasterBase(unittest.TestCase):
                 protocol = 'msgpack_experimental_v3'
                 dispatcher = list(m.msgmanager.dispatchers.values())[0]
 
-                if sandboxed_worker_path is not None and worker_python_version == '2.7':
-                    raise SkipTest('MessagePack protocol is not supported on python 2.7 worker')
+                unsupported_python_versions = ['2.7', '3.4', '3.5']
+                if sandboxed_worker_path is not None and \
+                        worker_python_version in unsupported_python_versions:
+                    raise SkipTest('MessagePack protocol requires worker python >= 3.6')
 
                 # We currently don't handle connection closing cleanly.
                 dispatcher.serverFactory.setProtocolOptions(closeHandshakeTimeout=0)

--- a/master/setup.py
+++ b/master/setup.py
@@ -152,9 +152,9 @@ setup_args = {
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     'packages': [
@@ -462,9 +462,9 @@ if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
 py_36 = sys.version_info[0] > 3 or (
-    sys.version_info[0] == 3 and sys.version_info[1] >= 6)
+    sys.version_info[0] == 3 and sys.version_info[1] >= 7)
 if not py_36:
-    raise RuntimeError("Buildbot master requires at least Python-3.6")
+    raise RuntimeError("Buildbot master requires at least Python-3.7")
 
 # pip<1.4 doesn't have the --pre flag, and will thus attempt to install alpha
 # and beta versions of Buildbot.  Prevent that from happening.

--- a/newsfragments/master-python-3.6.removal
+++ b/newsfragments/master-python-3.6.removal
@@ -1,0 +1,1 @@
+Removed support for Python 3.6 from master. The Python version requirements for the worker don't change.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,8 +3,7 @@ appdirs==1.4.4
 asn1crypto==1.4.0
 astroid==2.9.3
 attrs==21.2.0
-autobahn==20.12.3;  python_version < "3.7"  # pyup: ignore
-autobahn==21.3.1;  python_version >= "3.7"
+autobahn==21.3.1
 Automat==20.2.0
 Babel==2.9.1
 backports.functools-lru-cache==1.6.4
@@ -48,8 +47,7 @@ parameterized==0.8.1
 pathlib2==2.3.6
 pbr==5.6.0
 pep8==1.7.1
-Pillow==8.3.2;  python_version < "3.7"  # pyup: ignore
-Pillow==9.0.1;  python_version >= "3.7"
+Pillow==9.0.1
 psutil==5.9.0
 pyaml==20.4.0
 ruamel.yaml==0.17.16

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -1,6 +1,10 @@
 attrs==21.2.0
+autobahn==22.3.2;  python_version >= "3.7"
+autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
 Automat==20.2.0
+cffi==1.15.0;  python_version >= "3.6"
 constantly==15.1.0
+cryptography==37.0.2;  python_version >= "3.6"
 funcsigs==1.0.2
 future==0.18.2
 hyperlink==21.0.0
@@ -14,8 +18,12 @@ pbr==5.6.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
 psutil==5.9.0
+pycparser==2.21;  python_version >= "3.6"
 six==1.16.0
 Twisted==22.4.0;  python_version >= "3.6"
-Twisted==20.3.0;  python_version < "3.0"  # pyup: ignore
+Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
+txaio;  python_version >= "3.6"
+typing-extensions==4.2.0;  python_version >= "3.7"
+typing-extensions==3.10.0.2;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0
 -e worker

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -3,4 +3,3 @@
 -e worker[test]
 -e pkg
 buildbot_www==3.2.0
-autobahn==22.3.2

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -43,7 +43,7 @@ from buildbot_worker.pbutil import AutoLoginPBFactory
 from buildbot_worker.pbutil import decode
 from buildbot_worker.tunnel import HTTPTunnelEndpoint
 
-if sys.version_info.major >= 3:
+if sys.version_info >= (3, 6):
     from buildbot_worker.msgpack import BuildbotWebSocketClientFactory
     from buildbot_worker.msgpack import BuildbotWebSocketClientProtocol
     from buildbot_worker.msgpack import ProtocolCommandMsgpack
@@ -351,7 +351,7 @@ class BotPb(BotPbLike, pb.Referenceable):
     WorkerForBuilder = WorkerForBuilderPb
 
 
-if sys.version_info.major >= 3:
+if sys.version_info >= (3, 6):
     class BotMsgpack(BotBase):
         def __init__(self, basedir, unicode_encoding=None, delete_leftover_dirs=False):
             BotBase.__init__(self, basedir, unicode_encoding=unicode_encoding,
@@ -556,8 +556,10 @@ class Worker(WorkerBase):
         if protocol == 'pb':
             bot_class = BotPb
         elif protocol == 'msgpack_experimental_v3':
-            if sys.version_info.major < 3:
-                raise NotImplementedError('Msgpack protocol is not supported in Python2')
+            if sys.version_info < (3, 6):
+                raise NotImplementedError(
+                    'Msgpack protocol is only supported on Python 3.6 and newer'
+                )
             bot_class = BotMsgpack
         else:
             raise ValueError('Unknown protocol {}'.format(protocol))

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -32,7 +32,7 @@ from buildbot_worker import util
 from buildbot_worker.test.fake.runprocess import Expect
 from buildbot_worker.test.util import command
 
-if sys.version_info.major >= 3:
+if sys.version_info >= (3, 6):
     import msgpack
     # pylint: disable=ungrouped-imports
     from buildbot_worker.msgpack import decode_http_authorization_header
@@ -43,8 +43,8 @@ if sys.version_info.major >= 3:
 
 class TestHttpAuthorization(unittest.TestCase):
     maxDiff = None
-    if sys.version_info.major < 3:
-        skip = "Not python 3"
+    if sys.version_info < (3, 6):
+        skip = "Not python 3.6 or newer"
 
     def test_encode(self):
         result = encode_http_authorization_header(b'name', b'pass')
@@ -116,7 +116,7 @@ class FakeBot(base.BotBase):
 
 class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.TestCase):
     maxDiff = None
-    if sys.version_info.major < 3:
+    if sys.version_info < (3, 6):
         skip = "Not python 3"
 
     def setUp(self):

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -145,7 +145,6 @@ if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
 twisted_ver = ">= 17.9.0"
-autobahn_ver = ">= 0.16.0"
 
 if setuptools is not None:
     setup_args['install_requires'] = [
@@ -153,10 +152,10 @@ if setuptools is not None:
         'future',
     ]
 
-    if sys.version_info.major >= 3:
-        # Message pack is only supported on Python 3
+    if sys.version_info >= (3, 6):
+        # Message pack is only supported on Python 3.6 and newer
         setup_args['install_requires'] += [
-            'autobahn ' + autobahn_ver,
+            'autobahn >= 0.16.0',
             'msgpack >= 0.6.0',
         ]
 


### PR DESCRIPTION
Next release of Twisted will drop Python 3.6 support too, so it does not make a lot of sense to keep support of this old Python version for us.
