### PR TITLE
www/react: Use react-icons

### DIFF
--- a/www/react-base/package.json
+++ b/www/react-base/package.json
@@ -72,6 +72,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dev-utils": "^11.0.3",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.8.0",
     "react-refresh": "^0.8.3",
     "react-router-dom": "^6.3.0",
     "react-virtualized-auto-sizer": "^1.0.7",

--- a/www/react-base/package.json
+++ b/www/react-base/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-testing-library": "^3.9.2",
     "eslint-webpack-plugin": "^2.5.2",
     "file-loader": "6.1.1",
-    "font-awesome": "^4.7.0",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "4.5.0",
     "identity-obj-proxy": "3.0.0",

--- a/www/react-base/src/components/ArrowExpander/ArrowExpander.tsx
+++ b/www/react-base/src/components/ArrowExpander/ArrowExpander.tsx
@@ -15,6 +15,8 @@
   Copyright Buildbot Team Members
 */
 
+import {FaChevronCircleRight, FaChevronCircleDown} from "react-icons/fa";
+
 type ArrowExpanderProps = {
   isExpanded: boolean;
   setIsExpanded?: (expanded: boolean) => void;
@@ -23,11 +25,9 @@ type ArrowExpanderProps = {
 const ArrowExpander = ({isExpanded, setIsExpanded}: ArrowExpanderProps) => {
   const callback = setIsExpanded === undefined ? undefined : () => setIsExpanded(!isExpanded);
 
-  return (
-    <i onClick={callback}
-       className={"fa fa-chevron-circle-right rotate clickable" + (isExpanded ? " fa-rotate-90" : "")}>
-    </i>
-  );
+  return isExpanded
+    ? <FaChevronCircleDown onClick={callback} className={"rotate clickable"}/>
+    : <FaChevronCircleRight onClick={callback} className={"rotate clickable"}/>;
 }
 
 export default ArrowExpander;

--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -16,9 +16,10 @@
 */
 
 import './BuildSummary.scss';
-import {observer} from "mobx-react";
-import {results2class, results2text, SUCCESS} from "../../util/Results";
 import {useContext, useState} from "react";
+import {observer} from "mobx-react";
+import {FaExpand} from "react-icons/fa";
+import {results2class, results2text, SUCCESS} from "../../util/Results";
 import {ConfigContext} from "../../contexts/Config";
 import {useDataAccessor, useDataApiDynamicQuery, useDataApiQuery} from "../../data/ReactUtils";
 import {analyzeStepUrls, useStepUrlAnalyzer} from "../../util/StepUrls";
@@ -271,7 +272,7 @@ const BuildSummary = observer(({build, parentBuild, parentRelationship,
         </div>
         <div onClick={toggleDetails} title="Show steps according to their importance"
              className="btn btn-xs btn-default">
-          <i className="fa fa-expand"></i>
+          <FaExpand/>
           {detailLevelToString(detailLevel)}
         </div>
         { builder !== null

--- a/www/react-base/src/components/BuildSummaryTooltip/BuildSummaryTooltip.scss
+++ b/www/react-base/src/components/BuildSummaryTooltip/BuildSummaryTooltip.scss
@@ -1,0 +1,6 @@
+
+.bb-buildsummary-tooltip-collapsed-entries {
+  font-size: 1.333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}

--- a/www/react-base/src/components/BuildSummaryTooltip/BuildSummaryTooltip.tsx
+++ b/www/react-base/src/components/BuildSummaryTooltip/BuildSummaryTooltip.tsx
@@ -110,7 +110,7 @@ const BuildSummaryTooltip = observer(({build}: BuildSummaryTooltipProps) => {
         return (
           <li key={index} className="list-group-item">
             <div className="text-left">
-              <span className="fa-lg">⋮</span>
+              <span className="bb-buildsummary-tooltip-collapsed-entries">⋮</span>
             </div>
           </li>
         )

--- a/www/react-base/src/components/ChangesTable/ChangesTable.tsx
+++ b/www/react-base/src/components/ChangesTable/ChangesTable.tsx
@@ -16,6 +16,7 @@
 */
 
 import {action, makeObservable, observable} from "mobx";
+import {FaMinus, FaPlus} from "react-icons/fa";
 import {Link} from "react-router-dom";
 import DataCollection from "../../data/DataCollection";
 import {Change} from "../../data/classes/Change";
@@ -72,11 +73,11 @@ const ChangesTable = observer(({changes}: ChangesTableProps) => {
             <div className="form-group">
               <div onClick={() => tableState.setShowDetailsAll(false)} title="Collapse all"
                    className="btn btn-default">
-                <i className="fa fa-minus"></i>
+                <FaMinus/>
               </div>
               <div onClick={() => tableState.setShowDetailsAll(true)} title="Expand all"
                    className="btn btn-default">
-                <i className="fa fa-plus"></i>
+                <FaPlus/>
               </div>
             </div>
           </div>

--- a/www/react-base/src/components/LogDownloadButton/LogDownloadButton.tsx
+++ b/www/react-base/src/components/LogDownloadButton/LogDownloadButton.tsx
@@ -17,6 +17,7 @@
 
 import './LogDownloadButton.scss';
 import {useContext} from "react";
+import {FaDownload} from "react-icons/fa";
 import {Log} from "../../data/classes/Log";
 import {DataClientContext} from "../../data/ReactUtils";
 
@@ -31,7 +32,7 @@ const LogDownloadButton = ({log}: LogDownloadButtonProps) => {
   return (
     <a href={`${apiRootUrl}/logs/${log.id}/raw`} title="download log"
        className="btn btn-default btn-xs bb-log-download-button">
-      <i className="fa fa-download"></i>&nbsp;
+      <FaDownload/>&nbsp;
       Download
     </a>
   );

--- a/www/react-base/src/components/LogSearchField/LogSearchField.tsx
+++ b/www/react-base/src/components/LogSearchField/LogSearchField.tsx
@@ -17,6 +17,7 @@
 
 import './LogSearchField.scss'
 import {useState} from "react";
+import {FaChevronDown, FaChevronUp, FaSearch} from "react-icons/fa";
 
 export type LogSearchButtonProps = {
   currentResult: number;
@@ -40,17 +41,17 @@ const LogSearchField = ({currentResult, totalResults,
     <div className="bb-log-search-field-nav">
       <span className="bb-log-search-field-result-count">{currentResult}/{totalResults}</span>
       <button className="bb-log-search-field-nav-button" onClick={onPrevClicked}>
-        <i className="fa fa-chevron-up"/>
+        <FaChevronUp/>
       </button>
       <button className="bb-log-search-field-nav-button" onClick={onNextClicked}>
-        <i className="fa fa-chevron-down"/>
+        <FaChevronDown/>
       </button>
     </div>
   );
 
   return (
     <form role="search" className="bb-log-search-field">
-      <i className="fa fa-search bb-log-search-field-icon"></i>
+      <FaSearch className="bb-log-search-field-icon"/>
       <input className="bb-log-search-field-text" type="text" value={searchText}
              onFocus={() => setHasFocus(true)} onBlur={() => setHasFocus(false)}
              onChange={e => onSearchTextChanged(e.target.value)}

--- a/www/react-base/src/components/Loginbar/Loginbar.tsx
+++ b/www/react-base/src/components/Loginbar/Loginbar.tsx
@@ -17,9 +17,28 @@
 
 import './Loginbar.scss';
 import {useContext} from "react";
+import {
+  FaCogs, FaSignInAlt, FaSignOutAlt, FaUser,
+  FaGithub, FaGitlab, FaBitbucket, FaGoogle, FaFacebook, FaLinkedin, FaMicrosoft
+} from "react-icons/fa";
 import {ConfigContext} from "../../contexts/Config";
 import {useLocation} from "react-router-dom";
 import {Nav, NavDropdown} from "react-bootstrap";
+
+function getAuthIcon(faIcon: string) {
+  switch (faIcon) {
+    case "fa-github": return <FaGithub/>;
+    case "fa-gitlab": return <FaGitlab/>;
+    case "fa-bitbucket": return <FaBitbucket/>;
+    case "fa-google": return <FaGoogle/>;
+    case "fa-facebook": return <FaFacebook/>;
+    case "fa-linkedin": return <FaLinkedin/>;
+    case "fa-microsoft": return <FaMicrosoft/>;
+    case "": return <></>;
+    default:
+      return <FaCogs/>;
+  }
+}
 
 const Loginbar = () => {
   const config = useContext(ConfigContext);
@@ -42,9 +61,9 @@ const Loginbar = () => {
               {
                 config.auth.oauth2
                   ? <span>
-                      <i className={"fa " + config.auth.fa_icon}></i>&nbsp;Login with {config.auth.name}
+                      {getAuthIcon(config.auth.fa_icon)}&nbsp;Login with {config.auth.name}
                     </span>
-                  : <span><i className="fa fa-sign-in"></i>&nbsp;Login</span>
+                  : <span><FaSignInAlt/>&nbsp;Login</span>
               }
             </a>
           </NavDropdown.Item>
@@ -62,7 +81,7 @@ const Loginbar = () => {
   const userDropdownHeader = (user.full_name || user.email)
     ? <>
         <NavDropdown.Header>
-          <i className="fa fa-user"/>
+          <FaUser/>
           <span>{config.user.full_name ?? ""} {config.user.email ?? ""}</span>
         </NavDropdown.Header>
         <NavDropdown.Divider/>
@@ -75,7 +94,7 @@ const Loginbar = () => {
         {userDropdownHeader}
         <NavDropdown.Item>
           <a href={"auth/logout?redirect=" + encodeURI(redirect)}>
-            <i className="fa fa-sign-out"></i>
+            <FaSignOutAlt/>
             Logout
           </a>
         </NavDropdown.Item>

--- a/www/react-base/src/components/PageWithSidebar/PageWithSidebar.scss
+++ b/www/react-base/src/components/PageWithSidebar/PageWithSidebar.scss
@@ -2,7 +2,7 @@
 $gl-sidebar-transition-time: 0.2s;
 $gl-sidebar-small-threshold: 600px;
 $gl-sidebar-width: 600px;
-.fa-45{
+.bb-rotate-45{
   transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
 }
@@ -142,12 +142,13 @@ $gl-sidebar-width: 600px;
       li.sidebar-list {
         height: 40px;
         a, button {
+          padding: 0;
           text-indent: 25px;
           font-size: 15px;
           color: #b2bfdc;
           line-height: 40px;
-          .fa {
-            margin-left: -34px;
+          >svg {
+            margin-left: -1em;
           }
         }
         a:hover,

--- a/www/react-base/src/components/PageWithSidebar/PageWithSidebar.tsx
+++ b/www/react-base/src/components/PageWithSidebar/PageWithSidebar.tsx
@@ -17,6 +17,7 @@
 
 import './PageWithSidebar.scss';
 import {observer} from "mobx-react";
+import {FaAngleRight, FaBars, FaThumbtack} from "react-icons/fa";
 import {GlobalMenuSettings} from "../../plugins/GlobalMenuSettings";
 import SidebarStore from "../../stores/SidebarStore";
 import {Link} from "react-router-dom";
@@ -37,12 +38,12 @@ const PageWithSidebar = observer(({menuSettings, sidebarStore, children}: PageWi
   let sidebarIcon: JSX.Element;
   if (sidebarStore.active) {
     sidebarIcon = (
-      <span onClick={() => sidebarStore.togglePinned()}
-            className={"menu-icon fa fa-thumb-tack" + (sidebarStore.pinned ? "" : " fa-45")}/>
+      <FaThumbtack onClick={() => sidebarStore.togglePinned()}
+                   className={"menu-icon" + (sidebarStore.pinned ? "" : " bb-rotate-45")}/>
     );
   } else {
     sidebarIcon = (
-      <span onClick={() => sidebarStore.show()} className="menu-icon fa fa-bars"/>
+      <FaBars onClick={() => sidebarStore.show()} className="menu-icon"/>
     );
   }
 
@@ -65,8 +66,8 @@ const PageWithSidebar = observer(({menuSettings, sidebarStore, children}: PageWi
       return [
         <li key={`group-${group.name}`} className="sidebar-list">
           <button onClick={() => {sidebarStore.toggleGroup(group.name); }}>
-            <i className="fa fa-angle-right"></i>&nbsp;{group.caption}
-            <span className={"menu-icon fa fa-" + group.icon}></span>
+            <FaAngleRight/>{group.caption}
+            <span className="menu-icon">{group.icon}</span>
           </button>
         </li>,
         ...subGroups
@@ -81,10 +82,10 @@ const PageWithSidebar = observer(({menuSettings, sidebarStore, children}: PageWi
       <li key={`group-${group.name}`} className="sidebar-list">
         {group.route === null
           ? <button onClick={() => sidebarStore.toggleGroup(group.name)}>{group.caption}
-            <span className={"menu-icon fa fa-" + group.icon}></span>
+            <span className="menu-icon">{group.icon}</span>
           </button>
           : <Link to={group.route} onClick={() => sidebarStore.toggleGroup(group.name)}>{group.caption}
-            <span className={"menu-icon fa fa-" + group.icon}></span>
+            <span className="menu-icon">{group.icon}</span>
           </Link>
         }
       </li>

--- a/www/react-base/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/www/react-base/src/components/PropertiesTable/PropertiesTable.tsx
@@ -19,6 +19,7 @@ import './PropertiesTable.scss';
 import {Table} from "react-bootstrap";
 import CopyToClipboard from 'react-copy-to-clipboard';
 import {observer} from "mobx-react";
+import {FaCopy} from "react-icons/fa";
 
 type PropertiesTableProps = {
   properties: Map<string, any>;
@@ -34,7 +35,7 @@ const PropertiesTable = observer(({properties}: PropertiesTableProps) => {
         <td className="text-left">
           <pre className="bb-properties-value">{valueString}</pre>
           <CopyToClipboard text={valueString}>
-            <i className="bb-properties-copy fa fa-copy clickable"></i>
+            <FaCopy className="bb-properties-copy clickable"></FaCopy>
           </CopyToClipboard>
         </td>
         <td className="text-right">{source}</td>

--- a/www/react-base/src/components/PropertiesTable/__snapshots__/PropertiesTable.test.tsx.snap
+++ b/www/react-base/src/components/PropertiesTable/__snapshots__/PropertiesTable.test.tsx.snap
@@ -38,10 +38,26 @@ exports[`PropertiesTable component rendering 1`] = `
         >
           "string"
         </pre>
-        <i
-          className="bb-properties-copy fa fa-copy clickable"
+        <svg
+          className="bb-properties-copy clickable"
+          fill="currentColor"
+          height="1em"
           onClick={[Function]}
-        />
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+          />
+        </svg>
       </td>
       <td
         className="text-right"
@@ -63,10 +79,26 @@ exports[`PropertiesTable component rendering 1`] = `
         >
           123
         </pre>
-        <i
-          className="bb-properties-copy fa fa-copy clickable"
+        <svg
+          className="bb-properties-copy clickable"
+          fill="currentColor"
+          height="1em"
           onClick={[Function]}
-        />
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+          />
+        </svg>
       </td>
       <td
         className="text-right"
@@ -88,10 +120,26 @@ exports[`PropertiesTable component rendering 1`] = `
         >
           123.4
         </pre>
-        <i
-          className="bb-properties-copy fa fa-copy clickable"
+        <svg
+          className="bb-properties-copy clickable"
+          fill="currentColor"
+          height="1em"
           onClick={[Function]}
-        />
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+          />
+        </svg>
       </td>
       <td
         className="text-right"
@@ -113,10 +161,26 @@ exports[`PropertiesTable component rendering 1`] = `
         >
           true
         </pre>
-        <i
-          className="bb-properties-copy fa fa-copy clickable"
+        <svg
+          className="bb-properties-copy clickable"
+          fill="currentColor"
+          height="1em"
           onClick={[Function]}
-        />
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+          />
+        </svg>
       </td>
       <td
         className="text-right"
@@ -138,10 +202,26 @@ exports[`PropertiesTable component rendering 1`] = `
         >
           [321,"astr",false]
         </pre>
-        <i
-          className="bb-properties-copy fa fa-copy clickable"
+        <svg
+          className="bb-properties-copy clickable"
+          fill="currentColor"
+          height="1em"
           onClick={[Function]}
-        />
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+          />
+        </svg>
       </td>
       <td
         className="text-right"
@@ -163,10 +243,26 @@ exports[`PropertiesTable component rendering 1`] = `
         >
           {"s":"str","i":789,"b":false}
         </pre>
-        <i
-          className="bb-properties-copy fa fa-copy clickable"
+        <svg
+          className="bb-properties-copy clickable"
+          fill="currentColor"
+          height="1em"
           onClick={[Function]}
-        />
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+          />
+        </svg>
       </td>
       <td
         className="text-right"

--- a/www/react-base/src/components/RawData/RawData.test.tsx
+++ b/www/react-base/src/components/RawData/RawData.test.tsx
@@ -36,7 +36,7 @@ function assertRenderSnapshotExpanded(data: {[key: string]: any}) {
     </MemoryRouter>
   );
   act(() =>
-    component.root.findByType("i").props.onClick()
+    component.root.findByType("svg").props.onClick()
   );
   expect(component.toJSON()).toMatchSnapshot();
 }

--- a/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
+++ b/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
@@ -11,10 +11,26 @@ exports[`RawData component object with array of objects 1`] = `
       array
     </dt>
     <dd>
-      <i
-        className="fa fa-chevron-circle-right rotate clickable"
+      <svg
+        className="rotate clickable"
+        fill="currentColor"
+        height="1em"
         onClick={[Function]}
-      />
+        stroke="currentColor"
+        strokeWidth="0"
+        style={
+          Object {
+            "color": undefined,
+          }
+        }
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm113.9 231L234.4 103.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L285.1 256 183.5 357.6c-9.4 9.4-9.4 24.6 0 33.9l17 17c9.4 9.4 24.6 9.4 33.9 0L369.9 273c9.4-9.4 9.4-24.6 0-34z"
+        />
+      </svg>
       <span>
         [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true}]
       </span>
@@ -34,10 +50,26 @@ exports[`RawData component object with array of objects expanded 1`] = `
       array
     </dt>
     <dd>
-      <i
-        className="fa fa-chevron-circle-right rotate clickable fa-rotate-90"
+      <svg
+        className="rotate clickable"
+        fill="currentColor"
+        height="1em"
         onClick={[Function]}
-      />
+        stroke="currentColor"
+        strokeWidth="0"
+        style={
+          Object {
+            "color": undefined,
+          }
+        }
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
+        />
+      </svg>
       <ul>
         <li>
           <dl
@@ -186,10 +218,26 @@ exports[`RawData component observable object with array of objects 1`] = `
       array
     </dt>
     <dd>
-      <i
-        className="fa fa-chevron-circle-right rotate clickable"
+      <svg
+        className="rotate clickable"
+        fill="currentColor"
+        height="1em"
         onClick={[Function]}
-      />
+        stroke="currentColor"
+        strokeWidth="0"
+        style={
+          Object {
+            "color": undefined,
+          }
+        }
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm113.9 231L234.4 103.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L285.1 256 183.5 357.6c-9.4 9.4-9.4 24.6 0 33.9l17 17c9.4 9.4 24.6 9.4 33.9 0L369.9 273c9.4-9.4 9.4-24.6 0-34z"
+        />
+      </svg>
       <span>
         [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true}]
       </span>

--- a/www/react-base/src/components/TopbarActions/TopbarActions.tsx
+++ b/www/react-base/src/components/TopbarActions/TopbarActions.tsx
@@ -23,7 +23,7 @@ import React from "react";
 
 export type TopbarAction = {
   caption: string;
-  icon?: string;
+  icon?: JSX.Element;
   help?: string;
   variant?: ButtonVariant;
   action: () => void;
@@ -38,7 +38,7 @@ const TopbarActions = observer(({store}: TopbarActionsProps) => {
     return (
       <React.Fragment key={index}>
         <Button variant={action.variant ?? "light"} onClick={action.action} title={action.help ?? ""}>
-          {action.icon ?  <><i className={"fa fa-" + action.icon}></i><span>&nbsp;</span></> : <></> }
+          {action.icon ?  <>{action.icon}<span>&nbsp;</span></> : <></> }
           {action.caption}
         </Button>
         &nbsp;

--- a/www/react-base/src/components/WorkersTable/WorkersTable.tsx
+++ b/www/react-base/src/components/WorkersTable/WorkersTable.tsx
@@ -16,6 +16,8 @@
 */
 
 import {Table} from "react-bootstrap";
+import {FaPause, FaRegSmile, FaTimes} from "react-icons/fa";
+import {FaStop} from "react-icons/fa";
 import {Builder} from "../../data/classes/Builder";
 import {Master} from "../../data/classes/Master";
 import {Worker} from "../../data/classes/Worker";
@@ -30,17 +32,17 @@ import BadgeRound from "../BadgeRound/BadgeRound";
 export const getWorkerStatusIcon = (worker: Worker, onClick: () => void) => {
   if (worker.paused) {
     return (
-      <i title="paused" className="fa fa-pause" onClick={onClick}>&nbsp;</i>
+      <FaPause title="paused" onClick={onClick}>&nbsp;</FaPause>
     );
   }
   if (worker.graceful) {
     return (
-      <i title="graceful shutdown" className="fa fa-stop" onClick={onClick}></i>
+      <FaStop title="graceful shutdown" onClick={onClick}/>
     );
   }
   if (worker.connected_to.length > 0) {
     return (
-      <i className="fa fa-smile-o" onClick={onClick}></i>
+      <FaRegSmile onClick={onClick}/>
     );
   }
   return (<></>);
@@ -75,7 +77,7 @@ const WorkersTable = observer(({workers, buildersQuery, mastersQuery,
     if (worker.connected_to.length === 0) {
       return (
         <div key="disconnected">
-          <i title="disconnected" className="fa fa-times text-danger"></i>
+          <FaTimes title="disconnected" className="text-danger"/>
         </div>
       );
     }

--- a/www/react-base/src/plugins/GlobalMenuSettings.ts
+++ b/www/react-base/src/plugins/GlobalMenuSettings.ts
@@ -22,7 +22,7 @@ export type GroupSettings = {
   parentName: string | null;
   caption: string;
   route: string | null;
-  icon: string | null;
+  icon?: JSX.Element;
   order: number | null;
 };
 
@@ -30,7 +30,7 @@ export type ResolvedGroupSettings = {
   name: string;
   caption: string;
   route: string | null;
-  icon: string | null;
+  icon?: JSX.Element,
   order: number;
   subGroups: ResolvedGroupSettings[];
 };

--- a/www/react-base/src/styles/styles.scss
+++ b/www/react-base/src/styles/styles.scss
@@ -1,5 +1,4 @@
 @import "~bootstrap/scss/bootstrap";
-@import "~font-awesome/scss/font-awesome.scss";
 @import "animations.scss";
 @import "colors.scss";
 @import "mobile.scss";
@@ -137,11 +136,6 @@ span:hover>.mouse-over-only  {display: inline;}
   min-width: 600px;
   color: #262626;
 }
-
-/* glyphicon to font awesome translation, for angular-bootstrap-multiselect */
-.glyphicon { font-family: 'FontAwesome'; }
-.glyphicon-ok:before { content: $fa-var-check; }
-.glyphicon-remove:before { content: $fa-var-times; }
 
 #root, .modal .modal-dialog {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/www/react-base/src/views/AboutView/AboutView.tsx
+++ b/www/react-base/src/views/AboutView/AboutView.tsx
@@ -18,6 +18,7 @@
 import "./AboutView.scss";
 import {observer} from "mobx-react";
 import {Card} from "react-bootstrap";
+import {FaInfoCircle} from "react-icons/fa";
 import {DataClientContext} from "../../data/ReactUtils";
 import {useContext, useState} from "react";
 import {ConfigContext} from "../../contexts/Config";
@@ -125,7 +126,7 @@ const AboutView = observer(() => {
 globalMenuSettings.addGroup({
   name: 'about',
   caption: 'About',
-  icon: 'info-circle',
+  icon: <FaInfoCircle/>,
   order: 99,
   route: '/about',
   parentName: null,

--- a/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
+++ b/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
@@ -16,6 +16,7 @@
 */
 
 import {observer} from "mobx-react";
+import {FaSpinner, FaStop} from "react-icons/fa";
 import {
   useDataAccessor,
   useDataApiQuery,
@@ -52,13 +53,13 @@ const buildTopbarActions = (builder: Builder | null,
   if (isCancelling) {
     actions.push({
       caption: "Cancelling...",
-      icon: "spinner fa-spin",
+      icon: <FaSpinner/>,
       action: cancelBuildRequest
     });
   } else {
     actions.push({
       caption: "Cancel",
-      icon: "stop",
+      icon: <FaStop/>,
       action: cancelBuildRequest
     });
   }

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -17,6 +17,7 @@
 
 import './BuildView.scss';
 import {observer} from "mobx-react";
+import {FaSpinner} from "react-icons/fa";
 import {globalRoutes} from "../../plugins/GlobalRoutes";
 import {globalSettings} from "../../plugins/GlobalSettings";
 import AlertNotification from "../../components/AlertNotification/AlertNotification";
@@ -66,7 +67,7 @@ const buildTopbarActions = (build: Build | null, isRebuilding: boolean, isStoppi
     if (isRebuilding) {
       actions.push({
         caption: "Rebuilding...",
-        icon: "spinner fa-spin",
+        icon: <FaSpinner/>,
         action: doRebuild
       });
     } else {
@@ -79,7 +80,7 @@ const buildTopbarActions = (build: Build | null, isRebuilding: boolean, isStoppi
     if (isStopping) {
       actions.push({
         caption: "Stopping...",
-        icon: "spinner fa-spin",
+        icon: <FaSpinner/>,
         action: doStop
       });
     } else {

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -34,6 +34,7 @@ import DataCollection from "../../data/DataCollection";
 import AlertNotification from "../../components/AlertNotification/AlertNotification";
 import ForceBuildModal from "../../components/ForceBuildModal/ForceBuildModal";
 import TableHeading from "../../components/TableHeading/TableHeading";
+import {FaStop, FaSpinner} from "react-icons/fa";
 
 const anyCancellableBuilds = (builds: DataCollection<Build>,
                               buildrequests: DataCollection<Buildrequest>) => {
@@ -63,14 +64,14 @@ const buildTopbarActions = (builds: DataCollection<Build>,
     if (isCancelling) {
       actions.push({
         caption: "Cancelling...",
-        icon: "spinner fa-spin",
+        icon: <FaSpinner/>,
         action: cancelWholeQueue
       });
     } else {
       actions.push({
         caption: "Cancel whole queue",
         variant: "danger",
-        icon: "stop",
+        icon: <FaStop/>,
         action: cancelWholeQueue
       });
     }

--- a/www/react-base/src/views/BuildersView/BuildersView.tsx
+++ b/www/react-base/src/views/BuildersView/BuildersView.tsx
@@ -18,6 +18,7 @@
 import './BuildersView.scss';
 import {observer} from "mobx-react";
 import {useContext, useState} from "react";
+import {FaCogs, FaQuestionCircle} from "react-icons/fa";
 import {useDataAccessor, useDataApiDynamicQuery, useDataApiQuery} from "../../data/ReactUtils";
 import {Builder} from "../../data/classes/Builder";
 import {Worker} from "../../data/classes/Worker";
@@ -240,7 +241,7 @@ const BuildersView = observer(() => {
 
   const tagHelpElement = (
     <OverlayTrigger trigger="click" placement="bottom" overlay={tagHelpPopover} rootClose={true}>
-      <i style={{position: "relative"}} className="fa fa-question-circle clickable"></i>
+      <FaQuestionCircle style={{position: "relative"}} className="clickable"/>
     </OverlayTrigger>
   );
 
@@ -386,7 +387,7 @@ globalMenuSettings.addGroup({
   name: 'builds',
   parentName: null,
   caption: 'Builds',
-  icon: 'cogs',
+  icon: <FaCogs/>,
   order: 10,
   route: null,
 });
@@ -395,7 +396,6 @@ globalMenuSettings.addGroup({
   name: 'builders',
   parentName: 'builds',
   caption: 'Builders',
-  icon: null,
   order: null,
   route: '/builders',
 });

--- a/www/react-base/src/views/ChangesView/ChangesView.tsx
+++ b/www/react-base/src/views/ChangesView/ChangesView.tsx
@@ -42,7 +42,6 @@ globalMenuSettings.addGroup({
   name: 'changes',
   parentName: 'builds',
   caption: 'Last Changes',
-  icon: null,
   order: null,
   route: '/changes',
 });

--- a/www/react-base/src/views/HomeView/HomeView.tsx
+++ b/www/react-base/src/views/HomeView/HomeView.tsx
@@ -17,6 +17,7 @@
 
 import './HomeView.scss';
 import {observer} from "mobx-react";
+import {FaHome} from "react-icons/fa";
 import {useDataAccessor, useDataApiQuery} from "../../data/ReactUtils";
 import {useContext} from "react";
 import {Config, ConfigContext} from "../../contexts/Config";
@@ -160,7 +161,7 @@ const HomeView = observer(() => {
 globalMenuSettings.addGroup({
   name: 'home',
   caption: 'Home',
-  icon: 'home',
+  icon: <FaHome/>,
   order: 1,
   route: '/',
   parentName: null,

--- a/www/react-base/src/views/MastersView/MastersView.tsx
+++ b/www/react-base/src/views/MastersView/MastersView.tsx
@@ -17,6 +17,7 @@
 
 import {observer} from "mobx-react";
 import {Table} from "react-bootstrap";
+import {FaCheck, FaTimes} from "react-icons/fa";
 import {useDataAccessor, useDataApiQuery} from "../../data/ReactUtils";
 import {globalMenuSettings} from "../../plugins/GlobalMenuSettings";
 import {globalRoutes} from "../../plugins/GlobalRoutes";
@@ -87,7 +88,10 @@ const MastersView = observer(() => {
     return (
       <tr key={master.id}>
         <td>
-          <i className={"fa " + (master.active ? "fa-check text-success" : "fa-times text-danger")}/>
+          {master.active
+           ? <FaCheck className="text-success"/>
+           : <FaTimes className="text-danger"/>
+          }
         </td>
         <td>{master.name}</td>
         <td>
@@ -136,7 +140,6 @@ globalMenuSettings.addGroup({
   name: 'masters',
   parentName: 'builds',
   caption: 'Build Masters',
-  icon: null,
   order: null,
   route: '/masters',
 });

--- a/www/react-base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
+++ b/www/react-base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
@@ -126,7 +126,6 @@ globalMenuSettings.addGroup({
   name: 'pendingbuildrequests',
   parentName: 'builds',
   caption: 'Pending Buildrequests',
-  icon: null,
   order: null,
   route: '/pendingbuildrequests',
 });

--- a/www/react-base/src/views/SchedulersView/SchedulersView.tsx
+++ b/www/react-base/src/views/SchedulersView/SchedulersView.tsx
@@ -66,7 +66,6 @@ globalMenuSettings.addGroup({
   name: 'schedulers',
   parentName: 'builds',
   caption: 'Schedulers',
-  icon: null,
   order: null,
   route: '/schedulers',
 });

--- a/www/react-base/src/views/SettingsView/SettingsView.tsx
+++ b/www/react-base/src/views/SettingsView/SettingsView.tsx
@@ -17,6 +17,7 @@
 
 import {observer} from "mobx-react";
 import {Card} from "react-bootstrap";
+import {FaSlidersH} from "react-icons/fa";
 import {globalMenuSettings} from "../../plugins/GlobalMenuSettings";
 import {globalRoutes} from "../../plugins/GlobalRoutes";
 import {
@@ -135,7 +136,7 @@ const SettingsView = observer(() => {
 globalMenuSettings.addGroup({
   name: 'settings',
   caption: 'Settings',
-  icon: 'sliders',
+  icon: <FaSlidersH/>,
   order: 99,
   route: '/settings',
   parentName: null,

--- a/www/react-base/src/views/WorkersView/WorkersView.tsx
+++ b/www/react-base/src/views/WorkersView/WorkersView.tsx
@@ -110,7 +110,6 @@ globalMenuSettings.addGroup({
   name: 'workers',
   parentName: 'builds',
   caption: 'Workers',
-  icon: null,
   order: null,
   route: '/workers',
 });

--- a/www/react-base/yarn.lock
+++ b/www/react-base/yarn.lock
@@ -5295,11 +5295,6 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.9:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
-font-awesome@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
-  integrity sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==
-
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"

--- a/www/react-base/yarn.lock
+++ b/www/react-base/yarn.lock
@@ -9509,6 +9509,11 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-icons@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
+  integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
+
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"


### PR DESCRIPTION
Font Awesome 6 includes various icons styles, some of them are included in the free plan, others in the paid pro plan. The style that is currently used, "regular", is in the pro plan, which means there is no upgrade path for Font Awesome. Accordingly, a free alternative that supports the same icon set is chosen.