### PR TITLE
Send worker settings from master in msgpack protocol

### DIFF
--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -202,7 +202,7 @@ class RunMasterBase(unittest.TestCase):
                 proto = {"pb": {"port": "tcp:0:interface=127.0.0.1"}}
                 workerclass = worker.Worker
             if self.proto == 'msgpack':
-                proto = {"msgpack_experimental_v6": {"port": 0}}
+                proto = {"msgpack_experimental_v7": {"port": 0}}
                 workerclass = worker.Worker
             elif self.proto == 'null':
                 proto = {"null": {}}
@@ -226,7 +226,7 @@ class RunMasterBase(unittest.TestCase):
                 protocol = 'pb'
                 dispatcher = list(m.pbmanager.dispatchers.values())[0]
             else:
-                protocol = 'msgpack_experimental_v6'
+                protocol = 'msgpack_experimental_v7'
                 dispatcher = list(m.msgmanager.dispatchers.values())[0]
 
                 unsupported_python_versions = ['2.7', '3.4', '3.5']

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -57,10 +57,10 @@ class WorkerRegistration:
                 worker_config.workername, worker_config.password,
                 global_config.protocols['pb']['port'])
 
-        if 'msgpack_experimental_v6' in global_config.protocols:
+        if 'msgpack_experimental_v7' in global_config.protocols:
             self.msgpack_reg = yield self.master.workers.msgpack.updateRegistration(
                 worker_config.workername, worker_config.password,
-                global_config.protocols['msgpack_experimental_v6']['port'])
+                global_config.protocols['msgpack_experimental_v7']['port'])
 
     def getPBPort(self):
         return self.pbReg.getPort()

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -261,10 +261,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         result = None
         is_exception = False
         try:
-            self.contains_msg_key(msg, ('command_id',))
-
-            if "args" not in msg:
-                raise KeyError('message did not contain obligatory "args" key')
+            self.contains_msg_key(msg, ('command_id', 'args'))
 
             if msg['command_id'] not in self.command_id_to_writer_map:
                 raise KeyError('unknown "command_id"')

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -158,6 +158,19 @@ class Connection(base.Connection):
             self.path_expanduser = path_expand_user.posix_expanduser
         return self.info
 
+    def _set_worker_settings(self):
+        # the lookahead here (`(?=.)`) ensures that `\r` doesn't match at the end
+        # of the buffer
+        # we also convert cursor control sequence to newlines
+        # and ugly \b+ (use of backspace to implement progress bar)
+        newline_re = r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)'
+        return self.protocol.get_message_result({
+            'op': 'set_worker_settings',
+            'args': {'newline_re': newline_re,
+                     'max_line_length': 4096,
+                     'buffer_timeout': 5,
+                     'buffer_size': 64 * 1024}})
+
     def create_remote_command(self, worker_name, expected_keys, error_msg):
         command_id = remotecommand.RemoteCommand.generate_new_command_id()
         command = BasicRemoteCommand(worker_name, expected_keys, error_msg)
@@ -166,6 +179,8 @@ class Connection(base.Connection):
 
     @defer.inlineCallbacks
     def remoteSetBuilderList(self, builders):
+        yield self._set_worker_settings()
+
         basedir = self.info['basedir']
         builder_names = [name for name, _ in builders]
         self.builder_basedirs = {name: self.path_module.join(basedir, builddir)

--- a/master/docs/developer/master-worker-msgpack.rst
+++ b/master/docs/developer/master-worker-msgpack.rst
@@ -211,6 +211,46 @@ As a convention, there are files named 'admin' and 'host':
     Value is a string.
     It specifies the name of the host.
 
+set_worker_settings
+~~~~~~~~~~~~~~~~~~~
+
+Request
++++++++
+
+Master sends this message to set worker settings.
+The settings must be sent from master before first command.
+
+``seq_number``
+    Described in section on :ref:`MsgPack_Request_Message` structure.
+
+``op``
+    Value is a string ``set_worker_settings``.
+
+``args``
+    Value is a dictionary.
+    It represents the settings needed for worker to format command output and buffer messages.
+    The following settings are mandatory:
+
+    * "buffer_size" - the maximum size of buffer in bytes to fill before sending an update message.
+
+    * "buffer_timeout" - the maximum time in seconds that data can wait in buffer before update message is sent.
+
+    * "newline_re" - the pattern in output string, which will be replaced with newline symbol.
+
+    * "max_line_length" - the maximum size of command output line in bytes.
+
+Response
+++++++++
+
+``seq_number``
+    Described in section  on :ref:`MsgPack_Response_Message` structure.
+
+``op``
+    Value is a string ``response``.
+
+``result``
+    Value is ``None`` if success.
+    Otherwise – message of exception.
 
 start_command
 ~~~~~~~~~~~~~

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -59,10 +59,13 @@ def remote_print(self, message):
 
 
 class ProtocolCommandMsgpack(ProtocolCommandBase):
-    def __init__(self, unicode_encoding, worker_basedir, builder_is_running,
+    def __init__(self, unicode_encoding, worker_basedir, buffer_size, buffer_timeout,
+                 max_line_length, newline_re, builder_is_running,
                  on_command_complete, protocol, command_id, command, args):
-        ProtocolCommandBase.__init__(self, unicode_encoding, worker_basedir, builder_is_running,
-                                     on_command_complete, None, command, command_id, args)
+        ProtocolCommandBase.__init__(self, unicode_encoding, worker_basedir, buffer_size,
+                                     buffer_timeout, max_line_length, newline_re,
+                                     builder_is_running, on_command_complete, None, command,
+                                     command_id, args)
         self.protocol = protocol
         self.command_id = command_id
 

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -591,7 +591,7 @@ class Worker(WorkerBase):
 
         if protocol == 'pb':
             bot_class = BotPb
-        elif protocol == 'msgpack_experimental_v6':
+        elif protocol == 'msgpack_experimental_v7':
             if sys.version_info < (3, 6):
                 raise NotImplementedError(
                     'Msgpack protocol is only supported on Python 3.6 and newer'
@@ -624,7 +624,7 @@ class Worker(WorkerBase):
         if protocol == 'pb':
             bf = self.bf = BotFactory(buildmaster_host, port, keepalive, maxdelay)
             bf.startLogin(credentials.UsernamePassword(name, passwd), client=self.bot)
-        elif protocol == 'msgpack_experimental_v6':
+        elif protocol == 'msgpack_experimental_v7':
             if connection_string is None:
                 ws_conn_string = "ws://{}:{}".format(buildmaster_host, port)
             else:

--- a/worker/buildbot_worker/test/util/test_lineboundaries.py
+++ b/worker/buildbot_worker/test/util/test_lineboundaries.py
@@ -31,8 +31,8 @@ def join_line_info(info1, info2):
 class LBF(unittest.TestCase):
 
     def setUp(self):
-        # LineBoundaryFinder append function returns a tuple: (text, new_line_positions, line_times)
-        self.lbf = lineboundaries.LineBoundaryFinder(20)
+        newline_re = r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)'
+        self.lbf = lineboundaries.LineBoundaryFinder(20, newline_re)
 
     def test_empty_line(self):
         self.assertEqual(self.lbf.append('1234', 1.0), None)

--- a/worker/buildbot_worker/util/lineboundaries.py
+++ b/worker/buildbot_worker/util/lineboundaries.py
@@ -23,17 +23,13 @@ log = Logger()
 
 class LineBoundaryFinder:
 
-    __slots__ = ['max_line_length', 'partial_line', 'warned', 'time']
-    # the lookahead here (`(?=.)`) ensures that `\r` doesn't match at the end
-    # of the buffer
-    # we also convert cursor control sequence to newlines
-    # and ugly \b+ (use of backspace to implement progress bar)
-    newline_re = re.compile(r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)')
+    __slots__ = ['max_line_length', 'newline_re', 'partial_line', 'warned', 'time']
 
-    def __init__(self, max_line_length=4096):
+    def __init__(self, max_line_length, newline_re):
         # split at reasonable line length.
         # too big lines will fill master's memory, and slow down the UI too much.
         self.max_line_length = max_line_length
+        self.newline_re = re.compile(newline_re)
         self.partial_line = ""
         self.warned = False
         self.time = None


### PR DESCRIPTION
This PR implements setting worker settings to format command output and buffer messages. 
Master now sends a new protocol message `set_worker_settings` in msgpack protocol with relevant information to worker.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
