### PR TITLE
Add new buffering and splitting of update output lines in worker for pb protocol

### DIFF
--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -117,25 +117,52 @@ class ProtocolCommandPb(ProtocolCommandBase):
             del args['workdir']
             del args['workerdest']
 
+    def _message_consumer(self, message):
+        # after self.buffer.append log message is of type:
+        # (key, (text, newline_indexes, line_times))
+        # only key and text is sent to master in PB protocol
+        # if message is not log, simply sends the value (e.g.[("rc", 0)])
+        for key, value in message:
+            if key in ['stdout', 'stderr', 'header']:
+                update = [{key: value[0]}, 0]
+            elif key == "log":
+                logname, data = value
+                update = [{key: (logname, data[0])}, 0]
+            else:
+                update = [{key: value}, 0]
+            updates = [update]
+            d = self.command_ref.callRemote("update", updates)
+            d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
+
     # Returns a Deferred
     def protocol_update(self, data):
         # data is a list of tuples
         # first element of the tuple is dictionary key, second element is value
-        dl = []
         for key, value in data:
-            update = [{key: value}, 0]
-            updates = [update]
-            d = self.command_ref.callRemote("update", updates)
-            dl.append(d)
-        return defer.DeferredList(dl, fireOnOneErrback=True, consumeErrors=True)
+            if key in ['stdout', 'stderr', 'header']:
+                whole_line = self.split_lines(key, value)
+                if whole_line is not None:
+                    self.buffer.append(key, whole_line)
+            elif key == 'log':
+                logname, data = value
+                whole_line = self.split_lines(logname, data)
+                if whole_line is not None:
+                    self.buffer.append('log', (logname, whole_line))
+            else:
+                self.buffer.append(key, value)
+        return defer.succeed(None)
 
     def protocol_notify_on_disconnect(self):
         self.command_ref.notifyOnDisconnect(self.on_lost_remote_step)
 
-    # Returns a Deferred
+    @defer.inlineCallbacks
     def protocol_complete(self, failure):
+        d_update = self.flush_command_output()
         self.command_ref.dontNotifyOnDisconnect(self.on_lost_remote_step)
-        return self.command_ref.callRemote("complete", failure)
+        d_complete = self.command_ref.callRemote("complete", failure)
+
+        yield d_update
+        yield d_complete
 
     # Returns a Deferred
     def protocol_update_upload_file_close(self, writer):

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -217,12 +217,11 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
                                   "13", "shell", dict(command=['echo', 'hello'],
                                                       workdir='workdir'))
         yield st.wait_for_finish()
-
         self.assertEqual(st.actions, [
-            ['update', [[{'header': 'headers'}, 0]]],
             ['update', [[{'stdout': 'hello\n'}, 0]]],
             ['update', [[{'rc': 0}, 0]]],
             ['update', [[{'elapsed': 1}, 0]]],
+            ['update', [[{'header': 'headers\n'}, 0]]],
             ['complete', None],
         ])
 
@@ -254,9 +253,8 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         yield st.wait_for_finish()
 
         self.assertEqual(st.actions, [
-            ['update', [[{'header': 'headers'}, 0]]],
-            ['update', [[{'header': 'killing'}, 0]]],
             ['update', [[{'rc': -1}, 0]]],
+            ['update', [[{'header': 'headerskilling\n'}, 0]]],
             ['complete', None],
         ])
 


### PR DESCRIPTION
This PR implements using a new simpler buffering of update output messages for pb protocol. Now splitting of update output lines is done on worker side in both msgpack and pb protocols. This simplifies the buffering code on worker side.
This PR also fixes handling of update messages when output name is "log" and adds additional tests for this feature.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
