### PR TITLE
Remove python 2.6 workarounds

### DIFF
--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -287,10 +287,7 @@ class CaptureBuildDuration(CaptureBuildTimes):
                 duration = datetime.timedelta(0)
             else:
                 duration = end_time - start_time
-            # cannot use duration.total_seconds() on Python 2.6
-            duration = ((duration.microseconds + (duration.seconds +
-                                                  duration.days * 24 * 3600) * 1e6) / 1e6)
-            return duration / divisor
+            return duration.total_seconds() / divisor
 
         if not callback:
             callback = default_callback

--- a/master/buildbot/test/integration/test_notifier.py
+++ b/master/buildbot/test/integration/test_notifier.py
@@ -82,7 +82,9 @@ class NotifierMaster(RunMasterBase):
         })
 
     def assertEncodedIn(self, text, mail):
-        # python 2.6 default transfer in base64 for utf-8
+        # The default transfer encoding is base64 for utf-8 even when it could be represented
+        # accurately by quoted 7bit encoding. TODO: it is possible to override it,
+        # see https://bugs.python.org/issue12552
         if "base64" not in mail:
             self.assertIn(text, mail)
         else:  # b64encode and remove '=' padding (hence [:-1])

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -167,7 +167,9 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
 
         try:
             s = m.as_string()
-            # python 2.6 default transfer in base64 for utf-8
+            # The default transfer encoding is base64 for utf-8 even when it could be represented
+            # accurately by quoted 7bit encoding. TODO: it is possible to override it,
+            # see https://bugs.python.org/issue12552
             if "base64" not in s:
                 self.assertIn("Unicode log", s)
             else:  # b64encode and remove '=' padding (hence [:-1])

--- a/worker/buildbot_worker/monkeypatches/testcase_assert.py
+++ b/worker/buildbot_worker/monkeypatches/testcase_assert.py
@@ -15,44 +15,12 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import string_types
 
-import re
 import unittest
 
 
-def _assertRaisesRegexp(self, expected_exception, expected_regexp,
-                        callable_obj, *args, **kwds):
-    """
-    Asserts that the message in a raised exception matches a regexp.
-
-    This is a simple clone of unittest.TestCase.assertRaisesRegexp() method
-    introduced in python 2.7. The goal for this function is to behave exactly
-    as assertRaisesRegexp() in standard library.
-    """
-    exception = None
-    try:
-        callable_obj(*args, **kwds)
-    except expected_exception as ex:  # let unexpected exceptions pass through
-        exception = ex
-
-    if exception is None:
-        self.fail("{0} not raised".format(str(expected_exception.__name__)))
-
-    if isinstance(expected_regexp, string_types):
-        expected_regexp = re.compile(expected_regexp)
-
-    if not expected_regexp.search(str(exception)):
-        self.fail('"{0}" does not match "{1}"'.format(
-                  expected_regexp.pattern, str(exception)))
-
-
 def patch():
-    hasAssertRaisesRegexp = getattr(unittest.TestCase, "assertRaisesRegexp", None)
     hasAssertRaisesRegex = getattr(unittest.TestCase, "assertRaisesRegex", None)
-    if not hasAssertRaisesRegexp:
-        # Python 2.6
-        unittest.TestCase.assertRaisesRegexp = _assertRaisesRegexp
     if not hasAssertRaisesRegex:
         # Python 2.6 and Python 2.7
         unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp


### PR DESCRIPTION
The codebase still contained code specific to Python 2.6 which is no longer supported.