### PR TITLE
Send more that one update in a single update message on msgpack

### DIFF
--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -210,6 +210,21 @@ class StreamLog(Log):
             text = self.decoder(text)
         return self.split_lines('h', text)
 
+    def add_stdout_lines(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
+        return self._on_whole_lines('o', text)
+
+    def add_stderr_lines(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
+        return self._on_whole_lines('e', text)
+
+    def add_header_lines(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
+        return self._on_whole_lines('h', text)
+
     @defer.inlineCallbacks
     def finish(self):
         for stream, lbf in self.lbfs.items():

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -196,6 +196,16 @@ class RemoteCommand(base.RemoteCommandImpl):
         except Exception as e:
             log.msg("RemoteCommand.interrupt failed", self, e)
 
+    def remote_update_msgpack(self, updates):
+        self.worker.messageReceivedFromWorker()
+        try:
+            for key, value in updates:
+                if self.active and not self.ignore_updates:
+                    self.remoteUpdate({key: value})
+        except Exception:
+            # log failure, terminate build, let worker retire the update
+            self._finished(Failure())
+
     def remote_update(self, updates):
         """
         I am called by the worker's

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -77,6 +77,27 @@ class FakeLogFile:
         self._split_lines('e', text)
         return defer.succeed(None)
 
+    def add_header_lines(self, text):
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
+        self.header += text
+        self._on_whole_lines('h', text)
+        return defer.succeed(None)
+
+    def add_stdout_lines(self, text):
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
+        self.stdout += text
+        self._on_whole_lines('o', text)
+        return defer.succeed(None)
+
+    def add_stderr_lines(self, text):
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
+        self.stderr += text
+        self._on_whole_lines('e', text)
+        return defer.succeed(None)
+
     def isFinished(self):
         return self.finished
 

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -176,11 +176,11 @@ class Expect:
         Implement the given behavior.  Returns a Deferred.
         """
         if behavior == 'rc':
-            yield command.remoteUpdate({'rc': args[0]})
+            yield command.remoteUpdate('rc', args[0])
         elif behavior == 'err':
             raise args[0]
         elif behavior == 'update':
-            yield command.remoteUpdate({args[0]: args[1]})
+            yield command.remoteUpdate(args[0], args[1])
         elif behavior == 'log':
             name, streams = args
             for stream in streams:

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -176,11 +176,11 @@ class Expect:
         Implement the given behavior.  Returns a Deferred.
         """
         if behavior == 'rc':
-            yield command.remoteUpdate('rc', args[0])
+            yield command.remoteUpdate('rc', args[0], False)
         elif behavior == 'err':
             raise args[0]
         elif behavior == 'update':
-            yield command.remoteUpdate(args[0], args[1])
+            yield command.remoteUpdate(args[0], args[1], False)
         elif behavior == 'log':
             name, streams = args
             for stream in streams:
@@ -189,11 +189,11 @@ class Expect:
 
             if name == command.stdioLogName:
                 if 'header' in streams:
-                    command.addHeader(streams['header'])
+                    command.remote_update([({"header": streams['header']}, 0)])
                 if 'stdout' in streams:
-                    command.addStdout(streams['stdout'])
+                    command.remote_update([({"stdout": streams['stdout']}, 0)])
                 if 'stderr' in streams:
-                    command.addStderr(streams['stderr'])
+                    command.remote_update([({"stderr": streams['stderr']}, 0)])
             else:
                 if 'header' in streams or 'stderr' in streams:
                     raise Exception('Non stdio streams only support stdout')

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -44,7 +44,7 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir', command=['git', 'merge-base', 'HEAD', 'master'])
             .log('stdio-merge-base', stderr='fatal: Not a valid object name')
             .exit(128))
-        self.expect_log_file_stderr('stdio-merge-base', 'fatal: Not a valid object name')
+        self.expect_log_file_stderr('stdio-merge-base', 'fatal: Not a valid object name\n')
         self.expect_outcome(result=results.FAILURE, state_string="GitDiffInfo (failure)")
         return self.run_step()
 
@@ -60,7 +60,7 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .exit(1),
             )
         self.expect_log_file('stdio-merge-base', '1234123412341234')
-        self.expect_log_file_stderr('stdio-diff', 'fatal: ambiguous argument')
+        self.expect_log_file_stderr('stdio-diff', 'fatal: ambiguous argument\n')
         self.expect_outcome(result=results.FAILURE, state_string="GitDiffInfo (failure)")
         return self.run_step()
 

--- a/master/buildbot/test/unit/worker/test_protocols_manager_msgmanager.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_msgmanager.py
@@ -315,7 +315,7 @@ class TestBuildbotWebSocketServerProtocol(unittest.TestCase):
         msg = {'op': 'update', 'args': 'args', 'command_id': command_id}
         expected = {'op': 'response', 'result': None}
         yield self.send_msg_check_response(self.protocol, msg, expected)
-        command.remote_update.assert_called_once_with(msg['args'])
+        command.remote_update_msgpack.assert_called_once_with(msg['args'])
 
     @defer.inlineCallbacks
     def test_complete_success(self):

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -203,7 +203,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         self.protocol.get_message_result.reset_mock()
 
         remote_command = self.protocol.command_id_to_command_map[command_id]
-        remote_command.remote_update(update_msg)
+        remote_command.remote_update_msgpack(update_msg)
         remote_command.remote_complete(None)
 
     @defer.inlineCallbacks
@@ -211,20 +211,20 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
 
         self.check_message_send_response('listdir', {'path': 'testdir'},
-                                         [[{'files': ['dir1', 'dir2', 'dir3'], 'rc': 0}, 0]])
+                                         [('files', ['dir1', 'dir2', 'dir3']), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir1')
-        self.check_message_send_response('stat', {'path': path}, [[{'stat': (1,), 'rc': 0}, 0]])
+        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir2')
-        self.check_message_send_response('stat', {'path': path}, [[{'stat': (1,), 'rc': 0}, 0]])
+        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir3')
-        self.check_message_send_response('stat', {'path': path}, [[{'stat': (1,), 'rc': 0}, 0]])
+        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         paths = [os.path.join('testdir', 'info'), os.path.join('testdir', 'test_dir1'),
                  os.path.join('testdir', 'test_dir2')]
-        self.check_message_send_response('mkdir', {'paths': paths}, [[{'rc': 0}, 0]])
+        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -235,27 +235,27 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
 
         self.check_message_send_response('listdir', {'path': 'testdir'},
-                                         [[{'files': ['dir1', 'dir2', 'dir3'], 'rc': 0}, 0]])
+                                         [('files', ['dir1', 'dir2', 'dir3']), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir1')
         self.check_message_send_response('stat', {'path': path},
-                                         [[{'stat': (stat.S_IFDIR,), 'rc': 0}, 0]])
+                                         [('stat', (stat.S_IFDIR,)), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir2')
         self.check_message_send_response('stat', {'path': path},
-                                         [[{'stat': (stat.S_IFDIR,), 'rc': 0}, 0]])
+                                         [('stat', (stat.S_IFDIR,)), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir3')
         self.check_message_send_response('stat', {'path': path},
-                                         [[{'stat': (stat.S_IFDIR,), 'rc': 0}, 0]])
+                                         [('stat', (stat.S_IFDIR,)), ('rc', 0)])
 
         paths = [os.path.join('testdir', 'dir1'), os.path.join('testdir', 'dir2'),
                  os.path.join('testdir', 'dir3')]
-        self.check_message_send_response('rmdir', {'paths': paths}, [[{'rc': 0}, 0]])
+        self.check_message_send_response('rmdir', {'paths': paths}, [('rc', 0)])
 
         paths = [os.path.join('testdir', 'info'), os.path.join('testdir', 'test_dir1'),
                  os.path.join('testdir', 'test_dir2')]
-        self.check_message_send_response('mkdir', {'paths': paths}, [[{'rc': 0}, 0]])
+        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -267,11 +267,11 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
                                          delete_leftover_dirs=False)
 
         self.check_message_send_response('listdir', {'path': 'testdir'},
-                                         [[{'files': ['dir1', 'dir2', 'dir3'], 'rc': 0}, 0]])
+                                         [('files', ['dir1', 'dir2', 'dir3']), ('rc', 0)])
 
         paths = [os.path.join('testdir', 'info'), os.path.join('testdir', 'test_dir1'),
                  os.path.join('testdir', 'test_dir2')]
-        self.check_message_send_response('mkdir', {'paths': paths}, [[{'rc': 0}, 0]])
+        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -282,13 +282,13 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
 
         self.check_message_send_response('listdir', {'path': 'testdir'},
-                                         [[{'files': ['dir1', 'test_dir2'], 'rc': 0}, 0]])
+                                         [('files', ['dir1', 'test_dir2']), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir1')
-        self.check_message_send_response('stat', {'path': path}, [[{'stat': (1,), 'rc': 0}, 0]])
+        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         paths = [os.path.join('testdir', 'info'), os.path.join('testdir', 'test_dir1')]
-        self.check_message_send_response('mkdir', {'paths': paths}, [[{'rc': 0}, 0]])
+        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -299,8 +299,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
 
         self.check_message_send_response('listdir', {'path': 'testdir'},
-                                         [[{'files': ['test_dir1', 'test_dir2', 'info'], 'rc': 0},
-                                          0]])
+                                         [('files', ['test_dir1', 'test_dir2', 'info']), ('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -311,7 +310,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
 
         self.check_message_send_response('listdir', {'path': 'testdir'},
-                                         [[{'no_key': [], 'rc': 0}, 0]])
+                                         [('no_key', []), ('rc', 0)])
 
         with self.assertRaisesRegex(Exception, "Key 'files' is missing."):
             yield d
@@ -322,7 +321,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
     def test_remote_set_builder_list_key_rc_not_zero(self):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
 
-        self.check_message_send_response('listdir', {'path': 'testdir'}, [[{'rc': 123}, 0]])
+        self.check_message_send_response('listdir', {'path': 'testdir'}, [('rc', 123)])
 
         with self.assertRaisesRegex(Exception, "Error number: 123"):
             yield d

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -202,7 +202,7 @@ class RunMasterBase(unittest.TestCase):
                 proto = {"pb": {"port": "tcp:0:interface=127.0.0.1"}}
                 workerclass = worker.Worker
             if self.proto == 'msgpack':
-                proto = {"msgpack_experimental_v3": {"port": 0}}
+                proto = {"msgpack_experimental_v4": {"port": 0}}
                 workerclass = worker.Worker
             elif self.proto == 'null':
                 proto = {"null": {}}
@@ -226,7 +226,7 @@ class RunMasterBase(unittest.TestCase):
                 protocol = 'pb'
                 dispatcher = list(m.pbmanager.dispatchers.values())[0]
             else:
-                protocol = 'msgpack_experimental_v3'
+                protocol = 'msgpack_experimental_v4'
                 dispatcher = list(m.msgmanager.dispatchers.values())[0]
 
                 unsupported_python_versions = ['2.7', '3.4', '3.5']

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -57,10 +57,10 @@ class WorkerRegistration:
                 worker_config.workername, worker_config.password,
                 global_config.protocols['pb']['port'])
 
-        if 'msgpack_experimental_v3' in global_config.protocols:
+        if 'msgpack_experimental_v4' in global_config.protocols:
             self.msgpack_reg = yield self.master.workers.msgpack.updateRegistration(
                 worker_config.workername, worker_config.password,
-                global_config.protocols['msgpack_experimental_v3']['port'])
+                global_config.protocols['msgpack_experimental_v4']['port'])
 
     def getPBPort(self):
         return self.pbReg.getPort()

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -124,7 +124,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
                 raise KeyError('unknown "command_id"')
 
             command = self.command_id_to_command_map[msg['command_id']]
-            yield command.remote_update(msg['args'])
+            yield command.remote_update_msgpack(msg['args'])
         except Exception as e:
             is_exception = True
             result = str(e)

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -42,6 +42,8 @@ class Listener(base.UpdateRegistrationListener):
 
 
 class BasicRemoteCommand():
+    # only has basic functions needed for remoteSetBuilderList in class Connection
+    # when waiting for update messages
     def __init__(self, worker_name, expected_keys, error_msg):
         self.worker_name = worker_name
         self.update_results = {}
@@ -52,11 +54,12 @@ class BasicRemoteCommand():
     def wait_until_complete(self):
         return self.d
 
-    def remote_update(self, args):
-        for element in args:
-            for key, value in element[0].items():
-                if key not in self.update_results:
-                    self.update_results[key] = value
+    def remote_update_msgpack(self, args):
+        # args is a list of tuples
+        # first element of the tuple is a key, second element is a value
+        for key, value in args:
+            if key not in self.update_results:
+                self.update_results[key] = value
 
     def remote_complete(self, args):
         if 'rc' not in self.update_results:

--- a/master/docs/developer/master-worker-msgpack.rst
+++ b/master/docs/developer/master-worker-msgpack.rst
@@ -366,9 +366,9 @@ Request
     Value is a string ``update``.
 
 ``args``
-    Value is a list of lists.
-    Inner list contains a dictionary and an integer.
-    Keys and values of the dictionary are further explained in section :ref:`MsgPack_Keys_And_Values_Message`.
+    Value is a list of two-element lists.
+    These two elements in sub-lists represent name-value pairs: first element is the name of update and second is its value.
+    The names and values are further explained in section :ref:`MsgPack_Keys_And_Values_Message`.
 
 ``command_id``
     Value is a string which identifies command the update refers to.
@@ -1087,13 +1087,17 @@ This command removes the specified file.
 .. _MsgPack_Keys_And_Values_Message:
 
 
-Keys and values of ``args`` dictionary value in ``update`` request message
---------------------------------------------------------------------------
+Contents of the value corresponding to ``args`` key in the dictionary of ``update`` request message
+---------------------------------------------------------------------------------------------------
 
-Commands may have specific key-value pairs so only common ones are described here.
+The ``args`` key-value pair describes information that the request sends to master.
+The value is a list of lists.
+Each sub-list contains name-value pairs.
+First element in a list represents the name of update (see below) and second element represents its value.
+Commands may have their own update names so only common ones are described here.
 
 ``stdout``
-    Value is a standard output of a process.
+    Value is a standard output of a process as a string.
     Some of the commands that master requests worker to start, may initiate processes which output a result as a standard output and this result is saved in the value of ``stdout``.
 
 ``rc``
@@ -1103,7 +1107,7 @@ Commands may have specific key-value pairs so only common ones are described her
     Any other number represents a failure.
 
 ``header``
-    Value is a string.
+    Value is a string of a header.
     It represents additional information about how the command worked.
     For example, information may include the command name and arguments, working directory and environment or various errors or warnings of a process or other information that may be useful for debugging.
 
@@ -1115,11 +1119,11 @@ Commands may have specific key-value pairs so only common ones are described her
     2) If the ``update`` message was a response to master request message ``start_command`` with a key value pair ``command_name`` and ``listdir``, then strings in this list represent the names of the entries in the directory given by path, which master sent as an argument.
 
 ``stderr``
-    Value is a standard error of a process.
+    Value is a standard error of a process as a string.
     Some of the commands that master requests worker to start may initiate processes which can output a result as a standard error and this result is saved in the value of ``stderr``.
 
-``Tuple (“log”, name)``
-    Value is a string.
+``log``
+    Value is a list where first element represents the name of the log and second element represents the contents of the file as a string.
     This message is used to transfer the contents of the file that master requested worker to read.
     This file is identified by the second member in workers tuple.
     The same value is sent by master as the key of dictionary represented by ``logfile`` key within ``args`` dictionary of ``StartCommand`` command.

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -74,9 +74,7 @@ class ProtocolCommandBase:
         # master still expects to receive. Provide it to avoid significant
         # interoperability issues between new workers and old masters.
         if not self.is_complete:
-            update = [data, 0]
-            updates = [update]
-            d = self.protocol_update(updates)
+            d = self.protocol_update(data)
             d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
 
     def _ack_failed(self, why, where):

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -128,7 +128,7 @@ class Command(object):
     """
 
     # builder methods:
-    #  sendStatus(dict) (zero or more)
+    #  sendStatus(list of tuples) (zero or more)
     #  commandComplete() or commandInterrupted() (one, at end)
 
     requiredArgs = []
@@ -160,8 +160,7 @@ class Command(object):
         d = defer.maybeDeferred(self.start)
 
         def commandComplete(res):
-            self.sendStatus(
-                {"elapsed": util.now(self._reactor) - self.startTime})
+            self.sendStatus([("elapsed", util.now(self._reactor) - self.startTime)])
             self.running = False
             return res
         d.addBoth(commandComplete)
@@ -205,11 +204,11 @@ class Command(object):
         return rc
 
     def _sendRC(self, res):
-        self.sendStatus({'rc': 0})
+        self.sendStatus([('rc', 0)])
 
     def _checkAbandoned(self, why):
         log.msg("_checkAbandoned", why)
         why.trap(AbandonChain)
         log.msg(" abandoning chain", why.value)
-        self.sendStatus({'rc': why.value.args[0]})
+        self.sendStatus([('rc', why.value.args[0])])
         return None

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -47,11 +47,12 @@ class MakeDirectory(base.Command):
                     os.makedirs(dirname)
             except OSError as e:
                 log.msg("MakeDirectory {0} failed: {1}".format(dirname, e))
-                self.sendStatus(
-                    {'header': '{0}: {1}: {2}'.format(self.header, e.strerror, dirname)})
-                self.sendStatus({'rc': e.errno})
+                self.sendStatus([
+                    ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, dirname)),
+                    ('rc', e.errno)
+                ])
                 return
-        self.sendStatus({'rc': 0})
+        self.sendStatus([('rc', 0)])
 
 
 class RemoveDirectory(base.Command):
@@ -82,7 +83,7 @@ class RemoveDirectory(base.Command):
             if res != 0:
                 self.rc = res
 
-        self.sendStatus({'rc': self.rc})
+        self.sendStatus([('rc', self.rc)])
 
     def removeSingleDir(self, path):
         if runtime.platformType != "posix":
@@ -92,8 +93,9 @@ class RemoveDirectory(base.Command):
                 return 0  # rc=0
 
             def eb(f):
-                self.sendStatus(
-                    {'header': 'exception from rmdirRecursive\n' + f.getTraceback()})
+                self.sendStatus([
+                    ('header', 'exception from rmdirRecursive\n' + f.getTraceback())
+                ])
                 return -1  # rc=-1
             d.addCallbacks(cb, eb)
         else:
@@ -177,14 +179,13 @@ class CopyDirectory(base.Command):
                 return 0  # rc=0
 
             def eb(f):
-                self.sendStatus(
-                    {'header': 'exception from copytree\n' + f.getTraceback()})
+                self.sendStatus([('header', 'exception from copytree\n' + f.getTraceback())])
                 return -1  # rc=-1
             d.addCallbacks(cb, eb)
 
             @d.addCallback
             def send_rc(rc):
-                self.sendStatus({'rc': rc})
+                self.sendStatus([('rc', rc)])
         else:
             if not os.path.exists(os.path.dirname(to_path)):
                 os.makedirs(os.path.dirname(to_path))
@@ -220,13 +221,13 @@ class StatFile(base.Command):
 
         try:
             stat = os.stat(filename)
-            self.sendStatus({'stat': tuple(stat)})
-            self.sendStatus({'rc': 0})
+            self.sendStatus([('stat', tuple(stat)), ('rc', 0)])
         except OSError as e:
             log.msg("StatFile {0} failed: {1}".format(filename, e))
-            self.sendStatus(
-                {'header': '{0}: {1}: {2}'.format(self.header, e.strerror, filename)})
-            self.sendStatus({'rc': e.errno})
+            self.sendStatus([
+                ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, filename)),
+                ('rc', e.errno)
+            ])
 
 
 class GlobPath(base.Command):
@@ -245,13 +246,13 @@ class GlobPath(base.Command):
                 files = glob.glob(pathname, recursive=True)
             else:
                 files = glob.glob(pathname)
-            self.sendStatus({'files': files})
-            self.sendStatus({'rc': 0})
+            self.sendStatus([('files', files), ('rc', 0)])
         except OSError as e:
             log.msg("GlobPath {0} failed: {1}".format(pathname, e))
-            self.sendStatus(
-                {'header': '{0}: {1}: {2}'.format(self.header, e.strerror, pathname)})
-            self.sendStatus({'rc': e.errno})
+            self.sendStatus([
+                ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, pathname)),
+                ('rc', e.errno)
+            ])
 
 
 class ListDir(base.Command):
@@ -266,13 +267,13 @@ class ListDir(base.Command):
 
         try:
             files = os.listdir(dirname)
-            self.sendStatus({'files': files})
-            self.sendStatus({'rc': 0})
+            self.sendStatus([('files', files), ('rc', 0)])
         except OSError as e:
             log.msg("ListDir {0} failed: {1}".format(dirname, e))
-            self.sendStatus(
-                {'header': '{0}: {1}: {2}'.format(self.header, e.strerror, dirname)})
-            self.sendStatus({'rc': e.errno})
+            self.sendStatus([
+                ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, dirname)),
+                ('rc', e.errno)
+            ])
 
 
 class RemoveFile(base.Command):
@@ -287,9 +288,10 @@ class RemoveFile(base.Command):
 
         try:
             os.remove(pathname)
-            self.sendStatus({'rc': 0})
+            self.sendStatus([('rc', 0)])
         except OSError as e:
             log.msg("remove file {0} failed: {1}".format(pathname, e))
-            self.sendStatus(
-                {'header': '{0}: {1}: {2}'.format(self.header, e.strerror, pathname)})
-            self.sendStatus({'rc': e.errno})
+            self.sendStatus([
+                ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, pathname)),
+                ('rc', e.errno)
+            ])

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -34,10 +34,10 @@ class TransferCommand(Command):
 
         # don't use self.sendStatus here, since we may no longer be running
         # if we have been interrupted
-        upd = {'rc': self.rc}
+        updates = [('rc', self.rc)]
         if self.stderr:
-            upd['stderr'] = self.stderr
-        self.protocol_command.send_update(upd)
+            updates.append(('stderr', self.stderr))
+        self.protocol_command.send_update(updates)
         return res
 
     def interrupt(self):
@@ -98,7 +98,7 @@ class WorkerFileUploadCommand(TransferCommand):
             if self.debug:
                 log.msg("Cannot open file '{0}' for upload".format(self.path))
 
-        self.sendStatus({'header': "sending {0}\n".format(self.path)})
+        self.sendStatus([('header', "sending {0}\n".format(self.path))])
 
         d = defer.Deferred()
         self._reactor.callLater(0, self._loop, d)
@@ -227,7 +227,7 @@ class WorkerDirectoryUploadCommand(WorkerFileUploadCommand):
         # Transfer it
         self.fp.seek(0)
 
-        self.sendStatus({'header': "sending {0}\n".format(self.path)})
+        self.sendStatus([('header', "sending {0}\n".format(self.path))])
 
         d = defer.Deferred()
         self._reactor.callLater(0, self._loop, d)

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -86,9 +86,16 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
             args['reader'] = None
 
     # Returns a Deferred
-    def protocol_update(self, updates):
-        return self.protocol.get_message_result({'op': 'update', 'args': updates,
-                                                 'command_id': self.command_id})
+    def protocol_update(self, data):
+        dl = []
+        for element in data:
+            key, value = element
+            update = [{key: value}, 0]
+            updates = [update]
+            d = self.protocol.get_message_result({'op': 'update', 'args': updates,
+                                                  'command_id': self.command_id})
+            dl.append(d)
+        return defer.DeferredList(dl, fireOnOneErrback=True, consumeErrors=True)
 
     def protocol_notify_on_disconnect(self):
         pass

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -87,15 +87,8 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
 
     # Returns a Deferred
     def protocol_update(self, data):
-        dl = []
-        for element in data:
-            key, value = element
-            update = [{key: value}, 0]
-            updates = [update]
-            d = self.protocol.get_message_result({'op': 'update', 'args': updates,
-                                                  'command_id': self.command_id})
-            dl.append(d)
-        return defer.DeferredList(dl, fireOnOneErrback=True, consumeErrors=True)
+        return self.protocol.get_message_result({'op': 'update', 'args': data,
+                                                 'command_id': self.command_id})
 
     def protocol_notify_on_disconnect(self):
         pass

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -563,7 +563,7 @@ class Worker(WorkerBase):
 
         if protocol == 'pb':
             bot_class = BotPb
-        elif protocol == 'msgpack_experimental_v3':
+        elif protocol == 'msgpack_experimental_v4':
             if sys.version_info < (3, 6):
                 raise NotImplementedError(
                     'Msgpack protocol is only supported on Python 3.6 and newer'
@@ -596,7 +596,7 @@ class Worker(WorkerBase):
         if protocol == 'pb':
             bf = self.bf = BotFactory(buildmaster_host, port, keepalive, maxdelay)
             bf.startLogin(credentials.UsernamePassword(name, passwd), client=self.bot)
-        elif protocol == 'msgpack_experimental_v3':
+        elif protocol == 'msgpack_experimental_v4':
             if connection_string is None:
                 ws_conn_string = "ws://{}:{}".format(buildmaster_host, port)
             else:

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -118,8 +118,16 @@ class ProtocolCommandPb(ProtocolCommandBase):
             del args['workerdest']
 
     # Returns a Deferred
-    def protocol_update(self, updates):
-        return self.command_ref.callRemote("update", updates)
+    def protocol_update(self, data):
+        # data is a list of tuples
+        # first element of the tuple is dictionary key, second element is value
+        dl = []
+        for key, value in data:
+            update = [{key: value}, 0]
+            updates = [update]
+            d = self.command_ref.callRemote("update", updates)
+            dl.append(d)
+        return defer.DeferredList(dl, fireOnOneErrback=True, consumeErrors=True)
 
     def protocol_notify_on_disconnect(self):
         self.command_ref.notifyOnDisconnect(self.on_lost_remote_step)

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -412,8 +412,7 @@ class RunProcess(object):
         # and for .closeStdin to matter, we must use a pipe, not a PTY
         if runtime.platformType != "posix" or initialStdin is not None:
             if self.usePTY:
-                self.sendStatus(
-                    {'header': "WARNING: disabling usePTY for this command"})
+                self.sendStatus([('header', "WARNING: disabling usePTY for this command")])
             self.usePTY = False
 
         # use an explicit process group on POSIX, noting that usePTY always implies
@@ -687,7 +686,10 @@ class RunProcess(object):
         if not msg:
             return
         msg = self._collapseMsg(msg)
-        self.sendStatus(msg)
+        data = []
+        for key, value in msg.items():
+            data.append((key, value))
+        self.sendStatus(data)
 
     def _bufferTimeout(self):
         self.sendBuffersTimer = None
@@ -795,10 +797,9 @@ class RunProcess(object):
             rc = -1
         if self.sendRC:
             if sig is not None:
-                self.sendStatus(
-                    {'header': "process killed by signal {0}\n".format(sig)})
-            self.sendStatus({'rc': rc})
-        self.sendStatus({'header': "elapsedTime={0:0.6f}\n".format(self.elapsedTime)})
+                self.sendStatus([('header', "process killed by signal {0}\n".format(sig))])
+            self.sendStatus([('rc', rc)])
+        self.sendStatus([('header', "elapsedTime={0:0.6f}\n".format(self.elapsedTime))])
         self._cancelTimers()
         d = self.deferred
         self.deferred = None
@@ -947,7 +948,7 @@ class RunProcess(object):
         self._cancelTimers()
         msg += ", attempting to kill"
         log.msg(msg)
-        self.sendStatus({'header': "\n" + msg + "\n"})
+        self.sendStatus([('header', "\n" + msg + "\n")])
 
         # let the PP know that we are killing it, so that it can ensure that
         # the exit status comes out right
@@ -967,10 +968,9 @@ class RunProcess(object):
                 " finish anyway")
         self.killTimer = None
         signalName = "SIG" + self.interruptSignal
-        self.sendStatus({'header': signalName + " failed to kill process\n"})
+        self.sendStatus([('header', signalName + " failed to kill process\n")])
         if self.sendRC:
-            self.sendStatus({'header': "using fake rc=-1\n"})
-            self.sendStatus({'rc': -1})
+            self.sendStatus([('header', "using fake rc=-1\n"), ('rc', -1)])
         self.failed(RuntimeError(signalName + " failed to kill process"))
 
     def _cancelTimers(self):

--- a/worker/buildbot_worker/test/fake/protocolcommand.py
+++ b/worker/buildbot_worker/test/fake/protocolcommand.py
@@ -36,7 +36,8 @@ class FakeProtocolCommand(ProtocolCommandBase):
     def send_update(self, status):
         if self.debug:
             print("FakeWorkerForBuilder.sendUpdate", status)
-        self.updates.append(status)
+        for st in status:
+            self.updates.append(st)
 
     # Returns a Deferred
     def protocol_update_upload_file_close(self, writer):

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -175,7 +175,10 @@ class FakeRunProcess(object):
                 continue  # don't send this update
             if not upd:
                 continue
-            self.send_update(upd)
+            data = []
+            for key, value in upd.items():
+                data.append((key, value))
+            self.send_update(data)
 
         d = self.run_deferred = defer.Deferred()
 
@@ -191,6 +194,6 @@ class FakeRunProcess(object):
             self.run_deferred.callback(self._exp.result[1])
 
     def kill(self, reason):
-        self.send_update({'hdr': 'killing'})
-        self.send_update({'rc': -1})
+        self.send_update([('hdr', 'killing')])
+        self.send_update([('rc', -1)])
         self.run_deferred.callback(-1)

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from twisted.internet import defer
-from twisted.python import failure
 
 
 class Expect(object):
@@ -47,17 +46,6 @@ class Expect(object):
         self.result = None
         self.status_updates = []
 
-    def __add__(self, other):
-        if isinstance(other, dict):
-            self.status_updates.append(other)
-        elif isinstance(other, int):
-            self.result = ('c', other)
-        elif isinstance(other, failure.Failure):
-            self.result = ('e', other)
-        else:
-            raise ValueError("invalid expectation '{0!r}'".format(other))
-        return self
-
     def __str__(self):
         other_kwargs = self.kwargs.copy()
         del other_kwargs['command']
@@ -65,6 +53,18 @@ class Expect(object):
         return "Command: {0}\n  workdir: {1}\n  kwargs: {2}\n  result: {3}\n".format(
             self.kwargs['command'], self.kwargs['workdir'],
             other_kwargs, self.result)
+
+    def update(self, key, value):
+        self.status_updates.append((key, value))
+        return self
+
+    def exit(self, rc_code):
+        self.result = ('c', rc_code)
+        return self
+
+    def exception(self, error):
+        self.result = ('e', error)
+        return self
 
 
 class FakeRunProcess(object):
@@ -157,27 +157,22 @@ class FakeRunProcess(object):
         if keepStderr:
             self.stderr = ''
         finish_immediately = True
-
-        # send the updates, accounting for the stdio parameters
-        for upd in self._exp.status_updates:
-            if 'stdout' in upd:
+        for key, value in self._exp.status_updates:
+            if key == 'stdout':
                 if keepStdout:
-                    self.stdout += upd['stdout']
+                    self.stdout += value
                 if not sendStdout:
-                    del upd['stdout']
-            if 'stderr' in upd:
+                    continue  # don't send this update
+            if key == 'stderr':
                 if keepStderr:
-                    self.stderr += upd['stderr']
+                    self.stderr += value
                 if not sendStderr:
-                    del upd['stderr']
-            if 'wait' in upd:
+                    continue
+            if key == 'wait':
                 finish_immediately = False
-                continue  # don't send this update
-            if not upd:
                 continue
             data = []
-            for key, value in upd.items():
-                data.append((key, value))
+            data.append((key, value))
             self.send_update(data)
 
         d = self.run_deferred = defer.Deferred()

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -206,12 +206,11 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
 
         # patch runprocess to handle the 'echo', below
         self.patch_runprocess(
-            Expect(['echo', 'hello'], os.path.join(
-                self.basedir, 'wfb', 'workdir')) +
-            {'hdr': 'headers'} +
-            {'stdout': 'hello\n'} +
-            {'rc': 0} +
-            0,
+            Expect(['echo', 'hello'], os.path.join(self.basedir, 'wfb', 'workdir'))
+            .update('hdr', 'headers')
+            .update('stdout', 'hello\n')
+            .update('rc', 0)
+            .exit(0)
         )
 
         yield self.wfb.callRemote("startCommand", FakeRemote(st),
@@ -235,10 +234,9 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # patch runprocess to pretend to sleep (it will really just hang forever,
         # except that we interrupt it)
         self.patch_runprocess(
-            Expect(['sleep', '10'], os.path.join(
-                self.basedir, 'wfb', 'workdir')) +
-            {'hdr': 'headers'} +
-            {'wait': True}
+            Expect(['sleep', '10'], os.path.join(self.basedir, 'wfb', 'workdir'))
+            .update('hdr', 'headers')
+            .update('wait', True)
         )
 
         yield self.wfb.callRemote("startCommand", FakeRemote(st),
@@ -269,9 +267,8 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
 
         # patch runprocess to generate a failure
         self.patch_runprocess(
-            Expect(['sleep', '10'], os.path.join(
-                self.basedir, 'wfb', 'workdir')) +
-            failure.Failure(Exception("Oops"))
+            Expect(['sleep', '10'], os.path.join(self.basedir, 'wfb', 'workdir'))
+            .exception(failure.Failure(Exception("Oops")))
         )
         # patch the log.err, otherwise trial will think something *actually*
         # failed

--- a/worker/buildbot_worker/test/unit/test_commands_base.py
+++ b/worker/buildbot_worker/test/unit/test_commands_base.py
@@ -35,7 +35,10 @@ class DummyCommand(Command):
 
     def start(self):
         self.started = True
-        self.sendStatus(self.args)
+        data = []
+        for key, value in self.args.items():
+            data.append((key, value))
+        self.sendStatus(data)
         self.cmd_deferred = defer.Deferred()
         return self.cmd_deferred
 
@@ -100,7 +103,7 @@ class TestDummyCommand(CommandTestMixin, unittest.TestCase):
         d.addCallback(check)
 
         def checkresult(_):
-            self.assertUpdates([{'stdout': 'yay'}], "updates processed")
+            self.assertUpdates([('stdout', 'yay')], "updates processed")
         d.addCallback(checkresult)
         return d
 
@@ -123,7 +126,7 @@ class TestDummyCommand(CommandTestMixin, unittest.TestCase):
         d.addErrback(check)
 
         def checkresult(_):
-            self.assertUpdates([{}], "updates processed")
+            self.assertUpdates([], "updates processed")
         d.addCallback(checkresult)
         return d
 

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -52,7 +52,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveDirectory, {'paths': [file_path]}, True)
         yield self.run_command()
         self.assertFalse(os.path.exists(os.path.abspath(file_path)))
-        self.assertIn({'rc': 0}, self.get_updates(), self.protocol_command.show())
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
@@ -68,7 +68,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         yield self.run_command()
 
-        self.assertEqual(self.get_updates()[-2], {'rc': 0})
+        self.assertEqual(self.get_updates()[-2], ('rc', 0))
         self.assertIn('elapsed', self.get_updates()[-1])
 
     @defer.inlineCallbacks
@@ -82,7 +82,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveDirectory, {'paths': ['workdir']}, True)
         yield self.run_command()
 
-        self.assertIn({'rc': -1}, self.get_updates(), self.protocol_command.show())
+        self.assertIn(('rc', -1), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_multiple_dirs_real(self):
@@ -92,9 +92,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         for path in paths:
             self.assertFalse(os.path.exists(os.path.abspath(path)))
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
@@ -116,7 +114,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         yield self.run_command()
 
-        self.assertEqual(self.get_updates()[-2], {'rc': 0})
+        self.assertEqual(self.get_updates()[-2], ('rc', 0))
         self.assertIn('elapsed', self.get_updates()[-1])
 
     @skipUnlessPlatformIs('posix')
@@ -142,7 +140,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         yield self.run_command()
 
-        self.assertEqual(self.get_updates()[-2], {'rc': 0})
+        self.assertEqual(self.get_updates()[-2], ('rc', 0))
         self.assertIn('elapsed', self.get_updates()[-1])
 
     @skipUnlessPlatformIs('posix')
@@ -168,7 +166,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         yield self.run_command()
 
-        self.assertEqual(self.get_updates()[-2], {'rc': 1})
+        self.assertEqual(self.get_updates()[-2], ('rc', 1))
         self.assertIn('elapsed', self.get_updates()[-1])
 
 
@@ -189,7 +187,7 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
 
         self.assertTrue(
             os.path.exists(os.path.abspath(to_path)))
-        self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
+        self.assertIn(('rc', 0),  # this may ignore a 'header' : '..', which is OK
                       self.get_updates(),
                       self.protocol_command.show())
 
@@ -207,7 +205,7 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.CopyDirectory, {'from_path': from_path, 'to_path': to_path}, True)
         yield self.run_command()
 
-        self.assertIn({'rc': -1},
+        self.assertIn(('rc', -1),
                       self.get_updates(),
                       self.protocol_command.show())
 
@@ -225,7 +223,7 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.MakeDirectory, {'paths': []}, True)
         yield self.run_command()
 
-        self.assertUpdates([{'rc': 0}], self.protocol_command.show())
+        self.assertUpdates([('rc', 0)], self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_simple(self):
@@ -234,7 +232,7 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertTrue(os.path.exists(os.path.abspath(paths[0])))
-        self.assertUpdates([{'rc': 0}], self.protocol_command.show())
+        self.assertUpdates([('rc', 0)], self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_two_dirs(self):
@@ -245,7 +243,7 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
         for path in paths:
             self.assertTrue(os.path.exists(os.path.abspath(path)))
 
-        self.assertUpdates([{'rc': 0}], self.protocol_command.show())
+        self.assertUpdates([('rc', 0)], self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_already_exists(self):
@@ -253,7 +251,7 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
                           True)
         yield self.run_command()
 
-        self.assertUpdates([{'rc': 0}], self.protocol_command.show())
+        self.assertUpdates([('rc', 0)], self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_error_existing_file(self):
@@ -264,7 +262,7 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
             pass
         yield self.run_command()
 
-        self.assertIn({'rc': errno.EEXIST}, self.get_updates(), self.protocol_command.show())
+        self.assertIn(('rc', errno.EEXIST), self.get_updates(), self.protocol_command.show())
 
 
 class TestStatFile(CommandTestMixin, unittest.TestCase):
@@ -281,9 +279,7 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.StatFile, {'path': path}, True)
         yield self.run_command()
 
-        self.assertIn({'rc': errno.ENOENT},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertIn(('rc', errno.ENOENT), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_directory(self):
@@ -292,11 +288,8 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.StatFile, {'path': path}, True)
         yield self.run_command()
 
-        self.assertTrue(
-            stat.S_ISDIR(self.get_updates()[0]['stat'][stat.ST_MODE]))
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertTrue(stat.S_ISDIR(self.get_updates()[0][1][stat.ST_MODE]))
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_file(self):
@@ -308,11 +301,8 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
 
         yield self.run_command()
 
-        self.assertTrue(
-            stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertTrue(stat.S_ISREG(self.get_updates()[0][1][stat.ST_MODE]))
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_file_workdir(self):
@@ -323,12 +313,8 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
             pass
 
         yield self.run_command()
-
-        self.assertTrue(
-            stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertTrue(stat.S_ISREG(self.get_updates()[0][1][stat.ST_MODE]))
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
 
 class TestGlobPath(CommandTestMixin, unittest.TestCase):
@@ -344,21 +330,16 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.GlobPath, {'path': os.path.join(self.basedir, 'no-*-file')}, True)
         yield self.run_command()
 
-        self.assertEqual(self.get_updates()[0]['files'], [])
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertEqual(self.get_updates()[0][1], [])
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_directory(self):
         self.make_command(fs.GlobPath, {'path': os.path.join(self.basedir, '[wxyz]or?d*')}, True)
         yield self.run_command()
 
-        self.assertEqual(
-            self.get_updates()[0]['files'], [os.path.join(self.basedir, 'workdir')])
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertEqual(self.get_updates()[0][1], [os.path.join(self.basedir, 'workdir')])
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_file(self):
@@ -367,12 +348,8 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
             pass
 
         yield self.run_command()
-
-        self.assertEqual(
-            self.get_updates()[0]['files'], [os.path.join(self.basedir, 'test-file')])
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertEqual(self.get_updates()[0][1], [os.path.join(self.basedir, 'test-file')])
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_recursive(self):
@@ -389,13 +366,10 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
                 filename = 'test/testdir/test.txt'
 
             self.assertEqual(
-                self.get_updates()[0]['files'], [os.path.join(self.basedir, filename)])
+                self.get_updates()[0][1], [os.path.join(self.basedir, filename)])
         else:
-            self.assertEqual(
-                self.get_updates()[0]['files'], [])
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
+            self.assertEqual(self.get_updates()[0][1], [])
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
 
 
 class TestListDir(CommandTestMixin, unittest.TestCase):
@@ -413,9 +387,7 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.ListDir, {'path': path}, True)
         yield self.run_command()
 
-        self.assertIn({'rc': errno.ENOENT},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertIn(('rc', errno.ENOENT), self.get_updates(), self.protocol_command.show())
 
     @defer.inlineCallbacks
     def test_dir(self):
@@ -434,10 +406,9 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
                     return True
             return None
 
-        self.assertIn({'rc': 0},
-                      self.get_updates(),
-                      self.protocol_command.show())
-        self.assertTrue(any('files' in upd and sorted(upd['files']) == ['file1', 'file2']
+        self.assertIn(('rc', 0), self.get_updates(), self.protocol_command.show())
+
+        self.assertTrue(any('files' in upd and sorted(upd[1]) == ['file1', 'file2']
             for upd in self.get_updates()),
             self.protocol_command.show())
 
@@ -461,7 +432,7 @@ class TestRemoveFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertFalse(os.path.exists(file1_path))
-        self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
+        self.assertIn(('rc', 0),  # this may ignore a 'header' : '..', which is OK
                       self.get_updates(),
                       self.protocol_command.show())
 
@@ -473,6 +444,4 @@ class TestRemoveFile(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveFile, {'path': file2_path}, True)
         yield self.run_command()
 
-        self.assertIn({'rc': 2},
-                      self.get_updates(),
-                      self.protocol_command.show())
+        self.assertIn(('rc', 2), self.get_updates(), self.protocol_command.show())

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -62,8 +62,10 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(["rm", "-rf", file_path], self.basedir, sendRC=0, timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 0}
-            + 0,
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 0)
+            .exit(0)
         )
 
         yield self.run_command()
@@ -102,14 +104,16 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveDirectory, {'paths': [dir_1, dir_2]}, True)
 
         self.patch_runprocess(
-            Expect(["rm", "-rf", dir_1], self.basedir, sendRC=0,
-                   timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 0}
-            + 0,
-            Expect(["rm", "-rf", dir_2], self.basedir, sendRC=0,
-                   timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 0}
-            + 0,
+            Expect(["rm", "-rf", dir_1], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 0)
+            .exit(0),
+            Expect(["rm", "-rf", dir_2], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 0)
+            .exit(0)
         )
 
         yield self.run_command()
@@ -124,18 +128,21 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveDirectory, {'paths': [dir]}, True)
 
         self.patch_runprocess(
-            Expect(["rm", "-rf", dir], self.basedir, sendRC=0,
-                   timeout=120)
-            + {'hdr': 'headers'} + {'stderr': 'permission denied'} + {'rc': 1}
-            + 1,
-            Expect(['chmod', '-Rf', 'u+rwx', dir], self.basedir,
-                   sendRC=0, timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 0}
-            + 0,
-            Expect(["rm", "-rf", dir], self.basedir, sendRC=0,
-                   timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 0}
-            + 0,
+            Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stderr', 'permission denied')
+            .update('rc', 1)
+            .exit(1),
+            Expect(['chmod', '-Rf', 'u+rwx', dir], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 0)
+            .exit(0),
+            Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 0)
+            .exit(0)
         )
 
         yield self.run_command()
@@ -150,18 +157,21 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveDirectory, {'paths': [dir]}, True)
 
         self.patch_runprocess(
-            Expect(["rm", "-rf", dir], self.basedir, sendRC=0,
-                   timeout=120)
-            + {'hdr': 'headers'} + {'stderr': 'permission denied'} + {'rc': 1}
-            + 1,
-            Expect(['chmod', '-Rf', 'u+rwx', dir], self.basedir,
-                   sendRC=0, timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 0}
-            + 0,
-            Expect(["rm", "-rf", dir], self.basedir, sendRC=0,
-                   timeout=120)
-            + {'hdr': 'headers'} + {'stdout': ''} + {'rc': 1}
-            + 1,
+            Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stderr', 'permission denied')
+            .update('rc', 1)
+            .exit(1),
+            Expect(['chmod', '-Rf', 'u+rwx', dir], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 0)
+            .exit(0),
+            Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
+            .update('hdr', 'headers')
+            .update('stdout', '')
+            .update('rc', 1)
+            .exit(1)
         )
 
         yield self.run_command()

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -50,7 +50,7 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
 
         # note that WorkerShellCommand does not add any extra updates of it own
         self.assertUpdates(
-            [{'hdr': 'headers'}, {'stdout': 'hello\n'}, {'rc': 0}],
+            [('hdr', 'headers'), ('stdout', 'hello\n'), ('rc', 0)],
             self.protocol_command.show())
 
     # TODO: test all functionality that WorkerShellCommand adds atop RunProcess

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -42,8 +42,10 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(['echo', 'hello'], self.basedir_workdir)
-            + {'hdr': 'headers'} + {'stdout': 'hello\n'} + {'rc': 0}
-            + 0,
+            .update('hdr', 'headers')
+            .update('stdout', 'hello\n')
+            .update('rc', 0)
+            .exit(0)
         )
 
         yield self.run_command()

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -148,9 +148,9 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datafile)},
+            ('header', 'sending {0}\n'.format(self.datafile)),
             'write 64', 'write 64', 'write 52', 'close',
-            {'rc': 0}
+            ('rc', 0)
         ])
 
     @defer.inlineCallbacks
@@ -169,10 +169,10 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datafile)},
+            ('header', 'sending {0}\n'.format(self.datafile)),
             'write 64', 'write 36', 'close',
-            {'rc': 1,
-             'stderr': "Maximum filesize reached, truncating file '{0}'".format(self.datafile)}
+            ('rc', 1),
+            ('stderr', "Maximum filesize reached, truncating file '{0}'".format(self.datafile))
         ])
 
     @defer.inlineCallbacks
@@ -190,10 +190,10 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         df = self.datafile + "-nosuch"
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(df)},
+            ('header', 'sending {0}\n'.format(df)),
             'close',
-            {'rc': 1,
-             'stderr': "Cannot open file '{0}' for upload".format(df)}
+            ('rc', 1),
+            ('stderr', "Cannot open file '{0}' for upload".format(df))
         ])
 
     @defer.inlineCallbacks
@@ -213,9 +213,9 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.assertFailure(self.run_command(), RuntimeError)
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datafile)},
+            ('header', 'sending {0}\n'.format(self.datafile)),
             'write 64', 'close',
-            {'rc': 1}
+            ('rc', 1)
         ])
 
     @defer.inlineCallbacks
@@ -245,8 +245,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield defer.DeferredList([d, interrupt_d])
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datafile)},
-            'write(s)', 'close', {'rc': 1}
+            ('header', 'sending {0}\n'.format(self.datafile)), 'write(s)', 'close', ('rc', 1)
         ])
 
     @defer.inlineCallbacks
@@ -267,10 +266,10 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datafile)},
+            ('header', 'sending {0}\n'.format(self.datafile)),
             'write 64', 'write 64', 'write 52',
             'close', 'utime - {0}'.format(timestamp[0]),
-            {'rc': 0}
+            ('rc', 0)
         ])
 
 
@@ -313,9 +312,9 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datadir)},
+            ('header', 'sending {0}\n'.format(self.datadir)),
             'write(s)', 'unpack',  # note no 'close"
-            {'rc': 0}
+            ('rc', 0)
         ])
 
         f = io.BytesIO(self.fakemaster.data)
@@ -357,9 +356,9 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
         yield self.assertFailure(self.run_command(), RuntimeError)
 
         self.assertUpdates([
-            {'header': 'sending {0}\n'.format(self.datadir)},
+            ('header', 'sending {0}\n'.format(self.datadir)),
             'write(s)', 'unpack',
-            {'rc': 1}
+            ('rc', 1)
         ])
 
 
@@ -400,7 +399,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.assertUpdates([
             'read 32', 'read 32', 'read 32', 'close',
-            {'rc': 0}
+            ('rc', 0)
         ])
         datafile = os.path.join(self.basedir, 'data')
         self.assertTrue(os.path.exists(datafile))
@@ -428,7 +427,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.assertUpdates([
             'read(s)', 'close',
-            {'rc': 0}
+            ('rc', 0)
         ])
         datafile = os.path.join(self.basedir, 'workdir', 'subdir', 'data')
         self.assertTrue(os.path.exists(datafile))
@@ -454,9 +453,9 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.assertUpdates([
             'close',
-            {'rc': 1,
-             'stderr': "Cannot open file '{0}' for download".format(
-             os.path.join(self.basedir, 'dir'))}
+            ('rc', 1),
+            ('stderr', "Cannot open file '{0}' for download".format(
+             os.path.join(self.basedir, 'dir')))
         ])
 
     @defer.inlineCallbacks
@@ -475,9 +474,9 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.assertUpdates([
             'read(s)', 'close',
-            {'rc': 1,
-             'stderr': "Maximum filesize reached, truncating file '{0}'".format(
-             os.path.join(self.basedir, 'data'))}
+            ('rc', 1),
+            ('stderr', "Maximum filesize reached, truncating file '{0}'".format(
+             os.path.join(self.basedir, 'data')))
         ])
         datafile = os.path.join(self.basedir, 'data')
         self.assertTrue(os.path.exists(datafile))
@@ -513,5 +512,5 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
         yield defer.DeferredList([d, interrupt_d])
 
         self.assertUpdates([
-            'read(s)', 'close', {'rc': 1}
+            'read(s)', 'close', ('rc', 1)
         ])

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -344,24 +344,19 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [[{'header': 'mkdir: test_error: {}'.format(path)}, 0]],
+                'args': [['header', 'mkdir: test_error: {}'.format(path)], ['rc', 1]],
                 'command_id': '123',
                 'seq_number': 0
             }, {
                 'op': 'update',
-                'args': [[{'rc': 1}, 0]],
+                'args': [['elapsed', 0]],
                 'command_id': '123',
                 'seq_number': 1
-            }, {
-                'op': 'update',
-                'args': [[{'elapsed': 0}, 0]],
-                'command_id': '123',
-                'seq_number': 2
             }, {
                 'op': 'complete',
                 'args': None,
                 'command_id': '123',
-                'seq_number': 3
+                'seq_number': 2
             },
             # response result is always None, even if the command failed
             {'op': 'response', 'result': None, 'seq_number': 1}
@@ -377,7 +372,6 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         yield self.send_message(create_msg(0))
         yield self.send_message(create_msg(1))
         yield self.send_message(create_msg(2))
-        yield self.send_message(create_msg(3))
 
         # worker should not send any new messages in response to masters 'response'
         self.assertEqual(self.list_send_message_args, [])
@@ -406,22 +400,22 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [[{'hdr': 'headers'}, 0]],
+                'args': [['hdr', 'headers']],
                 'command_id': '123',
                 'seq_number': 0
             }, {
                 'op': 'update',
-                'args': [[{'stdout': 'hello\n'}, 0]],
+                'args': [['stdout', 'hello\n']],
                 'command_id': '123',
                 'seq_number': 1
             }, {
                 'op': 'update',
-                'args': [[{'rc': 0}, 0]],
+                'args': [['rc', 0]],
                 'command_id': '123',
                 'seq_number': 2
             }, {
                 'op': 'update',
-                'args': [[{'elapsed': 0}, 0]],
+                'args': [['elapsed', 0]],
                 'command_id': '123',
                 'seq_number': 3
             }, {
@@ -493,7 +487,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 0,
                 'command_id': '123',
-                'args': [[{'hdr': 'headers'}, 0]]
+                'args': [['hdr', 'headers']]
             }, {
                 'op': 'response',
                 'seq_number': 1,
@@ -513,12 +507,12 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 1,
                 'command_id': '123',
-                'args': [[{'hdr': 'killing'}, 0]],
+                'args': [['hdr', 'killing']],
             }, {
                 'op': 'update',
                 'seq_number': 2,
                 'command_id': '123',
-                'args': [[{'rc': -1}, 0]]
+                'args': [['rc', -1]]
             }, {
                 'op': 'complete', 'seq_number': 3, 'command_id': '123', 'args': None
             }, {

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -383,11 +383,12 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         # patch runprocess to handle the 'echo', below
         workdir = os.path.join('basedir', 'test_basedir')
         self.patch_runprocess(
-            Expect(['echo'], workdir) +
-            {'hdr': 'headers'} +
-            {'stdout': 'hello\n'} +
-            {'rc': 0} +
-            0,)
+            Expect(['echo'], workdir)
+            .update('hdr', 'headers')
+            .update('stdout', 'hello\n')
+            .update('rc', 0)
+            .exit(0)
+            )
 
         yield self.send_message({
             'op': 'start_command',
@@ -464,9 +465,9 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         # except that we interrupt it)
         workdir = os.path.join('basedir', 'test_basedir')
         self.patch_runprocess(
-            Expect(['sleep', '10'], workdir) +
-            {'hdr': 'headers'} +
-            {'wait': True}
+            Expect(['sleep', '10'], workdir)
+            .update('hdr', 'headers')
+            .update('wait', True)
         )
 
         yield self.send_message({

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -86,7 +86,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         self.updates = []
 
     def send_update(self, status):
-        self.updates.append(status)
+        for st in status:
+            self.updates.append(st)
 
     def show(self):
         return pprint.pformat(self.updates)
@@ -116,8 +117,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.assertTrue({'stdout': nl('hello\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('hello\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testNoStdout(self):
@@ -126,8 +127,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.failIf({'stdout': nl('hello\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.failIf(('stdout', nl('hello\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testKeepStdout(self):
@@ -136,8 +137,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.assertTrue({'stdout': nl('hello\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('hello\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
         self.assertEqual(s.stdout, nl('hello\n'))
 
     @defer.inlineCallbacks
@@ -146,8 +147,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.failIf({'stderr': nl('hello\n')} not in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.failIf(('stderr', nl('hello\n')) not in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testNoStderr(self):
@@ -156,8 +157,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.failIf({'stderr': nl('hello\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.failIf(('stderr', nl('hello\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def test_incrementalDecoder(self):
@@ -171,9 +172,9 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         pp.errReceived(b"\x98\x83")
         yield s.start()
 
-        self.assertTrue({'stderr': u"\N{SNOWMAN}"} in self.updates)
-        self.assertTrue({'stdout': u"\N{SNOWMAN}"} in self.updates)
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stderr', u"\N{SNOWMAN}") in self.updates)
+        self.assertTrue(('stdout', u"\N{SNOWMAN}") in self.updates)
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testInvalidUTF8(self):
@@ -185,10 +186,10 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
             INVALID_UTF8.decode('utf-8')
         pp.outReceived(INVALID_UTF8)
         yield s.start()
-        stdout = [up['stdout'] for up in self.updates if 'stdout' in up][0]
+        stdout = [value for key, value in self.updates if key == 'stdout'][0]
         # On Python < 2.7 bytes is used, on Python >= 2.7 unicode
         self.assertIn(stdout, (b'\xef\xbf\xbd', u'\ufffd'))
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testKeepStderr(self):
@@ -197,8 +198,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.assertTrue({'stderr': nl('hello\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stderr', nl('hello\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
         self.assertEqual(s.stderr, nl('hello\n'))
 
     @defer.inlineCallbacks
@@ -208,8 +209,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.assertTrue({'stdout': nl('hello\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('hello\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     def testObfuscatedCommand(self):
         s = runprocess.RunProcess([('obfuscated', 'abcd', 'ABCD')], self.basedir, 'utf-8',
@@ -227,8 +228,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         exp = nl('Happy Days and Jubilation\n')
         yield s.start()
 
-        self.assertTrue({'stdout': exp} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', exp) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testInitialStdinUnicode(self):
@@ -237,8 +238,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.assertTrue({'stdout': nl('hello')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('hello')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testMultiWordStringCommandQuotes(self):
@@ -254,8 +255,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
             exp = nl('Happy Days and Jubilation\n')
         yield s.start()
 
-        self.assertTrue({'stdout': exp} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', exp) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testTrickyArguments(self):
@@ -273,8 +274,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
                                   self.send_update)
         yield s.start()
 
-        self.assertTrue({'stdout': nl(repr(args))} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', nl(repr(args))) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     @compat.skipUnlessPlatformIs("win32")
@@ -286,8 +287,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        self.assertTrue({'stdout': nl('a\nb\n')} in self.updates, self.show())
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('a\nb\n')) in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testCommandTimeout(self):
@@ -300,9 +301,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         clock.advance(6)
         yield d
 
-        self.assertTrue(
-            {'stdout': nl('hello\n')} not in self.updates, self.show())
-        self.assertTrue({'rc': FATAL_RC} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('hello\n')) not in self.updates, self.show())
+        self.assertTrue(('rc', FATAL_RC) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testCommandMaxTime(self):
@@ -315,9 +315,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         clock.advance(6)  # should knock out maxTime
         yield d
 
-        self.assertTrue(
-            {'stdout': nl('hello\n')} not in self.updates, self.show())
-        self.assertTrue({'rc': FATAL_RC} in self.updates, self.show())
+        self.assertTrue(('stdout', nl('hello\n')) not in self.updates, self.show())
+        self.assertTrue(('rc', FATAL_RC) in self.updates, self.show())
 
     @compat.skipUnlessPlatformIs("posix")
     @defer.inlineCallbacks
@@ -329,7 +328,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
                                   logEnviron=False)
         yield s.start()
 
-        self.assertTrue({'rc': 0} in self.updates, self.show())
+        self.assertTrue(('rc', 0) in self.updates, self.show())
 
     @defer.inlineCallbacks
     def test_startCommand_exception(self):
@@ -348,9 +347,9 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         stderr = []
         # Here we're checking that the exception starting up the command
         # actually gets propagated back to the master in stderr.
-        for u in self.updates:
-            if 'stderr' in u:
-                stderr.append(u['stderr'])
+        for key, value in self.updates:
+            if key == 'stderr':
+                stderr.append(value)
         stderr = ''.join(stderr)
         self.assertTrue(stderr.startswith('error in RunProcess._startCommand (error message)'))
 
@@ -363,8 +362,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        headers = "".join([list(update.values())[0]
-                           for update in self.updates if list(update) == ["header"]])
+        headers = "".join([value for key, value in self.updates if key == "header"])
         self.assertTrue("FOO=BAR" in headers, "got:\n" + headers)
 
     @defer.inlineCallbacks
@@ -388,8 +386,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         yield s.start()
 
-        headers = "".join([list(update.values())[0]
-                           for update in self.updates if list(update) == ["header"]])
+        headers = "".join([value for key, value in self.updates if key == "header"])
         self.assertTrue("EXPND=-$" not in headers, "got:\n" + headers)
         self.assertTrue("DOESNT_FIND=--" in headers, "got:\n" + headers)
         self.assertTrue(
@@ -927,7 +924,8 @@ class TestLogging(BasedirMixin, unittest.TestCase):
         self.updates = []
 
     def send_update(self, status):
-        self.updates.append(status)
+        for st in status:
+            self.updates.append(st)
 
     def show(self):
         return pprint.pformat(self.updates)
@@ -937,15 +935,15 @@ class TestLogging(BasedirMixin, unittest.TestCase):
 
     def testSendStatus(self):
         s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
-        s.sendStatus({'stdout': nl('hello\n')})
-        self.assertEqual(self.updates, [{'stdout': nl('hello\n')}], self.show())
+        s.sendStatus([('stdout', nl('hello\n'))])
+        self.assertEqual(self.updates, [('stdout', nl('hello\n'))], self.show())
 
     def testSendBuffered(self):
         s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
         s._addToBuffers('stdout', 'hello ')
         s._addToBuffers('stdout', 'world')
         s._sendBuffers()
-        self.assertEqual(self.updates, [{'stdout': 'hello world'}], self.show())
+        self.assertEqual(self.updates, [('stdout', 'hello world')], self.show())
 
     def testSendBufferedInterleaved(self):
         s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
@@ -954,9 +952,9 @@ class TestLogging(BasedirMixin, unittest.TestCase):
         s._addToBuffers('stdout', 'world')
         s._sendBuffers()
         self.assertEqual(self.updates, [
-            {'stdout': 'hello '},
-            {'stderr': 'DIEEEEEEE'},
-            {'stdout': 'world'},
+            ('stdout', 'hello '),
+            ('stderr', 'DIEEEEEEE'),
+            ('stdout', 'world'),
         ])
 
     def testSendChunked(self):
@@ -976,9 +974,7 @@ class TestLogging(BasedirMixin, unittest.TestCase):
         s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
         s._addToBuffers(('log', 'stdout'), 'hello ')
         s._sendBuffers()
-        self.assertEqual(self.updates, [
-            {'log': ('stdout', 'hello ')},
-        ])
+        self.assertEqual(self.updates, [('log', ('stdout', 'hello '))])
 
 
 class TestLogFileWatcher(BasedirMixin, unittest.TestCase):
@@ -988,7 +984,8 @@ class TestLogFileWatcher(BasedirMixin, unittest.TestCase):
         self.updates = []
 
     def send_update(self, status):
-        self.updates.append(status)
+        for st in status:
+            self.updates.append(st)
 
     def show(self):
         return pprint.pformat(self.updates)
@@ -1040,7 +1037,7 @@ class TestLogFileWatcher(BasedirMixin, unittest.TestCase):
             # the log file content was captured and the invalid byte replaced with \ufffd (the
             # replacement character, often a black diamond with a white question mark)
             REPLACED = u'before\ufffdafter'
-            self.assertEqual(self.updates, [{'log': ('test', REPLACED)}])
+            self.assertEqual(self.updates, [('log', ('test', REPLACED))])
 
         finally:
             lf.stop()


### PR DESCRIPTION
This PR introduces a new protocol version where update messages are sent not as dictionaries but as a tuple.
This makes it possible to send several command update values in one update message.
Furthermore, splitting the command output into lines is now moved to the worker side to take the load off from the master.
 
* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation