### PR TITLE
test: Drop errno workaround for Python 2.4

### DIFF
--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import errno
 import os
 import shutil
 import stat
@@ -30,12 +31,6 @@ from buildbot_worker.commands import utils
 from buildbot_worker.test.fake.runprocess import Expect
 from buildbot_worker.test.util.command import CommandTestMixin
 from buildbot_worker.test.util.compat import skipUnlessPlatformIs
-
-# python-2.4 doesn't have os.errno
-if hasattr(os, 'errno'):
-    errno = os.errno
-else:
-    import errno
 
 
 class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):


### PR DESCRIPTION
There's no need for os.errno presence check, simple "errno" can be used unconditionally. Note that presence of os.errno was implementation-dependent. It actually got removed in Python 3.7.
