### PR TITLE
libvirt: specify backing_fmt for qemu-img

### DIFF
--- a/master/buildbot/test/unit/worker/test_libvirt.py
+++ b/master/buildbot/test/unit/worker/test_libvirt.py
@@ -130,7 +130,8 @@ class TestLibVirtWorker(TestReactorMixin, MasterRunProcessMixin, unittest.TestCa
     @defer.inlineCallbacks
     def test_prepare_base_image_cheap(self):
         self.expect_commands(
-            ExpectMasterShell(["qemu-img", "create", "-b", "o", "-f", "qcow2", "p"])
+            ExpectMasterShell(["qemu-img", "create", "-o", "backing_fmt=qcow2",
+                               "-b", "o", "-f", "qcow2", "p"])
         )
 
         bs = self.create_worker('bot', 'pass', hd_image='p', base_image='o')

--- a/master/buildbot/worker/libvirt.py
+++ b/master/buildbot/worker/libvirt.py
@@ -184,7 +184,10 @@ class LibVirtWorker(AbstractLatentWorker):
             return
 
         if self.cheap_copy:
-            clone_cmd = ['qemu-img', 'create', '-b', self.base_image, '-f', 'qcow2', self.image]
+            clone_cmd = ['qemu-img', 'create',
+                         '-o', 'backing_fmt=qcow2',
+                         '-b', self.base_image,
+                         '-f', 'qcow2', self.image]
         else:
             clone_cmd = ['cp', self.base_image, self.image]
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -671,6 +671,7 @@ pythonic
 Pythonic
 pywin
 qcow
+qemu
 qmail
 queried
 queuedir

--- a/newsfragments/qemu-img-compat.bugfix
+++ b/newsfragments/qemu-img-compat.bugfix
@@ -1,0 +1,1 @@
+Fix compatibility with qemu 6.1 and newer when using LibVirtWorker with ``cheap_copy=True`` (default).


### PR DESCRIPTION
When cheap_copy is True (default) in LibVirtWorker, clone_cmd doesn't specify the backing file format (backing_fmt).  qemu >= 6.1 requires that it's explicitly specified for several commands, including qemu-img.

Even though on more recent versions it allows the shorthand '-F' to be used, use the generic '-o' option to set it for backwards compatibility (backing_fmt option existed prior to v6.1).

Adapt unit test for this change.

I couldn't test how much backwards '-o backing_fmt' is supported, but on the oldest VM I have (SLES12-SP5) it has qemu 3.1.1 and that option is there.

References:
https://www.qemu.org/docs/master/about/removed-features.html#qemu-img-backing-file-without-format-removed-in-6-1

https://github.com/qemu/qemu/commit/1899bf47375ad40555dcdff12ba49b4b8b82df38