### PR TITLE
worker: Fix worker cpdir command on PB protocol

### DIFF
--- a/newsfragments/fix-worker-cpdir-pb.bugfix
+++ b/newsfragments/fix-worker-cpdir-pb.bugfix
@@ -1,0 +1,1 @@
+Fixed worker ``cpdir`` command handling when using PB protocol (:issue:`6539`)

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -80,7 +80,7 @@ class ProtocolCommandPb(ProtocolCommandBase):
 
         if command == "cpdir":
             args['from_path'] = os.path.join(self.basedir, args['fromdir'])
-            args['from_path'] = os.path.join(self.basedir, args['todir'])
+            args['to_path'] = os.path.join(self.basedir, args['todir'])
             del args['fromdir']
             del args['todir']
 


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/6539.