### PR TITLE
www/react: Remove dependency on react-tabs

### DIFF
--- a/www/react-base/package.json
+++ b/www/react-base/package.json
@@ -72,7 +72,6 @@
     "react-dom": "^18.2.0",
     "react-refresh": "^0.8.3",
     "react-router-dom": "^6.3.0",
-    "react-tabs": "^5.1.0",
     "react-virtualized": "^9.22.3",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",

--- a/www/react-base/src/views/BuildView/BuildView.scss
+++ b/www/react-base/src/views/BuildView/BuildView.scss
@@ -14,6 +14,8 @@
   }
 }
 
-.bb-build-view-tabs {
-  width: 100%;
+.bb-build-view {
+  .tab-content {
+    width: 100%;
+  }
 }

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -46,7 +46,7 @@ import PropertiesTable from "../../components/PropertiesTable/PropertiesTable";
 import ChangesTable from "../../components/ChangesTable/ChangesTable";
 import BuildSummary from "../../components/BuildSummary/BuildSummary";
 import ChangeUserAvatar from "../../components/ChangeUserAvatar/ChangeUserAvatar";
-import {Tab, TabList, TabPanel, Tabs} from "react-tabs";
+import {Tab, Tabs} from "react-bootstrap";
 
 const buildTopbarActions = (build: Build | null, isRebuilding: boolean, isStopping: boolean,
                             doRebuild: () => void, doStop: () => void) => {
@@ -312,32 +312,24 @@ const BuildView = observer(() => {
   }
 
   return (
-    <div className="container">
+    <div className="container bb-build-view">
       <AlertNotification text={errorMsg}/>
       <nav>
         {build !== null ? renderPager(build) : <></>}
       </nav>
       <div className="row">
-        <Tabs className="bb-build-view-tabs">
-          <TabList>
-            <Tab>Build steps</Tab>
-            <Tab>Build Properties</Tab>
-            <Tab>{`Worker: ${workerName}`}</Tab>
-            <Tab>Responsible Users</Tab>
-            <Tab>Changes</Tab>
-            <Tab>Debug</Tab>
-          </TabList>
-          <TabPanel>
+        <Tabs>
+          <Tab eventKey="build-steps" title="Build steps">
             { build !== null
               ? <BuildSummary build={build} condensed={false} parentBuild={parentBuild}
                               parentRelationship={buildset === null ? null : buildset.parent_relationship}/>
               : <></>
             }
-          </TabPanel>
-          <TabPanel>
+          </Tab>
+          <Tab eventKey="properties" title="Build Properties">
             <PropertiesTable properties={propertiesQuery.properties}/>
-          </TabPanel>
-          <TabPanel>
+          </Tab>
+          <Tab eventKey="worker" title={`Worker: ${workerName}`}>
             <table className="table table-hover table-striped table-condensed">
               <tbody>
                 <tr>
@@ -347,21 +339,21 @@ const BuildView = observer(() => {
                 {renderWorkerInfo()}
               </tbody>
             </table>
-          </TabPanel>
-          <TabPanel>
+          </Tab>
+          <Tab eventKey="responsible" title="Responsible Users">
             <ul className="list-group">
               {renderResponsibleUsers()}
             </ul>
-          </TabPanel>
-          <TabPanel>
+          </Tab>
+          <Tab eventKey="changes" title="Changes">
             {build !== null
               ? <ChangesTable changes={changesQuery.getParentCollectionOrEmpty(build.id)}/>
               : <></>
             }
-          </TabPanel>
-          <TabPanel>
+          </Tab>
+          <Tab eventKey="debug" title="Debug">
             {renderDebugInfo()}
-          </TabPanel>
+          </Tab>
         </Tabs>
       </div>
     </div>

--- a/www/react-base/yarn.lock
+++ b/www/react-base/yarn.lock
@@ -3468,7 +3468,7 @@ clone@^2.1.1:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
-clsx@^1.0.4, clsx@^1.1.0:
+clsx@^1.0.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -9237,7 +9237,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9545,14 +9545,6 @@ react-shallow-renderer@^16.15.0:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
-
-react-tabs@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-5.1.0.tgz#5ef8fad015c71c23b0fff65bd9b3bd419219c27b"
-  integrity sha512-jsPVEPuhG7JljTo8Q4ujz4UKRpG90nHlDClAdvV5KrLxCHU+MT/kg7dmhq8fDv8+frciDtaYeFFlTVRLm4N5AQ==
-  dependencies:
-    clsx "^1.1.0"
-    prop-types "^15.5.0"
 
 react-test-renderer@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
React-tabs were used only as an interim solution before Bootstrap was upgraded to 4.x.