### PR TITLE
Added treq respone wrapper

### DIFF
--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -30,54 +30,57 @@ from buildbot.util import unicode2bytes
 
 try:
     import txrequests
-    @implementer(IHttpResponse)
-    class TxRequestsResponseWrapper:
-
-        def __init__(self, res):
-            self._res = res
-
-        def content(self):
-            return defer.succeed(self._res.content)
-
-        def json(self):
-            return defer.succeed(self._res.json())
-
-        @property
-        def code(self):
-            return self._res.status_code
-
-        @property
-        def url(self):
-            return self._res.url
 except ImportError:
     txrequests = None
 
 try:
     import treq
-    @implementer(IHttpResponse)
-    class TreqResponseWrapper:
-
-        def __init__(self, res):
-            self._res = res
-
-        def content(self):
-            return self._res.content()
-
-        def json(self):
-            return self._res.json()
-
-        @property
-        def code(self):
-            return self._res.code
-
-        @property
-        def url(self):
-            return self._res.request.absoluteURI.decode()
-
 except ImportError:
     treq = None
 
 log = Logger()
+
+
+@implementer(IHttpResponse)
+class TxRequestsResponseWrapper:
+
+    def __init__(self, res):
+        self._res = res
+
+    def content(self):
+        return defer.succeed(self._res.content)
+
+    def json(self):
+        return defer.succeed(self._res.json())
+
+    @property
+    def code(self):
+        return self._res.status_code
+
+    @property
+    def url(self):
+        return self._res.url
+
+
+@implementer(IHttpResponse)
+class TreqResponseWrapper:
+
+    def __init__(self, res):
+        self._res = res
+
+    def content(self):
+        return self._res.content()
+
+    def json(self):
+        return self._res.json()
+
+    @property
+    def code(self):
+        return self._res.code
+
+    @property
+    def url(self):
+        return self._res.request.absoluteURI.decode()
 
 
 class HTTPClientService(service.SharedService):

--- a/newsfragments/fix-incomplete-logs-from-remote-commands.bugfix
+++ b/newsfragments/fix-incomplete-logs-from-remote-commands.bugfix
@@ -1,0 +1,1 @@
+Fix incomplete logs from remote commands introduced in  Buildbot 3.6 (:issue: `6632`).

--- a/newsfragments/treq_response_interface_implementation.feature
+++ b/newsfragments/treq_response_interface_implementation.feature
@@ -1,0 +1,2 @@
+Added treq respone wrapper to fix issue with missing url attribute.
+Moved txrequest response wrapper to only be setup if txrequests is being used.


### PR DESCRIPTION
Fixed an issue where the url property did not exist in a get response when using treq instead of txrequest.

Fixes #6633 

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

