### PR TITLE
Let 'vswhere.exe' search for all products including BuildTools.

### DIFF
--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -557,7 +557,8 @@ class MsBuild141(VisualStudio):
         self.descriptionDone = 'built ' + self.describe_project()
         yield self.updateSummary()
 
-        command = ('FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\') '
+        command = ('FOR /F "tokens=*" %%I in '
+                   '(\'vswhere.exe -products * -property installationPath\') '
                    f' do "%%I\\%VCENV_BAT%" x86 && msbuild "{self.projectfile}" '
                    f'/p:Configuration="{self.config}" /p:Platform="{self.platform}" /maxcpucount')
 

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -438,6 +438,14 @@ class VC141(VC14):
 VS2017 = VC141
 
 
+class VS2019(VS2017):
+    default_installdir = r"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
+
+
+class VS2022(VS2017):
+    default_installdir = r"C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\Community"
+
+
 def _msbuild_format_defines_parameter(defines):
     if defines is None or len(defines) == 0:
         return ""
@@ -528,6 +536,7 @@ class MsBuild141(VisualStudio):
     defines = None
     vcenv_bat = r"\VC\Auxiliary\Build\vcvarsall.bat"
     renderables = ['platform']
+    version_range = "[15.0,16.0)"
 
     def __init__(self, platform, defines=None, **kwargs):
         self.platform = platform
@@ -558,7 +567,8 @@ class MsBuild141(VisualStudio):
         yield self.updateSummary()
 
         command = ('FOR /F "tokens=*" %%I in '
-                   '(\'vswhere.exe -products * -property installationPath\') '
+                   f'(\'vswhere.exe -version "{self.version_range}" -products * '
+                   '-property installationPath\') '
                    f' do "%%I\\%VCENV_BAT%" x86 && msbuild "{self.projectfile}" '
                    f'/p:Configuration="{self.config}" /p:Platform="{self.platform}" /maxcpucount')
 
@@ -569,3 +579,14 @@ class MsBuild141(VisualStudio):
 
         res = yield super().run()
         return res
+
+
+MsBuild15 = MsBuild141
+
+
+class MsBuild16(MsBuild141):
+    version_range = "[16.0,17.0)"
+
+
+class MsBuild17(MsBuild141):
+    version_range = "[17.0,18.0)"

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -548,6 +548,8 @@ class MsBuild141(VisualStudio):
         self.env['VCENV_BAT'] = self.vcenv_bat
         self.add_env_path("PATH",
                    'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\')
+        self.add_env_path("PATH",
+                   'C:\\Program Files\\Microsoft Visual Studio\\Installer\\')
         self.add_env_path("PATH", r'${PATH}')
 
     def describe_project(self, done=False):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -880,7 +880,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -894,7 +894,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Build"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Build"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -908,7 +908,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Clean"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Clean"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -923,7 +923,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj" /p:DefineConstants="Define1;Define2=42"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj" /p:DefineConstants="Define1;Define2=42"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -937,9 +937,60 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="x64" /maxcpucount /t:Rebuild',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="x64" /maxcpucount /t:Rebuild',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
-                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
+        return self.run_step()
+
+    def test_aliases_MsBuild15(self):
+        self.assertIdentical(vstudio.MsBuild141, vstudio.MsBuild15)
+
+
+class TestMsBuild16(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setup_test_reactor()
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def test_version_range_is_correct(self):
+        self.setup_step(vstudio.MsBuild16(
+            projectfile='pf', config='cfg', platform='Win32', project='pj'))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[16.0,17.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
+                        env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
+        return self.run_step()
+
+
+class TestMsBuild17(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setup_test_reactor()
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def test_version_range_is_correct(self):
+        self.setup_step(vstudio.MsBuild17(
+            projectfile='pf', config='cfg', platform='Win32', project='pj'))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[17.0,18.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
+                        env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -880,7 +880,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -894,7 +894,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Build"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Build"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -908,7 +908,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Clean"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Clean"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
@@ -923,7 +923,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.expect_commands(
             ExpectShell(workdir='wkdir',
-                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj" /p:DefineConstants="Define1;Define2=42"',  # noqa pylint: disable=line-too-long
+                        command='FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj" /p:DefineConstants="Define1;Define2=42"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
                              'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -882,7 +882,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
-                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
@@ -896,7 +896,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Build"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
-                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
@@ -910,7 +910,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj:Clean"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
-                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
@@ -925,7 +925,7 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         command='FOR /F "tokens=*" %%I in (\'vswhere.exe -version "[15.0,16.0)" -products * -property installationPath\')  do "%%I\\%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /maxcpucount /t:"pj" /p:DefineConstants="Define1;Define2=42"',  # noqa pylint: disable=line-too-long
                         env={'VCENV_BAT': r'\VC\Auxiliary\Build\vcvarsall.bat',
-                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
+                             'PATH': 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\;C:\\Program Files\\Microsoft Visual Studio\\Installer\\;${PATH};'})  # noqa pylint: disable=line-too-long
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")

--- a/master/docs/manual/configuration/steps/visual_cxx.rst
+++ b/master/docs/manual/configuration/steps/visual_cxx.rst
@@ -16,11 +16,16 @@
 .. bb:step:: VS2013
 .. bb:step:: VS2015
 .. bb:step:: VS2017
+.. bb:step:: VS2019
+.. bb:step:: VS2022
 .. bb:step:: VCExpress9
 .. bb:step:: MsBuild4
 .. bb:step:: MsBuild12
 .. bb:step:: MsBuild14
 .. bb:step:: MsBuild141
+.. bb:step:: MsBuild15
+.. bb:step:: MsBuild16
+.. bb:step:: MsBuild17
 
 .. _Step-VisualCxx:
 
@@ -52,11 +57,16 @@ The available classes are:
 * ``VS2013``
 * ``VS2015``
 * ``VS2017``
+* ``VS2019``
+* ``VS2022``
 * ``VCExpress9``
 * ``MsBuild4``
 * ``MsBuild12``
 * ``MsBuild14``
 * ``MsBuild141``
+* ``MsBuild15``
+* ``MsBuild16``
+* ``MsBuild17``
 
 The available constructor arguments are
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -306,6 +306,7 @@ errbacks
 errorCb
 et
 eventPathPatterns
+executables
 explorable
 extensibility
 facto

--- a/master/setup.py
+++ b/master/setup.py
@@ -319,8 +319,9 @@ setup_args = {
             ('buildbot.steps.vstudio', [
                 'VC6', 'VC7', 'VS2003', 'VC8', 'VS2005', 'VCExpress9', 'VC9',
                 'VS2008', 'VC10', 'VS2010', 'VC11', 'VS2012', 'VC12', 'VS2013',
-                'VC14', 'VS2015', 'VC141', 'VS2017', 'MsBuild4', 'MsBuild',
-                'MsBuild12', 'MsBuild14', 'MsBuild141']),
+                'VC14', 'VS2015', 'VC141', 'VS2017', 'VS2019', 'VS2022',
+                'MsBuild4', 'MsBuild', 'MsBuild12', 'MsBuild14', 'MsBuild141',
+                'MsBuild15', 'MsBuild16', 'MsBuild17']),
             ('buildbot.steps.worker', [
                 'SetPropertiesFromEnv', 'FileExists', 'CopyDirectory',
                 'RemoveDirectory', 'MakeDirectory']),

--- a/newsfragments/msbuild-find-buildtools.bugfix
+++ b/newsfragments/msbuild-find-buildtools.bugfix
@@ -1,0 +1,1 @@
+Let MSBuild find the VS installation path if only the 'BuildTools' are installed.

--- a/newsfragments/new-visual-studio-steps.feature
+++ b/newsfragments/new-visual-studio-steps.feature
@@ -1,0 +1,1 @@
+Added ``VS2019``, ``VS2022``, ``MsBuild15``, ``MsBuild16``, ``MsBuild17`` steps.

--- a/newsfragments/search-program-files-paths.bugfix
+++ b/newsfragments/search-program-files-paths.bugfix
@@ -1,0 +1,1 @@
+Fixed search for Visual Studio executables by inspecting both ``C:\Program Files`` and ``C:\Program Files (x86)`` directories.


### PR DESCRIPTION
On dedicated servers, one would usually not install the full Visual Studio SDK, but only the command line `BuildTools`. I had the issue that the `steps.MSBuild` would not find the installation path if it wasn't configured to search for all Visual Studio products.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
