### PR TITLE
Use latest Python version for RTD build

### DIFF
--- a/newsfragments/documentation-build.bugfix
+++ b/newsfragments/documentation-build.bugfix
@@ -1,1 +1,1 @@
-Fix documentation build for ReadTheDocs.  Update Sphinx to current version.
+Fix documentation build for ReadTheDocs.  Update Sphinx to current version.  Use latest python version for RTD.

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -4,6 +4,6 @@ build:
     image: latest
 
 python:
-    version: 3.6
+    version: 3.10
     install:
         - requirements: requirements-readthedocs.txt


### PR DESCRIPTION
Fixes a build error for ReadTheDocs (requires at least 3.7).

Since buildbot requires at least Python 3.7, this change updates the ReadTheDocs' Python version to the most current, since RTD has to build buildbot to create the API documentation.

https://readthedocs.org/projects/buildbot/builds/16911152/

I updated the existing news fragment that fixed a precursor issue that I identified.

## Contributor Checklist:

* [N/A ] I have updated the unit tests
* [ Y] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ Y] I have updated the appropriate documentation
