### PR TITLE
Add missed newsfragment for mail sending fix

### DIFF
--- a/newsfragments/reporters-mail-twisted-21.2.bugfix
+++ b/newsfragments/reporters-mail-twisted-21.2.bugfix
@@ -1,0 +1,1 @@
+Fixed sending emails when using Twisted 21.2 or newer (:issue:`5943`)


### PR DESCRIPTION
This should have been included in https://github.com/buildbot/buildbot/pull/6579.