### PR TITLE
Added TreqResponseWrapper

### DIFF
--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -116,6 +116,7 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.util.git.GitStepMixin',
             'buildbot.util.giturlparse.GitUrl',
             'buildbot.util.httpclientservice.HTTPClientService',
+            'buildbot.util.httpclientservice.TreqResponseWrapper',
             'buildbot.util.httpclientservice.TxRequestsResponseWrapper',
             'buildbot.util.kubeclientservice.KubeClientService',
             'buildbot.util.kubeclientservice.KubeConfigLoaderBase',

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -35,8 +35,6 @@ except ImportError:
 
 try:
     import treq
-    implementer(IHttpResponse)(treq.response._Response)
-
 except ImportError:
     treq = None
 
@@ -62,6 +60,27 @@ class TxRequestsResponseWrapper:
     @property
     def url(self):
         return self._res.url
+
+
+@implementer(IHttpResponse)
+class TreqResponseWrapper:
+
+    def __init__(self, res):
+        self._res = res
+
+    def content(self):
+        return self._res.content()
+
+    def json(self):
+        return self._res.json()
+
+    @property
+    def code(self):
+        return self._res.code
+
+    @property
+    def url(self):
+        return self._res.request.absoluteURI.decode()
 
 
 class HTTPClientService(service.SharedService):
@@ -202,7 +221,7 @@ class HTTPClientService(service.SharedService):
         kwargs['agent'] = self._agent
 
         res = yield getattr(treq, method)(url, **kwargs)
-        return IHttpResponse(res)
+        return IHttpResponse(TreqResponseWrapper(res))
 
     # lets be nice to the auto completers, and don't generate that code
     def get(self, ep, **kwargs):

--- a/newsfragments/treq_response_interface_implementation.bugfix
+++ b/newsfragments/treq_response_interface_implementation.bugfix
@@ -1,0 +1,1 @@
+Added treq response wrapper to fix issue with missing url attribute.


### PR DESCRIPTION
This fixes issues with the url attribute missing in the response when treq is used.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation because
      I didn't think any documentation have to be updated, I use treq with GitHubPullrequestPoller

Fixes #6633 