### PR TITLE
Require Twisted>=18.7.0

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -45,7 +45,7 @@ matrix:
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
     - python: "3.9"
-      env: TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
+      env: TWISTED=18.7.0 SQLALCHEMY=latest TESTS=trial
     - python: "3.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=ci/coverage
     - python: "3.8"
@@ -73,7 +73,7 @@ matrix:
     # Worker tests on python and twisted package combinations.
     # We support worker on Python 2.7, on which Twisted 20.3.0 is the last version that works
     - python: "3.9"
-      env: TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial_worker
+      env: TWISTED=18.7.0 SQLALCHEMY=latest TESTS=trial_worker
     - python: "2.7"
       env: TWISTED=20.3.0 SQLALCHEMY=latest TESTS=trial_worker
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -484,7 +484,7 @@ if 'a' in version or 'b' in version:
         if parse_version(pip_dist.version) < parse_version('1.4'):
             raise RuntimeError(VERSION_MSG)
 
-twisted_ver = ">= 17.9.0"
+twisted_ver = ">= 18.7.0"
 autobahn_ver = ">= 0.16.0"
 txaio_ver = ">= 2.2.2"
 

--- a/newsfragments/twisted-new-dep.removal
+++ b/newsfragments/twisted-new-dep.removal
@@ -1,0 +1,1 @@
+``buildbot`` package now requires Twisted versions >= 18.7.0

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -144,7 +144,7 @@ setup_args = {
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
-twisted_ver = ">= 17.9.0"
+twisted_ver = ">= 18.7.0"
 
 if setuptools is not None:
     setup_args['install_requires'] = [


### PR DESCRIPTION
Recent treq requires Twisted 18.7.0. Additionally, on python3.9 unit tests are no longer working when using Twisted 17.9. It's simplier to upgrade to a new Twisted than to investigate how to support so old Twisted versions.
