### PR TITLE
Move splitting of lines to worker side in msgpack

### DIFF
--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -202,7 +202,7 @@ class RunMasterBase(unittest.TestCase):
                 proto = {"pb": {"port": "tcp:0:interface=127.0.0.1"}}
                 workerclass = worker.Worker
             if self.proto == 'msgpack':
-                proto = {"msgpack_experimental_v4": {"port": 0}}
+                proto = {"msgpack_experimental_v5": {"port": 0}}
                 workerclass = worker.Worker
             elif self.proto == 'null':
                 proto = {"null": {}}
@@ -226,7 +226,7 @@ class RunMasterBase(unittest.TestCase):
                 protocol = 'pb'
                 dispatcher = list(m.pbmanager.dispatchers.values())[0]
             else:
-                protocol = 'msgpack_experimental_v4'
+                protocol = 'msgpack_experimental_v5'
                 dispatcher = list(m.msgmanager.dispatchers.values())[0]
 
                 unsupported_python_versions = ['2.7', '3.4', '3.5']

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -57,10 +57,10 @@ class WorkerRegistration:
                 worker_config.workername, worker_config.password,
                 global_config.protocols['pb']['port'])
 
-        if 'msgpack_experimental_v4' in global_config.protocols:
+        if 'msgpack_experimental_v5' in global_config.protocols:
             self.msgpack_reg = yield self.master.workers.msgpack.updateRegistration(
                 worker_config.workername, worker_config.password,
-                global_config.protocols['msgpack_experimental_v4']['port'])
+                global_config.protocols['msgpack_experimental_v5']['port'])
 
     def getPBPort(self):
         return self.pbReg.getPort()

--- a/master/docs/developer/master-worker-msgpack.rst
+++ b/master/docs/developer/master-worker-msgpack.rst
@@ -1092,13 +1092,14 @@ Contents of the value corresponding to ``args`` key in the dictionary of ``updat
 
 The ``args`` key-value pair describes information that the request sends to master.
 The value is a list of lists.
-Each sub-list contains name-value pairs.
+Each sub-list contains a name-value pair and represents a single update.
 First element in a list represents the name of update (see below) and second element represents its value.
 Commands may have their own update names so only common ones are described here.
 
 ``stdout``
     Value is a standard output of a process as a string.
     Some of the commands that master requests worker to start, may initiate processes which output a result as a standard output and this result is saved in the value of ``stdout``.
+    The value is satisfies the requirements described in a section below.
 
 ``rc``
     Value is an integer.
@@ -1110,6 +1111,7 @@ Commands may have their own update names so only common ones are described here.
     Value is a string of a header.
     It represents additional information about how the command worked.
     For example, information may include the command name and arguments, working directory and environment or various errors or warnings of a process or other information that may be useful for debugging.
+    The value satisfies the requirements described in a section below.
 
 ``files``
     Value is a list of strings.
@@ -1121,6 +1123,7 @@ Commands may have their own update names so only common ones are described here.
 ``stderr``
     Value is a standard error of a process as a string.
     Some of the commands that master requests worker to start may initiate processes which can output a result as a standard error and this result is saved in the value of ``stderr``.
+    The value satisfies the requirements described in a section below.
 
 ``log``
     Value is a list where first element represents the name of the log and second element represents the contents of the file as a string.
@@ -1128,7 +1131,19 @@ Commands may have their own update names so only common ones are described here.
     This file is identified by the second member in workers tuple.
     The same value is sent by master as the key of dictionary represented by ``logfile`` key within ``args`` dictionary of ``StartCommand`` command.
     The string value of the message is the contents of a file that worker read.
+    The value satisfies the requirements described in a section below.
 
 ``elapsed``
     Value is an integer.
     It represents how much time has passed between the start of a command and the completion in seconds.
+
+Requirements for values of ``stdout``, ``stderr``, ``header`` and ``log``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Values of ``stdout``, ``header``, ``stderr``, ``log`` must be processed using the following algorithm:
+
+- Each value may contain one or more lines (characters with a terminating ``\n`` character).
+  Each line is not longer than internal ``maxsize`` value on worker side.
+  Longer lines are split into multiple lines where each except the last line contains exactly ``maxsize`` characters and the last line may contain less.
+
+- The lines are run through an internal worker cleanup regex.

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -427,6 +427,9 @@ if sys.version_info >= (3, 6):
                 # command that wasn't actually running
                 log.msg(" .. but none was running")
                 return
+            d = self.protocol_commands[command_id].flush_command_output()
+            d.addErrback(self.protocol_commands[command_id]._ack_failed,
+                         "ProtocolCommandMsgpack.flush_command_output")
             self.protocol_commands[command_id].command.doInterrupt()
 
 
@@ -563,7 +566,7 @@ class Worker(WorkerBase):
 
         if protocol == 'pb':
             bot_class = BotPb
-        elif protocol == 'msgpack_experimental_v4':
+        elif protocol == 'msgpack_experimental_v5':
             if sys.version_info < (3, 6):
                 raise NotImplementedError(
                     'Msgpack protocol is only supported on Python 3.6 and newer'
@@ -596,7 +599,7 @@ class Worker(WorkerBase):
         if protocol == 'pb':
             bf = self.bf = BotFactory(buildmaster_host, port, keepalive, maxdelay)
             bf.startLogin(credentials.UsernamePassword(name, passwd), client=self.bot)
-        elif protocol == 'msgpack_experimental_v4':
+        elif protocol == 'msgpack_experimental_v5':
             if connection_string is None:
                 ws_conn_string = "ws://{}:{}".format(buildmaster_host, port)
             else:

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -189,6 +189,6 @@ class FakeRunProcess(object):
             self.run_deferred.callback(self._exp.result[1])
 
     def kill(self, reason):
-        self.send_update([('hdr', 'killing')])
+        self.send_update([('header', 'killing')])
         self.send_update([('rc', -1)])
         self.run_deferred.callback(-1)

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -207,7 +207,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # patch runprocess to handle the 'echo', below
         self.patch_runprocess(
             Expect(['echo', 'hello'], os.path.join(self.basedir, 'wfb', 'workdir'))
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', 'hello\n')
             .update('rc', 0)
             .exit(0)
@@ -219,7 +219,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         yield st.wait_for_finish()
 
         self.assertEqual(st.actions, [
-            ['update', [[{'hdr': 'headers'}, 0]]],
+            ['update', [[{'header': 'headers'}, 0]]],
             ['update', [[{'stdout': 'hello\n'}, 0]]],
             ['update', [[{'rc': 0}, 0]]],
             ['update', [[{'elapsed': 1}, 0]]],
@@ -235,7 +235,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # except that we interrupt it)
         self.patch_runprocess(
             Expect(['sleep', '10'], os.path.join(self.basedir, 'wfb', 'workdir'))
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('wait', True)
         )
 
@@ -254,8 +254,8 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         yield st.wait_for_finish()
 
         self.assertEqual(st.actions, [
-            ['update', [[{'hdr': 'headers'}, 0]]],
-            ['update', [[{'hdr': 'killing'}, 0]]],
+            ['update', [[{'header': 'headers'}, 0]]],
+            ['update', [[{'header': 'killing'}, 0]]],
             ['update', [[{'rc': -1}, 0]]],
             ['complete', None],
         ])

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -62,7 +62,7 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(["rm", "-rf", file_path], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 0)
             .exit(0)
@@ -105,12 +105,12 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(["rm", "-rf", dir_1], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 0)
             .exit(0),
             Expect(["rm", "-rf", dir_2], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 0)
             .exit(0)
@@ -129,17 +129,17 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stderr', 'permission denied')
             .update('rc', 1)
             .exit(1),
             Expect(['chmod', '-Rf', 'u+rwx', dir], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 0)
             .exit(0),
             Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 0)
             .exit(0)
@@ -158,17 +158,17 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stderr', 'permission denied')
             .update('rc', 1)
             .exit(1),
             Expect(['chmod', '-Rf', 'u+rwx', dir], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 0)
             .exit(0),
             Expect(["rm", "-rf", dir], self.basedir, sendRC=0, timeout=120)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', '')
             .update('rc', 1)
             .exit(1)

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -42,7 +42,7 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(
             Expect(['echo', 'hello'], self.basedir_workdir)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', 'hello\n')
             .update('rc', 0)
             .exit(0)
@@ -52,7 +52,7 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
 
         # note that WorkerShellCommand does not add any extra updates of it own
         self.assertUpdates(
-            [('hdr', 'headers'), ('stdout', 'hello\n'), ('rc', 0)],
+            [('header', 'headers'), ('stdout', 'hello\n'), ('rc', 0)],
             self.protocol_command.show())
 
     # TODO: test all functionality that WorkerShellCommand adds atop RunProcess

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -344,7 +344,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [['header', 'mkdir: test_error: {}'.format(path)], ['rc', 1]],
+                'args': [['rc', 1]],
                 'command_id': '123',
                 'seq_number': 0
             }, {
@@ -353,10 +353,15 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'command_id': '123',
                 'seq_number': 1
             }, {
+                'op': 'update',
+                'args': [['header', 'mkdir: test_error: {}\n'.format(path)]],
+                'command_id': '123',
+                'seq_number': 2
+            }, {
                 'op': 'complete',
                 'args': None,
                 'command_id': '123',
-                'seq_number': 2
+                'seq_number': 3
             },
             # response result is always None, even if the command failed
             {'op': 'response', 'result': None, 'seq_number': 1}
@@ -384,7 +389,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         workdir = os.path.join('basedir', 'test_basedir')
         self.patch_runprocess(
             Expect(['echo'], workdir)
-            .update('header', 'headers')
+            .update('header', 'headers')  # note that this is partial line
             .update('stdout', 'hello\n')
             .update('rc', 0)
             .exit(0)
@@ -401,22 +406,22 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [['header', 'headers']],
+                'args': [['stdout', 'hello\n']],
                 'command_id': '123',
                 'seq_number': 0
             }, {
                 'op': 'update',
-                'args': [['stdout', 'hello\n']],
+                'args': [['rc', 0]],
                 'command_id': '123',
                 'seq_number': 1
             }, {
                 'op': 'update',
-                'args': [['rc', 0]],
+                'args': [['elapsed', 0]],
                 'command_id': '123',
                 'seq_number': 2
             }, {
                 'op': 'update',
-                'args': [['elapsed', 0]],
+                'args': [['header', 'headers\n']],
                 'command_id': '123',
                 'seq_number': 3
             }, {
@@ -485,11 +490,6 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
         self.assert_sent_messages([
             {
-                'op': 'update',
-                'seq_number': 0,
-                'command_id': '123',
-                'args': [['header', 'headers']]
-            }, {
                 'op': 'response',
                 'seq_number': 1,
                 'result': None
@@ -506,14 +506,19 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
+                'seq_number': 0,
+                'command_id': '123',
+                'args': [['header', 'headers\n']]
+            }, {
+                'op': 'update',
                 'seq_number': 1,
                 'command_id': '123',
-                'args': [['header', 'killing']],
+                'args': [['rc', -1]]
             }, {
                 'op': 'update',
                 'seq_number': 2,
                 'command_id': '123',
-                'args': [['rc', -1]]
+                'args': [['header', 'killing\n']],
             }, {
                 'op': 'complete', 'seq_number': 3, 'command_id': '123', 'args': None
             }, {

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -384,7 +384,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         workdir = os.path.join('basedir', 'test_basedir')
         self.patch_runprocess(
             Expect(['echo'], workdir)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('stdout', 'hello\n')
             .update('rc', 0)
             .exit(0)
@@ -401,7 +401,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [['hdr', 'headers']],
+                'args': [['header', 'headers']],
                 'command_id': '123',
                 'seq_number': 0
             }, {
@@ -466,7 +466,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         workdir = os.path.join('basedir', 'test_basedir')
         self.patch_runprocess(
             Expect(['sleep', '10'], workdir)
-            .update('hdr', 'headers')
+            .update('header', 'headers')
             .update('wait', True)
         )
 
@@ -488,7 +488,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 0,
                 'command_id': '123',
-                'args': [['hdr', 'headers']]
+                'args': [['header', 'headers']]
             }, {
                 'op': 'response',
                 'seq_number': 1,
@@ -508,7 +508,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 1,
                 'command_id': '123',
-                'args': [['hdr', 'killing']],
+                'args': [['header', 'killing']],
             }, {
                 'op': 'update',
                 'seq_number': 2,

--- a/worker/buildbot_worker/test/util/test_lineboundaries.py
+++ b/worker/buildbot_worker/test/util/test_lineboundaries.py
@@ -108,9 +108,9 @@ class LBF(unittest.TestCase):
             result = [e for e in result if e is not None]
             res = ''.join(result)
 
-            log.msg(f'feeding {repr(a)}, {repr(b)} gives {repr(res)}')
+            log.msg('feeding {}, {} gives {}'.format(repr(a), repr(b), repr(res)))
             self.assertEqual(res, 'a\nb\nc\nd\n\ne\n')
-            result.clear()
+            del result[:]
 
     def test_split_terminal_control(self):
         """terminal control characters are converted"""

--- a/worker/buildbot_worker/test/util/test_lineboundaries.py
+++ b/worker/buildbot_worker/test/util/test_lineboundaries.py
@@ -1,0 +1,155 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.python import log
+from twisted.trial import unittest
+
+from buildbot_worker.util import lineboundaries
+
+
+class LBF(unittest.TestCase):
+
+    def setUp(self):
+        self.lbf = lineboundaries.LineBoundaryFinder()
+
+    # tests
+
+    def test_already_terminated(self):
+        res = self.lbf.append('abcd\ndefg\n')
+        self.assertEqual(res, 'abcd\ndefg\n')
+        res = self.lbf.append('xyz\n')
+        self.assertEqual(res, 'xyz\n')
+        res = self.lbf.flush()
+        self.assertEqual(res, None)
+
+    def test_partial_line(self):
+        res = self.lbf.append('hello\nworld')
+        self.assertEqual(res, 'hello\n')
+        res = self.lbf.flush()
+        self.assertEqual(res, 'world\n')
+
+    def test_empty_appends(self):
+        res = self.lbf.append('hello ')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('world\n')
+        self.assertEqual(res, 'hello world\n')
+
+        res = self.lbf.append('')
+        self.assertEqual(res, None)
+
+    def test_embedded_newlines(self):
+        res = self.lbf.append('hello, ')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('cruel\nworld')
+        self.assertEqual(res, 'hello, cruel\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, 'world\n')
+
+    def test_windows_newlines_folded(self):
+        r"Windows' \r\n is treated as and converted to a newline"
+        res = self.lbf.append('hello, ')
+        self.assertEqual(res, None)
+
+        res = self.lbf.append('cruel\r\n\r\nworld')
+        self.assertEqual(res, 'hello, cruel\n\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, 'world\n')
+
+    def test_bare_cr_folded(self):
+        r"a bare \r is treated as and converted to a newline"
+        self.lbf.append('1%\r5%\r15%\r100%\nfinished')
+        res = self.lbf.flush()
+        self.assertEqual(res, 'finished\n')
+
+    def test_backspace_folded(self):
+        r"a lot of \b is treated as and converted to a newline"
+        self.lbf.append('1%\b\b5%\b\b15%\b\b\b100%\nfinished')
+        res = self.lbf.flush()
+        self.assertEqual(res, 'finished\n')
+
+    def test_mixed_consecutive_newlines(self):
+        r"mixing newline styles back-to-back doesn't collapse them"
+        res = self.lbf.append('1\r\n\n\r')
+        self.assertEqual(res, '1\n\n')
+
+        res = self.lbf.append('2\n\r\n')
+        self.assertEqual(res, '\n2\n\n')
+
+    def test_split_newlines(self):
+        r"multi-character newlines, split across chunks, are converted"
+        input = 'a\nb\r\nc\rd\n\re'
+        result = []
+        for splitpoint in range(1, len(input) - 1):
+            a, b = input[:splitpoint], input[splitpoint:]
+            result.append(self.lbf.append(a))
+            result.append(self.lbf.append(b))
+            result.append(self.lbf.flush())
+
+            result = [e for e in result if e is not None]
+            res = ''.join(result)
+
+            log.msg(f'feeding {repr(a)}, {repr(b)} gives {repr(res)}')
+            self.assertEqual(res, 'a\nb\nc\nd\n\ne\n')
+            result.clear()
+
+    def test_split_terminal_control(self):
+        """terminal control characters are converted"""
+        res = self.lbf.append('1234\033[u4321')
+        self.assertEqual(res, '1234\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, '4321\n')
+
+        res = self.lbf.append('1234\033[1;2H4321')
+        self.assertEqual(res, '1234\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, '4321\n')
+
+        res = self.lbf.append('1234\033[1;2f4321')
+        self.assertEqual(res, '1234\n')
+
+        res = self.lbf.flush()
+        self.assertEqual(res, '4321\n')
+
+    def test_long_lines(self):
+        """long lines are split"""
+        res = []
+        for _ in range(4):
+            res.append(self.lbf.append('12' * 1000))
+        res = [e for e in res if e is not None]
+        res = ''.join(res)
+        # a split at 4096 + the remaining chars
+        self.assertEqual(res, '12' * 2048 + '\n' + '12' * 952 + '\n')
+
+    def test_huge_lines(self):
+        """huge lines are split"""
+        res = []
+        res.append(self.lbf.append('12' * 32768))
+        res.append(self.lbf.flush())
+        res = [e for e in res if e is not None]
+        self.assertEqual(res, [('12' * 2048 + '\n') * 16])
+
+    def test_empty_flush(self):
+        res = self.lbf.flush()
+        self.assertEqual(res, None)

--- a/worker/buildbot_worker/util/lineboundaries.py
+++ b/worker/buildbot_worker/util/lineboundaries.py
@@ -1,0 +1,78 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import re
+
+from twisted.logger import Logger
+
+log = Logger()
+
+
+class LineBoundaryFinder:
+
+    __slots__ = ['partial_line', 'warned']
+    # split at reasonable line length.
+    # too big lines will fill master's memory, and slow down the UI too much.
+    MAX_LINELENGTH = 4096
+    # the lookahead here (`(?=.)`) ensures that `\r` doesn't match at the end
+    # of the buffer
+    # we also convert cursor control sequence to newlines
+    # and ugly \b+ (use of backspace to implement progress bar)
+    newline_re = re.compile(r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)')
+
+    def __init__(self):
+        self.partial_line = None
+        self.warned = False
+
+    def append(self, text):
+        if self.partial_line:
+            if len(self.partial_line) > self.MAX_LINELENGTH:
+                if not self.warned:
+                    # Unfortunately we cannot give more hint as per which log that is
+                    log.warn("Splitting long line: {line_start} {length} "
+                             "(not warning anymore for this log)",
+                             line_start=self.partial_line[:30],
+                             length=len(self.partial_line))
+                    self.warned = True
+                # switch the variables, and return previous _partial_line_,
+                # split every MAX_LINELENGTH plus a trailing \n
+                self.partial_line, text = text, self.partial_line
+                ret = []
+                while len(text) > self.MAX_LINELENGTH:
+                    ret.append(text[:self.MAX_LINELENGTH])
+                    text = text[self.MAX_LINELENGTH:]
+                ret.append(text)
+                result = ("\n".join(ret) + "\n")
+                return result
+            text = self.partial_line + text
+            self.partial_line = None
+        text = self.newline_re.sub('\n', text)
+        if text:
+            if text[-1] != '\n':
+                i = text.rfind('\n')
+                if i >= 0:
+                    i = i + 1
+                    text, self.partial_line = text[:i], text[i:]
+                else:
+                    self.partial_line = text
+                    return None
+            return text
+        return None
+
+    def flush(self):
+        if self.partial_line is not None:
+            return self.append('\n')
+        return None


### PR DESCRIPTION
This PR moves the splitting of command output lines to worker side in msgpack.
It takes the load off from master.
These changes will also help to  introduce an new feature for msgpack protocol in the future: the ability to send the exact command output times to the master.

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
