### PR TITLE
Fix a test failure when influxdb is installed

### DIFF
--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -121,14 +121,14 @@ class TestInfluxDB(TestStatsServicesBase, logging.LoggingMixin):
             [influxdb]
         except ImportError:
             with self.assertRaises(config.ConfigErrors):
-                InfluxStorageService("fake_url", "fake_port", "fake_user",
+                InfluxStorageService("fake_url", 12345, "fake_user",
                                      "fake_password", "fake_db", captures)
 
         # if instead influxdb is installed, then initialize it - no errors
         # should be realized
         else:
             new_storage_backends = [
-                InfluxStorageService("fake_url", "fake_port", "fake_user", "fake_password",
+                InfluxStorageService("fake_url", 12345, "fake_user", "fake_password",
                                      "fake_db", captures)
             ]
             yield self.stats_service.reconfigService(new_storage_backends)


### PR DESCRIPTION
A test failed as influxdb insists the port should be an integer since version 3.0 [1].

    [ERROR]
    Traceback (most recent call last):
      File "/usr/lib/python3.10/site-packages/twisted/internet/defer.py", line 1661, in _inlineCallbacks
        result = current_context.run(gen.send, result)
      File "/home/yen/buildbot/master/buildbot/test/unit/test_stats_service.py", line 131, in test_influxdb_not_installed
        InfluxStorageService("fake_url", "fake_port", "fake_user", "fake_password",
      File "/home/yen/buildbot/buildbot/master/buildbot/statistics/storage_backends/influxdb_client.py", line 46, in __init__
        self.client = InfluxDBClient(self.url, self.port, self.user,
      File "/usr/lib/python3.10/site-packages/influxdb/client.py", line 108, in __init__
        self.__port = int(port)
    builtins.ValueError: invalid literal for int() with base 10: 'fake_port'

    buildbot.test.unit.test_stats_service.TestInfluxDB.test_influxdb_not_installed

[1] https://github.com/influxdata/influxdb-python/commit/0a193cf2e87327eec8110815efa14f1f70765628

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory) - not needed IMO
* [ ] I have updated the appropriate documentation - not needed IMO
