### PR TITLE
util: Make callback optional for LineBoundaryFinder

### DIFF
--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -129,20 +129,24 @@ class PlainLog(Log):
     def __init__(self, master, name, type, logid, decoder):
         super().__init__(master, name, type, logid, decoder)
 
-        def wholeLines(lines):
-            self.subPoint.deliver(None, lines)
-            return self.addRawLines(lines)
-        self.lbf = lineboundaries.LineBoundaryFinder(wholeLines)
+        self.lbf = lineboundaries.LineBoundaryFinder()
 
     def addContent(self, text):
         if not isinstance(text, str):
             text = self.decoder(text)
         # add some text in the log's default stream
-        return self.lbf.append(text)
+        lines = self.lbf.append(text)
+        if lines is None:
+            return defer.succeed(None)
+        self.subPoint.deliver(None, lines)
+        return self.addRawLines(lines)
 
     @defer.inlineCallbacks
     def finish(self):
-        yield self.lbf.flush()
+        lines = self.lbf.flush()
+        if lines is not None:
+            self.subPoint.deliver(None, lines)
+            yield self.addRawLines(lines)
         yield super().finish()
 
 
@@ -174,35 +178,44 @@ class StreamLog(Log):
         try:
             return self.lbfs[stream]
         except KeyError:
-            def wholeLines(lines):
-                # deliver the un-annotated version to subscribers
-                self.subPoint.deliver(stream, lines)
-                # strip the last character, as the regexp will add a
-                # prefix character after the trailing newline
-                return self.addRawLines(self.pat.sub(stream, lines)[:-1])
-            lbf = self.lbfs[stream] = \
-                lineboundaries.LineBoundaryFinder(wholeLines)
+            lbf = self.lbfs[stream] = lineboundaries.LineBoundaryFinder()
             return lbf
+
+    def _on_whole_lines(self, stream, lines):
+        # deliver the un-annotated version to subscribers
+        self.subPoint.deliver(stream, lines)
+        # strip the last character, as the regexp will add a
+        # prefix character after the trailing newline
+        return self.addRawLines(self.pat.sub(stream, lines)[:-1])
+
+    def split_lines(self, stream, text):
+        lbf = self._getLbf(stream)
+        lines = lbf.append(text)
+        if lines is None:
+            return defer.succeed(None)
+        return self._on_whole_lines(stream, lines)
 
     def addStdout(self, text):
         if not isinstance(text, str):
             text = self.decoder(text)
-        return self._getLbf('o').append(text)
+        return self.split_lines('o', text)
 
     def addStderr(self, text):
         if not isinstance(text, str):
             text = self.decoder(text)
-        return self._getLbf('e').append(text)
+        return self.split_lines('e', text)
 
     def addHeader(self, text):
         if not isinstance(text, str):
             text = self.decoder(text)
-        return self._getLbf('h').append(text)
+        return self.split_lines('h', text)
 
     @defer.inlineCallbacks
     def finish(self):
-        for lbf in self.lbfs.values():
-            yield lbf.flush()
+        for stream, lbf in self.lbfs.items():
+            lines = lbf.flush()
+            if lines is not None:
+                self._on_whole_lines(stream, lines)
         yield super().finish()
 
 

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -38,36 +38,43 @@ class FakeLogFile:
     def subscribe(self, callback):
         return self.subPoint.subscribe(callback)
 
-    def _getLbf(self, stream, meth):
+    def _getLbf(self, stream):
         try:
             return self.lbfs[stream]
         except KeyError:
-            def wholeLines(lines):
-                self.subPoint.deliver(stream, lines)
-                assert not self.finished
-            lbf = self.lbfs[stream] = \
-                lineboundaries.LineBoundaryFinder(wholeLines)
+            lbf = self.lbfs[stream] = lineboundaries.LineBoundaryFinder()
             return lbf
+
+    def _on_whole_lines(self, stream, lines):
+        self.subPoint.deliver(stream, lines)
+        assert not self.finished
+
+    def _split_lines(self, stream, text):
+        lbf = self._getLbf(stream)
+        lines = lbf.append(text)
+        if lines is None:
+            return
+        self._on_whole_lines(stream, lines)
 
     def addHeader(self, text):
         if not isinstance(text, str):
             text = text.decode('utf-8')
         self.header += text
-        self._getLbf('h', 'headerReceived').append(text)
+        self._split_lines('h', text)
         return defer.succeed(None)
 
     def addStdout(self, text):
         if not isinstance(text, str):
             text = text.decode('utf-8')
         self.stdout += text
-        self._getLbf('o', 'outReceived').append(text)
+        self._split_lines('o', text)
         return defer.succeed(None)
 
     def addStderr(self, text):
         if not isinstance(text, str):
             text = text.decode('utf-8')
         self.stderr += text
-        self._getLbf('e', 'errReceived').append(text)
+        self._split_lines('e', text)
         return defer.succeed(None)
 
     def isFinished(self):
@@ -82,8 +89,10 @@ class FakeLogFile:
         return d
 
     def flushFakeLogfile(self):
-        for lbf in self.lbfs.values():
-            lbf.flush()
+        for stream, lbf in self.lbfs.items():
+            lines = lbf.flush()
+            if lines is not None:
+                self.subPoint.deliver(stream, lines)
 
     def had_errors(self):
         return self._had_errors

--- a/master/buildbot/test/unit/util/test_lineboundaries.py
+++ b/master/buildbot/test/unit/util/test_lineboundaries.py
@@ -19,14 +19,18 @@ from twisted.internet import reactor
 from twisted.python import log
 from twisted.trial import unittest
 
+from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import lineboundaries
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class LBF(unittest.TestCase):
 
     def setUp(self):
         self.callbacks = []
-        self.lbf = lineboundaries.LineBoundaryFinder(self._callback)
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern="does not accept callback anymore"):
+            self.lbf = lineboundaries.LineBoundaryFinder(self._callback)
 
     def _callback(self, wholeLines):
         self.assertEqual(wholeLines[-1], '\n', f'got {repr(wholeLines)}')
@@ -154,3 +158,136 @@ class LBF(unittest.TestCase):
         yield self.lbf.flush()
 
         self.assertEqual(self.callbacks, [])
+
+
+class LBFNoCallback(unittest.TestCase):
+
+    def setUp(self):
+        self.lbf = lineboundaries.LineBoundaryFinder()
+
+    def test_already_terminated(self):
+        res = self.lbf.append('abcd\ndefg\n')
+        self.assertEqual(res, 'abcd\ndefg\n')
+        res = self.lbf.append('xyz\n')
+        self.assertEqual(res, 'xyz\n')
+        res = self.lbf.flush()
+        self.assertEqual(res, None)
+
+    def test_partial_line(self):
+        res = self.lbf.append('hello\nworld')
+        self.assertEqual(res, 'hello\n')
+        res = self.lbf.flush()
+        self.assertEqual(res, 'world\n')
+
+    def test_empty_appends(self):
+        res = self.lbf.append('hello ')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('world\n')
+        self.assertEqual(res, 'hello world\n')
+
+        res = self.lbf.append('')
+        self.assertEqual(res, None)
+
+    def test_embedded_newlines(self):
+        res = self.lbf.append('hello, ')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('cruel\nworld')
+        self.assertEqual(res, 'hello, cruel\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, 'world\n')
+
+    def test_windows_newlines_folded(self):
+        r"Windows' \r\n is treated as and converted to a newline"
+        res = self.lbf.append('hello, ')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('cruel\r\n\r\nworld')
+        self.assertEqual(res, 'hello, cruel\n\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, 'world\n')
+
+    def test_bare_cr_folded(self):
+        r"a bare \r is treated as and converted to a newline"
+        self.lbf.append('1%\r5%\r15%\r100%\nfinished')
+        res = self.lbf.flush()
+        self.assertEqual(res, 'finished\n')
+
+    def test_backspace_folded(self):
+        r"a lot of \b is treated as and converted to a newline"
+        self.lbf.append('1%\b\b5%\b\b15%\b\b\b100%\nfinished')
+        res = self.lbf.flush()
+        self.assertEqual(res, 'finished\n')
+
+    def test_mixed_consecutive_newlines(self):
+        r"mixing newline styles back-to-back doesn't collapse them"
+        res = self.lbf.append('1\r\n\n\r')
+        self.assertEqual(res, '1\n\n')
+
+        res = self.lbf.append('2\n\r\n')
+        self.assertEqual(res, '\n2\n\n')
+
+    def test_split_newlines(self):
+        r"multi-character newlines, split across chunks, are converted"
+        input = 'a\nb\r\nc\rd\n\re'
+        result = []
+        for splitpoint in range(1, len(input) - 1):
+            a, b = input[:splitpoint], input[splitpoint:]
+            result.append(self.lbf.append(a))
+            result.append(self.lbf.append(b))
+            result.append(self.lbf.flush())
+
+            result = [e for e in result if e is not None]
+            res = ''.join(result)
+
+            log.msg(f'feeding {repr(a)}, {repr(b)} gives {repr(res)}')
+            self.assertEqual(res, 'a\nb\nc\nd\n\ne\n')
+            result.clear()
+
+    def test_split_terminal_control(self):
+        """terminal control characters are converted"""
+        res = self.lbf.append('1234\033[u4321')
+        self.assertEqual(res, '1234\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, '4321\n')
+
+        res = self.lbf.append('1234\033[1;2H4321')
+        self.assertEqual(res, '1234\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, '4321\n')
+
+        res = self.lbf.append('1234\033[1;2f4321')
+        self.assertEqual(res, '1234\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, '4321\n')
+
+    def test_long_lines(self):
+        """long lines are split"""
+        res = []
+        for _ in range(4):
+            res.append(self.lbf.append('12' * 1000))
+        res = [e for e in res if e is not None]
+        res = ''.join(res)
+        # a split at 4096 + the remaining chars
+        self.assertEqual(res, '12' * 2048 + '\n' + '12' * 952 + '\n')
+
+    def test_huge_lines(self):
+        """huge lines are split"""
+        res = []
+        res.append(self.lbf.append('12' * 32768))
+        res.append(self.lbf.flush())
+        res = [e for e in res if e is not None]
+        self.assertEqual(res, [('12' * 2048 + '\n') * 16])
+
+    def test_empty_flush(self):
+        res = self.lbf.flush()
+        self.assertEqual(res, None)

--- a/master/buildbot/util/lineboundaries.py
+++ b/master/buildbot/util/lineboundaries.py
@@ -19,6 +19,8 @@ import re
 from twisted.internet import defer
 from twisted.logger import Logger
 
+from buildbot.warnings import warn_deprecated
+
 log = Logger()
 
 
@@ -34,12 +36,14 @@ class LineBoundaryFinder:
     # and ugly \b+ (use of backspace to implement progress bar)
     newline_re = re.compile(r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)')
 
-    def __init__(self, callback):
+    def __init__(self, callback=None):
+        if callback is not None:
+            warn_deprecated('3.6.0', f'{self.__class__.__name__} does not accept callback anymore')
         self.partialLine = None
         self.callback = callback
         self.warned = False
 
-    def append(self, text):
+    def adjust_line(self, text):
         if self.partialLine:
             if len(self.partialLine) > self.MAX_LINELENGTH:
                 if not self.warned:
@@ -56,7 +60,8 @@ class LineBoundaryFinder:
                     ret.append(text[:self.MAX_LINELENGTH])
                     text = text[self.MAX_LINELENGTH:]
                 ret.append(text)
-                return self.callback("\n".join(ret) + "\n")
+                result = ("\n".join(ret) + "\n")
+                return result
             text = self.partialLine + text
             self.partialLine = None
         text = self.newline_re.sub('\n', text)
@@ -68,11 +73,22 @@ class LineBoundaryFinder:
                     text, self.partialLine = text[:i], text[i:]
                 else:
                     self.partialLine = text
-                    return defer.succeed(None)
-            return self.callback(text)
-        return defer.succeed(None)
+                    return None
+            return text
+        return None
+
+    def append(self, text):
+        lines = self.adjust_line(text)
+        if self.callback is None:
+            return lines
+
+        if lines is None:
+            return defer.succeed(None)
+        return self.callback(lines)
 
     def flush(self):
-        if self.partialLine:
+        if self.partialLine is not None:
             return self.append('\n')
-        return defer.succeed(None)
+        if self.callback is not None:
+            return defer.succeed(None)
+        return None

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -845,26 +845,46 @@ This module makes it easy to manipulate identifiers.
 
 .. py:class:: LineBoundaryFinder
 
-    This class accepts a sequence of arbitrary strings and invokes a callback only with complete (newline-terminated) substrings.
-    It buffers any partial lines until a subsequent newline is seen.
+    This class accepts a sequence of arbitrary strings and computes newline-terminated substrings.
+    Input strings are accepted in append function, and newline-terminated substrings are returned.
+
+    Alternatively, a callback maybe provided into class constructor.
+    This callback is invoked with complete (newline-terminated) substrings.
+    This method of returning results is deprecated.
+
+    The class buffers any partial lines until a subsequent newline is seen.
     It considers any of ``\r``, ``\n``, and ``\r\n`` to be newlines.
     Because of the ambiguity of an append operation ending in the character ``\r`` (it may be a bare ``\r`` or half of ``\r\n``), the last line of such an append operation will be buffered until the next append or flush.
 
-    :param callback: asynchronous function to call with newline-terminated strings
+    :param callback: (optional and deprecated) asynchronous function to call with newline-terminated strings
 
     .. py:method:: append(text)
 
         :param text: text to append to the boundary finder
-        :returns: Deferred
+        :returns: Deferred (deprecated) or newline-terminated substring
 
         Add additional text to the boundary finder.
-        If the addition of this text completes at least one line, the callback will be invoked with as many complete lines as possible.
+        If the addition of this text completes at least one line, as many complete lines as possible are selected as a result.
+        If no lines are completed, the result will be ``None``.
+
+        If the class constructor did not receive ``callback`` argument, then result is returned.
+        Otherwise, if result is not ``None``, ``callback`` will be invoked with it.
+        Otherwise, ``defer.succeed(None)`` is returned.
+
 
     .. py:method:: flush()
 
-        :returns: Deferred
+        :returns: Deferred (deprecated), newline-terminated substring or None
 
-        Flush any remaining partial line by adding a newline and invoking the callback.
+        Flush any remaining partial line by adding a newline.
+
+        Function works differently depending on whether class constructor received ``callback`` argument.
+
+        If ``callback`` was not received, and  there was a remaining partial line, its result is returned.
+        Otherwise, ``None`` is returned.
+
+        If ``callback`` was received, and there was a remaining partial line, callback is invoked with it.
+        Otherwise, ``defer.succeed(None)`` is returned.
 
 :py:mod:`buildbot.util.service`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -818,6 +818,7 @@ Subqueries
 subquery
 subshell
 substrings
+substring
 subunit
 successCb
 sucessful

--- a/newsfragments/lineboundaryfinder-callback-optional.feature
+++ b/newsfragments/lineboundaryfinder-callback-optional.feature
@@ -1,0 +1,1 @@
+Callback argument of class LineBoundaryFinder is now optional and deprecated.


### PR DESCRIPTION
Callback argument of class LineBoundaryFinder is now optional and deprecated. This simplifies code usage as asynchronous processing is not needed.


* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
