### PR TITLE
docker: call docker_client.close() to prevent connection leaks

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -115,6 +115,10 @@ class Client:
     def remove_container(self, id, **kwargs):
         del self._containers[id]
 
+    def close(self):
+        # dummy close, no connection to cleanup
+        pass
+
 
 class APIClient(Client):
     pass

--- a/newsfragments/docker-py-close-connection.bugfix
+++ b/newsfragments/docker-py-close-connection.bugfix
@@ -1,0 +1,1 @@
+Fix issue with :bb:worker:`DockerLatentWorker` accumulating connections with the docker server (:issue:`6538`).


### PR DESCRIPTION
In DockerLatentWorker both _thd_start_instance and _thd_stop_instance
use a new docker_client instance that is never cleaned up. This can
cause (ssh) connections to the docker socket to linger for a long
time. Explicitly call docker_client.close() when done with the client.

Also add a mock close def to test/fake/docker.py.

Original work from  mjw:
https://code.wildebeest.org/git/user/mjw/buildbot/?h=docker-py-close

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
