### PR TITLE
Send master newlines indexes and times of log output in msgpack

### DIFF
--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -204,15 +204,10 @@ class RemoteCommand(base.RemoteCommandImpl):
             for key, value in updates:
                 if self.active and not self.ignore_updates:
                     if key in ['stdout', 'stderr', 'header']:
-                        whole_line = self.split_line(key, value)
-                        if whole_line is not None:
-                            self.remoteUpdate(key, whole_line, False)
+                        self.remoteUpdate(key, value[0], False)
                     elif key == "log":
                         logname, data = value
-                        whole_line = self.split_line(logname, data)
-                        value = (logname, whole_line)
-                        if whole_line is not None:
-                            self.remoteUpdate(key, value, False)
+                        self.remoteUpdate(key, (logname, data[0]), False)
                     else:
                         self.remoteUpdate(key, value, False)
         except Exception:

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -202,7 +202,7 @@ class RunMasterBase(unittest.TestCase):
                 proto = {"pb": {"port": "tcp:0:interface=127.0.0.1"}}
                 workerclass = worker.Worker
             if self.proto == 'msgpack':
-                proto = {"msgpack_experimental_v5": {"port": 0}}
+                proto = {"msgpack_experimental_v6": {"port": 0}}
                 workerclass = worker.Worker
             elif self.proto == 'null':
                 proto = {"null": {}}
@@ -226,7 +226,7 @@ class RunMasterBase(unittest.TestCase):
                 protocol = 'pb'
                 dispatcher = list(m.pbmanager.dispatchers.values())[0]
             else:
-                protocol = 'msgpack_experimental_v5'
+                protocol = 'msgpack_experimental_v6'
                 dispatcher = list(m.msgmanager.dispatchers.values())[0]
 
                 unsupported_python_versions = ['2.7', '3.4', '3.5']

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -57,10 +57,10 @@ class WorkerRegistration:
                 worker_config.workername, worker_config.password,
                 global_config.protocols['pb']['port'])
 
-        if 'msgpack_experimental_v5' in global_config.protocols:
+        if 'msgpack_experimental_v6' in global_config.protocols:
             self.msgpack_reg = yield self.master.workers.msgpack.updateRegistration(
                 worker_config.workername, worker_config.password,
-                global_config.protocols['msgpack_experimental_v5']['port'])
+                global_config.protocols['msgpack_experimental_v6']['port'])
 
     def getPBPort(self):
         return self.pbReg.getPort()

--- a/master/docs/developer/master-worker-msgpack.rst
+++ b/master/docs/developer/master-worker-msgpack.rst
@@ -782,7 +782,7 @@ Runs a ``shell`` command on the worker.
 
 
     If command succeeded, worker sends ``rc`` value 0 as an ``update`` message ``args`` key-value pair.
-    It can also send many other ``update`` messages with keys ``header``, ``stdout`` or ``stderr`` to inform about command execution.
+    It can also send many other ``update`` messages with keys such as ``header``, ``stdout`` or ``stderr`` to inform about command execution.
     If command failed, it sends ``rc`` value with the error number.
 
     The basic structure of worker ``update`` message is explained in section :ref:`MsgPack_Keys_And_Values_Message`.
@@ -1090,7 +1090,7 @@ This command removes the specified file.
 Contents of the value corresponding to ``args`` key in the dictionary of ``update`` request message
 ---------------------------------------------------------------------------------------------------
 
-The ``args`` key-value pair describes information that the request sends to master.
+The ``args`` key-value pair describes information that the request message sends to master.
 The value is a list of lists.
 Each sub-list contains a name-value pair and represents a single update.
 First element in a list represents the name of update (see below) and second element represents its value.
@@ -1099,7 +1099,7 @@ Commands may have their own update names so only common ones are described here.
 ``stdout``
     Value is a standard output of a process as a string.
     Some of the commands that master requests worker to start, may initiate processes which output a result as a standard output and this result is saved in the value of ``stdout``.
-    The value is satisfies the requirements described in a section below.
+    The value satisfies the requirements described in a section below.
 
 ``rc``
     Value is an integer.
@@ -1126,24 +1126,30 @@ Commands may have their own update names so only common ones are described here.
     The value satisfies the requirements described in a section below.
 
 ``log``
-    Value is a list where first element represents the name of the log and second element represents the contents of the file as a string.
+    Value is a list where the first element represents the name of the log and the second element is a list, representing the contents of the file.
+    The composition of this second element is described in the section below.
     This message is used to transfer the contents of the file that master requested worker to read.
-    This file is identified by the second member in workers tuple.
+    This file is identified by the name of the log.
     The same value is sent by master as the key of dictionary represented by ``logfile`` key within ``args`` dictionary of ``StartCommand`` command.
-    The string value of the message is the contents of a file that worker read.
-    The value satisfies the requirements described in a section below.
 
 ``elapsed``
     Value is an integer.
     It represents how much time has passed between the start of a command and the completion in seconds.
 
-Requirements for values of ``stdout``, ``stderr``, ``header`` and ``log``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Requirements for content lists of ``stdout``, ``stderr``, ``header`` and ``log``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The lists that represents the contents of the output or a file consist of three elements.
 
-Values of ``stdout``, ``header``, ``stderr``, ``log`` must be processed using the following algorithm:
+First element is a string with the content, which must be processed using the following algorithm:
 
-- Each value may contain one or more lines (characters with a terminating ``\n`` character).
-  Each line is not longer than internal ``maxsize`` value on worker side.
-  Longer lines are split into multiple lines where each except the last line contains exactly ``maxsize`` characters and the last line may contain less.
+* Each value may contain one or more lines (characters with a terminating ``\n`` character).
+    Each line is not longer than internal ``maxsize`` value on worker side.
+    Longer lines are split into multiple lines where each except the last line contains exactly ``maxsize`` characters and the last line may contain less.
 
-- The lines are run through an internal worker cleanup regex.
+* The lines are run through an internal worker cleanup regex.
+
+Second element is a list of indexes, representing the positions of newline characters in the string of first tuple element.
+
+Third element is a list of numbers, representing at what time each line was received as an output while processing the command.
+
+The number of elements in both lists is always the same.

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -24,9 +24,11 @@ from autobahn.twisted.websocket import WebSocketClientFactory
 from autobahn.twisted.websocket import WebSocketClientProtocol
 from autobahn.websocket.types import ConnectingRequest
 from twisted.internet import defer
+from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot_worker.base import ProtocolCommandBase
+from buildbot_worker.util import buffer_manager
 from buildbot_worker.util import deferwaiter
 from buildbot_worker.util import lineboundaries
 
@@ -60,6 +62,11 @@ def remote_print(self, message):
 
 
 class ProtocolCommandMsgpack(ProtocolCommandBase):
+    # Don't send any data until at least BUFFER_SIZE bytes have been collected
+    # or BUFFER_TIMEOUT elapsed
+    BUFFER_SIZE = 64 * 1024
+    BUFFER_TIMEOUT = 5
+
     def __init__(self, unicode_encoding, worker_basedir, builder_is_running,
                  on_command_complete, protocol, command_id, command, args):
         ProtocolCommandBase.__init__(self, unicode_encoding, worker_basedir, builder_is_running,
@@ -67,21 +74,15 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
         self.protocol = protocol
         self.command_id = command_id
         self._lbfs = {}
+        self.buffer = buffer_manager.BufferManager(reactor, self._message_consumer,
+                                                   self.BUFFER_SIZE, self.BUFFER_TIMEOUT)
 
     def split_lines(self, stream, text):
         try:
-            result = self._lbfs[stream].append(text, 0.0)
-            if result is not None:
-                text, _, _ = result
-                result = text
-            return result
+            return self._lbfs[stream].append(text, 0.0)
         except KeyError:
             lbf = self._lbfs[stream] = lineboundaries.LineBoundaryFinder()
-            result = lbf.append(text, 0.0)
-            if result is not None:
-                text, _, _ = result
-                result = text
-            return result
+            return lbf.append(text, 0.0)
 
     def protocol_args_setup(self, command, args):
         if "want_stdout" in args:
@@ -102,50 +103,57 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
         if command == "download_file" and 'reader' not in args:
             args['reader'] = None
 
+    def _cleanup_update(self, message):
+        new_message = []
+        if message[0] in ["stdout", "stderr", "header", "log"]:
+            new_message.append(message[0])
+            new_message.append(message[1][0])
+            return new_message
+        return message
+
+    def _message_consumer(self, message):
+        new_message = []
+        for one_message in message:
+            new_message_part = self._cleanup_update(one_message)
+            new_message.append(new_message_part)
+
+        d = self.protocol.get_message_result({'op': 'update', 'args': new_message,
+                                              'command_id': self.command_id})
+        d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
+
     # Returns a Deferred
     def protocol_update(self, data):
-        lines = []
         for key, value in data:
             if key in ['stdout', 'stderr', 'header']:
                 whole_line = self.split_lines(key, value)
                 if whole_line is not None:
-                    lines.append((key, whole_line))
+                    self.buffer.append(key, whole_line)
             elif key == 'log':
                 logname, data = value
                 whole_line = self.split_lines(logname, data)
-                value = (logname, whole_line)
                 if whole_line is not None:
-                    lines.append((key, value))
+                    self.buffer.append('log', (logname, whole_line))
             else:
-                lines.append((key, value))
-        if lines:
-            return self.protocol.get_message_result({'op': 'update', 'args': lines,
-                                                     'command_id': self.command_id})
+                self.buffer.append(key, value)
         return defer.succeed(None)
 
     def protocol_notify_on_disconnect(self):
         pass
 
     def flush_command_output(self):
-        lines = []
         for key, lbf in self._lbfs.items():
             if key in ['stdout', 'stderr', 'header']:
                 whole_line = lbf.flush()
                 if whole_line is not None:
-                    text, _, _ = whole_line
-                    lines.append((key, text))
+                    self.buffer.append(key, whole_line)
             else:  # custom logfile
                 logname = key
                 whole_line = lbf.flush()
                 if whole_line is not None:
-                    whole_line, _, _ = whole_line
-                    value = (logname, whole_line)
-                    lines.append((key, value))
-        d_update = defer.succeed(None)
-        if lines:
-            d_update = self.protocol.get_message_result({'op': 'update', 'args': lines,
-                                                         'command_id': self.command_id})
-        return d_update
+                    self.buffer.append('log', (logname, whole_line))
+
+        self.buffer.flush()
+        return defer.succeed(None)
 
     @defer.inlineCallbacks
     def protocol_complete(self, failure):

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -103,21 +103,8 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
         if command == "download_file" and 'reader' not in args:
             args['reader'] = None
 
-    def _cleanup_update(self, message):
-        new_message = []
-        if message[0] in ["stdout", "stderr", "header", "log"]:
-            new_message.append(message[0])
-            new_message.append(message[1][0])
-            return new_message
-        return message
-
     def _message_consumer(self, message):
-        new_message = []
-        for one_message in message:
-            new_message_part = self._cleanup_update(one_message)
-            new_message.append(new_message_part)
-
-        d = self.protocol.get_message_result({'op': 'update', 'args': new_message,
+        d = self.protocol.get_message_result({'op': 'update', 'args': message,
                                               'command_id': self.command_id})
         d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
 

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -566,7 +566,7 @@ class Worker(WorkerBase):
 
         if protocol == 'pb':
             bot_class = BotPb
-        elif protocol == 'msgpack_experimental_v5':
+        elif protocol == 'msgpack_experimental_v6':
             if sys.version_info < (3, 6):
                 raise NotImplementedError(
                     'Msgpack protocol is only supported on Python 3.6 and newer'
@@ -599,7 +599,7 @@ class Worker(WorkerBase):
         if protocol == 'pb':
             bf = self.bf = BotFactory(buildmaster_host, port, keepalive, maxdelay)
             bf.startLogin(credentials.UsernamePassword(name, passwd), client=self.bot)
-        elif protocol == 'msgpack_experimental_v5':
+        elif protocol == 'msgpack_experimental_v6':
             if connection_string is None:
                 ws_conn_string = "ws://{}:{}".format(buildmaster_host, port)
             else:

--- a/worker/buildbot_worker/test/fake/reactor.py
+++ b/worker/buildbot_worker/test/fake/reactor.py
@@ -1,0 +1,175 @@
+# Copyright Buildbot Team Members
+# Portions copyright 2015-2016 ClusterHQ Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+from twisted.internet import defer
+from twisted.internet import reactor
+from twisted.internet.base import _ThreePhaseEvent
+from twisted.internet.interfaces import IReactorCore
+from twisted.internet.interfaces import IReactorThreads
+from twisted.internet.task import Clock
+from twisted.python import log
+from twisted.python.failure import Failure
+from zope.interface import implementer
+
+# The code here is based on the implementations in
+# https://twistedmatrix.com/trac/ticket/8295
+# https://twistedmatrix.com/trac/ticket/8296
+
+
+@implementer(IReactorCore)
+class CoreReactor(object):
+
+    """
+    Partial implementation of ``IReactorCore``.
+    """
+
+    def __init__(self):
+        super(CoreReactor, self).__init__()
+        self._triggers = {}
+
+    def addSystemEventTrigger(self, phase, eventType, f, *args, **kw):
+        event = self._triggers.setdefault(eventType, _ThreePhaseEvent())
+        return eventType, event.addTrigger(phase, f, *args, **kw)
+
+    def removeSystemEventTrigger(self, triggerID):
+        eventType, handle = triggerID
+        event = self._triggers.setdefault(eventType, _ThreePhaseEvent())
+        event.removeTrigger(handle)
+
+    def fireSystemEvent(self, eventType):
+        event = self._triggers.get(eventType)
+        if event is not None:
+            event.fireEvent()
+
+    def callWhenRunning(self, f, *args, **kwargs):
+        f(*args, **kwargs)
+
+
+class NonThreadPool(object):
+
+    """
+    A stand-in for ``twisted.python.threadpool.ThreadPool`` so that the
+    majority of the test suite does not need to use multithreading.
+
+    This implementation takes the function call which is meant to run in a
+    thread pool and runs it synchronously in the calling thread.
+
+    :ivar int calls: The number of calls which have been dispatched to this
+        object.
+    """
+    calls = 0
+
+    def __init__(self, **kwargs):
+        pass
+
+    def callInThreadWithCallback(self, onResult, func, *args, **kw):
+        self.calls += 1
+        try:
+            result = func(*args, **kw)
+        except:  # noqa pylint: disable=bare-except
+            # We catch *everything* here, since normally this code would be
+            # running in a thread, where there is nothing that will catch
+            # error.
+            onResult(False, Failure())
+        else:
+            onResult(True, result)
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+@implementer(IReactorThreads)
+class NonReactor(object):
+
+    """
+    A partial implementation of ``IReactorThreads`` which fits into
+    the execution model defined by ``NonThreadPool``.
+    """
+
+    def callFromThread(self, f, *args, **kwargs):
+        f(*args, **kwargs)
+
+    def getThreadPool(self):
+        return NonThreadPool()
+
+
+class TestReactor(NonReactor, CoreReactor, Clock):
+
+    def __init__(self):
+        super(TestReactor, self).__init__()
+
+        # whether there are calls that should run right now
+        self._pendingCurrentCalls = False
+        self.stop_called = False
+
+    def _executeCurrentDelayedCalls(self):
+        while self.getDelayedCalls():
+            first = sorted(self.getDelayedCalls(),
+                           key=lambda a: a.getTime())[0]
+            if first.getTime() > self.seconds():
+                break
+            self.advance(0)
+
+        self._pendingCurrentCalls = False
+
+    @defer.inlineCallbacks
+    def _catchPrintExceptions(self, what, *a, **kw):
+        try:
+            r = what(*a, **kw)
+            if isinstance(r, defer.Deferred):
+                yield r
+        except Exception as e:
+            log.msg('Unhandled exception from deferred when doing '
+                    'TestReactor.advance()', e)
+            raise
+
+    def callLater(self, when, what, *a, **kw):
+        # Buildbot often uses callLater(0, ...) to defer execution of certain
+        # code to the next iteration of the reactor. This means that often
+        # there are pending callbacks registered to the reactor that might
+        # block other code from proceeding unless the test reactor has an
+        # iteration. To avoid deadlocks in tests we give the real reactor a
+        # chance to advance the test reactor whenever we detect that there
+        # are callbacks that should run in the next iteration of the test
+        # reactor.
+        #
+        # Additionally, we wrap all calls with a function that prints any
+        # unhandled exceptions
+        if when <= 0 and not self._pendingCurrentCalls:
+            reactor.callLater(0, self._executeCurrentDelayedCalls)
+
+        return super(TestReactor, self).callLater(when, self._catchPrintExceptions,
+                                                  what, *a, **kw)
+
+    def stop(self):
+        # first fire pending calls until the current time. Note that the real
+        # reactor only advances until the current time in the case of shutdown.
+        self.advance(0)
+
+        # then, fire the shutdown event
+        self.fireSystemEvent('shutdown')
+
+        self.stop_called = True

--- a/worker/buildbot_worker/test/reactor.py
+++ b/worker/buildbot_worker/test/reactor.py
@@ -1,0 +1,40 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import threads
+from twisted.python import threadpool
+
+from buildbot_worker.test.fake.reactor import NonThreadPool
+from buildbot_worker.test.fake.reactor import TestReactor
+
+
+class TestReactorMixin(object):
+
+    """
+    Mix this in to get TestReactor as self.reactor which is correctly cleaned up
+    at the end
+    """
+    def setup_test_reactor(self):
+
+        self.patch(threadpool, 'ThreadPool', NonThreadPool)
+        self.reactor = TestReactor()
+
+        def deferToThread(f, *args, **kwargs):
+            return threads.deferToThreadPool(self.reactor, self.reactor.getThreadPool(),
+                                             f, *args, **kwargs)
+        self.patch(threads, 'deferToThread', deferToThread)
+
+        self.addCleanup(self.reactor.stop)

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -344,24 +344,18 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [['rc', 1]],
+                'args': [
+                    ['rc', 1],
+                    ['elapsed', 0],
+                    ['header', 'mkdir: test_error: {}\n'.format(path)]
+                ],
                 'command_id': '123',
                 'seq_number': 0
-            }, {
-                'op': 'update',
-                'args': [['elapsed', 0]],
-                'command_id': '123',
-                'seq_number': 1
-            }, {
-                'op': 'update',
-                'args': [['header', 'mkdir: test_error: {}\n'.format(path)]],
-                'command_id': '123',
-                'seq_number': 2
             }, {
                 'op': 'complete',
                 'args': None,
                 'command_id': '123',
-                'seq_number': 3
+                'seq_number': 1
             },
             # response result is always None, even if the command failed
             {'op': 'response', 'result': None, 'seq_number': 1}
@@ -376,7 +370,6 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
         yield self.send_message(create_msg(0))
         yield self.send_message(create_msg(1))
-        yield self.send_message(create_msg(2))
 
         # worker should not send any new messages in response to masters 'response'
         self.assertEqual(self.list_send_message_args, [])
@@ -406,29 +399,19 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [['stdout', 'hello\n']],
+                'args': [
+                    ['stdout', 'hello\n'],
+                    ['rc', 0],
+                    ['elapsed', 0],
+                    ['header', 'headers\n']
+                ],
                 'command_id': '123',
                 'seq_number': 0
-            }, {
-                'op': 'update',
-                'args': [['rc', 0]],
-                'command_id': '123',
-                'seq_number': 1
-            }, {
-                'op': 'update',
-                'args': [['elapsed', 0]],
-                'command_id': '123',
-                'seq_number': 2
-            }, {
-                'op': 'update',
-                'args': [['header', 'headers\n']],
-                'command_id': '123',
-                'seq_number': 3
             }, {
                 'op': 'complete',
                 'args': None,
                 'command_id': '123',
-                'seq_number': 4
+                'seq_number': 1
             }, {
                 'op': 'response', 'seq_number': 1, 'result': None
             }
@@ -457,24 +440,19 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
         self.assert_sent_messages([
             {
                 'op': 'update',
-                'args': [['stdout', 'hello\n'], ['rc', 0]],
+                'args': [
+                    ['stdout', 'hello\n'],
+                    ['rc', 0],
+                    ['elapsed', 0],
+                    ['header', 'headers\n']
+                ],
                 'command_id': '123',
                 'seq_number': 0
-            }, {
-                'op': 'update',
-                'args': [['elapsed', 0]],
-                'command_id': '123',
-                'seq_number': 1
-            }, {
-                'op': 'update',
-                'args': [['header', 'headers\n']],
-                'command_id': '123',
-                'seq_number': 2
             }, {
                 'op': 'complete',
                 'args': None,
                 'command_id': '123',
-                'seq_number': 3
+                'seq_number': 1
             }, {
                 'op': 'response', 'seq_number': 1, 'result': None
             }
@@ -559,14 +537,9 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 1,
                 'command_id': '123',
-                'args': [['rc', -1]]
+                'args': [['rc', -1], ['header', 'killing\n']],
             }, {
-                'op': 'update',
-                'seq_number': 2,
-                'command_id': '123',
-                'args': [['header', 'killing\n']],
-            }, {
-                'op': 'complete', 'seq_number': 3, 'command_id': '123', 'args': None
+                'op': 'complete', 'seq_number': 2, 'command_id': '123', 'args': None
             }, {
                 'op': 'response', 'seq_number': 1, 'result': None
             }

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -347,7 +347,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'args': [
                     ['rc', 1],
                     ['elapsed', 0],
-                    ['header', 'mkdir: test_error: {}\n'.format(path)]
+                    ['header', ['mkdir: test_error: {}\n'.format(path), [35], [0.0]]]
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -400,10 +400,10 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
             {
                 'op': 'update',
                 'args': [
-                    ['stdout', 'hello\n'],
+                    ['stdout', ['hello\n', [5], [0.0]]],
                     ['rc', 0],
                     ['elapsed', 0],
-                    ['header', 'headers\n']
+                    ['header', ['headers\n', [7], [0.0]]]
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -441,10 +441,10 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
             {
                 'op': 'update',
                 'args': [
-                    ['stdout', 'hello\n'],
+                    ['stdout', ['hello\n', [5], [0.0]]],
                     ['rc', 0],
                     ['elapsed', 0],
-                    ['header', 'headers\n']
+                    ['header', ['headers\n', [7], [0.0]]]
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -532,12 +532,12 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 0,
                 'command_id': '123',
-                'args': [['header', 'headers\n']]
+                'args': [['header', ['headers\n', [7], [0.0]]]]
             }, {
                 'op': 'update',
                 'seq_number': 1,
                 'command_id': '123',
-                'args': [['rc', -1], ['header', 'killing\n']],
+                'args': [['rc', -1], ['header', ['killing\n', [7], [0.0]]]],
             }, {
                 'op': 'complete', 'seq_number': 2, 'command_id': '123', 'args': None
             }, {

--- a/worker/buildbot_worker/test/util/test_buffer_manager.py
+++ b/worker/buildbot_worker/test/util/test_buffer_manager.py
@@ -1,0 +1,353 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.trial import unittest
+
+from buildbot_worker.test.reactor import TestReactorMixin
+from buildbot_worker.util import buffer_manager
+
+
+class BufferManager(TestReactorMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.results_collected = []
+        self.setup_test_reactor()
+
+    def message_consumer(self, msg_data):
+        self.results_collected.append(msg_data)
+
+    def assert_sent_messages(self, expected):
+        self.assertEqual(self.results_collected, expected)
+        self.results_collected = []
+
+    def test_append_message_rc_fits_in_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("rc", 1)
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([[("rc", 1)]])
+
+    def test_append_message_rc_in_one_msg(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 40, 5)
+
+        manager.append("stdout", ('12\n', [2], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("rc", 1)
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [("stdout", ('12\n', [2], [1.0])), ("rc", 1)]
+        ])
+
+    def test_append_message_rc_exceeds_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ('12\n', [2], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("rc", 1)
+        self.assert_sent_messages([
+            [("stdout", ('12\n', [2], [1.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [("rc", 1)]
+        ])
+
+    def test_append_two_messages_rc_exceeds_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 15, 5)
+
+        manager.append("rc", 1)
+        self.assert_sent_messages([
+            [("rc", 1)]
+        ])
+
+        manager.append("rc", 0)
+        self.assert_sent_messages([
+            [("rc", 0)]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_two_messages_rc_fits_in_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 40, 5)
+
+        manager.append("rc", 1)
+        self.assert_sent_messages([])
+
+        manager.append("rc", 0)
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([[("rc", 1), ("rc", 0)]])
+
+    def test_append_message_exceeds_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ('12345\n', [5], [1.0]))
+        self.assert_sent_messages([
+            [("stdout", ("12345\n", [5], [1.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_message_fits_in_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 18, 5)
+
+        manager.append("stdout", ("1\n", [1], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [("stdout", ("1\n", [1], [1.0]))]
+        ])
+
+        # only to see if flush does not send any more messages
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_two_messages_exceeds_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ("1\n", [1], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stdout", ("22\n", [2], [2.0]))
+        self.assert_sent_messages([
+            [("stdout", ("1\n", [1], [1.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [('stdout', ('22\n', [2], [2.0]))]
+        ])
+
+    def test_append_two_messages_same_logname_joined(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 40, 5)
+
+        manager.append("stdout", ("1\n", [1], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stdout", ("2\n", [1], [2.0]))
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [("stdout", ("1\n2\n", [1, 3], [1.0, 2.0]))]
+        ])
+
+    def test_append_two_messages_same_logname_joined_many_lines(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 80, 5)
+
+        manager.append("stdout", ("1\n2\n", [1, 3], [1.0, 2.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stdout", ("3\n4\n", [1, 3], [3.0, 4.0]))
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [("stdout", ("1\n2\n3\n4\n", [1, 3, 5, 7], [1.0, 2.0, 3.0, 4.0]))]
+        ])
+
+    def test_append_three_messages_not_same_logname_not_joined(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 60, 5)
+
+        manager.append("stdout", ("1\n", [1], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stderr", ("2\n", [1], [2.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stdout", ("3\n", [1], [3.0]))
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([
+            [("stdout", ("1\n", [1], [1.0])),
+             ("stderr", ("2\n", [1], [2.0])),
+             ("stdout", ("3\n", [1], [3.0]))]
+        ])
+
+    def test_append_two_messages_same_logname_exceeds_buffer(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ("1234\n", [4], [1.0]))
+        self.assert_sent_messages([
+            [("stdout", ("1234\n", [4], [1.0]))]
+        ])
+
+        manager.append("stdout", ("5678\n", [4], [2.0]))
+        self.assert_sent_messages([
+            [("stdout", ("5678\n", [4], [2.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_exceeds_buffer_long_line_first_line_too_long(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout",
+                       ("tbe5\nta4\ntbe5\nt3\ntd4\n", [4, 8, 13, 16, 20],
+                        [1.0, 2.0, 3.0, 4.0, 5.0]))
+
+        self.assert_sent_messages([
+            [("stdout", ("tbe5\n", [4], [1.0]))],
+            [("stdout", ("ta4\n", [3], [2.0]))],
+            [("stdout", ("tbe5\n", [4], [3.0]))],
+            [("stdout", ("t3\n", [2], [4.0]))],
+            [("stdout", ("td4\n", [3], [5.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_exceeds_buffer_long_line_middle_line_too_long(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout",
+                       ("t3\nta4\ntbe5\nt3\ntd4\n", [2, 6, 11, 14, 18], [1.0, 2.0, 3.0, 4.0, 5.0]))
+
+        self.assert_sent_messages([
+            [("stdout", ("t3\n", [2], [1.0]))],
+            [("stdout", ("ta4\n", [3], [2.0]))],
+            [("stdout", ("tbe5\n", [4], [3.0]))],
+            [("stdout", ("t3\n", [2], [4.0]))],
+            [("stdout", ("td4\n", [3], [5.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_long_line_concatenate(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 60, 5)
+
+        manager.append("stdout",
+                       ("text_text_text_text_text_text_text_text_\nlex\nteym\nte\ntuz\n",
+                        [40, 44, 49, 52, 56],
+                        [1.0, 2.0, 3.0, 4.0, 5.0]))
+
+        self.assert_sent_messages([
+            [("stdout", ("text_text_text_text_text_text_text_text_\n", [40], [1.0]))],
+            [("stdout", ("lex\nteym\nte\n", [3, 8, 11], [2.0, 3.0, 4.0]))],
+            [("stdout", ("tuz\n", [3], [5.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_not_fitting_line_after_fitting_line(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ("12\n", [4], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stdout", ("345678\n", [6], [2.0]))
+        self.assert_sent_messages([
+            [("stdout", ("12\n", [4], [1.0]))],
+            [("stdout", ("345678\n", [6], [2.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_timeout_fits_in_buffer_timeout_expires_with_message(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ('12\n', [2], [1.0]))
+        self.assert_sent_messages([])
+
+        self.reactor.advance(4)
+        self.assert_sent_messages([])
+
+        self.reactor.advance(1)
+        self.assert_sent_messages([
+            [("stdout", ("12\n", [2], [1.0]))]
+        ])
+
+        self.reactor.advance(5)
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_timeout_fits_in_buffer_two_messages_before_timeout_expires(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 40, 5)
+
+        manager.append("stdout", ('12\n', [2], [1.0]))
+        self.assert_sent_messages([])
+
+        self.reactor.advance(1)
+        manager.append("stdout", ('345\n', [3], [2.0]))
+        self.assert_sent_messages([])
+
+        self.reactor.advance(4)
+        self.assert_sent_messages([
+            [("stdout", ("12\n345\n", [2, 6], [1.0, 2.0]))]
+        ])
+
+        self.reactor.advance(5)
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_timeout_two_messages_timeout_expires_with_single_message(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 40, 5)
+
+        manager.append("stdout", ('12\n', [2], [1.0]))
+        self.assert_sent_messages([])
+
+        self.reactor.advance(5)
+        self.assert_sent_messages([
+            [("stdout", ("12\n", [2], [1.0]))]
+        ])
+
+        manager.append("stdout", ('345\n', [3], [2.0]))
+        self.assert_sent_messages([])
+
+        self.reactor.advance(5)
+        self.assert_sent_messages([
+            [("stdout", ("345\n", [3], [2.0]))]
+        ])
+
+        manager.flush()
+        self.assert_sent_messages([])
+
+    def test_append_timeout_long_line_flushes_short_line_before_timeout(self):
+        manager = buffer_manager.BufferManager(self.reactor, self.message_consumer, 20, 5)
+
+        manager.append("stdout", ('12\n', [2], [1.0]))
+        self.assert_sent_messages([])
+
+        manager.append("stdout", ('345678\n', [6], [2.0]))
+        self.assert_sent_messages([
+            [("stdout", ("12\n", [2], [1.0]))],
+            [("stdout", ("345678\n", [6], [2.0]))]
+        ])
+
+        self.reactor.advance(5)
+        self.assert_sent_messages([])
+
+        manager.flush()
+        self.assert_sent_messages([])

--- a/worker/buildbot_worker/test/util/test_lineboundaries.py
+++ b/worker/buildbot_worker/test/util/test_lineboundaries.py
@@ -14,142 +14,113 @@
 # Copyright Buildbot Team Members
 
 
-from twisted.python import log
 from twisted.trial import unittest
 
 from buildbot_worker.util import lineboundaries
 
 
+def join_line_info(info1, info2):
+    len_text1 = len(info1[0])
+    return (
+        info1[0] + info2[0],
+        info1[1] + [(len_text1 + index) for index in info2[1]],
+        info1[2] + info2[2]
+    )
+
+
 class LBF(unittest.TestCase):
 
     def setUp(self):
-        self.lbf = lineboundaries.LineBoundaryFinder()
+        # LineBoundaryFinder append function returns a tuple: (text, new_line_positions, line_times)
+        self.lbf = lineboundaries.LineBoundaryFinder(20)
 
-    # tests
+    def test_empty_line(self):
+        self.assertEqual(self.lbf.append('1234', 1.0), None)
+        self.assertEqual(self.lbf.append('\n', 2.0), ('1234\n', [4], [1.0]))
+        self.assertEqual(self.lbf.append('5678\n', 3.0), ('5678\n', [4], [3.0]))
+        self.assertEqual(self.lbf.flush(), None)
 
     def test_already_terminated(self):
-        res = self.lbf.append('abcd\ndefg\n')
-        self.assertEqual(res, 'abcd\ndefg\n')
-        res = self.lbf.append('xyz\n')
-        self.assertEqual(res, 'xyz\n')
-        res = self.lbf.flush()
-        self.assertEqual(res, None)
+        self.assertEqual(self.lbf.append('abcd\ndefg\n', 1.0), ('abcd\ndefg\n', [4, 9], [1.0, 1.0]))
+        self.assertEqual(self.lbf.append('xyz\n', 2.0), ('xyz\n', [3], [2.0]))
+        self.assertEqual(self.lbf.flush(), None)
 
     def test_partial_line(self):
-        res = self.lbf.append('hello\nworld')
-        self.assertEqual(res, 'hello\n')
-        res = self.lbf.flush()
-        self.assertEqual(res, 'world\n')
+        self.assertEqual(self.lbf.append('hello\nworld', 1.0), ('hello\n', [5], [1.0]))
+        self.assertEqual(self.lbf.flush(), ('world\n', [5], [1.0]))
 
     def test_empty_appends(self):
-        res = self.lbf.append('hello ')
-        self.assertEqual(res, None)
-
-        res = self.lbf.append('')
-        self.assertEqual(res, None)
-
-        res = self.lbf.append('world\n')
-        self.assertEqual(res, 'hello world\n')
-
-        res = self.lbf.append('')
-        self.assertEqual(res, None)
+        self.assertEqual(self.lbf.append('hello ', 1.0), None)
+        self.assertEqual(self.lbf.append('', 2.0), None)
+        self.assertEqual(self.lbf.append('world\n', 3.0), ('hello world\n', [11], [1.0]))
+        self.assertEqual(self.lbf.append('', 1.0), None)
 
     def test_embedded_newlines(self):
-        res = self.lbf.append('hello, ')
-        self.assertEqual(res, None)
-
-        res = self.lbf.append('cruel\nworld')
-        self.assertEqual(res, 'hello, cruel\n')
-
-        res = self.lbf.flush()
-        self.assertEqual(res, 'world\n')
+        self.assertEqual(self.lbf.append('hello, ', 1.0), None)
+        self.assertEqual(self.lbf.append('cruel\nworld', 2.0), ('hello, cruel\n', [12], [1.0]))
+        self.assertEqual(self.lbf.flush(), ('world\n', [5], [2.0]))
 
     def test_windows_newlines_folded(self):
         r"Windows' \r\n is treated as and converted to a newline"
-        res = self.lbf.append('hello, ')
-        self.assertEqual(res, None)
-
-        res = self.lbf.append('cruel\r\n\r\nworld')
-        self.assertEqual(res, 'hello, cruel\n\n')
-
-        res = self.lbf.flush()
-        self.assertEqual(res, 'world\n')
+        self.assertEqual(self.lbf.append('hello, ', 1.0), None)
+        self.assertEqual(self.lbf.append('cruel\r\n\r\nworld', 2.0),
+                         ('hello, cruel\n\n', [12, 13], [1.0, 2.0]))
+        self.assertEqual(self.lbf.flush(), ('world\n', [5], [2.0]))
 
     def test_bare_cr_folded(self):
         r"a bare \r is treated as and converted to a newline"
-        self.lbf.append('1%\r5%\r15%\r100%\nfinished')
-        res = self.lbf.flush()
-        self.assertEqual(res, 'finished\n')
+        self.assertEqual(self.lbf.append('1%\r5%\r15%\r100%\nfinished', 1.0),
+                         ('1%\n5%\n15%\n100%\n', [2, 5, 9, 14], [1.0, 1.0, 1.0, 1.0]))
+        self.assertEqual(self.lbf.flush(), ('finished\n', [8], [1.0]))
 
     def test_backspace_folded(self):
         r"a lot of \b is treated as and converted to a newline"
-        self.lbf.append('1%\b\b5%\b\b15%\b\b\b100%\nfinished')
-        res = self.lbf.flush()
-        self.assertEqual(res, 'finished\n')
+        self.lbf.append('1%\b\b5%\b\b15%\b\b\b100%\nfinished', 1.0)
+        self.assertEqual(self.lbf.flush(), ('finished\n', [8], [1.0]))
 
     def test_mixed_consecutive_newlines(self):
         r"mixing newline styles back-to-back doesn't collapse them"
-        res = self.lbf.append('1\r\n\n\r')
-        self.assertEqual(res, '1\n\n')
-
-        res = self.lbf.append('2\n\r\n')
-        self.assertEqual(res, '\n2\n\n')
+        self.assertEqual(self.lbf.append('1\r\n\n\r', 1.0), ('1\n\n', [1, 2], [1.0, 1.0]))
+        self.assertEqual(self.lbf.append('2\n\r\n', 2.0), ('\n2\n\n', [0, 2, 3], [1.0, 2.0, 2.0]))
 
     def test_split_newlines(self):
         r"multi-character newlines, split across chunks, are converted"
         input = 'a\nb\r\nc\rd\n\re'
-        result = []
+
         for splitpoint in range(1, len(input) - 1):
             a, b = input[:splitpoint], input[splitpoint:]
-            result.append(self.lbf.append(a))
-            result.append(self.lbf.append(b))
-            result.append(self.lbf.flush())
+            lines_info = []
+            lines_info.append(self.lbf.append(a, 2.0))
+            lines_info.append(self.lbf.append(b, 2.0))
+            lines_info.append(self.lbf.flush())
 
-            result = [e for e in result if e is not None]
-            res = ''.join(result)
+            lines_info = [e for e in lines_info if e is not None]
 
-            log.msg('feeding {}, {} gives {}'.format(repr(a), repr(b), repr(res)))
-            self.assertEqual(res, 'a\nb\nc\nd\n\ne\n')
-            del result[:]
+            joined_line_info = lines_info[0]
+            for line_info in lines_info[1:]:
+                joined_line_info = join_line_info(joined_line_info, line_info)
+            self.assertEqual(joined_line_info,
+                             ('a\nb\nc\nd\n\ne\n', [1, 3, 5, 7, 8, 10],
+                              [2.0, 2.0, 2.0, 2.0, 2.0, 2.0]))
 
     def test_split_terminal_control(self):
         """terminal control characters are converted"""
-        res = self.lbf.append('1234\033[u4321')
-        self.assertEqual(res, '1234\n')
-
-        res = self.lbf.flush()
-        self.assertEqual(res, '4321\n')
-
-        res = self.lbf.append('1234\033[1;2H4321')
-        self.assertEqual(res, '1234\n')
-
-        res = self.lbf.flush()
-        self.assertEqual(res, '4321\n')
-
-        res = self.lbf.append('1234\033[1;2f4321')
-        self.assertEqual(res, '1234\n')
-
-        res = self.lbf.flush()
-        self.assertEqual(res, '4321\n')
+        self.assertEqual(self.lbf.append('1234\033[u4321', 1.0), ('1234\n', [4], [1.0]))
+        self.assertEqual(self.lbf.flush(), ('4321\n', [4], [1.0]))
+        self.assertEqual(self.lbf.append('1234\033[1;2H4321', 2.0), ('1234\n', [4], [2.0]))
+        self.assertEqual(self.lbf.flush(), ('4321\n', [4], [2.0]))
+        self.assertEqual(self.lbf.append('1234\033[1;2f4321', 3.0), ('1234\n', [4], [3.0]))
+        self.assertEqual(self.lbf.flush(), ('4321\n', [4], [3.0]))
 
     def test_long_lines(self):
         """long lines are split"""
-        res = []
-        for _ in range(4):
-            res.append(self.lbf.append('12' * 1000))
-        res = [e for e in res if e is not None]
-        res = ''.join(res)
-        # a split at 4096 + the remaining chars
-        self.assertEqual(res, '12' * 2048 + '\n' + '12' * 952 + '\n')
-
-    def test_huge_lines(self):
-        """huge lines are split"""
-        res = []
-        res.append(self.lbf.append('12' * 32768))
-        res.append(self.lbf.flush())
-        res = [e for e in res if e is not None]
-        self.assertEqual(res, [('12' * 2048 + '\n') * 16])
+        self.assertEqual(self.lbf.append('123456789012', 1.0), None)
+        self.assertEqual(self.lbf.append('123456789012', 2.0),
+                         ('1234567890121234567\n', [19], [1.0]))
+        self.assertEqual(self.lbf.append('123456789012345', 3.0),
+                         ('8901212345678901234\n', [19], [2.0]))
+        self.assertEqual(self.lbf.append('123456789012', 4.0), None)
+        self.assertEqual(self.lbf.flush(), ('5123456789012\n', [13], [3.0]))
 
     def test_empty_flush(self):
-        res = self.lbf.flush()
-        self.assertEqual(res, None)
+        self.assertEqual(self.lbf.flush(), None)

--- a/worker/buildbot_worker/util/buffer_manager.py
+++ b/worker/buildbot_worker/util/buffer_manager.py
@@ -1,0 +1,149 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+class BufferManager:
+    def __init__(self, reactor, message_consumer, buffer_size, buffer_timeout):
+        self._reactor = reactor
+        self._buflen = 0
+        self._buffered = []
+        self._buffer_size = buffer_size
+        self._buffer_timeout = buffer_timeout
+        self._send_message_timer = None
+        self._message_consumer = message_consumer
+
+    def buffered_append_maybe_join_lines(self, logname, msg_data):
+        # if logname is the same as before: join message's information with previous one
+        if len(self._buffered) > 0 and self._buffered[-1][0] == logname:
+            previous_msg_text = self._buffered[-1][1][0]
+            len_previous_msg_text = len(previous_msg_text)
+
+            new_text = previous_msg_text + msg_data[0]
+
+            new_indexes = self._buffered[-1][1][1]
+            for index in msg_data[1]:
+                new_indexes.append(len_previous_msg_text + index)
+
+            new_times = self._buffered[-1][1][2]
+            for time in msg_data[2]:
+                new_times.append(time)
+
+            self._buffered[-1] = (logname, (new_text, new_indexes, new_times))
+            return
+
+        self._buffered.append((logname, msg_data))
+
+    def setup_timeout(self):
+        if not self._send_message_timer:
+            self._send_message_timer = self._reactor.callLater(self._buffer_timeout,
+                                                               self.send_message_from_buffer)
+
+    def append(self, logname, data):
+        # add data to the buffer for logname
+        # keep appending to self._buffered until it gets longer than BUFFER_SIZE
+        # which requires emptying the buffer by sending the message to the master
+
+        is_log_message = logname in ("log", "stdout", "stderr", "header")
+
+        if not is_log_message:
+            len_data = 20
+        else:
+            # data = (output_lines, positions_new_line_characters, lines_times)
+            len_data = len(data[0]) + 8 * (len(data[1]) + len(data[2]))
+
+        space_left = self._buffer_size - self._buflen
+
+        if len_data <= space_left:
+            # fills the buffer with short lines
+            if not is_log_message:
+                self._buffered.append((logname, data))
+            else:
+                self.buffered_append_maybe_join_lines(logname, data)
+            self._buflen += len_data
+            self.setup_timeout()
+            return
+
+        self.send_message_from_buffer()
+
+        if len_data <= self._buffer_size:
+            self._buffered.append((logname, data))
+            self._buflen += len_data
+            self.setup_timeout()
+            return
+
+        if not is_log_message:
+            self.send_message([(logname, data)])
+            return
+
+        pos_start = 0
+        while pos_start < len(data[1]):
+            # pos_end: which line is the last to be sent as a message (non-inclusive range)
+            pos_end = pos_start + 1
+
+            # Finds the range of lines to be sent:
+            # pos_start - inclusive index of first line to be sent
+            # pos_end - exclusive index of last line to be sent
+            while pos_end <= len(data[1]):
+                if pos_start == 0:
+                    string_part_size = data[1][pos_end - 1] + 1
+                else:
+                    string_part_size = data[1][pos_end - 1] - (data[1][pos_start - 1])
+                index_list_part_size = (pos_end - pos_start) * 8
+                times_list_part_size = (pos_end - pos_start) * 8
+                line_size = string_part_size + index_list_part_size + times_list_part_size
+
+                if line_size <= self._buffer_size:
+                    pos_end += 1
+                else:
+                    if pos_end > pos_start + 1:
+                        pos_end -= 1
+                    break
+
+            if pos_end > len(data[1]):
+                # no more lines are left to grab
+                pos_end -= 1
+
+            pos_substring_end = data[1][pos_end - 1] + 1
+            if pos_start != 0:
+                pos_substring_start = data[1][pos_start - 1] + 1
+                msg_data = (data[0][pos_substring_start:pos_substring_end],
+                            [index - pos_substring_start for index in data[1][pos_start:pos_end]],
+                            data[2][pos_start: pos_end])
+            else:
+                msg_data = (data[0][:pos_substring_end],
+                            data[1][:pos_end],
+                            data[2][:pos_end])
+
+            self.send_message([(logname, msg_data)])
+            pos_start = pos_end
+
+    def send_message_from_buffer(self):
+        self.send_message(self._buffered)
+        self._buffered = []
+        self._buflen = 0
+
+        if self._send_message_timer:
+            if self._send_message_timer.active():
+                self._send_message_timer.cancel()
+            self._send_message_timer = None
+
+    def send_message(self, data_to_send):
+        if len(data_to_send) == 0:
+            return
+        self._message_consumer(data_to_send)
+
+    def flush(self):
+        if len(self._buffered) > 0:
+            self.send_message_from_buffer()

--- a/worker/buildbot_worker/util/lineboundaries.py
+++ b/worker/buildbot_worker/util/lineboundaries.py
@@ -23,56 +23,100 @@ log = Logger()
 
 class LineBoundaryFinder:
 
-    __slots__ = ['partial_line', 'warned']
-    # split at reasonable line length.
-    # too big lines will fill master's memory, and slow down the UI too much.
-    MAX_LINELENGTH = 4096
+    __slots__ = ['max_line_length', 'partial_line', 'warned', 'time']
     # the lookahead here (`(?=.)`) ensures that `\r` doesn't match at the end
     # of the buffer
     # we also convert cursor control sequence to newlines
     # and ugly \b+ (use of backspace to implement progress bar)
     newline_re = re.compile(r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)')
 
-    def __init__(self):
-        self.partial_line = None
+    def __init__(self, max_line_length=4096):
+        # split at reasonable line length.
+        # too big lines will fill master's memory, and slow down the UI too much.
+        self.max_line_length = max_line_length
+        self.partial_line = ""
         self.warned = False
+        self.time = None
 
-    def append(self, text):
+    def append(self, text, time):
+        # returns a tuple containing three elements:
+        # - text: string containing one or more lines
+        # - lf_positions: newline position in returned string
+        # - line times: times when first line symbol was received
+        had_partial_line = False
         if self.partial_line:
-            if len(self.partial_line) > self.MAX_LINELENGTH:
-                if not self.warned:
-                    # Unfortunately we cannot give more hint as per which log that is
-                    log.warn("Splitting long line: {line_start} {length} "
-                             "(not warning anymore for this log)",
-                             line_start=self.partial_line[:30],
-                             length=len(self.partial_line))
-                    self.warned = True
-                # switch the variables, and return previous _partial_line_,
-                # split every MAX_LINELENGTH plus a trailing \n
-                self.partial_line, text = text, self.partial_line
-                ret = []
-                while len(text) > self.MAX_LINELENGTH:
-                    ret.append(text[:self.MAX_LINELENGTH])
-                    text = text[self.MAX_LINELENGTH:]
-                ret.append(text)
-                result = ("\n".join(ret) + "\n")
-                return result
+            had_partial_line = True
             text = self.partial_line + text
-            self.partial_line = None
+            time_partial_line = self.time
+
         text = self.newline_re.sub('\n', text)
-        if text:
-            if text[-1] != '\n':
-                i = text.rfind('\n')
-                if i >= 0:
-                    i = i + 1
-                    text, self.partial_line = text[:i], text[i:]
-                else:
-                    self.partial_line = text
-                    return None
-            return text
-        return None
+
+        lf_positions = self.get_lf_positions(text)
+
+        ret_lines = []  # lines with appropriate number of symbols and their separators \n
+        ret_indexes = []  # ret_indexes is a list of '\n' symbols
+        ret_text_length = -1
+        ret_line_count = 0
+
+        first_position = 0
+        for position in lf_positions:
+            # finds too long lines and splits them, each element in ret_lines will be a line of
+            # appropriate length
+            while position - first_position >= self.max_line_length:
+                line = text[first_position: self.max_line_length - 1] + '\n'
+                ret_lines.append(line)
+                ret_line_count += 1
+                ret_text_length = ret_text_length + len(line)
+                ret_indexes.append(ret_text_length)
+                first_position = first_position + self.max_line_length
+
+            line = text[first_position: (position + 1)]
+            ret_lines.append(line)
+            ret_line_count += 1
+            ret_text_length = ret_text_length + len(line)
+            ret_indexes.append(ret_text_length)
+            first_position = position + 1
+
+        position = len(text)
+        while position - first_position >= self.max_line_length:
+            line = text[first_position: self.max_line_length - 1] + '\n'
+            ret_lines.append(line)
+            ret_text_length = ret_text_length + len(line)
+            ret_indexes.append(ret_text_length)
+            first_position = first_position + self.max_line_length - 1
+
+        if had_partial_line:
+            times = []
+            if ret_line_count > 1:
+                times = [time] * (ret_line_count - 1)
+            line_times = [time_partial_line] + times
+        else:
+            line_times = ret_line_count * [time]
+
+        ret_text = "".join(ret_lines)
+
+        if ret_text != '' or not had_partial_line:
+            self.time = time
+
+        self.partial_line = text[first_position: position]
+
+        if ret_text == '':
+            return None
+
+        return (ret_text, ret_indexes, line_times)
+
+    def get_lf_positions(self, text):
+        lf_position = 0
+        lf_positions = []
+        while lf_position != -1:
+            lf_position = text.find('\n', lf_position)
+            if lf_position < 0:
+                break
+            lf_positions.append(lf_position)
+            lf_position = lf_position + 1
+        return lf_positions
 
     def flush(self):
-        if self.partial_line is not None:
-            return self.append('\n')
+        if self.partial_line != "":
+            return self.append('\n', self.time)
         return None


### PR DESCRIPTION
This PR introduces new functionality of the worker: now it sends more information about command "update" output messages to the master.
Not only the text of output or file contents is sent, but also additional information about those lines: indexes of newline positions in the text and specific times each output line was received. This will be needed for more informative master logs.
Worker also now takes the load of from master, by splitting the output contents into lines of appropriate size.

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
