### PR TITLE
.github: Add configuration for running tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,31 @@ jobs:
       - run: coverage run --rcfile=.coveragerc $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test
 
       - run: codecov
+
+  win:
+    name: Win / python ${{ matrix.python-version }}
+    runs-on: windows-2019
+
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
+
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: "Install dependencies"
+        run: |
+          python -c "import sys; print(sys.prefix)"
+          python -c "import sys; print(sys.exec_prefix)"
+          python -c "import sys; print(sys.executable)"
+          python -V -V
+          python -m pip install -U pip setuptools
+          python -m pip install -r requirements-ci.txt
+          python -m pip list
+          # Check that pywin32 is properly installed
+          python -c "import win32api"
+
+      - name: "Run tests for ${{ matrix.python-version }}"
+        run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+import os
+
 from parameterized import parameterized
 
 import mock
@@ -29,10 +31,8 @@ from buildbot.util.runprocess import RunProcess
 # windows returns rc 1, because exit status cannot indicate "signalled";
 # posix returns rc -1 for "signalled"
 FATAL_RC = -1
-EXPECTED_PWD = '/workdir'
 if runtime.platformType == 'win32':
     FATAL_RC = 1
-    EXPECTED_PWD = 'C:\\workdir'
 
 
 class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
@@ -71,7 +71,8 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
     def test_no_output(self):
         d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False)
         self.assertEqual(self.process_spawned_args,
-                         ('cmd', ['cmd'], {'OS_ENV': 'value', 'PWD': EXPECTED_PWD}, '/workdir'))
+                         ('cmd', ['cmd'], {'OS_ENV': 'value', 'PWD': os.path.abspath('/workdir')},
+                          '/workdir'))
 
         self.pp.connectionMade()
         self.assertFalse(d.called)
@@ -86,7 +87,7 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
         d = self.run_process(['cmd'], collect_stdout=False, collect_stderr=False,
                              env={'custom': 'custom-value'})
         self.assertEqual(self.process_spawned_args,
-                         ('cmd', ['cmd'], {'OS_ENV': 'value', 'PWD': EXPECTED_PWD,
+                         ('cmd', ['cmd'], {'OS_ENV': 'value', 'PWD': os.path.abspath('/workdir'),
                                            'custom': 'custom-value'}, '/workdir'))
 
         self.pp.connectionMade()
@@ -100,7 +101,8 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
         d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False,
                              env={'OS_ENV': 'custom-value'})
         self.assertEqual(self.process_spawned_args,
-                         ('cmd', ['cmd'], {'OS_ENV': 'custom-value', 'PWD': EXPECTED_PWD},
+                         ('cmd', ['cmd'], {'OS_ENV': 'custom-value',
+                                           'PWD': os.path.abspath('/workdir')},
                           '/workdir'))
 
         self.pp.connectionMade()
@@ -114,7 +116,7 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
         d = self.run_process(['cmd'], collect_stdout=True, collect_stderr=False,
                              env={'OS_ENV': None})
         self.assertEqual(self.process_spawned_args,
-                         ('cmd', ['cmd'], {'PWD': EXPECTED_PWD}, '/workdir'))
+                         ('cmd', ['cmd'], {'PWD': os.path.abspath('/workdir')}, '/workdir'))
 
         self.pp.connectionMade()
         self.end_process()


### PR DESCRIPTION
Appveyor only supports single concurrent job which becomes a bottleneck when multiple PRs are updated in short amount of time. We could work around this by running most of the tests on Github and leaving just a single build and release artifact packaging in Appveyor. 
