### PR TITLE
Fix tests due to codecov package removal

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -211,7 +211,12 @@ notifications:
 after_script:
   - |
       # codecov
-      if [ $TESTS = ci/coverage ]; then CODECOV_TOKEN="b80c80d7-689d-46d7-b1aa-59168bb4c9a9" codecov; fi
+      if [ $TESTS = ci/coverage ]; then
+        curl -Os https://uploader.codecov.io/v0.4.1/linux/codecov
+        echo "32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c  codecov" | sha256sum --check
+        chmod +x ./codecov
+        CODECOV_TOKEN="b80c80d7-689d-46d7-b1aa-59168bb4c9a9" ./codecov
+      fi
   # List installed packages along with their versions.
   - "pip list"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,11 @@ jobs:
       # https://github.com/codecov/support/wiki/Merging-Reports
       - run: coverage run --rcfile=.coveragerc $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test
 
-      - run: codecov
+      - run: |
+          curl -Os https://uploader.codecov.io/v0.4.1/linux/codecov
+          echo "32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c  codecov" | sha256sum --check
+          chmod +x ./codecov
+          CODECOV_TOKEN="b80c80d7-689d-46d7-b1aa-59168bb4c9a9" ./codecov
 
   win:
     name: Win / python ${{ matrix.python-version }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,9 @@ test_script:
 
 on_success:
   - "coverage xml --rcfile=common/coveragerc -o coverage.xml -i"
-  - "codecov"
+  - ps: |
+        (New-Object System.Net.WebClient).DownloadFile("https://uploader.codecov.io/v0.4.1/windows/codecov.exe", (Join-Path $pwd "codecov.exe"))
+        .\codecov.exe
 
 on_failure:
   # Store _trial_temp directory as artifact on build failure.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -33,7 +33,6 @@ chardet==5.0.0
 charset-normalizer==2.1.0
 click-default-group==1.2.2
 click==8.1.3
-codecov==2.1.12
 configparser==5.2.0
 constantly==15.1.0
 cookies==2.2.1


### PR DESCRIPTION
Codecov deprecated language-specific uploaders already in September 2021
https://about.codecov.io/blog/codecov-uploader-deprecation-plan/. The solution is to download the codecov uploader application on each test run.