### PR TITLE
Fix env override when calling makeRemoteShellCommand

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -915,8 +915,10 @@ class ShellMixin:
 
         # merge the builder's environment with that supplied here
         builderEnv = self.build.builder.config.env
-        kwargs['env'] = yield self.build.render(builderEnv)
-        kwargs['env'].update(self.env)
+        kwargs['env'] = {
+            **(yield self.build.render(builderEnv)),
+            **kwargs['env'],
+        }
         kwargs['stdioLogName'] = stdioLogName
 
         # default the workdir appropriately

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1244,6 +1244,30 @@ class TestShellMixin(TestBuildStepMixin,
         yield self.run_step()
 
     @defer.inlineCallbacks
+    def test_step_env_default(self):
+        env = {'ENV': 'TRUE'}
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg'], env=env))
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['cmd', 'arg'], env=env)
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+        yield self.run_step()
+
+    @defer.inlineCallbacks
+    def test_step_env_overridden(self):
+        env = {'ENV': 'TRUE'}
+        env_override = {'OVERRIDE': 'TRUE'}
+        self.setup_step(SimpleShellCommand(command=['cmd', 'arg'], env=env,
+                                           make_cmd_kwargs={'env': env_override}))
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['cmd', 'arg'], env=env_override)
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+        yield self.run_step()
+
+    @defer.inlineCallbacks
     def test_extra_logfile(self):
         self.setup_step(SimpleShellCommand(command=['cmd', 'arg'],
                                           logfiles={'logname': 'logpath.log'}))

--- a/newsfragments/env-override.bugfix
+++ b/newsfragments/env-override.bugfix
@@ -1,0 +1,1 @@
+Fixed issue with overriding `env` when calling `ShellMixin.makeRemoteShellCommand`


### PR DESCRIPTION
Before this change, setting env when directly calling `makeRemoteShellCommand` was effectively ignored. This change updates that to use the override if it exists.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
