### PR TITLE
Fix `retryFetch` and `clobberOnFailure`.

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -305,7 +305,7 @@ class Git(Source, GitStepMixin):
         return self.workdir
 
     @defer.inlineCallbacks
-    def _fetch(self, _):
+    def _fetch(self, _, abandonOnFailure=True):
         fetch_required = True
 
         # If the revision already exists in the repo, we don't need to fetch.
@@ -327,15 +327,16 @@ class Git(Source, GitStepMixin):
                 else:
                     log.msg("Git versions < 1.7.2 don't support progress")
 
-            yield self._dovccmd(command)
+            res = yield self._dovccmd(command, abandonOnFailure=abandonOnFailure)
+            if res != RC_SUCCESS:
+                return res
 
         if self.revision:
             rev = self.revision
         else:
             rev = 'FETCH_HEAD'
         command = ['checkout', '-f', rev]
-        abandonOnFailure = not self.retryFetch and not self.clobberOnFailure
-        res = yield self._dovccmd(command, abandonOnFailure)
+        res = yield self._dovccmd(command, abandonOnFailure=abandonOnFailure)
 
         # Rename the branch if needed.
         if res == RC_SUCCESS and self.branch != 'HEAD':
@@ -350,7 +351,10 @@ class Git(Source, GitStepMixin):
         Handles fallbacks for failure of fetch,
         wrapper for self._fetch
         """
-        res = yield self._fetch(None)
+
+        abandonOnFailure = not self.retryFetch and not self.clobberOnFailure
+
+        res = yield self._fetch(None, abandonOnFailure=abandonOnFailure)
         if res == RC_SUCCESS:
             return res
         elif self.retryFetch:

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -3228,6 +3228,206 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl="http://github.com/buildbot/buildbot.git",
                            mode='full', method='unknown')
 
+    def test_mode_full_copy_recursive(self):
+        self.setup_step(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='copy', submodules='True'))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            .stdout('git version 1.7.5')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
+            .exit(1),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
+            ExpectListdir(dir='source')
+            .files(['.git'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'checkout', '-f', 'FETCH_HEAD'])
+            .exit(0),
+
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'sync'])
+            .exit(0),
+
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'update', '--init', '--recursive'])
+            .exit(0),
+
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=1200)
+            .exit(0),
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+        self.expect_property(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.run_step()
+
+
+    def test_mode_full_copy_recursive_fetch_fail(self):
+        self.setup_step(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='copy', submodules='True'))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            .stdout('git version 1.7.5')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
+            .exit(1),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
+            ExpectListdir(dir='source')
+            .files(['.git'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(1)
+        )
+        self.expect_outcome(result=FAILURE)
+        return self.run_step()
+
+    def test_mode_full_copy_recursive_fetch_fail_retry_fail(self):
+        self.setup_step(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='copy', submodules='True', retryFetch=True))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            .stdout('git version 1.7.5')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
+            .exit(1),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
+            ExpectListdir(dir='source')
+            .files(['.git'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(1),
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(1)
+        )
+        self.expect_outcome(result=FAILURE)
+        return self.run_step()
+
+    def test_mode_full_copy_recursive_fetch_fail_retry_succeed(self):
+        self.setup_step(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='copy', submodules='True', retryFetch=True))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            .stdout('git version 1.7.5')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
+            .exit(1),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
+            ExpectListdir(dir='source')
+            .files(['.git'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(1),
+            # retry Fetch
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(0),
+            # continue as normal
+            ExpectShell(workdir='source',
+                        command=['git', 'checkout', '-f', 'FETCH_HEAD'])
+            .exit(0),
+
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'sync'])
+            .exit(0),
+
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'update', '--init', '--recursive'])
+            .exit(0),
+
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=1200)
+            .exit(0),
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
+    def test_mode_full_copy_recursive_fetch_fail_clobberOnFailure(self):
+        self.setup_step(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='copy', submodules='True', clobberOnFailure=True))
+
+        self.expect_commands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            .stdout('git version 1.7.5')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True)
+            .exit(1),
+            ExpectRmdir(dir='wkdir', log_environ=True, timeout=1200),
+            ExpectListdir(dir='source')
+            .files(['.git'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'fetch', '-f', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD', '--progress'])
+            .exit(1),
+
+            # clobber and re-clone the source dir here
+            ExpectRmdir(dir='source', log_environ=True, timeout=1200)
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'clone',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 '.', '--progress'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'update', '--init', '--recursive'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'sync'])
+            .exit(0),
+            ExpectShell(workdir='source',
+                        command=['git', 'submodule', 'update', '--init', '--recursive'])
+            .exit(0),
+            ExpectCpdir(fromdir='source', todir='wkdir', log_environ=True, timeout=1200)
+            .exit(0),
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
 
 class TestGitPush(TestBuildStepMixin, config.ConfigErrorsMixin,
                   TestReactorMixin,

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -3273,7 +3273,6 @@ class TestGit(sourcesteps.SourceStepMixin,
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.run_step()
 
-
     def test_mode_full_copy_recursive_fetch_fail(self):
         self.setup_step(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',

--- a/newsfragments/retryFetch-clobberOnFailure.bugfix
+++ b/newsfragments/retryFetch-clobberOnFailure.bugfix
@@ -1,0 +1,1 @@
+Fixing the "retry fetch" and "clobber on failure" git checkout options.


### PR DESCRIPTION
As per http://docs.buildbot.net/latest/manual/configuration/steps/source_git.html#
>  retryFetch (optional, default: False)
>
>    If true, if the git fetch fails, then Buildbot retries to fetch again instead of failing the entire source checkout.

However, this does not currently work.

In `Git._fetchOrFallback`, the call to `self._fetch(None)` will throw a `BuildStepFailed` if the fetch command fails. The fallback code in `_fetchOrFallback` will not be executed and the fetch will not be retried. Same for `clobberOnFailure=True` if it is requested.

This change modifies `_fetch` to accept an `abandonOnFailure` flag to control whether it should throw.

## Test Plan

In the first commit I've added tests to test_source_git.py for the `retryFetch=True` case that fail, demonstrating the issue. 
The second commit fixes the failing tests.


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation - :thinking: Not sure this is needed. Please advise.