### PR TITLE
www/react: Don't use globals to support plugins

### DIFF
--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -19,6 +19,7 @@ import './BuildSummary.scss';
 import {useContext, useState} from "react";
 import {observer} from "mobx-react";
 import {FaExpand} from "react-icons/fa";
+import {buildbotGetSettings} from "buildbot-plugin-support";
 import {
   ArrowExpander,
   BadgeRound,

--- a/www/react-base/src/components/LogPreview/LogPreview.tsx
+++ b/www/react-base/src/components/LogPreview/LogPreview.tsx
@@ -22,6 +22,7 @@ import {useEffect, useRef, useState} from 'react';
 import {ansi2html, generateStyleElement} from "../../util/AnsiEscapeCodes";
 import {action, makeObservable, observable} from 'mobx';
 import {useLocalObservable} from "mobx-react";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {ArrowExpander, useStateWithDefaultIfNotSet} from "buildbot-ui";
 import {CancellablePromise, Log, useDataAccessor} from "buildbot-data-js";
 import {LogDownloadButton} from "../LogDownloadButton/LogDownloadButton";

--- a/www/react-base/src/globals.ts
+++ b/www/react-base/src/globals.ts
@@ -8,6 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import * as ReactRouterDOM from 'react-router-dom';
 import * as jquery from 'jquery';
+import * as BuildbotPluginSupport from 'buildbot-plugin-support';
 
 declare global {
   interface Window {
@@ -17,6 +18,7 @@ declare global {
     ReactRouterDOM: any;
     jQuery: any;
     $: any;
+    BuildbotPluginSupport: any;
   }
 }
 
@@ -28,3 +30,4 @@ window.ReactDOM = ReactDOM as any;
 window.ReactRouterDOM = ReactRouterDOM;
 window.jQuery = jquery;
 window.$ = jquery;
+window.BuildbotPluginSupport = BuildbotPluginSupport;

--- a/www/react-base/src/plugins/GlobalSettings.ts
+++ b/www/react-base/src/plugins/GlobalSettings.ts
@@ -17,7 +17,7 @@
 
 import {action, makeObservable, observable} from "mobx";
 import {Config} from "buildbot-ui";
-import {ISettings} from "../../../plugin_support";
+import {ISettings, registerBuildbotSettingsSingleton} from "buildbot-plugin-support";
 
 export type SettingValue = string | number | boolean;
 export type SettingType = "string" | "integer" | "float" | "boolean";
@@ -275,8 +275,4 @@ export class GlobalSettings implements ISettings {
 
 export const globalSettings = new GlobalSettings();
 
-declare global {
-  function buildbotGetSettings(): ISettings;
-}
-
-window.buildbotGetSettings = () => { return globalSettings; }
+registerBuildbotSettingsSingleton(globalSettings);

--- a/www/react-base/src/plugins/GlobalSetup.ts
+++ b/www/react-base/src/plugins/GlobalSetup.ts
@@ -17,21 +17,21 @@
 
 import {
   GroupSettings,
-  RegistrationCallbacks, RouteConfig, SettingGroupConfig
-} from "../../../plugin_support/src";
+  registerPluginRegistrationConsumer,
+  RegistrationCallbacks,
+  RouteConfig,
+  SettingGroupConfig
+} from "buildbot-plugin-support";
 import {globalMenuSettings} from "./GlobalMenuSettings";
 import {globalRoutes} from "./GlobalRoutes";
 import {globalSettings} from "./GlobalSettings";
 
-declare global {
-  function buildbotSetupPlugin(
-    callback: (registrationCallbacks: RegistrationCallbacks) => void): void;
-}
-
-window.buildbotSetupPlugin = (callback: (registrationCallbacks: RegistrationCallbacks) => void) => {
+const onBuildbotSetupPlugin = (callback: (registrationCallbacks: RegistrationCallbacks) => void) => {
   callback({
     registerMenuGroup: (group: GroupSettings) => { globalMenuSettings.addGroup(group); },
     registerRoute: (route: RouteConfig) => { globalRoutes.addRoute(route); },
     registerSettingGroup: (group: SettingGroupConfig) => { globalSettings.addGroup(group); },
   });
 }
+
+registerPluginRegistrationConsumer(onBuildbotSetupPlugin);

--- a/www/react-base/src/views/AboutView/AboutView.tsx
+++ b/www/react-base/src/views/AboutView/AboutView.tsx
@@ -19,6 +19,7 @@ import "./AboutView.scss";
 import {observer} from "mobx-react";
 import {Card} from "react-bootstrap";
 import {FaInfoCircle} from "react-icons/fa";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   DataClientContext,
   EndpointDescription,

--- a/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
+++ b/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
@@ -17,6 +17,7 @@
 
 import {observer} from "mobx-react";
 import {FaSpinner, FaStop} from "react-icons/fa";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
   Builder,

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -23,6 +23,7 @@ import {useContext, useState} from "react";
 import {useTopbarItems} from "../../stores/TopbarStore";
 import {StoresContext} from "../../contexts/Stores";
 import {Link, useNavigate, useParams} from "react-router-dom";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
   Buildrequest,

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -17,6 +17,7 @@
 
 import {observer} from "mobx-react";
 import {useContext, useState} from "react";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
   Builder,

--- a/www/react-base/src/views/BuildersView/BuildersView.tsx
+++ b/www/react-base/src/views/BuildersView/BuildersView.tsx
@@ -19,6 +19,7 @@ import './BuildersView.scss';
 import {observer} from "mobx-react";
 import {useContext, useState} from "react";
 import {FaCogs} from "react-icons/fa";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
   Builder,

--- a/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
+++ b/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
@@ -16,6 +16,7 @@
 */
 
 import {observer} from "mobx-react";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Builder,
   Change,

--- a/www/react-base/src/views/ChangesView/ChangesView.tsx
+++ b/www/react-base/src/views/ChangesView/ChangesView.tsx
@@ -16,6 +16,7 @@
 */
 
 import {observer} from "mobx-react";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {Change, useDataAccessor, useDataApiQuery} from "buildbot-data-js";
 import {ChangesTable} from "../../components/ChangesTable/ChangesTable";
 

--- a/www/react-base/src/views/HomeView/HomeView.tsx
+++ b/www/react-base/src/views/HomeView/HomeView.tsx
@@ -18,6 +18,7 @@
 import './HomeView.scss';
 import {observer} from "mobx-react";
 import {FaHome} from "react-icons/fa";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
   Builder,

--- a/www/react-base/src/views/LogView/LogView.tsx
+++ b/www/react-base/src/views/LogView/LogView.tsx
@@ -21,6 +21,7 @@ import {useContext} from "react";
 import {useTopbarItems} from "../../stores/TopbarStore";
 import {StoresContext} from "../../contexts/Stores";
 import {useNavigate, useParams} from "react-router-dom";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {Builder, Build, useDataAccessor, useDataApiQuery} from "buildbot-data-js";
 import {LogViewer} from "../../components/LogViewer/LogViewer";
 

--- a/www/react-base/src/views/MastersView/MastersView.tsx
+++ b/www/react-base/src/views/MastersView/MastersView.tsx
@@ -18,6 +18,7 @@
 import {observer} from "mobx-react";
 import {Table} from "react-bootstrap";
 import {FaCheck, FaTimes} from "react-icons/fa";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {Build, Builder, Master, Worker, useDataAccessor, useDataApiQuery} from "buildbot-data-js";
 import {computed} from "mobx";
 import {Link} from "react-router-dom";

--- a/www/react-base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
+++ b/www/react-base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
@@ -26,6 +26,7 @@ import {
   useDataApiQuery
 } from "buildbot-data-js";
 import {BadgeRound, dateFormat, durationFromNowFormat, useCurrentTime} from "buildbot-ui";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {TableHeading} from "../../components/TableHeading/TableHeading";
 
 export const PendingBuildRequestsView = observer(() => {

--- a/www/react-base/src/views/SchedulersView/SchedulersView.tsx
+++ b/www/react-base/src/views/SchedulersView/SchedulersView.tsx
@@ -17,6 +17,7 @@
 
 import {observer} from "mobx-react";
 import {Table} from "react-bootstrap";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {Scheduler, useDataAccessor, useDataApiQuery} from "buildbot-data-js";
 
 export const SchedulersView = observer(() => {

--- a/www/react-base/src/views/SettingsView/SettingsView.tsx
+++ b/www/react-base/src/views/SettingsView/SettingsView.tsx
@@ -18,6 +18,7 @@
 import {observer} from "mobx-react";
 import {Card} from "react-bootstrap";
 import {FaSlidersH} from "react-icons/fa";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   GlobalSettings,
   globalSettings,

--- a/www/react-base/src/views/WorkerView/WorkerView.tsx
+++ b/www/react-base/src/views/WorkerView/WorkerView.tsx
@@ -25,6 +25,7 @@ import {
   useDataApiQuery
 } from "buildbot-data-js";
 import {useParams} from "react-router-dom";
+import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 

--- a/www/react-base/src/views/WorkersView/WorkersView.tsx
+++ b/www/react-base/src/views/WorkersView/WorkersView.tsx
@@ -17,6 +17,7 @@
 
 import {observer} from "mobx-react";
 import {useState} from "react";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
   Builder,


### PR DESCRIPTION
Undefined-by-default globals make it more complicated to run tests within the plugin code. Instead, just mark buildbot-plugin-support package as external as is with other common dependencies.
