### PR TITLE
Wait for sent statuses before sending new ones

### DIFF
--- a/newsfragments/report-in-event-order.bugfix
+++ b/newsfragments/report-in-event-order.bugfix
@@ -1,0 +1,1 @@
+Generate and send reports in event queue order in `ReporterBase` (:issue:`6563`).


### PR DESCRIPTION
Both as a workaround for https://gitlab.com/gitlab-org/gitlab/-/issues/13134 but also to generally preclude the possibility of reports being sent out of order.

@p12tic @tardyp @g-arjones @kalvdans

Closes #6563

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] ~~I have updated the appropriate documentation~~
