### PR TITLE
Objects don't seem to have a .keys(). Use Object.keys(rev)

### DIFF
--- a/www/console_view/src/module/main.module.js
+++ b/www/console_view/src/module/main.module.js
@@ -371,7 +371,7 @@ class Console {
                 }
 
                 if ((change == null)) {
-                    revision = rev === {} ? "" : rev[rev.keys()[0]];
+                    revision = rev === {} ? "" : rev[Object.keys(rev)[0]];
                     change = this.makeFakeChange(codebase, revision, build.started_at);
                 }
             }


### PR DESCRIPTION
I'm not the best at Javascript, but this patch made the console view work for me. To test, try making the number of fetched revisions be 1 or 2. Console view breaks because the current code throws an exception.

No doc updates needed