### PR TITLE
steps: Add support to steps.GitCommit for --no-verify

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -696,7 +696,7 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
 
     def __init__(self, workdir=None, paths=None, messages=None, env=None,
                  timeout=20 * 60, logEnviron=True, emptyCommits='disallow',
-                 config=None, **kwargs):
+                 config=None, no_verify=False, **kwargs):
 
         self.workdir = workdir
         self.messages = messages
@@ -706,6 +706,7 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
         self.logEnviron = logEnviron
         self.config = config
         self.emptyCommits = emptyCommits
+        self.no_verify = no_verify
         # The repourl, sshPrivateKey and sshHostKey attributes are required by
         # GitStepMixin, but aren't needed by git add and commit operations
         self.repourl = " "
@@ -780,6 +781,9 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
 
         if self.emptyCommits == 'create-empty-commit':
             cmd.extend(['--allow-empty'])
+
+        if self.no_verify:
+            cmd.extend(['--no-verify'])
 
         ret = yield self._dovccmd(cmd)
         return ret

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -3702,6 +3702,29 @@ class TestGitCommit(TestBuildStepMixin, config.ConfigErrorsMixin,
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
+    def test_commit_noverify(self):
+        self.setup_step(
+            self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,
+                           no_verify=True))
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            .stdout('git version 1.7.5')
+            .exit(0),
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'symbolic-ref', 'HEAD'])
+            .stdout('refs/head/myBranch')
+            .exit(0),
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'add', 'file1.txt', 'file2.txt'])
+            .exit(0),
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'commit', '-m', 'my commit', '-m', '42', '--no-verify'])
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
     def test_commit_empty_disallow(self):
         self.setup_step(
             self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,

--- a/master/docs/manual/configuration/steps/gitcommit.rst
+++ b/master/docs/manual/configuration/steps/gitcommit.rst
@@ -36,6 +36,10 @@ The GitCommit step takes the following arguments:
 ``config``
     (optional) A dict of git configuration settings to pass to the remote git commands.
 
+``no_verify``
+    (optional) Specifies whether ``--no-verify`` option should be supplied to git.
+    The default is ``False``.
+
 ``emptyCommits``
     (optional) One of the values ``disallow`` (default), ``create-empty-commit``, and ``ignore``. Decides the behavior when there is nothing to be committed.
     The value ``disallow`` will make the buildstep fail.

--- a/newsfragments/git-commit-step-no-verify.feature
+++ b/newsfragments/git-commit-step-no-verify.feature
@@ -1,0 +1,1 @@
+Implemented support for ``--no-verify`` git option to the ``GitCommit`` step.


### PR DESCRIPTION
This is a copy of https://github.com/buildbot/buildbot/pull/6484 made so that I could rebase on top of latest master.

Original description by @shareefj follows:

> This update adds support for running steps.GitCommit with the --no-verify switch to bypass any Git commit hooks that would otherwise prevent Buildbot committing. I've added a test to test_source_git.
