### PR TITLE
Add cancel reason to cancelled build state string

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -98,6 +98,7 @@ class Build(properties.PropertiesMixin):
         # overall results, may downgrade after each step
         self.results = SUCCESS
         self.properties = properties.Properties()
+        self.stopped_reason = None
 
         # tracks execution during the build finish phase
         self._locks_released = False
@@ -640,7 +641,7 @@ class Build(properties.PropertiesMixin):
         log.msg(f" {self}: stopping build: {reason} {results}")
         if self.finished:
             return
-        # TODO: include 'reason' in this point event
+        self.stopped_reason = reason
         self.stopped = True
         if self.currentStep and self.currentStep.results is None:
             yield self.currentStep.interrupt(reason)
@@ -668,6 +669,8 @@ class Build(properties.PropertiesMixin):
             text = ["cancelled"]
         else:
             text = ["build", "successful"]
+        if self.stopped_reason is not None:
+            text.extend([f'({self.stopped_reason})'])
         text.extend(self.text)
         return self.buildFinished(text, self.results)
 

--- a/newsfragments/cancelled-build-state-script.bugfix
+++ b/newsfragments/cancelled-build-state-script.bugfix
@@ -1,0 +1,1 @@
+Cancelled builds now have stop reason included into the state string.


### PR DESCRIPTION
Previously it was not clear what was the reason if a build was cancelled.