### PR TITLE
updated path of master.cfg to match the tutorial

### DIFF
--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -189,7 +189,7 @@ The username (``example-worker``), and password (``pass``) should be the same as
 
 .. code-block:: bash
 
-  cat ../bb-master/master/master.cfg
+  cat ../master/master/master.cfg
 
 And finally, start the worker:
 


### PR DESCRIPTION
It feels like this tutorial was updated from a previous tutorial, and bb-master is residual from that.


## Contributor Checklist:

* [x] I have not updated the unit tests
* [x] I have not created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I **have** updated the appropriate documentation
