### PR TITLE
Custom class hook without plugin

### DIFF
--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -120,15 +120,15 @@ class ChangeHookResource(resource.Resource):
             raise ValueError(m)
 
         if dialect not in self._dialect_handlers:
-            if dialect not in self._plugins:
-                m = (f"The dialect specified, '{dialect}', is not registered as "
-                     "a buildbot.webhook plugin")
-                log.msg(m)
-                raise ValueError(m)
             options = self.dialects[dialect]
             if isinstance(options, dict) and 'custom_class' in options:
                 klass = options['custom_class']
             else:
+                if dialect not in self._plugins:
+                    m = (f"The dialect specified, '{dialect}', is not registered as "
+                         "a buildbot.webhook plugin")
+                    log.msg(m)
+                    raise ValueError(m)
                 klass = self._plugins.get(dialect)
             self._dialect_handlers[dialect] = klass(self.master, self.dialects[dialect])
 

--- a/newsfragments/custom-class-hook-without-plugin.bugfix
+++ b/newsfragments/custom-class-hook-without-plugin.bugfix
@@ -1,0 +1,1 @@
+Fix ``custom_class`` change hook checks to allow hook without a plugin.


### PR DESCRIPTION
`custom_class` is supposed to allow registration of hooks without having to write a plug-in. However, the check for whether a plug-in exists for a specific dialect is performed even when a custom_class is given.

Instead, only check for a plug-in if no custom_class is given.