### PR TITLE
Fix compatibility of hvac implementation with Vault 1.10.x

### DIFF
--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -148,9 +148,6 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
         query secret from Vault and re-authenticate if not authenticated
         """
 
-        # no need to "try" import, it was already handled by reconfigService()
-        import hvac
-
         if not self.client.is_authenticated():
             self.authenticator.authenticate(self.client)
 

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -145,18 +145,16 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
 
     def thd_hvac_get(self, path):
         """
-        query secret from Vault and try to re-authenticate in case Unauthorized
-        exception when active token reaches its TTL
+        query secret from Vault and re-authenticate if not authenticated
         """
 
         # no need to "try" import, it was already handled by reconfigService()
         import hvac
 
-        try:
-            response = self.thd_hvac_wrap_read(path=path)
-        except (hvac.exceptions.Unauthorized, hvac.exceptions.InvalidRequest):
+        if not self.client.is_authenticated():
             self.authenticator.authenticate(self.client)
-            response = self.thd_hvac_wrap_read(path=path)
+
+        response = self.thd_hvac_wrap_read(path=path)
 
         return response
 

--- a/master/buildbot/test/unit/test_secret_in_hvac.py
+++ b/master/buildbot/test/unit/test_secret_in_hvac.py
@@ -91,6 +91,9 @@ class FakeHvacClient:
         self.secrets.kv.v1.token = new_token
         self.secrets.kv.v2.token = new_token
 
+    def is_authenticated(self):
+        return self._token
+
 
 def mock_vault(*args, **kwargs):
     client = FakeHvacClient()

--- a/newsfragments/hvac-vault-compat.bugfix
+++ b/newsfragments/hvac-vault-compat.bugfix
@@ -1,0 +1,1 @@
+Fix compatibility of hvac implementation with Vault 1.10.x (:issue:`6475`).


### PR DESCRIPTION
This fixes compatibilty with hvac and Vault 1.10+ as issued in #6475. As stated before, the issue comes from obsolete exceptions. The fix will make use of hvac `is_authenticated()` method rather then relying on obsolete exceptions or implementing new ones.