### PR TITLE
Make first run documentation clearer

### DIFF
--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -55,7 +55,10 @@ To make this work, you will need the following installed:
 
 Preferably, use your distribution package manager to install these.
 
-You will also need a working Internet connection, as virtualenv and pip will need to download other projects from the Internet. The master and builder daemons will need to be able to connect to ``github.com`` via HTTPS to fetch the repo we're testing; if you need to use a proxy for this ensure that either the ``HTTPS_PROXY`` or ``ALL_PROXY`` environment variable is set to your proxy, e.g., by executing ``export HTTPS_PROXY=http://localhost:9080`` in the shell before starting each daemon.
+You will also need a working Internet connection, as virtualenv and pip will need to download other projects from the Internet.
+The master and builder daemons will need to be able to connect to ``github.com`` via HTTPS to fetch the repo we're testing.
+
+If you need to use a proxy for this ensure that either the ``HTTPS_PROXY`` or ``ALL_PROXY`` environment variable is set to your proxy, e.g., by executing ``export HTTPS_PROXY=http://localhost:9080`` in the shell before starting each daemon.
 
 .. note::
 
@@ -70,8 +73,8 @@ We first create a separate directory to demonstrate the distinction between a ma
 
 .. code-block:: bash
 
-  mkdir -p ~/buildbot-test/master
-  cd ~/buildbot-test/master
+  mkdir -p ~/buildbot-test/master_root
+  cd ~/buildbot-test/master_root
 
 Then we create the virtual environment. On Python 3:
 
@@ -110,26 +113,26 @@ Now that we are ready, we need to install buildbot:
   pip install --upgrade pip
   pip install 'buildbot[bundle]'
 
-Now that buildbot is installed, it's time to create the master:
+Now that buildbot is installed, it's time to create the master.
+``my_master`` represents a path to a directory, where future master will be created:
 
 .. code-block:: bash
 
-  buildbot create-master master
+  buildbot create-master my_master
 
 Buildbot's activity is controlled by a configuration file.
-Buildbot by default uses configuration from file at ``master.cfg``.
-Buildbot comes with a sample configuration file named ``master.cfg.sample``.
-We will use the sample configuration file unchanged:
+Buildbot by default uses configuration from file at ``master.cfg``, but its installation comes with a sample configuration file named ``master.cfg.sample``.
+We will use the sample configuration file unchanged, but we have to rename it to ``master.cfg``:
 
 .. code-block:: bash
 
-  mv master/master.cfg.sample master/master.cfg
+  mv my_master/master.cfg.sample my_master/master.cfg
 
 Finally, start the master:
 
 .. code-block:: bash
 
-  buildbot start master
+  buildbot start my_master
 
 You will now see some log information from the master in this terminal.
 It should end with lines like these:
@@ -141,7 +144,7 @@ It should end with lines like these:
 
 From now on, feel free to visit the web status page running on the port 8010: http://localhost:8010/
 
-Our master now needs (at least) a worker to execute its commands.
+Our master now needs (at least) one worker to execute its commands.
 For that, head on to the next section!
 
 Creating a worker
@@ -152,14 +155,14 @@ In this tutorial, we are using the buildbot/hello-world project as an example.
 As a consequence of this, your worker will need access to the git_ command in order to checkout some code.
 Be sure that it is installed, or the builds will fail.
 
-Same as we did for our master, we will create a virtualenv for our worker next to the other one.
-It would however be completely ok to do this on another computer - as long as the *worker* computer is able to connect to the *master* one.
+Same as we did for our master, we will create a virtualenv for our worker next to the master's one.
+It would however be completely ok to do this on another computer - as long as the *worker* computer is able to connect to the *master's* .
 We first create a new directory for the worker:
 
 .. code-block:: bash
 
-  mkdir -p ~/buildbot-test/worker
-  cd ~/buildbot-test/worker
+  mkdir -p ~/buildbot-test/worker_root
+  cd ~/buildbot-test/worker_root
 
 Again, we create a virtual environment. On Python 3:
 
@@ -181,21 +184,21 @@ Now, create the worker:
 
 .. code-block:: bash
 
-  buildbot-worker create-worker worker localhost example-worker pass
+  buildbot-worker create-worker my_worker localhost example-worker pass
 
 .. note:: If you decided to create this from another computer, you should replace ``localhost`` with the name of the computer where your master is running.
 
-The username (``example-worker``), and password (``pass``) should be the same as those in :file:`master/master.cfg`; verify this is the case by looking at the section for ``c['workers']``:
+The username (``example-worker``), and password (``pass``) should be the same as those in :file:`my_master/master.cfg`; verify this is the case by looking at the section for ``c['workers']``:
 
 .. code-block:: bash
 
-  cat ../master/master/master.cfg
+  cat ../master_root/my_master/master.cfg
 
 And finally, start the worker:
 
 .. code-block:: bash
 
-  buildbot-worker start worker
+  buildbot-worker start my_worker
 
 Check the worker's output.
 It should end with lines like these:
@@ -214,6 +217,19 @@ Meanwhile, from the other terminal, in the master log (:file:`twisted.log` in th
   IPv4Address(TCP, '127.0.0.1', 54015)
   2014-11-01 15:56:51+0100 [Broker,1,127.0.0.1] Got workerinfo from 'example-worker'
   2014-11-01 15:56:51+0100 [-] bot attached
+
+Wrapping up
+-----------
+
+Your directory tree now should look like this:
+
+.. code-block:: none
+
+    ~/buildbot-test/master_root/my_master  # master base directory
+    ~/buildbot-test/master_root/sandbox    # virtualenv for master
+
+    ~/buildbot-test/worker_root/my_worker  # worker base directory
+    ~/buildbot-test/worker_root/sandbox    # virtualenv for worker
 
 You should now be able to go to http://localhost:8010, where you will see a web page similar to:
 


### PR DESCRIPTION
While reviewing documentation, some parts looked unclear, I improved it.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
