### PR TITLE
Rest: Filter buildsets by sourcestamp attributes

### DIFF
--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -14,11 +14,14 @@
 # Copyright Buildbot Team Members
 
 
+import json
+
 from twisted.internet import defer
 
 from buildbot.data import base
 from buildbot.data import patches
 from buildbot.data import types
+from buildbot.util import bytes2unicode
 
 
 def _db2data(ss):
@@ -89,4 +92,12 @@ class SourceStamp(base.ResourceType):
         codebase = types.String()
         patch = types.NoneOk(patches.Patch.entityType)
         created_at = types.DateTime()
+
+        def valueFromString(self, arg):
+            d = json.loads(bytes2unicode(arg))
+            d = {k: self.fields[k].valueFromString(v) for k, v in d.items()}
+            if len(d.keys()) == 0:
+                raise TypeError  # don't allow {}
+            return d
+
     entityType = EntityType(name, 'Sourcestamp')

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -17,6 +17,9 @@ Support for buildsets in the database
 """
 
 import json
+from functools import reduce
+from operator import and_
+from operator import or_
 
 import sqlalchemy as sa
 
@@ -165,15 +168,35 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
     @defer.inlineCallbacks
     def getBuildsets(self, complete=None, resultSpec=None):
         def thd(conn):
+            if resultSpec is not None:
+                sourceStampFilter = resultSpec.popFilter('sourcestamps', 'contains')
+            else:
+                sourceStampFilter = None
+
             bs_tbl = self.db.model.buildsets
-            q = bs_tbl.select()
+            ss_tbl = self.db.model.sourcestamps
+
+            j = bs_tbl
+            if sourceStampFilter is not None:
+                j = bs_tbl
+                j = j.join(self.db.model.buildset_sourcestamps)
+                j = j.join(ss_tbl)
+            q = sa.select(columns=[bs_tbl], from_obj=[j], distinct=True)
+
             if complete is not None:
                 if complete:
                     q = q.where(bs_tbl.c.complete != 0)
                 else:
                     q = q.where((bs_tbl.c.complete == 0) |
                                 (bs_tbl.c.complete == NULL))
+
             if resultSpec is not None:
+                if sourceStampFilter:
+                    def ssid_as_id(key):
+                        return "id" if key == "ssid" else key
+                    q = q.where(reduce(or_, [reduce(and_, [ss_tbl.c[ssid_as_id(key)] == value
+                                for key, value in filter.items()])
+                                for filter in sourceStampFilter]))
                 return resultSpec.thd_execute(conn, q, lambda x: self._thd_row2dict(conn, x))
             res = conn.execute(q)
             return [self._thd_row2dict(conn, row) for row in res.fetchall()]


### PR DESCRIPTION
Before implementing unit tests I'd first like to confirm that this approach can go forward. Open questions that I need feedback on:
- Is it ok to encode the sourcestamp objects as JSON in the REST query?
- Is the SQL query approach reasonable?

## Description
Allow the buildsets REST endpoint to filter by sourcestamp attributes.
We use the 'contains' relation to filter by a set of sourcestamp attributes:
`buildsets?sourcestamps__contains={"ssid":26}`

The list of buildsets is then only listing buildsets that have a
sourcetsamp with that ssid. If the sourcestamps__contains filter is used
multiple times it follows the "or" semantics like the other filters. If
a single filter lists multiple attributes these follow and semantics,
within the filter.

The filters are implemented on SQL-level. Necessary joins are only
performed if this filter is actually used.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
