### PR TITLE
Issue 3457 Fix: Removed negative value from appearing in the elapsed time for current build 

### DIFF
--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -282,7 +282,7 @@ class CaptureBuildDuration(CaptureBuildTimes):
                 divisor = 60
             elif report_in == 'hours':
                 divisor = 60 * 60
-            duration = end_time - start_time
+            duration = abs(end_time - start_time)
             # cannot use duration.total_seconds() on Python 2.6
             duration = ((duration.microseconds + (duration.seconds +
                                                   duration.days * 24 * 3600) * 1e6) / 1e6)


### PR DESCRIPTION

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

* Not sure if the above applies to the very minor change, but this is a minor fix. Draft PR 