### PR TITLE
Update docker-py version check

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-version = "1.10.6"
+__version__ = "1.10.6"
 
 
 class Client:

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -96,7 +96,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_contruction_minimal_docker_py(self):
-        docker.version = "1.10.6"
+        self.patch(dockerworker, 'docker_py_version', 1.10)
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         yield bs.start_instance(self.build)
         client = docker.APIClient.latest
@@ -106,7 +106,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_contruction_minimal_docker(self):
-        docker.version = "2.0.0"
+        self.patch(dockerworker, 'docker_py_version', 2.0)
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         yield bs.start_instance(self.build)
         client = docker.Client.latest

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -210,7 +210,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         return volume_list, volumes
 
     def _getDockerClient(self, client_args):
-        if docker.version[0] == '1':
+        if 1.0 <= docker_py_version < 2.0:
             docker_client = client.Client(**client_args)
         else:
             docker_client = client.APIClient(**client_args)


### PR DESCRIPTION
Probably, fixes #6657.

Use `docker_py_version` variable to determine version of docker-py 3rd-party instead of deprecated (since docker-py >= 6.0.0) `docker.version` variable. 

Note: This may not add a complete support of docker-py >= 6.0.0.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
  * Just a small bug-fix to support newer verrsion of 3rd-party. It seems that it does not require a news about it.
* [ ] I have updated the appropriate documentation
  * No update of docs are required.