### PR TITLE
.github: Use specific version of Ubuntu for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   db:
     name: DB / ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This fixes the CI due to missing enchant package.