### PR TITLE
www/react: Reinitialize queries when component gets different props

### DIFF
--- a/www/react-base/src/components/BuildRequestSummary/BuildRequestSummary.tsx
+++ b/www/react-base/src/components/BuildRequestSummary/BuildRequestSummary.tsx
@@ -29,7 +29,7 @@ type BuildRequestSummaryProps = {
 }
 
 const BuildRequestSummary = observer(({buildrequestid}: BuildRequestSummaryProps) => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([buildrequestid]);
 
   const buildRequestQuery = useDataApiQuery(
     () => Buildrequest.getAll(accessor, {id: buildrequestid}));

--- a/www/react-base/src/components/BuildSticker/__snapshots__/BuildSticker.test.tsx.snap
+++ b/www/react-base/src/components/BuildSticker/__snapshots__/BuildSticker.test.tsx.snap
@@ -2,19 +2,19 @@
 
 exports[`buildsticker component failed 1`] = `
 <div
-  className="panel panel-default buildsticker results_FAILURE"
+  className="bb-buildsticker results_FAILURE card"
 >
   <div
-    className="panel-body no-select"
+    className="card-body"
   >
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
-      <span
-        className="pull-right label results_FAILURE"
+      <div
+        className="bb-badge-status pull-right results_FAILURE"
       >
         FAILURE
-      </span>
+      </div>
       <a
         href="/builders/2/builds/1"
         onClick={[Function]}
@@ -24,12 +24,12 @@ exports[`buildsticker component failed 1`] = `
       </a>
     </div>
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
       <span
         className="pull-right"
       >
-        10 s
+        10 s 
       </span>
       <span>
         failed
@@ -41,19 +41,19 @@ exports[`buildsticker component failed 1`] = `
 
 exports[`buildsticker component pending 1`] = `
 <div
-  className="panel panel-default buildsticker results_PENDING"
+  className="bb-buildsticker results_PENDING card"
 >
   <div
-    className="panel-body no-select"
+    className="card-body"
   >
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
-      <span
-        className="pull-right label results_PENDING"
+      <div
+        className="bb-badge-status pull-right results_PENDING"
       >
         ...
-      </span>
+      </div>
       <a
         href="/builders/2/builds/1"
         onClick={[Function]}
@@ -63,7 +63,7 @@ exports[`buildsticker component pending 1`] = `
       </a>
     </div>
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
       <span
         className="pull-right"
@@ -80,19 +80,19 @@ exports[`buildsticker component pending 1`] = `
 
 exports[`buildsticker component simple 1`] = `
 <div
-  className="panel panel-default buildsticker results_UNKNOWN"
+  className="bb-buildsticker results_UNKNOWN card"
 >
   <div
-    className="panel-body no-select"
+    className="card-body"
   >
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
-      <span
-        className="pull-right label results_UNKNOWN"
+      <div
+        className="bb-badge-status pull-right results_UNKNOWN"
       >
         ...
-      </span>
+      </div>
       <a
         href="/builders/2/builds/1"
         onClick={[Function]}
@@ -102,7 +102,7 @@ exports[`buildsticker component simple 1`] = `
       </a>
     </div>
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
       <span
         className="pull-right"
@@ -117,19 +117,19 @@ exports[`buildsticker component simple 1`] = `
 
 exports[`buildsticker component success 1`] = `
 <div
-  className="panel panel-default buildsticker results_SUCCESS"
+  className="bb-buildsticker results_SUCCESS card"
 >
   <div
-    className="panel-body no-select"
+    className="card-body"
   >
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
-      <span
-        className="pull-right label results_SUCCESS"
+      <div
+        className="bb-badge-status pull-right results_SUCCESS"
       >
         SUCCESS
-      </span>
+      </div>
       <a
         href="/builders/2/builds/1"
         onClick={[Function]}
@@ -139,12 +139,12 @@ exports[`buildsticker component success 1`] = `
       </a>
     </div>
     <div
-      className="row"
+      className="bb-buildsticker-left"
     >
       <span
         className="pull-right"
       >
-        10 s
+        10 s 
       </span>
       <span>
         finished

--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -206,7 +206,7 @@ type BuildSummaryProps = {
 
 const BuildSummary = observer(({build, parentBuild, parentRelationship,
                                 condensed}: BuildSummaryProps) => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([build.id]);
   const now = useCurrentTime();
 
   const propertiesQuery = useDataApiQuery(() => build.getProperties());

--- a/www/react-base/src/components/BuildSummaryTooltip/BuildSummaryTooltip.tsx
+++ b/www/react-base/src/components/BuildSummaryTooltip/BuildSummaryTooltip.tsx
@@ -47,7 +47,7 @@ type BuildSummaryTooltipProps = {
 }
 
 const BuildSummaryTooltip = observer(({build}: BuildSummaryTooltipProps) => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([build.id]);
   const config = useContext(ConfigContext);
 
   const propertiesQuery = useDataApiQuery(() => build.getProperties());

--- a/www/react-base/src/components/LogPreview/LogPreview.tsx
+++ b/www/react-base/src/components/LogPreview/LogPreview.tsx
@@ -79,7 +79,7 @@ const LogPreview = ({builderid, buildnumber, stepnumber, log,
 
   const [fullDisplay, setFullDisplay] = useStateWithDefaultIfNotSet(() => initialFullDisplay);
 
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([builderid, buildnumber, stepnumber, log.id]);
   const dataClient = useContext(DataClientContext);
   const apiRootUrl = dataClient.restClient.rootUrl;
 

--- a/www/react-base/src/components/LogViewer/LogViewerHtml.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerHtml.tsx
@@ -25,7 +25,7 @@ export type LogViewerHtmlProps = {
 }
 
 const LogViewerHtml = ({log}: LogViewerHtmlProps) => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
   const [htmlLog, setHtmlLog] = useState('');
   const pendingRequest = useRef<CancellablePromise<any> | null>(null);
 

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -201,7 +201,7 @@ export type LogViewerProps = {
 
 const LogViewerText = observer(({log, fetchOverscanRowCount, destroyOverscanRowCount}: LogViewerProps) => {
   const viewerState = useLocalObservable(() => new LogViewerState());
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const pendingRequest = useRef<PendingRequest | null>(null);
   const logLineDigitCount = digitCount(log.num_lines);

--- a/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
+++ b/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`RawData component object with array of objects 1`] = `
 <dl
   className="dl-horizontal"
 >
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       array
     </dt>
@@ -25,7 +27,9 @@ exports[`RawData component object with array of objects expanded 1`] = `
 <dl
   className="dl-horizontal"
 >
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       array
     </dt>
@@ -39,7 +43,9 @@ exports[`RawData component object with array of objects expanded 1`] = `
           <dl
             className="dl-horizontal"
           >
-            <div>
+            <div
+              className="bb-raw-data-key-value"
+            >
               <dt>
                 str
               </dt>
@@ -54,7 +60,9 @@ exports[`RawData component object with array of objects expanded 1`] = `
           <dl
             className="dl-horizontal"
           >
-            <div>
+            <div
+              className="bb-raw-data-key-value"
+            >
               <dt>
                 int
               </dt>
@@ -69,7 +77,9 @@ exports[`RawData component object with array of objects expanded 1`] = `
           <dl
             className="dl-horizontal"
           >
-            <div>
+            <div
+              className="bb-raw-data-key-value"
+            >
               <dt>
                 float
               </dt>
@@ -84,7 +94,9 @@ exports[`RawData component object with array of objects expanded 1`] = `
           <dl
             className="dl-horizontal"
           >
-            <div>
+            <div
+              className="bb-raw-data-key-value"
+            >
               <dt>
                 boolean
               </dt>
@@ -105,7 +117,9 @@ exports[`RawData component observable object 1`] = `
 <dl
   className="dl-horizontal"
 >
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       str
     </dt>
@@ -114,7 +128,9 @@ exports[`RawData component observable object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       int
     </dt>
@@ -123,7 +139,9 @@ exports[`RawData component observable object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       float
     </dt>
@@ -132,7 +150,9 @@ exports[`RawData component observable object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       boolean
     </dt>
@@ -141,7 +161,9 @@ exports[`RawData component observable object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       array
     </dt>
@@ -157,7 +179,9 @@ exports[`RawData component observable object with array of objects 1`] = `
 <dl
   className="dl-horizontal"
 >
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       array
     </dt>
@@ -178,7 +202,9 @@ exports[`RawData component simple object 1`] = `
 <dl
   className="dl-horizontal"
 >
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       str
     </dt>
@@ -187,7 +213,9 @@ exports[`RawData component simple object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       int
     </dt>
@@ -196,7 +224,9 @@ exports[`RawData component simple object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       float
     </dt>
@@ -205,7 +235,9 @@ exports[`RawData component simple object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       boolean
     </dt>
@@ -214,7 +246,9 @@ exports[`RawData component simple object 1`] = `
        
     </dd>
   </div>
-  <div>
+  <div
+    className="bb-raw-data-key-value"
+  >
     <dt>
       array
     </dt>

--- a/www/react-base/src/data/BasicDataMultiCollection.ts
+++ b/www/react-base/src/data/BasicDataMultiCollection.ts
@@ -106,7 +106,7 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
 
   close() : Promise<void> {
     this.disposer();
-    return Promise.all(Object.values(this.byParentId).map((collection => collection.close()))).then();
+    return Promise.all([...this.byParentId.values()].map((collection => collection.close()))).then();
   }
 
   @action addByParentId(id: string, collection: Collection) {

--- a/www/react-base/src/data/BasicDataMultiCollection.ts
+++ b/www/react-base/src/data/BasicDataMultiCollection.ts
@@ -26,12 +26,14 @@ import {
 } from "mobx";
 import DataCollection, {IDataCollection} from "./DataCollection";
 import {IReactionDisposer} from "mobx";
+import {IDataAccessor} from "./DataAccessor";
 
 /* This class wraps multiple DataCollections of the same thing.
  */
 export class BasicDataMultiCollection<ParentDataType extends BaseClass,
   Collection extends IDataCollection> implements IDataCollection {
 
+  accessor: IDataAccessor;
   parentArray: IObservableArray<ParentDataType> | null;
   parentArrayMap: ObservableMap<string, DataCollection<ParentDataType>> | null;
   parentFilteredIds: IObservableArray<string>;
@@ -41,12 +43,14 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
   callback: (child: ParentDataType) => Collection;
   private disposer: IReactionDisposer;
 
-  constructor(parentArray: IObservableArray<ParentDataType> | null,
+  constructor(accessor: IDataAccessor,
+              parentArray: IObservableArray<ParentDataType> | null,
               parentArrayMap: ObservableMap<string, DataCollection<ParentDataType>> | null,
               parentFilteredIds: IObservableArray<string> | null,
               callback: (child: ParentDataType) => Collection) {
     makeObservable(this);
 
+    this.accessor = accessor;
     this.parentArray = parentArray;
     this.parentArrayMap = parentArrayMap;
     this.parentFilteredIds = parentFilteredIds ?? observable([]);
@@ -96,6 +100,10 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
     } else {
       throw Error("Either parentArray or parentArrayMap must not be null");
     }
+  }
+
+  isExpired() {
+    return !this.accessor.isOpen();
   }
 
   subscribe() {

--- a/www/react-base/src/data/DataAccessor.ts
+++ b/www/react-base/src/data/DataAccessor.ts
@@ -26,6 +26,7 @@ import {CancellablePromise} from "../util/CancellablePromise";
 export interface IDataAccessor {
   registerCollection(c: IDataCollection): void;
   unregisterCollection(c: IDataCollection): void;
+  isOpen(): boolean;
   close(): void;
   get<DataType extends BaseClass>(endpoint: string, query: RequestQuery,
                                   descriptor: IDataDescriptor<DataType>): DataCollection<DataType>;
@@ -38,6 +39,7 @@ export interface IDataAccessor {
 export default class BaseDataAccessor implements IDataAccessor {
   private registeredCollections: IDataCollection[] = [];
   private client: DataClient;
+  private _isOpen: boolean = true;
 
   constructor(client: DataClient) {
     this.client = client;
@@ -54,7 +56,10 @@ export default class BaseDataAccessor implements IDataAccessor {
     }
   }
 
+  isOpen() { return this._isOpen; }
+
   close() {
+    this._isOpen = false;
     // We take a copy because collections will remove themselves from the
     // registeredCollections array
     for (const c of [...this.registeredCollections]) {
@@ -90,6 +95,7 @@ export class EmptyDataAccessor implements IDataAccessor {
   registerCollection(c: IDataCollection) {}
   unregisterCollection(c: IDataCollection) {}
 
+  isOpen() { return false; }
   close() {}
 
   get<DataType extends BaseClass>(endpoint: string, query: RequestQuery,

--- a/www/react-base/src/data/DataCollection.ts
+++ b/www/react-base/src/data/DataCollection.ts
@@ -27,6 +27,7 @@ import DataPropertiesCollection from "./DataPropertiesCollection";
 import DataMultiPropertiesCollection from "./DataMultiPropertiesCollection";
 
 export interface IDataCollection {
+  isExpired(): boolean;
   subscribe(): Promise<void>;
   initial(data: any[]): void;
   close(): Promise<void>;
@@ -62,6 +63,13 @@ export default class DataCollection<DataType extends BaseClass> implements IData
     }
   }
 
+  isExpired() {
+    if (this.accessor === undefined) {
+      return false;
+    }
+    return !this.accessor.isOpen();
+  }
+
   subscribe() {
     return this.webSocketClient.subscribe(this.socketPath, this);
   }
@@ -94,18 +102,20 @@ export default class DataCollection<DataType extends BaseClass> implements IData
 
   getRelated<ChildDataType extends BaseClass>(
       callback: (child: DataType) => DataCollection<ChildDataType>) {
-    return new DataMultiCollection<DataType, ChildDataType>(this.array, null, null, callback);
+    return new DataMultiCollection<DataType, ChildDataType>(this.accessor, this.array, null, null,
+      callback);
   }
 
   getRelatedProperties(callback: (child: DataType) => DataPropertiesCollection) {
-    return new DataMultiPropertiesCollection<DataType>(this.array, null, null, callback);
+    return new DataMultiPropertiesCollection<DataType>(this.accessor, this.array, null, null,
+      callback);
   }
 
   getRelatedOfFiltered<ChildDataType extends BaseClass>(
       filteredIds: IObservableArray<string>,
       callback: (child: DataType) => DataCollection<ChildDataType>) {
-    return new DataMultiCollection<DataType, ChildDataType>(this.array, null, filteredIds,
-      callback);
+    return new DataMultiCollection<DataType, ChildDataType>(this.accessor, this.array, null,
+      filteredIds, callback);
   }
 
   getNthOrNull(index: number): DataType | null {

--- a/www/react-base/src/data/DataMultiCollection.ts
+++ b/www/react-base/src/data/DataMultiCollection.ts
@@ -19,20 +19,23 @@ import BaseClass from "./classes/BaseClass";
 import {IObservableArray, ObservableMap} from "mobx";
 import DataCollection from "./DataCollection";
 import {BasicDataMultiCollection} from "./BasicDataMultiCollection";
+import {IDataAccessor} from "./DataAccessor";
 
 export default class DataMultiCollection<ParentDataType extends BaseClass,
     DataType extends BaseClass> extends BasicDataMultiCollection<ParentDataType, DataCollection<DataType>> {
 
-  constructor(parentArray: IObservableArray<ParentDataType> | null,
+  constructor(accessor: IDataAccessor,
+              parentArray: IObservableArray<ParentDataType> | null,
               parentArrayMap: ObservableMap<string, DataCollection<ParentDataType>> | null,
               parentFilteredIds: IObservableArray<string> | null,
               callback: (child: ParentDataType) => DataCollection<DataType>) {
-    super(parentArray, parentArrayMap, parentFilteredIds, callback);
+    super(accessor, parentArray, parentArrayMap, parentFilteredIds, callback);
   }
 
   getRelated<ChildDataType extends BaseClass>(
     callback: (child: DataType) => DataCollection<ChildDataType>) {
-    return new DataMultiCollection<DataType, ChildDataType>(null, this.byParentId, null, callback);
+    return new DataMultiCollection<DataType, ChildDataType>(this.accessor, null, this.byParentId,
+      null, callback);
   }
 
   // Acquires nth element across all collections tracked by this multi collection. The iteration

--- a/www/react-base/src/data/DataMultiPropertiesCollection.ts
+++ b/www/react-base/src/data/DataMultiPropertiesCollection.ts
@@ -17,6 +17,7 @@
 
 import BaseClass from "./classes/BaseClass";
 import {IObservableArray, ObservableMap} from "mobx";
+import {IDataAccessor} from "./DataAccessor";
 import DataCollection from "./DataCollection";
 import {BasicDataMultiCollection} from "./BasicDataMultiCollection";
 import DataPropertiesCollection from "./DataPropertiesCollection";
@@ -24,11 +25,12 @@ import DataPropertiesCollection from "./DataPropertiesCollection";
 export default class DataMultiPropertiesCollection<ParentDataType extends BaseClass>
   extends BasicDataMultiCollection<ParentDataType, DataPropertiesCollection> {
 
-  constructor(parentArray: IObservableArray<ParentDataType> | null,
+  constructor(accessor: IDataAccessor,
+              parentArray: IObservableArray<ParentDataType> | null,
               parentArrayMap: ObservableMap<string, DataCollection<ParentDataType>> | null,
               parentFilteredIds: IObservableArray<string> | null,
               callback: (child: ParentDataType) => DataPropertiesCollection) {
-    super(parentArray, parentArrayMap, parentFilteredIds, callback);
+    super(accessor, parentArray, parentArrayMap, parentFilteredIds, callback);
   }
 
   getParentCollectionOrEmpty(parentId: string): DataPropertiesCollection {

--- a/www/react-base/src/data/DataPropertiesCollection.ts
+++ b/www/react-base/src/data/DataPropertiesCollection.ts
@@ -61,6 +61,13 @@ export default class DataPropertiesCollection implements IDataCollection {
     }
   }
 
+  isExpired() {
+    if (this.accessor === undefined) {
+      return false;
+    }
+    return !this.accessor.isOpen();
+  }
+
   subscribe() {
     return this.webSocketClient.subscribe(this.socketPath, this);
   }

--- a/www/react-base/src/data/ReactUtils.ts
+++ b/www/react-base/src/data/ReactUtils.ts
@@ -24,12 +24,19 @@ import {IDataCollection} from "./DataCollection";
 export const DataClientContext =
   createContext(new DataClient(undefined as any, undefined as any));
 
-export function useDataAccessor() {
+export function useDataAccessor<T>(dependency: (T|null)[]) {
   const dataClient = useContext(DataClientContext);
 
+  const storedDependency = useRef<(T|null)[]>([]);
   const accessor= useRef<IDataAccessor|null>(null);
+
   if (accessor.current === null) {
     accessor.current = dataClient.open();
+    storedDependency.current = [...dependency];
+  } else if (!arrayElementsEqual(dependency, storedDependency.current)) {
+    accessor.current.close();
+    accessor.current = dataClient.open();
+    storedDependency.current = [...dependency];
   }
 
   useEffect(() => {
@@ -39,7 +46,7 @@ export function useDataAccessor() {
         accessor.current = null;
       }
     }
-  }, [accessor.current]);
+  }, []);
 
   return accessor.current;
 }

--- a/www/react-base/src/data/ReactUtils.ts
+++ b/www/react-base/src/data/ReactUtils.ts
@@ -44,9 +44,14 @@ export function useDataAccessor() {
   return accessor.current;
 }
 
-export function useDataApiQuery<Collection>(callback: () => Collection): Collection {
+export function useDataApiQuery<Collection extends IDataCollection>(
+    callback: () => Collection): Collection {
   let storedCollection = useRef<Collection|null>(null);
-  if (storedCollection.current === null) {
+  if (storedCollection.current === null ||
+      storedCollection.current.isExpired()) {
+    if (storedCollection.current !== null) {
+      storedCollection.current.close();
+    }
     storedCollection.current = callback();
   }
   return storedCollection.current;
@@ -69,7 +74,9 @@ export function useDataApiDynamicQuery<T, Collection extends IDataCollection>(
   const storedDependency = useRef<(T|null)[]>([]);
   let storedCollection = useRef<Collection|null>(null);
 
-  if (storedCollection.current === null || !arrayElementsEqual(dependency, storedDependency.current)) {
+  if (storedCollection.current === null ||
+      !arrayElementsEqual(dependency, storedDependency.current) ||
+      storedCollection.current.isExpired()) {
     if (storedCollection.current !== null) {
       storedCollection.current.close();
     }

--- a/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
+++ b/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
@@ -63,10 +63,11 @@ const buildTopbarActions = (builder: Builder | null,
 }
 
 const BuildRequestView = observer(() => {
-  const accessor = useDataAccessor();
   const buildRequestId = Number.parseInt(useParams<"buildrequestid">().buildrequestid ?? "");
   const [searchParams, setSearchParams] = useSearchParams();
   const redirectToBuild = searchParams.get("redirect_to_build") === "true";
+
+  const accessor = useDataAccessor([buildRequestId]);
 
   const navigate = useNavigate();
 

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -116,7 +116,7 @@ const BuildView = observer(() => {
   const navigate = useNavigate();
 
   const stores = useContext(StoresContext);
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([builderid, buildnumber]);
 
   const buildersQuery = useDataApiQuery(() => Builder.getAll(accessor, {id: builderid.toString()}));
   const builder = buildersQuery.getNthOrNull(0);

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -91,7 +91,7 @@ const BuilderView = observer(() => {
   const navigate = useNavigate();
 
   const stores = useContext(StoresContext);
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([builderid]);
 
   const numBuilds = 200;
 

--- a/www/react-base/src/views/BuildersView/BuildersView.tsx
+++ b/www/react-base/src/views/BuildersView/BuildersView.tsx
@@ -151,7 +151,7 @@ const toggleTag = (tags: string[], tag: string, searchParams: URLSearchParams,
 
 const BuildersView = observer(() => {
   const stores = useContext(StoresContext);
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const [searchParams, setSearchParams] = useSearchParams();
 

--- a/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
+++ b/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
@@ -32,7 +32,7 @@ import BuildsTable from "../../components/BuildsTable/BuildsTable";
 const ChangeBuildsView = observer(() => {
   const changeid = Number.parseInt(useParams<"changeid">().changeid ?? "");
 
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([changeid]);
   const buildsFetchLimit = globalSettings.getIntegerSetting('ChangeBuilds.buildsFetchLimit');
 
   const changeQuery = useDataApiQuery(() => Change.getAll(accessor, {id: changeid.toString()}));

--- a/www/react-base/src/views/ChangesView/ChangesView.tsx
+++ b/www/react-base/src/views/ChangesView/ChangesView.tsx
@@ -25,7 +25,7 @@ import ChangesTable from "../../components/ChangesTable/ChangesTable";
 
 
 const ChangesView = observer(() => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const changesFetchLimit = globalSettings.getIntegerSetting("Changes.changesFetchLimit");
   const changesQuery = useDataApiQuery(

--- a/www/react-base/src/views/HomeView/HomeView.tsx
+++ b/www/react-base/src/views/HomeView/HomeView.tsx
@@ -76,7 +76,7 @@ function computeBuildsByBuilder(builders: DataCollection<Builder>,
 
 const HomeView = observer(() => {
   const config = useContext(ConfigContext);
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const buildsRunning = useDataApiQuery(
     () => Build.getAll(accessor, {query: {order: '-started_at', complete: false}}));

--- a/www/react-base/src/views/LogView/LogView.tsx
+++ b/www/react-base/src/views/LogView/LogView.tsx
@@ -35,7 +35,7 @@ const LogView = observer(() => {
   const navigate = useNavigate();
 
   const stores = useContext(StoresContext);
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([builderid, buildnumber, stepnumber]);
 
   const buildersQuery = useDataApiQuery(() => Builder.getAll(accessor, {id: builderid.toString()}));
   const builder = buildersQuery.getNthOrNull(0);

--- a/www/react-base/src/views/MastersView/MastersView.tsx
+++ b/www/react-base/src/views/MastersView/MastersView.tsx
@@ -33,7 +33,7 @@ import BadgeRound from "../../components/BadgeRound/BadgeRound";
 
 const MastersView = observer(() => {
   const now = useCurrentTime();
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const workersQuery = useDataApiQuery(() => Worker.getAll(accessor));

--- a/www/react-base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
+++ b/www/react-base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
@@ -29,7 +29,7 @@ import BadgeRound from "../../components/BadgeRound/BadgeRound";
 
 const PendingBuildRequestsView = observer(() => {
   const now = useCurrentTime();
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const buildRequestFetchLimit = globalSettings.getIntegerSetting("BuildRequests.buildrequestFetchLimit");
   const buildRequestsQuery = useDataApiQuery(

--- a/www/react-base/src/views/SchedulersView/SchedulersView.tsx
+++ b/www/react-base/src/views/SchedulersView/SchedulersView.tsx
@@ -22,7 +22,7 @@ import {useDataAccessor, useDataApiQuery} from "../../data/ReactUtils";
 import {Scheduler} from "../../data/classes/Scheduler";
 
 const SchedulersView = observer(() => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const schedulersQuery = useDataApiQuery(
     () => Scheduler.getAll(accessor, {query: {order: "name"}}));

--- a/www/react-base/src/views/WorkerView/WorkerView.tsx
+++ b/www/react-base/src/views/WorkerView/WorkerView.tsx
@@ -27,8 +27,8 @@ import WorkersTable from "../../components/WorkersTable/WorkersTable";
 import BuildsTable from "../../components/BuildsTable/BuildsTable";
 
 const WorkerView = observer(() => {
-  const accessor = useDataAccessor();
   const workerid = Number.parseInt(useParams<"workerid">().workerid ?? "");
+  const accessor = useDataAccessor([workerid]);
 
   const workersQuery = useDataApiQuery(() => Worker.getAll(accessor, {id: workerid.toString()}));
   const buildersQuery = useDataApiQuery(() => Builder.getAll(accessor));

--- a/www/react-base/src/views/WorkersView/WorkersView.tsx
+++ b/www/react-base/src/views/WorkersView/WorkersView.tsx
@@ -62,7 +62,7 @@ const getBuildsForWorkerMap = (workersQuery: DataCollection<Worker>,
 }
 
 const WorkersView = observer(() => {
-  const accessor = useDataAccessor();
+  const accessor = useDataAccessor([]);
 
   const showOldWorkers = globalSettings.getBooleanSetting("Workers.show_old_workers");
 


### PR DESCRIPTION
React tries to not unmount-remount components when navigating across pages if possible. This causes stale data to be present when navigating e.g. from one build page to another because the data API queries don't know to reload. This PR implements an explicit query invalidation which addresses this issue.