### PR TITLE
bbtravis: Add Python 3.10 and Python 3.11 to the test matrix

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -36,6 +36,8 @@ matrix:
     - env: PYTHON=3.9 TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.10 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.11 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
 
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=dev_virtualenv
 


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/6693.