### PR TITLE
Actually send current time of update message output to master

### DIFF
--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -85,26 +85,10 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
         if command == "download_file" and 'reader' not in args:
             args['reader'] = None
 
-    def _message_consumer(self, message):
+    def protocol_send_update_message(self, message):
         d = self.protocol.get_message_result({'op': 'update', 'args': message,
                                               'command_id': self.command_id})
         d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
-
-    # Returns a Deferred
-    def protocol_update(self, data, data_time):
-        for key, value in data:
-            if key in ['stdout', 'stderr', 'header']:
-                whole_line = self.split_lines(key, value, data_time)
-                if whole_line is not None:
-                    self.buffer.append(key, whole_line)
-            elif key == 'log':
-                logname, data = value
-                whole_line = self.split_lines(logname, data, data_time)
-                if whole_line is not None:
-                    self.buffer.append('log', (logname, whole_line))
-            else:
-                self.buffer.append(key, value)
-        return defer.succeed(None)
 
     def protocol_notify_on_disconnect(self):
         pass

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -91,15 +91,15 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
         d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
 
     # Returns a Deferred
-    def protocol_update(self, data):
+    def protocol_update(self, data, data_time):
         for key, value in data:
             if key in ['stdout', 'stderr', 'header']:
-                whole_line = self.split_lines(key, value)
+                whole_line = self.split_lines(key, value, data_time)
                 if whole_line is not None:
                     self.buffer.append(key, whole_line)
             elif key == 'log':
                 logname, data = value
-                whole_line = self.split_lines(logname, data)
+                whole_line = self.split_lines(logname, data, data_time)
                 if whole_line is not None:
                     self.buffer.append('log', (logname, whole_line))
             else:

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -135,17 +135,17 @@ class ProtocolCommandPb(ProtocolCommandBase):
             d.addErrback(self._ack_failed, "ProtocolCommandBase.send_update")
 
     # Returns a Deferred
-    def protocol_update(self, data):
+    def protocol_update(self, data, data_time):
         # data is a list of tuples
         # first element of the tuple is dictionary key, second element is value
         for key, value in data:
             if key in ['stdout', 'stderr', 'header']:
-                whole_line = self.split_lines(key, value)
+                whole_line = self.split_lines(key, value, data_time)
                 if whole_line is not None:
                     self.buffer.append(key, whole_line)
             elif key == 'log':
                 logname, data = value
-                whole_line = self.split_lines(logname, data)
+                whole_line = self.split_lines(logname, data, data_time)
                 if whole_line is not None:
                     self.buffer.append('log', (logname, whole_line))
             else:

--- a/worker/buildbot_worker/test/unit/test_msgpack.py
+++ b/worker/buildbot_worker/test/unit/test_msgpack.py
@@ -16,6 +16,7 @@
 import base64
 import os
 import sys
+import time
 
 from parameterized import parameterized
 
@@ -326,6 +327,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def test_call_start_command_failed(self):
+        self.patch(time, 'time', lambda: 123.0)
         self.setup_with_worker_for_builder()
 
         path = os.path.join('basedir', 'test_dir')
@@ -347,7 +349,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'args': [
                     ['rc', 1],
                     ['elapsed', 0],
-                    ['header', ['mkdir: test_error: {}\n'.format(path), [35], [0.0]]]
+                    ['header', ['mkdir: test_error: {}\n'.format(path), [35], [123.0]]]
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -376,6 +378,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def test_call_start_command_shell_success(self):
+        self.patch(time, 'time', lambda: 123.0)
         self.setup_with_worker_for_builder()
 
         # patch runprocess to handle the 'echo', below
@@ -400,10 +403,10 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
             {
                 'op': 'update',
                 'args': [
-                    ['stdout', ['hello\n', [5], [0.0]]],
+                    ['stdout', ['hello\n', [5], [123.0]]],
                     ['rc', 0],
                     ['elapsed', 0],
-                    ['header', ['headers\n', [7], [0.0]]]
+                    ['header', ['headers\n', [7], [123.0]]]
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -419,6 +422,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def test_call_start_command_shell_success_logs(self):
+        self.patch(time, 'time', lambda: 123.0)
         self.setup_with_worker_for_builder()
 
         workdir = os.path.join('basedir', 'test_basedir')
@@ -445,12 +449,12 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
             {
                 'op': 'update',
                 'args': [
-                    ['header', ['headers\n', [7], [0.0]]],
-                    ['log', ['test_log', ['hellohello1\n', [11], [0.0]]]],
-                    ['log', ['test_log2', ['hello2\n', [6], [0.0]]]],
+                    ['header', ['headers\n', [7], [123.0]]],
+                    ['log', ['test_log', ['hellohello1\n', [11], [123.0]]]],
+                    ['log', ['test_log2', ['hello2\n', [6], [123.0]]]],
                     ['rc', 0],
                     ['elapsed', 0],
-                    ['log', ['test_log3', ['hello3\n', [6], [0.0]]]],
+                    ['log', ['test_log3', ['hello3\n', [6], [123.0]]]],
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -466,6 +470,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def test_start_command_shell_success_updates_single(self):
+        self.patch(time, 'time', lambda: 123.0)
         self.setup_with_worker_for_builder()
 
         # patch runprocess to handle the 'echo', below
@@ -488,10 +493,10 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
             {
                 'op': 'update',
                 'args': [
-                    ['stdout', ['hello\n', [5], [0.0]]],
+                    ['stdout', ['hello\n', [5], [123.0]]],
                     ['rc', 0],
                     ['elapsed', 0],
-                    ['header', ['headers\n', [7], [0.0]]]
+                    ['header', ['headers\n', [7], [123.0]]]
                 ],
                 'command_id': '123',
                 'seq_number': 0
@@ -534,6 +539,7 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def test_call_interrupt_command_success(self):
+        self.patch(time, 'time', lambda: 123.0)
         self.setup_with_worker_for_builder()
         self.protocol.factory.command.doInterrupt = mock.Mock()
 
@@ -579,12 +585,12 @@ class TestBuildbotWebSocketClientProtocol(command.CommandTestMixin, unittest.Tes
                 'op': 'update',
                 'seq_number': 0,
                 'command_id': '123',
-                'args': [['header', ['headers\n', [7], [0.0]]]]
+                'args': [['header', ['headers\n', [7], [123.0]]]]
             }, {
                 'op': 'update',
                 'seq_number': 1,
                 'command_id': '123',
-                'args': [['rc', -1], ['header', ['killing\n', [7], [0.0]]]],
+                'args': [['rc', -1], ['header', ['killing\n', [7], [123.0]]]],
             }, {
                 'op': 'complete', 'seq_number': 2, 'command_id': '123', 'args': None
             }, {

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -917,28 +917,6 @@ class TestWindowsKilling(BasedirMixin, unittest.TestCase):
         self.assert_alive(child_pid)
 
 
-class TestLogging(BasedirMixin, unittest.TestCase):
-
-    def setUp(self):
-        self.setUpBasedir()
-        self.updates = []
-
-    def send_update(self, status):
-        for st in status:
-            self.updates.append(st)
-
-    def show(self):
-        return pprint.pformat(self.updates)
-
-    def tearDown(self):
-        self.tearDownBasedir()
-
-    def testSendStatus(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
-        s.sendStatus([('stdout', nl('hello\n'))])
-        self.assertEqual(self.updates, [('stdout', nl('hello\n'))], self.show())
-
-
 class TestLogFileWatcher(BasedirMixin, unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Previously fake zero time was sent in update messages.
This PR improves and completes sending the current time of update message output to the master.
PR also simplifies the code regarding protocol_update() function.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
