### PR TITLE
Fix git URL for master.cfg file in sample

### DIFF
--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -31,7 +31,7 @@ c['protocols'] = {'pb': {'port': 9989}}
 
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/hello-world.git',
+        'https://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollInterval=300))
 
@@ -58,7 +58,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 # check out the source
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
 # run the tests (note that this will require that 'trial' is installed)
 factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))

--- a/smokes/e2e/hook.scenarios.ts
+++ b/smokes/e2e/hook.scenarios.ts
@@ -22,7 +22,7 @@ describe('change hook', function() {
         await post(`${testPageUrl}/change_hook/base`).form({
             comments:'sd',
             project:'pyflakes',
-            repository:'git://github.com/buildbot/hello-world.git',
+            repository:'https://github.com/buildbot/hello-world.git',
             author:'foo <foo@bar.com>',
             committer:'foo <foo@bar.com>',
             revision: 'HEAD',


### PR DESCRIPTION
This PR fixes git URL in master.cfg file sample. Sample build was stuck since it could not get the code from git.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
