### PR TITLE
Add tls config option to LdapUserInfo

### DIFF
--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -53,7 +53,8 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
                  groupName=None,
                  avatarPattern=None,
                  avatarData=None,
-                 accountExtraFields=None):
+                 accountExtraFields=None,
+                 tls=None):
         # Throw import error now that this is being used
         if not ldap3:
             importlib.import_module('ldap3')
@@ -81,13 +82,14 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
             accountExtraFields = []
         self.accountExtraFields = accountExtraFields
         self.ldap_encoding = ldap3.get_config_parameter('DEFAULT_SERVER_ENCODING')
+        self.tls = tls
 
     def connectLdap(self):
         server = urlparse(self.uri)
         netloc = server.netloc.split(":")
         # define the server and the connection
         s = ldap3.Server(netloc[0], port=int(netloc[1]), use_ssl=server.scheme == 'ldaps',
-                         get_info=ldap3.ALL)
+                         get_info=ldap3.ALL, tls=self.tls)
 
         auth = ldap3.SIMPLE
         if self.bindUser is None and self.bindPw is None:

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -691,7 +691,7 @@ In this case the username provided by oauth2 will be used, and all other informa
 
 Currently only one provider is available:
 
-.. py:class:: buildbot.ldapuserinfo.LdapUserInfo(uri, bindUser, bindPw, accountBase, accountPattern, groupBase=None, groupMemberPattern=None, groupName=None, accountFullName, accountEmail, avatarPattern=None, avatarData=None, accountExtraFields=None)
+.. py:class:: buildbot.ldapuserinfo.LdapUserInfo(uri, bindUser, bindPw, accountBase, accountPattern, groupBase=None, groupMemberPattern=None, groupName=None, accountFullName, accountEmail, avatarPattern=None, avatarData=None, accountExtraFields=None, tls=None)
 
         :param uri: uri of the ldap server
         :param bindUser: username of the ldap account that is used to get the infos for other users (usually a "faceless" account)
@@ -710,6 +710,7 @@ Currently only one provider is available:
         :param avatarData: the name of the field in groups ldap database where the avatar picture is to be found.
                            This field is supposed to contain the raw picture, format is automatically detected from jpeg, png or git.
         :param accountExtraFields: extra fields to extracts for use with the authorization policies
+        :param tls: an instance of ``ldap.Tls`` that specifies TLS settings.
 
         If one of the three optional groups parameters is supplied, then all of them become mandatory. If none is supplied, the retrieved user info has an empty list of groups.
 

--- a/newsfragments/ldab3-tls.feature
+++ b/newsfragments/ldab3-tls.feature
@@ -1,0 +1,1 @@
+Implemented a way to customize TLS setting for ``LdapUserInfo``.


### PR DESCRIPTION
Python 3.10 by default disables ciphers that some servers still use and require of their clients. By exposing ldap3's TLS option these ciphers can be enabled for the LDAP connection.

This PR upstreams code by @jangmarker.
