### PR TITLE
appveyor: Reduce the number of Python versions tested on Appveyor to 1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ environment:
   matrix:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python
-    - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python39"
 
 install:


### PR DESCRIPTION
Appveyor is often the bottleneck when many parallel pull requests are submitted to Buildbot repository. We currently test Windows builds on Github anyway, so limiting to just single Appveyor version is enough.
