### PR TITLE
Github hook: Include "previous filename" key in list of files

### DIFF
--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -451,7 +451,8 @@ gitJsonPayloadCommit = {
 
 gitJsonPayloadFiles = [
     {
-        "filename": "README.md"
+        "filename": "README.md",
+        "previous_filename": "old_README.md"
     }
 ]
 
@@ -1182,7 +1183,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
                          "This is a pretty simple change that we need to pull into master.")
         self.assertEqual(change["branch"], "refs/pull/50/merge")
         if valid_token:
-            self.assertEqual(change['files'], ['README.md'])
+            self.assertEqual(change['files'], ['README.md', 'old_README.md'])
         else:
             self.assertEqual(change['files'], [])
         self.assertEqual(change["revlink"],

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -276,7 +276,15 @@ class GitHubEventHandler(PullRequestMixin):
         res = yield http.get(url)
         if 200 <= res.code < 300:
             data = yield res.json()
-            return [f["filename"] for f in data]
+            filenames = []
+            for f in data:
+                filenames.append(f["filename"])
+                # If a file was moved this tell us where it was moved from.
+                previous_filename = f.get("previous_filename")
+                if previous_filename is not None:
+                    filenames.append(previous_filename)
+
+            return filenames
 
         log.msg(f'Failed fetching PR files: response code {res.code}')
         return []

--- a/newsfragments/github-moved-files.bugfix
+++ b/newsfragments/github-moved-files.bugfix
@@ -1,0 +1,3 @@
+Buildbot will now include the previous location of moved files when evaluating a Github commit.
+This fixes an issue where a commit that moves a file out of a folder, would not be shown in the
+web UI for a builder that is tracking that same folder.


### PR DESCRIPTION
Over in LLVM we have a builder that only looks at the llvm/ subfolder of the repo. The change https://github.com/llvm/llvm-project/commit/efae3174f09560353fb0f3d528bcbffe060d5438 moved a file out of that folder, which broke the build.

However because buildbot only collects the "filename" key, it did not think this was a commit the builder cared about so in the UI the commit was filtered out.

Github provides a "previous_filename" key so you can detect moved files, for the change above you would get:
```
{
  "filename": "cmake/Modules/LLVMCheckLinkerFlag.cmake",
   <...>
  "previous_filename": "llvm/cmake/modules/LLVMCheckLinkerFlag.cmake"
},
```

We should include the previous name also, since moving a file can break a build just as well as deleting or changing one.

You might wonder if including moved file names is a good idea since they don't exist anymore. We do the same thing with deleted files already. Since those only have a "filename" key:
```
    {
      "sha": "f61ec0585f9a45a1ee8a0e850a2388d3c67bd856",
      "filename": "cmake/Modules/LLVMCheckCompilerLinkerFlag.cmake",
      "status": "removed",
```

And as far as I can tell this list is for file changes of all kinds a builder might care about. Not "here are the files that now exist".
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation