### PR TITLE
buildbot try: give the possibility to trigger build with no diff patch

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -601,7 +601,7 @@ class Try(pb.Referenceable):
         self.sourcestamp = ss
         patchlevel, diff = ss.patch
         if diff is None:
-            raise RuntimeError("There is no patch to try, diff is empty.")
+            output("WARNING: There is no patch to try, diff is empty.")
 
         if self.connect == "ssh":
             revspec = ss.revision

--- a/newsfragments/try-accept-empty-diff.feature
+++ b/newsfragments/try-accept-empty-diff.feature
@@ -1,0 +1,1 @@
+``buildbot try`` now accepts empty diffs and prints a warning instead of rejecting the diff.


### PR DESCRIPTION
for testing purpose sometime is useful to trigger the build without any diff,
give such possibility with a warning.

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>