### PR TITLE
Let logwatcher follow file names (not descriptors)

### DIFF
--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -113,7 +113,7 @@ class LogWatcher(LineOnlyLongLineReceiver):
         else:
             tailBin = "/usr/bin/tail"
 
-        args = ("tail", "-f", "-n", "0", self.logfile)
+        args = ("tail", "-F", "-n", "0", self.logfile)
         self.p = self._reactor.spawnProcess(self.pp, tailBin, args,
                                             env=os.environ)
         self.running = True

--- a/newsfragments/logwatcher-follow-files.bugfix
+++ b/newsfragments/logwatcher-follow-files.bugfix
@@ -1,0 +1,2 @@
+Improved reliability of Buildbot log watching to follow log files even after rotation.
+This improves reliability of Buildbot start and restart scripts.


### PR DESCRIPTION
The logwatcher is used to figure out whether reconfiguration has finished. But with the `-f` option for tail it follows file descriptors, so if the log file is being rotated the watcher is not seeing the changes. Let tail follow by file name instead `-F`.

This PR upstreams code by @jangmarker.