### PR TITLE
Drop worker connection when interrupt response takes too long

### DIFF
--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -130,7 +130,23 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
                         else:
                             results = RETRY
                         is_building = build.workerforbuilder.state == States.BUILDING
-                        build.stopBuild("Master Shutdown", results)
+
+                        # Master should not wait build.stopBuild for ages to complete if worker
+                        # does not send any message about shutting the builds down quick enough.
+                        # Just kill the connection with the worker
+                        def lose_connection(b):
+                            if b.workerforbuilder.worker.conn is not None:
+                                b.workerforbuilder.worker.conn.loseConnection()
+
+                        sheduled_call = self.master.reactor.callLater(5, lose_connection, build)
+
+                        def cancel_lose_connection(_, call):
+                            if call.active():
+                                call.cancel()
+
+                        d = build.stopBuild("Master Shutdown", results)
+                        d.addBoth(cancel_lose_connection, sheduled_call)
+
                         if not is_building:
                             # if it is not building, then it must be a latent worker
                             # which is substantiating. Cancel it.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -628,6 +628,7 @@ class Build(properties.PropertiesMixin):
     def controlStopBuild(self, key, params):
         return self.stopBuild(**params)
 
+    @defer.inlineCallbacks
     def stopBuild(self, reason="<no reason given>", results=CANCELLED):
         # the idea here is to let the user cancel a build because, e.g.,
         # they realized they committed a bug and they don't want to waste
@@ -642,7 +643,7 @@ class Build(properties.PropertiesMixin):
         # TODO: include 'reason' in this point event
         self.stopped = True
         if self.currentStep and self.currentStep.results is None:
-            self.currentStep.interrupt(reason)
+            yield self.currentStep.interrupt(reason)
 
         self.results = results
 

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -62,6 +62,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         self.reason = reason
         self.results = results
         self.finishFakeBuild()
+        return defer.succeed(None)
 
     def finishFakeBuild(self):
         self.fake_builder.building = []

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -129,7 +129,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         self.conn.loseConnection()
 
         self.assertEqual(self.conn.keepalive_timer, None)
-        self.protocol.sendClose.assert_called()
+        self.protocol.transport.abortConnection.assert_called()
 
     def test_do_keepalive(self):
         self.conn._do_keepalive()

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -121,7 +121,7 @@ class Connection(base.Connection):
 
     def loseConnection(self):
         self.stopKeepaliveTimer()
-        self.protocol.sendClose()
+        self.protocol.transport.abortConnection()
 
     # keepalive handling
 


### PR DESCRIPTION
After calling `buildbot stop` and sending `interrupt_command` to the
worker, master would wait for workers response message for potentially
long time. This would happen in case connection between master and
worker has been compromised.

After this PR master would wait for worker response message for at
most 5 seconds and would just kill the connection if it is not received.
No response from worker indicates that there is a high chance that
worker connection has already been broken and master should drop it.

* [x] I have updated the unit tests
* [not_needed(already exsisted)] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
