### PR TITLE
Switch to updated RTD configuration

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,9 +1,10 @@
 version: 2
 
 build:
-    image: latest
+    os: ubuntu-22.04
+    tools:
+        python: "3.10"
 
 python:
-    version: 3.10
     install:
         - requirements: requirements-readthedocs.txt


### PR DESCRIPTION
Switch to the current [`build` section configuration](https://docs.readthedocs.io/en/stable/config-file/v2.html#build), which allows the Python version to be set to any current version.

The version could be set to "3", to use the latest generally available release, but I kept it at "3.10" to match the latest supported version for buildbot.

Newsfragment for previous fixes still applied; no need to add another.

## Contributor Checklist:

* [N/A ] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation
