### PR TITLE
worker: Add check_instance() API for latent workers

### DIFF
--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -56,6 +56,7 @@ class LatentController(SeverWorkerConnectionMixin):
                  starts_without_substantiate=None, **kwargs):
         self.case = case
         self.build_wait_timeout = build_wait_timeout
+        self.has_crashed = False
         self.worker = ControllableLatentWorker(name, self, **kwargs)
         self.remote_worker = None
 
@@ -226,3 +227,6 @@ class ControllableLatentWorker(AbstractLatentWorker):
             return True
         self._controller._stop_deferred = defer.Deferred()
         return (yield self._controller._stop_deferred)
+
+    def check_instance(self):
+        return not self._controller.has_crashed

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -163,16 +163,20 @@ class AbstractLatentWorker(AbstractWorker):
         self._substantiation_notifier = Notifier()
         self._start_stop_lock = defer.DeferredLock()
         self._deferwaiter = deferwaiter.DeferWaiter()
+        self._check_instance_timer = None
 
     def checkConfig(self, name, password,
                     build_wait_timeout=60 * 10,
+                    check_instance_interval=10,
                     **kwargs):
         super().checkConfig(name, password, **kwargs)
 
     def reconfigService(self, name, password,
                         build_wait_timeout=60 * 10,
+                        check_instance_interval=10,
                         **kwargs):
         self.build_wait_timeout = build_wait_timeout
+        self.check_instance_interval = check_instance_interval
         return super().reconfigService(name, password, **kwargs)
 
     def _generate_random_password(self):
@@ -223,6 +227,9 @@ class AbstractLatentWorker(AbstractWorker):
     def stop_instance(self, fast=False):
         # responsible for shutting down instance.
         raise NotImplementedError
+
+    def check_instance(self):
+        return True
 
     @property
     def substantiated(self):
@@ -302,6 +309,8 @@ class AbstractLatentWorker(AbstractWorker):
                 log.msg(f"Worker {self.name} substantiated (already attached)")
                 self.state = States.SUBSTANTIATED
                 self._fireSubstantiationNotifier(True)
+            else:
+                self._start_check_instance_timer()
 
         except Exception as e:
             self.stopMissingTimer()
@@ -320,6 +329,8 @@ class AbstractLatentWorker(AbstractWorker):
 
     @defer.inlineCallbacks
     def attached(self, conn):
+        self._stop_check_instance_timer()
+
         if self.state != States.SUBSTANTIATING_STARTING and \
                 self.build_wait_timeout >= 0:
             msg = (f'Worker {self.name} received connection while not trying to substantiate.'
@@ -420,6 +431,51 @@ class AbstractLatentWorker(AbstractWorker):
         self.build_wait_timer = self.master.reactor.callLater(
             self.build_wait_timeout, self._soft_disconnect)
 
+    def _stop_check_instance_timer(self):
+        if self._check_instance_timer is not None:
+            if self._check_instance_timer.active():
+                self._check_instance_timer.cancel()
+            self._check_instance_timer = None
+
+    def _start_check_instance_timer(self):
+        self._stop_check_instance_timer()
+        self._check_instance_timer = self.master.reactor.callLater(
+            self.check_instance_interval, self._check_instance_timer_fired
+        )
+
+    def _check_instance_timer_fired(self):
+        self._deferwaiter.add(self._check_instance_timer_fired_impl())
+
+    @defer.inlineCallbacks
+    def _check_instance_timer_fired_impl(self):
+        self._check_instance_timer = None
+        if self.state != States.SUBSTANTIATING_STARTING:
+            # The only case when we want to recheck whether the instance has not failed is
+            # between call to start_instance() and successful attachment of the worker.
+            return
+
+        if self._start_stop_lock.locked:  # pragma: no cover
+            # This can't actually happen, because we start the timer for instance checking after
+            # start_instance() completed and in insubstantiation the state is changed from
+            # SUBSTANTIATING_STARTING as soon as the lock is acquired.
+            return
+
+        try:
+            yield self._start_stop_lock.acquire()
+            is_good = yield self.check_instance()
+            if not is_good:
+                yield self._substantiation_failed(
+                    LatentWorkerFailedToSubstantiate(
+                        self.name, 'latent worker crashed before connecting'
+                    )
+                )
+                return
+        finally:
+            self._start_stop_lock.release()
+
+        # if check passes, schedule another one until worker connects
+        self._start_check_instance_timer()
+
     @defer.inlineCallbacks
     def insubstantiate(self, fast=False, force_substantiation_build=None):
         # If force_substantiation_build is not None, we'll try to substantiate the given build
@@ -459,6 +515,7 @@ class AbstractLatentWorker(AbstractWorker):
                     failure.Failure(LatentWorkerSubstantiatiationCancelled()))
 
             self._clearBuildWaitTimer()
+            self._stop_check_instance_timer()
 
             if prev_state in [States.SUBSTANTIATING_STARTING, States.SUBSTANTIATED]:
                 try:
@@ -533,6 +590,7 @@ class AbstractLatentWorker(AbstractWorker):
             self.state = States.SHUT_DOWN
 
         self._clearBuildWaitTimer()
+        self._stop_check_instance_timer()
         res = yield super().stopService()
         return res
 

--- a/master/docs/manual/configuration/workers.rst
+++ b/master/docs/manual/configuration/workers.rst
@@ -249,6 +249,12 @@ The following options are available for all latent workers.
     If this is set to 0, then the worker will be shut down immediately.
     If it is less than 0, it will be shut down only when shutting down master.
 
+``check_instance_interval``
+    This option controls the interval that the health checks run during worker startup.
+    The health checks speed up the detection of irrecoverably crashed worker (e.g. due to an issue with Docker image in the case of Docker workers).
+    Without such checks build would continue waiting for the worker to connect until ``missing_timeout`` time elapses.
+    The value of the option defaults to 10 seconds.
+
 .. _Supported-Latent-Workers:
 
 Supported Latent Workers

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -638,6 +638,13 @@ Overriding these members ensures that builds aren't ran on incompatible workers 
         The method may be called when the instance is not yet started and should indicate compatible build in that case.
         In the default implementation the callback returns ``True``.
 
+    .. py:method:: check_instance(self)
+
+        This method determines the health of an instance.
+        The method should return ``False`` if it determines that a serious error has occurred and worker will not connect to the master.
+        Otherwise, the method should return ``True``.
+
+
 Custom Build Classes
 --------------------
 

--- a/newsfragments/latent-worker-check-instance.feature
+++ b/newsfragments/latent-worker-check-instance.feature
@@ -1,0 +1,1 @@
+Added health check API that latent workers can use to specify that a particular worker will not connect and build should not wait for it and mark itself as failure immediately.


### PR DESCRIPTION
This allows builds to detect when the worker a build waits for won't connect due to some unrecoverable failure. The builds then can mark themselves as failure instead of waiting until missing_timeout elapses.
