### PR TITLE
Call reactor.stop() after master finished stopping its services

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -118,6 +118,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         # local cache for this master's object ID
         self._object_id = None
 
+        self._got_sigterm = False
+
         # Check environment is sensible
         check_functional_environment(self.config)
 
@@ -325,6 +327,16 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
             self.reactor.stop()
 
         finally:
+            @defer.inlineCallbacks
+            def call_after_signal(sig_num, stack):
+                if not self._got_sigterm:
+                    self._got_sigterm = True
+                    yield self.disownServiceParent()
+                    self.reactor.stop()
+                else:
+                    log.msg('Ignoring SIGTERM, master is already shutting down.')
+
+            signal.signal(signal.SIGTERM, call_after_signal)
             if startup_succeed:
                 log.msg("BuildMaster is running")
             else:

--- a/newsfragments/buildbot-stop-not-reliable.bugfix
+++ b/newsfragments/buildbot-stop-not-reliable.bugfix
@@ -1,0 +1,1 @@
+Improved reliability of "buildbot stop" (:issue:`3535`).


### PR DESCRIPTION
This PR fixes the problem #3535.

"buildbot stop" command was unstable especially in cases when stopping
of builds takes longer or connection between master and worker is slow
or disappears. This happens due to reactor.stop() being called before
finishing of the services of master had a chance to complete.
Sometimes master process would be stopped successfuly, sometimes this
action would make master process unresponsive.

This change improves reliability of master process shutdown: now after
master gets SIGTERM, it first stops all its services and only then
reactor.stop() is called. In this way reactor.stop() can not interfere
with master shutdown.

* [not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
