### PR TITLE
Wait for remoteUpdate() completion in remoteComplete()

### DIFF
--- a/newsfragments/fix-incomplete-logs-from-remote-commands.bugfix
+++ b/newsfragments/fix-incomplete-logs-from-remote-commands.bugfix
@@ -1,0 +1,1 @@
+Fix incomplete logs from remote commands introduced in  Buildbot 3.6 (:issue: `6632`).


### PR DESCRIPTION
This PR fixes issue https://github.com/buildbot/buildbot/issues/6632.
remoteComplete() should wait for remoteUpdate() to be completed so yield is added to wait for remoteUpdate() deferred value.
To prevent the deadlock, lock was moved specificaly where it is needed in the remoteComplete().


## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
