### PR TITLE
Add dummy workflow_run github event handler

### DIFF
--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -141,6 +141,9 @@ class GitHubEventHandler(PullRequestMixin):
     def handle_ping(self, _, __):
         return [], 'git'
 
+    def handle_workflow_run(self, _, __):
+        return [], 'git'
+
     def handle_push(self, payload, event):
         # This field is unused:
         user = None


### PR DESCRIPTION
When you add a buildbot webhook to github, github will send your server a workflow_run event as a "ping" to sanity check that
everything is setup correctly.  Buildbot doesn't support the workflow_run event and will return an error to github:

	400 - Unknown event: workflow_run

This commit adds in a dummy event handler for workflow_run that returns `200 - no change found`, which in turn makes github
happy.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
