### PR TITLE
schedulers: Implement branch_key parameter for OldBuildCanceller

### DIFF
--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -59,7 +59,7 @@ class TestOldBuildTracker(unittest.TestCase):
                                       branch_eq=['br1', 'br2'])
         filter.add_filter(['bldr1', 'bldr2'], ss_filter)
         self.cancellations = []
-        self.tracker = _OldBuildTracker(filter, self.on_cancel)
+        self.tracker = _OldBuildTracker(filter, lambda ss: ss['branch'], self.on_cancel)
 
     def on_cancel(self, id_tuple):
         is_build, id = id_tuple
@@ -339,6 +339,7 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
             fakedb.Worker(id=13, name='wrk'),
             fakedb.Builder(id=79, name='builder1'),
             fakedb.Builder(id=80, name='builder2'),
+            fakedb.Builder(id=81, name='builder3'),
 
             fakedb.Buildset(id=98, results=None, reason="reason98"),
             fakedb.BuildsetSourceStamp(buildsetid=98, sourcestampid=234),
@@ -355,6 +356,15 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
             fakedb.BuildRequest(id=11, buildsetid=99, builderid=80),
             fakedb.Build(id=20, number=1, builderid=80, buildrequestid=11, workerid=13,
                          masterid=92, results=None, state_string="state2"),
+
+            fakedb.Buildset(id=100, results=None, reason="reason100"),
+            fakedb.BuildsetSourceStamp(buildsetid=100, sourcestampid=236),
+            fakedb.SourceStamp(id=236, revision='revision2', project='project2',
+                               codebase='codebase2', repository='repository2',
+                               branch='refs/changes/10/12310/2'),
+            fakedb.BuildRequest(id=12, buildsetid=100, builderid=81),
+            fakedb.Build(id=21, number=1, builderid=81, buildrequestid=12, workerid=13,
+                         masterid=92, results=None, state_string="state3"),
         ])
 
     @defer.inlineCallbacks
@@ -362,6 +372,7 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
         self.canceller = OldBuildCanceller('canceller', [
             (['builder1'], SourceStampFilter(branch_eq=['branch1'])),
             (['builder2'], SourceStampFilter(branch_eq=['branch2'])),
+            (['builder3'], SourceStampFilter()),
         ])
         yield self.canceller.setServiceParent(self.master)
 
@@ -397,6 +408,19 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
         self.master.mq.callConsumer(('changes', '123', 'new'), ss_dict)
         self.assert_cancelled([('build', 19)])
+
+        self.master.mq.callConsumer(('changes', '124', 'new'), ss_dict)
+        self.assert_cancelled([])
+
+    @defer.inlineCallbacks
+    def test_cancel_build_after_new_commit_gerrit_branch_filter(self):
+        yield self.setup_canceller_with_filters()
+
+        ss_dict = self.create_ss_dict('project2', 'codebase2', 'repository2',
+                                      'refs/changes/10/12310/3')
+
+        self.master.mq.callConsumer(('changes', '123', 'new'), ss_dict)
+        self.assert_cancelled([('build', 21)])
 
         self.master.mq.callConsumer(('changes', '124', 'new'), ss_dict)
         self.assert_cancelled([])
@@ -482,8 +506,8 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
         on_build_new_d.callback(None)
         on_buildrequest_new_d.callback(None)
         yield d
-        self.assertEqual(on_build_new_build_ids, [19, 20])
-        self.assertEqual(on_buildrequest_new_breq_ids, [10, 11])
+        self.assertEqual(on_build_new_build_ids, [19, 20, 21])
+        self.assertEqual(on_buildrequest_new_breq_ids, [10, 11, 12])
 
         self.assertFalse(self.canceller._build_tracker.is_build_tracked(19))
         self.assertFalse(self.canceller._build_tracker.is_build_tracked(20))

--- a/master/docs/manual/configuration/services/old_build_canceller.rst
+++ b/master/docs/manual/configuration/services/old_build_canceller.rst
@@ -15,6 +15,9 @@ This is controlled by the ``filters`` parameter.
 The decision on whether to track a build is done on build startup.
 Configuration changes are ignored for builds that have already started.
 
+Certain version control systems have multiple branch names that map to a single logical branch which makes ``OldBuildCanceller`` unable to cancel builds even in the presence of new commits.
+The handling of such scenarios is controlled by ``branch_key``.
+
 The following parameters are supported by the :py:class:`OldBuildCanceller`:
 
 ``name``
@@ -28,3 +31,16 @@ The following parameters are supported by the :py:class:`OldBuildCanceller`:
     The source stamp filters that specify which builds the build canceller should track.
     The first element of each tuple must be a list of builder names that the filter would apply to.
     The second element of each tuple must be an instance of :py:class:`buildbot.util.SourceStampFilter`.
+
+``branch_key``
+    (optional, a function that receives source stamp or change dictionary and returns a string)
+    Allows customizing the branch that is used to track builds and decide whether to cancel them.
+    The function receives a dictionary with at least the following keys: ``project``, ``codebase``, ``repository``, ``branch`` and must return a string.
+
+    The default implementation implements custom handling for the following Version control systems:
+     - Gerrit: branches that identify changes (use format ``refs/changes/*/*/*``) have the change iteration number removed.
+
+    Pass ``lambda ss: ss['branch']`` to always use branch property directly.
+
+    Note that ``OldBuildCanceller`` will only cancel builds with the same ``project``, ``codebase``, ``repository`` tuple as incoming change, so these do not need to be taken into account by this function.
+

--- a/newsfragments/old-build-canceller-branch-key.feature
+++ b/newsfragments/old-build-canceller-branch-key.feature
@@ -1,0 +1,2 @@
+Added support for custom branch keys to ``OldBuildCanceller``.
+This is useful in Version Control Systems such as Gerrit that have multiple branch names for the same logical branch that should be tracked by the canceller.


### PR DESCRIPTION
This allows using OldBuildCanceller with VCS such as Gerrit where the branch name is different for each change even for related set of changes.


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
