### PR TITLE
steps: Initialize error counts earlier in PyLint step

### DIFF
--- a/newsfragments/pylint-crash-no-logs.bugfix
+++ b/newsfragments/pylint-crash-no-logs.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition in PyLint step that may lead to step throwing exceptions.


### PR DESCRIPTION
This fixes a race condition that may result in crashes.