### PR TITLE
Automatic generation of Telegram commands

### DIFF
--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -614,7 +614,8 @@ class TelegramStatusBot(StatusBot):
             channel = self.getChannel(c)
             channel.add_notification_events(self.notify_events)
         yield self.loadState()
-        commands = [{'command': command, 'description': doc} for command, doc in TelegramContact.get_commands()]
+        commands = [{'command': command, 'description': doc}
+                    for command, doc in TelegramContact.get_commands()]
         self.post('/setMyCommands', json={'commands': commands})
 
     results_emoji = {

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -185,8 +185,8 @@ class TelegramContact(Contact):
         if self.is_private_chat:
             self.send(f"Your ID is `{self.user_id}`.")
         else:
-            yield self.send(f"{self.user_name}, your ID is {self.user_id}.")
-            self.send(f'This {self.channel.chat_info.get("type", "group")} ID is {self.chat_id}.')
+            yield self.send(f"{self.user_name}, your ID is `{self.user_id}`.")
+            self.send(f'This {self.channel.chat_info.get("type", "group")} ID is `{self.chat_id}`.')
     command_GETID.usage = "getid - get user and chat ID that can be put in the master " \
                           "configuration file"
 

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -61,6 +61,9 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
 
     master = None
 
+    _commands = [{'command': command, 'description': doc}
+                 for command, doc in telegram.TelegramContact.get_commands()]
+
     @defer.inlineCallbacks
     def get_http(self, bot_token):
         base_url = "https://api.telegram.org/telegram" + bot_token
@@ -69,6 +72,8 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
         # This is necessary as Telegram will make requests in the reconfig
         http.expect("post", "/getMe",
                     content_json={'ok': 1, 'result': {'username': 'testbot'}})
+        http.expect("post", "/setMyCommands", json={'commands': self._commands},
+                    content_json={'ok': 1})
         if bot_token == 'poll':
             http.expect("post", "/deleteWebhook",
                         content_json={'ok': 1})

--- a/master/buildbot/test/unit/reporters/test_telegram.py
+++ b/master/buildbot/test/unit/reporters/test_telegram.py
@@ -85,6 +85,9 @@ class TestTelegramContact(ContactMixin, unittest.TestCase):
         def getChannel(self, channel):
             return self.channelClass(self, channel)
 
+        def post(self, path, **kwargs):
+            return True
+
     USER = {
         "id": 123456789,
         "first_name": "Harry",

--- a/newsfragments/telegram-commands.feature
+++ b/newsfragments/telegram-commands.feature
@@ -1,1 +1,1 @@
-Added automatic generation of commands for Telegram bot without need to send the to BotFather.
+Added automatic generation of commands for Telegram bot without need to send them manually to BotFather.

--- a/newsfragments/telegram-commands.feature
+++ b/newsfragments/telegram-commands.feature
@@ -1,0 +1,1 @@
+Added automatic generation of commands for Telegram bot without need to send the to BotFather.


### PR DESCRIPTION
Telegram API now allows to specify bot commands automatically by the bot. This patch does this, so anyone using it, will not have to add them manually to BotFather.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
