### PR TITLE
Fix generated documentation that misses properties

### DIFF
--- a/master/docs/templates/raml.jinja
+++ b/master/docs/templates/raml.jinja
@@ -11,6 +11,11 @@
     {% if 'properties' in type -%}
     {% for key, value in type.properties.items() -%}
     :attr {{value.type}} {{key}}: {{raml.reindent(value.description, 4*2)}}
+        {% if 'properties' in value %}
+        {% for prop_name, prop_type in value.properties.items() -%}
+        * ``{{prop_name}}`` (*{{prop_type}}*)
+        {% endfor %}
+        {% endif %}{# if value has properties #}
     {% endfor %}
 {% if 'example' in type -%}
 


### PR DESCRIPTION
Fixes #6604.

Before:

![image](https://user-images.githubusercontent.com/196535/202763983-28cca76c-26cf-4764-9ff0-de6d10755d90.png)

After:
![image](https://user-images.githubusercontent.com/196535/202763806-9b00dd8d-9a67-4051-b35c-351b8a375b86.png)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
