### PR TITLE
Implement packaging for base_react www plugin

### DIFF
--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -167,3 +167,72 @@ class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         rsrc.reconfigResource(master.config)
         self.assertNotIn('custom_templates_dir', rsrc.frontend_config)
         self.assertEqual('returnvalue', rsrc.custom_templates)
+
+
+class IndexResourceReactTest(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setup_test_reactor()
+
+    def get_react_static_path(self):
+        path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+        for _ in range(0, 4):
+            path = os.path.dirname(path)
+        return os.path.join(path, 'www/react-base/public')
+
+    def find_matching_line(self, lines, match, start_i):
+        for i in range(start_i, len(lines)):
+            if match in lines[i]:
+                return i
+        return None
+
+    def extract_config_json(self, res):
+        lines = res.split('\n')
+
+        first_line = self.find_matching_line(lines, '<script id="bb-config">', 0)
+        if first_line is None:
+            raise Exception("Could not find first config line")
+        first_line += 1
+
+        last_line = self.find_matching_line(lines, '</script>', first_line)
+        if last_line is None:
+            raise Exception("Could not find last config line")
+
+        config_json = '\n'.join(lines[first_line:last_line])
+        config_json = config_json.replace('window.buildbotFrontendConfig = ', '').strip()
+        config_json = config_json.strip(';').strip()
+        return json.loads(config_json)
+
+    @defer.inlineCallbacks
+    def test_render(self):
+        _auth = auth.NoAuth()
+        _auth.maybeAutoLogin = mock.Mock()
+
+        custom_versions = [['test compoent', '0.1.2'], ['test component 2', '0.2.1']]
+
+        master = self.make_master(url='h:/a/b/', auth=_auth, versions=custom_versions,
+                                  plugins=['base_react'])
+
+        rsrc = config.IndexResourceReact(master, self.get_react_static_path())
+        rsrc.reconfigResource(master.config)
+
+        vjson = [list(v)
+                 for v in config.get_environment_versions()] + custom_versions
+
+        res = yield self.render_resource(rsrc, b'/')
+        config_json = self.extract_config_json(bytes2unicode(res))
+
+        _auth.maybeAutoLogin.assert_called_with(mock.ANY)
+        exp = {
+            "authz": {},
+            "titleURL": "http://buildbot.net",
+            "versions": vjson,
+            "title": "Buildbot",
+            "auth": {"name": "NoAuth"},
+            "user": {"anonymous": True},
+            "buildbotURL": "h:/a/b/",
+            "multiMaster": False,
+            "port": None,
+            "plugins": ["base_react"],
+        }
+        self.assertEqual(config_json, exp)

--- a/www/react-base/buildbot_www_react/__init__.py
+++ b/www/react-base/buildbot_www_react/__init__.py
@@ -1,0 +1,19 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.www.plugin import Application
+
+# create the interface for the setuptools entry point
+ep = Application(__name__, "Buildbot UI (React)")

--- a/www/react-base/config/paths.js
+++ b/www/react-base/config/paths.js
@@ -21,7 +21,7 @@ const publicUrlOrPath = getPublicUrlOrPath(
   process.env.PUBLIC_URL
 );
 
-const buildPath = process.env.BUILD_PATH || 'build';
+const buildPath = process.env.BUILD_PATH || __dirname + '/../buildbot_www_react/static';
 
 const moduleFileExtensions = [
   'web.mjs',

--- a/www/react-base/config/webpack.config.js
+++ b/www/react-base/config/webpack.config.js
@@ -106,7 +106,7 @@ module.exports = function (webpackEnv) {
         // css is located in `static/css`, use '../../' to locate index.html folder
         // in production `paths.publicUrlOrPath` can be a relative path
         options: paths.publicUrlOrPath.startsWith('.')
-          ? { publicPath: '../../' }
+          ? { publicPath: '../' }
           : {},
       },
       {
@@ -206,14 +206,14 @@ module.exports = function (webpackEnv) {
       // There will be one main bundle, and one file per asynchronous chunk.
       // In development, it does not produce real files.
       filename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].js'
-        : isEnvDevelopment && 'static/js/bundle.js',
+        ? 'js/[name].[contenthash:8].js'
+        : isEnvDevelopment && 'js/bundle.js',
       // TODO: remove this when upgrading to webpack 5
       futureEmitAssets: true,
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].chunk.js'
-        : isEnvDevelopment && 'static/js/[name].chunk.js',
+        ? 'js/[name].[contenthash:8].chunk.js'
+        : isEnvDevelopment && 'js/[name].chunk.js',
       // webpack uses `publicPath` to determine where the app is being served from.
       // It requires a trailing slash, or the file assets will get an incorrect path.
       // We inferred the "public path" (such as / or /my-project) from homepage.
@@ -379,7 +379,7 @@ module.exports = function (webpackEnv) {
               options: {
                 limit: imageInlineSizeLimit,
                 mimetype: 'image/avif',
-                name: 'static/media/[name].[hash:8].[ext]',
+                name: 'media/[name].[hash:8].[ext]',
               },
             },
             // "url" loader works like "file" loader except that it embeds assets
@@ -390,7 +390,7 @@ module.exports = function (webpackEnv) {
               loader: require.resolve('url-loader'),
               options: {
                 limit: imageInlineSizeLimit,
-                name: 'static/media/[name].[hash:8].[ext]',
+                name: 'media/[name].[hash:8].[ext]',
               },
             },
             // Process application JS with Babel.
@@ -568,7 +568,7 @@ module.exports = function (webpackEnv) {
               // by webpacks internal loaders.
               exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
               options: {
-                name: 'static/media/[name].[hash:8].[ext]',
+                name: 'media/[name].[hash:8].[ext]',
               },
             },
             // ** STOP ** Are you adding a new loader?
@@ -656,8 +656,8 @@ module.exports = function (webpackEnv) {
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional
-          filename: 'static/css/[name].[contenthash:8].css',
-          chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
+          filename: 'css/[name].[contenthash:8].css',
+          chunkFilename: 'css/[name].[contenthash:8].chunk.css',
         }),
       // Generate an asset manifest file with the following content:
       // - "files" key: Mapping of all asset filenames to their corresponding

--- a/www/react-base/public/index.html
+++ b/www/react-base/public/index.html
@@ -18,5 +18,5 @@
   <script src="browser-warning.js"></script>
   <link href="browser-warning.css" rel="stylesheet">
   <script src="browser-warning-list.js"></script>
-  <!-- TODO: plugin inclusion and definition of buildbot_config -->
+  <!-- BUILDBOT_CONFIG_PLACEHOLDER -->
 </html>

--- a/www/react-base/setup.py
+++ b/www/react-base/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+try:
+    from buildbot_pkg import setup_www_plugin
+except ImportError:
+    import sys
+    print('Please install buildbot_pkg module in order to install that '
+          'package, or use the pre-build .whl modules available on pypi',
+          file=sys.stderr)
+    sys.exit(1)
+
+setup_www_plugin(
+    name='buildbot-www-react',
+    description='Buildbot UI (React)',
+    author='Povilas Kanapickas',
+    author_email='povilas@radix.lt',
+    setup_requires=['buildbot_pkg'],
+    install_requires=['buildbot'],
+    url='http://buildbot.net/',
+    packages=['buildbot_www_react'],
+    package_data={
+        '': [
+            'VERSION',
+            'static/*',
+            'static/js/*',
+            'static/css/*',
+            'static/img/*',
+            'static/fonts/*',
+        ]
+    },
+    entry_points="""
+        [buildbot.www]
+        base_react = buildbot_www_react:ep
+    """,
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)'
+    ],
+)


### PR DESCRIPTION
This also allows the new React-based frontend to be tested by simply adding `plugins={"base_react": {}}` to www config dictionary.