### PR TITLE
Cleanup integration tests

### DIFF
--- a/master/buildbot/test/integration/interop/test_commandmixin.py
+++ b/master/buildbot/test/integration/interop/test_commandmixin.py
@@ -28,7 +28,7 @@ class CommandMixinMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_commandmixin(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
 
         change = dict(branch="master",
                       files=["foo.c"],

--- a/master/buildbot/test/integration/interop/test_compositestepmixin.py
+++ b/master/buildbot/test/integration/interop/test_compositestepmixin.py
@@ -36,7 +36,7 @@ class CompositeStepMixinMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def do_compositemixin_test(self, is_list_mkdir, is_list_rmdir):
-        yield self.setupConfig(masterConfig(is_list_mkdir=is_list_mkdir,
+        yield self.setup_master(masterConfig(is_list_mkdir=is_list_mkdir,
                                             is_list_rmdir=is_list_rmdir))
 
         change = dict(branch="master",

--- a/master/buildbot/test/integration/interop/test_compositestepmixin.py
+++ b/master/buildbot/test/integration/interop/test_compositestepmixin.py
@@ -22,49 +22,6 @@ from buildbot.steps.worker import CompositeStepMixin
 from buildbot.test.util.integration import RunMasterBase
 
 
-# This integration test creates a master and worker environment,
-# and makes sure the composite step mixin is working.
-class CompositeStepMixinMaster(RunMasterBase):
-
-    @defer.inlineCallbacks
-    def test_compositemixin_rmdir_list(self):
-        yield self.do_compositemixin_test(is_list_mkdir=False, is_list_rmdir=True)
-
-    @defer.inlineCallbacks
-    def test_compositemixin(self):
-        yield self.do_compositemixin_test(is_list_mkdir=False, is_list_rmdir=False)
-
-    @defer.inlineCallbacks
-    def do_compositemixin_test(self, is_list_mkdir, is_list_rmdir):
-        yield self.setup_master(masterConfig(is_list_mkdir=is_list_mkdir,
-                                            is_list_rmdir=is_list_rmdir))
-
-        change = dict(branch="master",
-                      files=["foo.c"],
-                      author="me@foo.com",
-                      committer="me@foo.com",
-                      comments="good stuff",
-                      revision="HEAD",
-                      project="none"
-                      )
-        build = yield self.doForceBuild(wantSteps=True, useChange=change,
-                                        wantLogs=True)
-        self.assertEqual(build['buildid'], 1)
-        self.assertEqual(build['results'], results.SUCCESS)
-
-
-class CompositeStepMixinMasterPb(CompositeStepMixinMaster):
-    proto = "pb"
-
-
-class CompositeStepMixinMasterMsgPack(CompositeStepMixinMaster):
-    proto = "msgpack"
-
-    @defer.inlineCallbacks
-    def test_compositemixin_mkdir_rmdir_lists(self):
-        yield self.do_compositemixin_test(is_list_mkdir=True, is_list_rmdir=True)
-
-
 class TestCompositeMixinStep(BuildStep, CompositeStepMixin):
 
     def __init__(self, is_list_mkdir, is_list_rmdir):
@@ -118,23 +75,63 @@ class TestCompositeMixinStep(BuildStep, CompositeStepMixin):
         return results.SUCCESS
 
 
-# master configuration
-def masterConfig(is_list_mkdir=True, is_list_rmdir=True):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import schedulers
+# This integration test creates a master and worker environment,
+# and makes sure the composite step mixin is working.
+class CompositeStepMixinMaster(RunMasterBase):
 
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["testy"])]
+    @defer.inlineCallbacks
+    def setup_config(self, is_list_mkdir=True, is_list_rmdir=True):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
 
-    f = BuildFactory()
-    f.addStep(TestCompositeMixinStep(is_list_mkdir=is_list_mkdir,
-                                     is_list_rmdir=is_list_rmdir))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(name="sched", builderNames=["testy"])
+        ]
+
+        f = BuildFactory()
+        f.addStep(TestCompositeMixinStep(is_list_mkdir=is_list_mkdir,
+                                         is_list_rmdir=is_list_rmdir))
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
+    def test_compositemixin_rmdir_list(self):
+        yield self.do_compositemixin_test(is_list_mkdir=False, is_list_rmdir=True)
+
+    @defer.inlineCallbacks
+    def test_compositemixin(self):
+        yield self.do_compositemixin_test(is_list_mkdir=False, is_list_rmdir=False)
+
+    @defer.inlineCallbacks
+    def do_compositemixin_test(self, is_list_mkdir, is_list_rmdir):
+        yield self.setup_config(is_list_mkdir=is_list_mkdir, is_list_rmdir=is_list_rmdir)
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      committer="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change,
+                                        wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['results'], results.SUCCESS)
+
+
+class CompositeStepMixinMasterPb(CompositeStepMixinMaster):
+    proto = "pb"
+
+
+class CompositeStepMixinMasterMsgPack(CompositeStepMixinMaster):
+    proto = "msgpack"
+
+    @defer.inlineCallbacks
+    def test_compositemixin_mkdir_rmdir_lists(self):
+        yield self.do_compositemixin_test(is_list_mkdir=True, is_list_rmdir=True)

--- a/master/buildbot/test/integration/interop/test_integration_secrets.py
+++ b/master/buildbot/test/integration/interop/test_integration_secrets.py
@@ -42,7 +42,7 @@ class SecretsConfig(RunMasterBase):
     @defer.inlineCallbacks
     def test_secret(self, name, use_interpolation):
         c = masterConfig(use_interpolation)
-        yield self.setupConfig(c)
+        yield self.setup_master(c)
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
 
@@ -69,7 +69,7 @@ class SecretsConfig(RunMasterBase):
     @defer.inlineCallbacks
     def test_secretReconfig(self, name, use_interpolation):
         c = masterConfig(use_interpolation)
-        yield self.setupConfig(c)
+        yield self.setup_master(c)
         c['secretsProviders'] = [FakeSecretStorage(
             secretdict={"foo": "different_value", "something": "more"})]
         yield self.master.reconfig()

--- a/master/buildbot/test/integration/interop/test_integration_secrets.py
+++ b/master/buildbot/test/integration/interop/test_integration_secrets.py
@@ -33,6 +33,47 @@ class FakeSecretReporter(HttpStatusPush):
 
 class SecretsConfig(RunMasterBase):
 
+    @defer.inlineCallbacks
+    def setup_config(self, use_interpolation):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers, steps, util
+
+        fake_reporter = FakeSecretReporter('http://example.com/hook',
+                                           auth=('user', Interpolate('%(secret:httppasswd)s')))
+
+        c['services'] = [fake_reporter]
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        c['secretsProviders'] = [FakeSecretStorage(secretdict={"foo": "secretvalue",
+                                                               "something": "more",
+                                                               'httppasswd': 'myhttppasswd'})]
+        f = BuildFactory()
+
+        if use_interpolation:
+            if os.name == "posix":
+                # on posix we can also check whether the password was passed to the command
+                command = Interpolate('echo %(secret:foo)s | ' +
+                                      'sed "s/secretvalue/The password was there/"')
+            else:
+                command = Interpolate('echo %(secret:foo)s')
+        else:
+            command = ['echo', util.Secret('foo')]
+
+        f.addStep(steps.ShellCommand(command=command))
+
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        yield self.setup_master(c)
+
+        return fake_reporter
+
     # Note that the secret name must be long enough so that it does not crash with random directory
     # or file names in the build dictionary.
     @parameterized.expand([
@@ -41,8 +82,7 @@ class SecretsConfig(RunMasterBase):
     ])
     @defer.inlineCallbacks
     def test_secret(self, name, use_interpolation):
-        c = masterConfig(use_interpolation)
-        yield self.setup_master(c)
+        fake_reporter = yield self.setup_config(use_interpolation)
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
 
@@ -60,7 +100,7 @@ class SecretsConfig(RunMasterBase):
         # at this point, build contains all the log and steps info that is in the db
         # we check that our secret is not in there!
         self.assertNotIn("secretvalue", repr(build))
-        self.assertTrue(c['services'][0].reported)
+        self.assertTrue(fake_reporter.reported)
 
     @parameterized.expand([
         ('with_interpolation', True),
@@ -68,10 +108,11 @@ class SecretsConfig(RunMasterBase):
     ])
     @defer.inlineCallbacks
     def test_secretReconfig(self, name, use_interpolation):
-        c = masterConfig(use_interpolation)
-        yield self.setup_master(c)
-        c['secretsProviders'] = [FakeSecretStorage(
-            secretdict={"foo": "different_value", "something": "more"})]
+        yield self.setup_config(use_interpolation)
+        self.master_config_dict['secretsProviders'] = [
+            FakeSecretStorage(secretdict={"foo": "different_value", "something": "more"})
+        ]
+
         yield self.master.reconfig()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -88,41 +129,3 @@ class SecretsConfigPB(SecretsConfig):
 
 class SecretsConfigMsgPack(SecretsConfig):
     proto = "msgpack"
-
-
-# master configuration
-def masterConfig(use_interpolation):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import schedulers, steps, util
-
-    c['services'] = [FakeSecretReporter('http://example.com/hook',
-                                        auth=('user', Interpolate('%(secret:httppasswd)s')))]
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    c['secretsProviders'] = [FakeSecretStorage(secretdict={"foo": "secretvalue",
-                                                           "something": "more",
-                                                           'httppasswd': 'myhttppasswd'})]
-    f = BuildFactory()
-
-    if use_interpolation:
-        if os.name == "posix":
-            # on posix we can also check whether the password was passed to the command
-            command = Interpolate('echo %(secret:foo)s | ' +
-                                  'sed "s/secretvalue/The password was there/"')
-        else:
-            command = Interpolate('echo %(secret:foo)s')
-    else:
-        command = ['echo', util.Secret('foo')]
-
-    f.addStep(steps.ShellCommand(command=command))
-
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/interop/test_interruptcommand.py
+++ b/master/buildbot/test/integration/interop/test_interruptcommand.py
@@ -25,10 +25,42 @@ from buildbot.util import asyncSleep
 class InterruptCommand(RunMasterBase):
     """Make sure we can interrupt a command"""
 
+    @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.plugins import schedulers, steps, util
+
+        class SleepAndInterrupt(steps.ShellSequence):
+            @defer.inlineCallbacks
+            def run(self):
+                if self.worker.worker_system == "nt":
+                    sleep = "waitfor SomethingThatIsNeverHappening /t 100 >nul 2>&1"
+                else:
+                    sleep = ["sleep", "100"]
+                d = self.runShellSequence([util.ShellArg(sleep)])
+                yield asyncSleep(1)
+                self.interrupt("just testing")
+                res = yield d
+                return res
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = util.BuildFactory()
+        f.addStep(SleepAndInterrupt())
+        c['builders'] = [
+            util.BuilderConfig(name="testy",
+                               workernames=["local1"],
+                               factory=f)]
+
+        yield self.setup_master(c)
+
     @flaky(bugNumber=4404, onPlatform='win32')
     @defer.inlineCallbacks
     def test_interrupt(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         build = yield self.doForceBuild(wantSteps=True)
         self.assertEqual(build['steps'][-1]['results'], CANCELLED)
 
@@ -39,38 +71,3 @@ class InterruptCommandPb(InterruptCommand):
 
 class InterruptCommandMsgPack(InterruptCommand):
     proto = "msgpack"
-
-
-# master configuration
-
-
-def masterConfig():
-    c = {}
-    from buildbot.plugins import schedulers, steps, util
-
-    class SleepAndInterrupt(steps.ShellSequence):
-        @defer.inlineCallbacks
-        def run(self):
-            if self.worker.worker_system == "nt":
-                sleep = "waitfor SomethingThatIsNeverHappening /t 100 >nul 2>&1"
-            else:
-                sleep = ["sleep", "100"]
-            d = self.runShellSequence([util.ShellArg(sleep)])
-            yield asyncSleep(1)
-            self.interrupt("just testing")
-            res = yield d
-            return res
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = util.BuildFactory()
-    f.addStep(SleepAndInterrupt())
-    c['builders'] = [
-        util.BuilderConfig(name="testy",
-                           workernames=["local1"],
-                           factory=f)]
-
-    return c

--- a/master/buildbot/test/integration/interop/test_interruptcommand.py
+++ b/master/buildbot/test/integration/interop/test_interruptcommand.py
@@ -28,7 +28,7 @@ class InterruptCommand(RunMasterBase):
     @flaky(bugNumber=4404, onPlatform='win32')
     @defer.inlineCallbacks
     def test_interrupt(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         build = yield self.doForceBuild(wantSteps=True)
         self.assertEqual(build['steps'][-1]['results'], CANCELLED)
 

--- a/master/buildbot/test/integration/interop/test_setpropertyfromcommand.py
+++ b/master/buildbot/test/integration/interop/test_setpropertyfromcommand.py
@@ -28,7 +28,7 @@ class SetPropertyFromCommand(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_setProp(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         oldNewLog = self.master.data.updates.addLog
 
         @defer.inlineCallbacks

--- a/master/buildbot/test/integration/interop/test_setpropertyfromcommand.py
+++ b/master/buildbot/test/integration/interop/test_setpropertyfromcommand.py
@@ -20,15 +20,34 @@ from twisted.internet import task
 
 from buildbot.test.util.integration import RunMasterBase
 
+
 # This integration test helps reproduce http://trac.buildbot.net/ticket/3024
 # we make sure that we can reconfigure the master while build is running
-
-
 class SetPropertyFromCommand(RunMasterBase):
 
     @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.plugins import schedulers, steps, util
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = util.BuildFactory()
+        f.addStep(steps.SetPropertyFromCommand(
+            property="test", command=["echo", "foo"]))
+        c['builders'] = [
+            util.BuilderConfig(name="testy",
+                               workernames=["local1"],
+                               factory=f)]
+
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_setProp(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         oldNewLog = self.master.data.updates.addLog
 
         @defer.inlineCallbacks
@@ -52,30 +71,3 @@ class SetPropertyFromCommandPB(SetPropertyFromCommand):
 
 class SetPropertyFromCommandMsgPack(SetPropertyFromCommand):
     proto = "msgpack"
-
-
-# master configuration
-
-num_reconfig = 0
-
-
-def masterConfig():
-    global num_reconfig
-    num_reconfig += 1
-    c = {}
-    from buildbot.plugins import schedulers, steps, util
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = util.BuildFactory()
-    f.addStep(steps.SetPropertyFromCommand(
-        property="test", command=["echo", "foo"]))
-    c['builders'] = [
-        util.BuilderConfig(name="testy",
-                           workernames=["local1"],
-                           factory=f)]
-
-    return c

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -20,8 +20,15 @@ import shutil
 
 from twisted.internet import defer
 
+from buildbot.process.buildstep import BuildStep
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
+from buildbot.steps.transfer import DirectoryUpload
+from buildbot.steps.transfer import FileDownload
+from buildbot.steps.transfer import FileUpload
+from buildbot.steps.transfer import MultipleFileUpload
+from buildbot.steps.transfer import StringDownload
+from buildbot.steps.worker import CompositeStepMixin
 from buildbot.test.util.decorators import flaky
 from buildbot.test.util.integration import RunMasterBase
 
@@ -35,6 +42,93 @@ from buildbot.test.util.integration import RunMasterBase
 class TransferStepsMasterPb(RunMasterBase):
     proto = "pb"
 
+    @defer.inlineCallbacks
+    def setup_config(self, bigfilename):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+        # do a bunch of transfer to exercise the protocol
+        f.addStep(StringDownload("filecontent", workerdest="dir/file1.txt"))
+        f.addStep(StringDownload("filecontent2", workerdest="dir/file2.txt"))
+        # create 8 MB file
+        with open(bigfilename, 'w', encoding='utf-8') as o:
+            buf = "xxxxxxxx" * 1024
+            for _ in range(1000):
+                o.write(buf)
+        f.addStep(FileDownload(mastersrc=bigfilename, workerdest="bigfile.txt"))
+        f.addStep(FileUpload(workersrc="dir/file2.txt", masterdest="master.txt"))
+        f.addStep(FileDownload(mastersrc="master.txt", workerdest="dir/file3.txt"))
+        f.addStep(DirectoryUpload(workersrc="dir", masterdest="dir"))
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
+    def setup_config_glob(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
+
+        class CustomStep(BuildStep, CompositeStepMixin):
+            @defer.inlineCallbacks
+            def run(self):
+                content = yield self.getFileContentFromWorker(
+                    "dir/file1.txt", abandonOnFailure=True)
+                assert content == "filecontent"
+                return SUCCESS
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force", builderNames=["testy"])
+        ]
+
+        f = BuildFactory()
+        f.addStep(StringDownload("filecontent", workerdest="dir/file1.txt"))
+        f.addStep(StringDownload("filecontent2", workerdest="dir/notafile1.txt"))
+        f.addStep(StringDownload("filecontent2", workerdest="dir/only1.txt"))
+        f.addStep(
+            MultipleFileUpload(
+                workersrcs=["dir/file*.txt", "dir/not*.txt", "dir/only?.txt"],
+                masterdest="dest/",
+                glob=True))
+        f.addStep(CustomStep())
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
+    def setup_config_single_step(self, step):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+
+        f.addStep(FileUpload(workersrc="dir/noexist_path", masterdest="master_dest"))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)
+        ]
+        yield self.setup_master(c)
+
     def readMasterDirContents(self, top):
         contents = {}
         for root, _, files in os.walk(top):
@@ -44,46 +138,10 @@ class TransferStepsMasterPb(RunMasterBase):
                     contents[fn] = f.read()
         return contents
 
-    def get_config_single_step(self, step):
-        c = {}
-        from buildbot.config import BuilderConfig
-        from buildbot.process.factory import BuildFactory
-        from buildbot.plugins import steps, schedulers
-
-        c['schedulers'] = [
-            schedulers.ForceScheduler(
-                name="force",
-                builderNames=["testy"])]
-
-        f = BuildFactory()
-
-        f.addStep(steps.FileUpload(workersrc="dir/noexist_path", masterdest="master_dest"))
-        c['builders'] = [
-            BuilderConfig(name="testy",
-                          workernames=["local1"],
-                          factory=f)
-        ]
-        return c
-
-    def get_non_existing_file_upload_config(self):
-        from buildbot.plugins import steps
-        step = steps.FileUpload(workersrc="dir/noexist_path", masterdest="master_dest")
-        return self.get_config_single_step(step)
-
-    def get_non_existing_directory_upload_config(self):
-        from buildbot.plugins import steps
-        step = steps.DirectoryUpload(workersrc="dir/noexist_path", masterdest="master_dest")
-        return self.get_config_single_step(step)
-
-    def get_non_existing_multiple_file_upload_config(self):
-        from buildbot.plugins import steps
-        step = steps.MultipleFileUpload(workersrcs=["dir/noexist_path"], masterdest="master_dest")
-        return self.get_config_single_step(step)
-
     @flaky(bugNumber=4407, onPlatform='win32')
     @defer.inlineCallbacks
     def test_transfer(self):
-        yield self.setup_master(masterConfig(bigfilename=self.mktemp()))
+        yield self.setup_config(bigfilename=self.mktemp())
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], SUCCESS)
@@ -100,7 +158,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_globTransfer(self):
-        yield self.setup_master(masterGlobConfig())
+        yield self.setup_config_glob()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], SUCCESS)
         dirContents = self.readMasterDirContents("dest")
@@ -115,7 +173,9 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_no_exist_file_upload(self):
-        yield self.setup_master(self.get_non_existing_file_upload_config())
+        step = FileUpload(workersrc="dir/noexist_path", masterdest="master_dest")
+        yield self.setup_config_single_step(step)
+
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
@@ -123,7 +183,9 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_no_exist_directory_upload(self):
-        yield self.setup_master(self.get_non_existing_directory_upload_config())
+        step = DirectoryUpload(workersrc="dir/noexist_path", masterdest="master_dest")
+        yield self.setup_config_single_step(step)
+
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
@@ -131,7 +193,9 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_no_exist_multiple_file_upload(self):
-        yield self.setup_master(self.get_non_existing_multiple_file_upload_config())
+        step = MultipleFileUpload(workersrcs=["dir/noexist_path"], masterdest="master_dest")
+        yield self.setup_config_single_step(step)
+
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
@@ -140,79 +204,3 @@ class TransferStepsMasterPb(RunMasterBase):
 
 class TransferStepsMasterNull(TransferStepsMasterPb):
     proto = "null"
-
-
-# master configuration
-def masterConfig(bigfilename):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    # do a bunch of transfer to exercise the protocol
-    f.addStep(steps.StringDownload("filecontent", workerdest="dir/file1.txt"))
-    f.addStep(steps.StringDownload("filecontent2", workerdest="dir/file2.txt"))
-    # create 8 MB file
-    with open(bigfilename, 'w', encoding='utf-8') as o:
-        buf = "xxxxxxxx" * 1024
-        for _ in range(1000):
-            o.write(buf)
-    f.addStep(
-        steps.FileDownload(
-            mastersrc=bigfilename, workerdest="bigfile.txt"))
-    f.addStep(
-        steps.FileUpload(workersrc="dir/file2.txt", masterdest="master.txt"))
-    f.addStep(
-        steps.FileDownload(mastersrc="master.txt", workerdest="dir/file3.txt"))
-    f.addStep(steps.DirectoryUpload(workersrc="dir", masterdest="dir"))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)
-    ]
-    return c
-
-
-def masterGlobConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-    from buildbot.steps.worker import CompositeStepMixin
-
-    class CustomStep(steps.BuildStep, CompositeStepMixin):
-        @defer.inlineCallbacks
-        def run(self):
-            content = yield self.getFileContentFromWorker(
-                "dir/file1.txt", abandonOnFailure=True)
-            assert content == "filecontent"
-            return SUCCESS
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force", builderNames=["testy"])
-    ]
-
-    f = BuildFactory()
-    f.addStep(steps.StringDownload("filecontent", workerdest="dir/file1.txt"))
-    f.addStep(
-        steps.StringDownload(
-            "filecontent2", workerdest="dir/notafile1.txt"))
-    f.addStep(steps.StringDownload("filecontent2", workerdest="dir/only1.txt"))
-    f.addStep(
-        steps.MultipleFileUpload(
-            workersrcs=["dir/file*.txt", "dir/not*.txt", "dir/only?.txt"],
-            masterdest="dest/",
-            glob=True))
-    f.addStep(CustomStep())
-    c['builders'] = [
-        BuilderConfig(
-            name="testy", workernames=["local1"], factory=f)
-    ]
-    return c

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -83,7 +83,7 @@ class TransferStepsMasterPb(RunMasterBase):
     @flaky(bugNumber=4407, onPlatform='win32')
     @defer.inlineCallbacks
     def test_transfer(self):
-        yield self.setupConfig(masterConfig(bigfilename=self.mktemp()))
+        yield self.setup_master(masterConfig(bigfilename=self.mktemp()))
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], SUCCESS)
@@ -100,7 +100,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_globTransfer(self):
-        yield self.setupConfig(masterGlobConfig())
+        yield self.setup_master(masterGlobConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], SUCCESS)
         dirContents = self.readMasterDirContents("dest")
@@ -115,7 +115,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_no_exist_file_upload(self):
-        yield self.setupConfig(self.get_non_existing_file_upload_config())
+        yield self.setup_master(self.get_non_existing_file_upload_config())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
@@ -123,7 +123,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_no_exist_directory_upload(self):
-        yield self.setupConfig(self.get_non_existing_directory_upload_config())
+        yield self.setup_master(self.get_non_existing_directory_upload_config())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
@@ -131,7 +131,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_no_exist_multiple_file_upload(self):
-        yield self.setupConfig(self.get_non_existing_multiple_file_upload_config())
+        yield self.setup_master(self.get_non_existing_multiple_file_upload_config())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")

--- a/master/buildbot/test/integration/interop/test_worker_reconnect.py
+++ b/master/buildbot/test/integration/interop/test_worker_reconnect.py
@@ -39,7 +39,7 @@ class WorkerReconnectPb(RunMasterBase):
     @defer.inlineCallbacks
     def test_eventually_reconnect(self):
         DisconnectingStep.disconnection_list = []
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         build = yield self.doForceBuild()
         self.assertEqual(build['buildid'], 2)
         self.assertEqual(len(DisconnectingStep.disconnection_list), 2)

--- a/master/buildbot/test/integration/interop/test_worker_reconnect.py
+++ b/master/buildbot/test/integration/interop/test_worker_reconnect.py
@@ -37,9 +37,29 @@ class WorkerReconnectPb(RunMasterBase):
     proto = "pb"
 
     @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
+
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(name="sched", builderNames=["testy"]),
+            schedulers.ForceScheduler(name="force", builderNames=["testy"])
+        ]
+
+        f = BuildFactory()
+        f.addStep(DisconnectingStep())
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_eventually_reconnect(self):
         DisconnectingStep.disconnection_list = []
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
+
         build = yield self.doForceBuild()
         self.assertEqual(build['buildid'], 2)
         self.assertEqual(len(DisconnectingStep.disconnection_list), 2)
@@ -47,27 +67,3 @@ class WorkerReconnectPb(RunMasterBase):
 
 class WorkerReconnectMsgPack(WorkerReconnectPb):
     proto = "msgpack"
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import schedulers
-
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["testy"]),
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    f.addStep(DisconnectingStep())
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_URLs.py
+++ b/master/buildbot/test/integration/test_URLs.py
@@ -30,7 +30,7 @@ class UrlForBuildMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_url(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], SUCCESS)

--- a/master/buildbot/test/integration/test_integration_force_with_patch.py
+++ b/master/buildbot/test/integration/test_integration_force_with_patch.py
@@ -47,10 +47,34 @@ class MySource(Source):
 
 class ShellMaster(RunMasterBase):
 
+    @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers, util
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                codebases=[util.CodebaseParameter(
+                    "foo", patch=util.PatchParameter())],
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+        f.addStep(MySource(codebase='foo'))
+        # if the patch was applied correctly, then make will work!
+        f.addStep(steps.ShellCommand(command=["make"]))
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+
+        yield self.setup_master(c)
+
     @skipUnlessPlatformIs("posix")  # make is not installed on windows
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True,
                                         forceParams={'foo_patch_body': PATCH})
         self.assertEqual(build['buildid'], 1)
@@ -59,35 +83,10 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell_no_patch(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         # if no patch, the source step is happy, but the make step cannot find makefile
         self.assertEqual(build['steps'][1]['results'], SUCCESS)
         self.assertEqual(build['steps'][2]['results'], FAILURE)
         self.assertEqual(build['results'], FAILURE)
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers, util
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            codebases=[util.CodebaseParameter(
-                "foo", patch=util.PatchParameter())],
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    f.addStep(MySource(codebase='foo'))
-    # if the patch was applied correctly, then make will work!
-    f.addStep(steps.ShellCommand(command=["make"]))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_integration_force_with_patch.py
+++ b/master/buildbot/test/integration/test_integration_force_with_patch.py
@@ -50,7 +50,7 @@ class ShellMaster(RunMasterBase):
     @skipUnlessPlatformIs("posix")  # make is not installed on windows
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True,
                                         forceParams={'foo_patch_body': PATCH})
         self.assertEqual(build['buildid'], 1)
@@ -59,7 +59,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell_no_patch(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         # if no patch, the source step is happy, but the make step cannot find makefile

--- a/master/buildbot/test/integration/test_integration_mastershell.py
+++ b/master/buildbot/test/integration/test_integration_mastershell.py
@@ -31,7 +31,8 @@ from buildbot.util import asyncSleep
 # meant to be a template for integration steps
 class ShellMaster(RunMasterBase):
 
-    def config_for_master_command(self, **kwargs):
+    @defer.inlineCallbacks
+    def setup_config_for_master_command(self, **kwargs):
         c = {}
 
         c['schedulers'] = [
@@ -43,7 +44,7 @@ class ShellMaster(RunMasterBase):
         c['builders'] = [
             BuilderConfig(name="testy", workernames=["local1"], factory=f)
         ]
-        return c
+        yield self.setup_master(c)
 
     def get_change(self):
         return {
@@ -58,7 +59,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setup_master(self.config_for_master_command(command='echo hello'))
+        yield self.setup_config_for_master_command(command='echo hello')
 
         build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -66,9 +67,9 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_logs(self):
-        yield self.setup_master(self.config_for_master_command(command=[
+        yield self.setup_config_for_master_command(command=[
             sys.executable, '-c', 'print("hello")'
-        ]))
+        ])
 
         build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -78,9 +79,9 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_fails(self):
-        yield self.setup_master(self.config_for_master_command(command=[
+        yield self.setup_config_for_master_command(command=[
             sys.executable, '-c', 'exit(1)'
-        ]))
+        ])
 
         build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -88,9 +89,9 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_interrupt(self):
-        yield self.setup_master(self.config_for_master_command(name='sleep', command=[
+        yield self.setup_config_for_master_command(name='sleep', command=[
             sys.executable, '-c', "while True: pass"
-        ]))
+        ])
 
         d = self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
 

--- a/master/buildbot/test/integration/test_integration_mastershell.py
+++ b/master/buildbot/test/integration/test_integration_mastershell.py
@@ -58,7 +58,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(self.config_for_master_command(command='echo hello'))
+        yield self.setup_master(self.config_for_master_command(command='echo hello'))
 
         build = yield self.doForceBuild(wantSteps=True, useChange=self.get_change(), wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -66,7 +66,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_logs(self):
-        yield self.setupConfig(self.config_for_master_command(command=[
+        yield self.setup_master(self.config_for_master_command(command=[
             sys.executable, '-c', 'print("hello")'
         ]))
 
@@ -78,7 +78,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_fails(self):
-        yield self.setupConfig(self.config_for_master_command(command=[
+        yield self.setup_master(self.config_for_master_command(command=[
             sys.executable, '-c', 'exit(1)'
         ]))
 
@@ -88,7 +88,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_interrupt(self):
-        yield self.setupConfig(self.config_for_master_command(name='sleep', command=[
+        yield self.setup_master(self.config_for_master_command(name='sleep', command=[
             sys.executable, '-c', "while True: pass"
         ]))
 

--- a/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
+++ b/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
@@ -25,9 +25,33 @@ from buildbot.test.util.integration import RunMasterBase
 # meant to be a template for integration steps
 class ShellMaster(RunMasterBase):
 
+    def create_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps
+
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(
+                name="sched1",
+                builderNames=["testy1"]),
+            schedulers.ForceScheduler(
+                name="sched2",
+                builderNames=["testy2"])
+        ]
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        c['builders'] = [
+            BuilderConfig(name=name,
+                          workernames=["local1"],
+                          factory=f)
+            for name in ['testy1', 'testy2']
+        ]
+        return c
+
     @defer.inlineCallbacks
     def test_shell(self):
-        cfg = masterConfig()
+        cfg = self.create_config()
         yield self.setup_master(cfg)
 
         change = dict(branch="master",
@@ -52,29 +76,3 @@ class ShellMaster(RunMasterBase):
         self.assertEqual(build['buildid'], 1)
         builder = yield self.master.data.get(('builders', build['builderid']))
         self.assertEqual(builder['name'], 'testy2')
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps
-
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched1",
-            builderNames=["testy1"]),
-        schedulers.ForceScheduler(
-            name="sched2",
-            builderNames=["testy2"])
-    ]
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    c['builders'] = [
-        BuilderConfig(name=name,
-                      workernames=["local1"],
-                      factory=f)
-        for name in ['testy1', 'testy2']
-    ]
-    return c

--- a/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
+++ b/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
@@ -28,7 +28,7 @@ class ShellMaster(RunMasterBase):
     @defer.inlineCallbacks
     def test_shell(self):
         cfg = masterConfig()
-        yield self.setupConfig(cfg)
+        yield self.setup_master(cfg)
 
         change = dict(branch="master",
                       files=["foo.c"],

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -70,7 +70,7 @@ class SecretsConfig(RunMasterBase):
     @defer.inlineCallbacks
     def do_secret_test(self, secret_specifier, expected_obfuscation, expected_value):
         with assertProducesWarning(DeprecatedApiWarning):
-            yield self.setupConfig(masterConfig(secret_specifier=secret_specifier))
+            yield self.setup_master(masterConfig(secret_specifier=secret_specifier))
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
 

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -64,13 +64,42 @@ class SecretsConfig(RunMasterBase):
         except (FileNotFoundError, subprocess.CalledProcessError) as e:
             raise SkipTest("Vault integration needs docker environment to be setup") from e
 
+    @defer.inlineCallbacks
+    def setup_config(self, secret_specifier):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        # note that as of December 2018, the vault docker image default to kv
+        # version 2 to be enabled by default
+        c['secretsProviders'] = [HashiCorpVaultSecretProvider(
+            vaultToken='my_vaulttoken',
+            vaultServer="http://localhost:8200",
+            apiVersion=2
+        )]
+
+        f = BuildFactory()
+        f.addStep(ShellCommand(command=Interpolate(f'echo {secret_specifier} | base64')))
+
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        yield self.setup_master(c)
+
     def remove_container(self):
         subprocess.call(['docker', 'rm', '-f', 'vault_for_buildbot'])
 
     @defer.inlineCallbacks
     def do_secret_test(self, secret_specifier, expected_obfuscation, expected_value):
         with assertProducesWarning(DeprecatedApiWarning):
-            yield self.setup_master(masterConfig(secret_specifier=secret_specifier))
+            yield self.setup_config(secret_specifier=secret_specifier)
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
 
@@ -97,32 +126,3 @@ class SecretsConfig(RunMasterBase):
     @defer.inlineCallbacks
     def test_nested_key(self):
         yield self.do_secret_test('%(secret:key1/key2/id)s', '<key1/key2/id>', 'val')
-
-
-def masterConfig(secret_specifier):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import schedulers
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    # note that as of December 2018, the vault docker image default to kv
-    # version 2 to be enabled by default
-    c['secretsProviders'] = [HashiCorpVaultSecretProvider(
-        vaultToken='my_vaulttoken',
-        vaultServer="http://localhost:8200",
-        apiVersion=2
-    )]
-
-    f = BuildFactory()
-    f.addStep(ShellCommand(command=Interpolate(f'echo {secret_specifier} | base64')))
-
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault_hvac.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault_hvac.py
@@ -75,7 +75,7 @@ class TestVaultHvac(RunMasterBase):
     @defer.inlineCallbacks
     def do_secret_test(self, image_tag, secret_specifier, expected_obfuscation, expected_value):
         self.start_container(image_tag)
-        yield self.setupConfig(master_config(secret_specifier=secret_specifier))
+        yield self.setup_master(master_config(secret_specifier=secret_specifier))
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
 

--- a/master/buildbot/test/integration/test_integration_template.py
+++ b/master/buildbot/test/integration/test_integration_template.py
@@ -25,8 +25,32 @@ from buildbot.test.util.integration import RunMasterBase
 class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers
+
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(
+                name="sched",
+                builderNames=["testy"]),
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        c['www'] = {'graphql': True}
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         # if you don't need change, you can just remove this change, and useChange parameter
         change = dict(branch="master",
                       files=["foo.c"],
@@ -40,28 +64,3 @@ class ShellMaster(RunMasterBase):
                                         wantProperties=True)
         self.assertEqual(build['buildid'], 1)
         self.assertEqual(build['properties']['owners'], (['me@foo.com'], 'Build'))
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["testy"]),
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    c['www'] = {'graphql': True}
-    return c

--- a/master/buildbot/test/integration/test_integration_template.py
+++ b/master/buildbot/test/integration/test_integration_template.py
@@ -26,7 +26,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         # if you don't need change, you can just remove this change, and useChange parameter
         change = dict(branch="master",
                       files=["foo.c"],

--- a/master/buildbot/test/integration/test_integration_with_secrets.py
+++ b/master/buildbot/test/integration/test_integration_with_secrets.py
@@ -24,7 +24,7 @@ class SecretsConfig(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_secret(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         res = yield self.checkBuildStepLogExist(build, "<foo>")
@@ -32,7 +32,7 @@ class SecretsConfig(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_withsecrets(self):
-        yield self.setupConfig(masterConfig(use_with=True))
+        yield self.setup_master(masterConfig(use_with=True))
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         res = yield self.checkBuildStepLogExist(build, "<foo>")

--- a/master/buildbot/test/integration/test_integration_with_secrets.py
+++ b/master/buildbot/test/integration/test_integration_with_secrets.py
@@ -23,8 +23,36 @@ from buildbot.test.util.integration import RunMasterBase
 class SecretsConfig(RunMasterBase):
 
     @defer.inlineCallbacks
+    def setup_config(self, use_with=False):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers, steps
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        c['secretsProviders'] = [FakeSecretStorage(
+            secretdict={"foo": "bar", "something": "more"})]
+        f = BuildFactory()
+        if use_with:
+            secrets_list = [("pathA", Interpolate('%(secret:something)s'))]
+            with f.withSecrets(secrets_list):
+                f.addStep(steps.ShellCommand(command=Interpolate('echo %(secret:foo)s')))
+        else:
+            f.addSteps([steps.ShellCommand(command=Interpolate('echo %(secret:foo)s'))],
+                       withSecrets=[("pathA", Interpolate('%(secret:something)s'))])
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_secret(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         res = yield self.checkBuildStepLogExist(build, "<foo>")
@@ -32,37 +60,8 @@ class SecretsConfig(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_withsecrets(self):
-        yield self.setup_master(masterConfig(use_with=True))
+        yield self.setup_config(use_with=True)
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         res = yield self.checkBuildStepLogExist(build, "<foo>")
         self.assertTrue(res)
-
-
-# master configuration
-def masterConfig(use_with=False):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import schedulers, steps
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    c['secretsProviders'] = [FakeSecretStorage(
-        secretdict={"foo": "bar", "something": "more"})]
-    f = BuildFactory()
-    if use_with:
-        secrets_list = [("pathA", Interpolate('%(secret:something)s'))]
-        with f.withSecrets(secrets_list):
-            f.addStep(steps.ShellCommand(command=Interpolate('echo %(secret:foo)s')))
-    else:
-        f.addSteps([steps.ShellCommand(command=Interpolate('echo %(secret:foo)s'))],
-                   withSecrets=[("pathA", Interpolate('%(secret:something)s'))])
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_log_finish.py
+++ b/master/buildbot/test/integration/test_log_finish.py
@@ -25,7 +25,8 @@ from buildbot.test.util.integration import RunMasterBase
 class TestLog(RunMasterBase):
     # master configuration
 
-    def masterConfig(self, step):
+    @defer.inlineCallbacks
+    def setup_config(self, step):
         c = {}
         from buildbot.config import BuilderConfig
         from buildbot.process.factory import BuildFactory
@@ -42,7 +43,7 @@ class TestLog(RunMasterBase):
             BuilderConfig(name="testy",
                           workernames=["local1"],
                           factory=f)]
-        return c
+        yield self.setup_master(c)
 
     @defer.inlineCallbacks
     def test_shellcommand(self):
@@ -57,7 +58,7 @@ class TestLog(RunMasterBase):
 
         step = MyStep(command='echo hello')
 
-        yield self.setup_master(self.masterConfig(step))
+        yield self.setup_config(step)
 
         change = dict(branch="master",
                       files=["foo.c"],
@@ -84,7 +85,7 @@ class TestLog(RunMasterBase):
 
         step = MyStep(command='echo hello')
 
-        yield self.setup_master(self.masterConfig(step))
+        yield self.setup_config(step)
 
         change = dict(branch="master",
                       files=["foo.c"],
@@ -112,7 +113,7 @@ class TestLog(RunMasterBase):
 
         step = MyStep(command='echo hello')
 
-        yield self.setup_master(self.masterConfig(step))
+        yield self.setup_config(step)
 
         change = dict(branch="master",
                       files=["foo.c"],

--- a/master/buildbot/test/integration/test_log_finish.py
+++ b/master/buildbot/test/integration/test_log_finish.py
@@ -57,7 +57,7 @@ class TestLog(RunMasterBase):
 
         step = MyStep(command='echo hello')
 
-        yield self.setupConfig(self.masterConfig(step))
+        yield self.setup_master(self.masterConfig(step))
 
         change = dict(branch="master",
                       files=["foo.c"],
@@ -84,7 +84,7 @@ class TestLog(RunMasterBase):
 
         step = MyStep(command='echo hello')
 
-        yield self.setupConfig(self.masterConfig(step))
+        yield self.setup_master(self.masterConfig(step))
 
         change = dict(branch="master",
                       files=["foo.c"],
@@ -112,7 +112,7 @@ class TestLog(RunMasterBase):
 
         step = MyStep(command='echo hello')
 
-        yield self.setupConfig(self.masterConfig(step))
+        yield self.setup_master(self.masterConfig(step))
 
         change = dict(branch="master",
                       files=["foo.c"],

--- a/master/buildbot/test/integration/test_master.py
+++ b/master/buildbot/test/integration/test_master.py
@@ -36,7 +36,7 @@ class RunMaster(RunMasterBase, www.RequiresWwwMixin):
 
     @defer.inlineCallbacks
     def do_test_master(self):
-        yield self.setupConfig(BuildmasterConfig, startWorker=False)
+        yield self.setup_master(BuildmasterConfig, startWorker=False)
 
         # hang out for a fraction of a second, to let startup processes run
         yield deferLater(reactor, 0.01, lambda: None)

--- a/master/buildbot/test/integration/test_notifier.py
+++ b/master/buildbot/test/integration/test_notifier.py
@@ -41,6 +41,10 @@ class NotifierMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def create_master_config(self, build_set_summary=False):
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers, reporters
+
         self.mailDeferred = defer.Deferred()
 
         # patch MailNotifier.sendmail to know when the mail has been sent
@@ -54,7 +58,48 @@ class NotifierMaster(RunMasterBase):
             self.notification.callback(params)
         self.patch(PushoverNotifier, "sendNotification", sendNotification)
 
-        yield self.setup_master(masterConfig(build_set_summary=build_set_summary))
+        c = {}
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(
+                name="sched",
+                builderNames=["testy"])
+        ]
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)
+        ]
+
+        formatter = MessageFormatter(template='This is a message.')
+        formatter_worker = MessageFormatterMissingWorker(template='No worker.')
+
+        if build_set_summary:
+            generators_mail = [
+                BuildSetStatusGenerator(mode='all'),
+                WorkerMissingGenerator(workers='all'),
+            ]
+            generators_pushover = [
+                BuildSetStatusGenerator(mode='all', message_formatter=formatter),
+                WorkerMissingGenerator(workers=['local1'], message_formatter=formatter_worker),
+            ]
+        else:
+            generators_mail = [
+                BuildStatusGenerator(mode='all'),
+                WorkerMissingGenerator(workers='all'),
+            ]
+            generators_pushover = [
+                BuildStatusGenerator(mode='all', message_formatter=formatter),
+                WorkerMissingGenerator(workers=['local1'], message_formatter=formatter_worker),
+            ]
+
+        c['services'] = [
+            reporters.MailNotifier("bot@foo.com", generators=generators_mail),
+            reporters.PushoverNotifier('1234', 'abcd', generators=generators_pushover)
+        ]
+
+        yield self.setup_master(c)
 
     @defer.inlineCallbacks
     def doTest(self, what):
@@ -120,51 +165,3 @@ class NotifierMaster(RunMasterBase):
         params = yield self.notification
         self.assertEqual(params, {'title': "Buildbot Buildbot worker local1 missing",
                                   'message': b"No worker."})
-
-
-# master configuration
-def masterConfig(build_set_summary):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers, reporters
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["testy"])
-    ]
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)
-    ]
-
-    formatter = MessageFormatter(template='This is a message.')
-    formatter_worker = MessageFormatterMissingWorker(template='No worker.')
-
-    if build_set_summary:
-        generators_mail = [
-            BuildSetStatusGenerator(mode='all'),
-            WorkerMissingGenerator(workers='all'),
-        ]
-        generators_pushover = [
-            BuildSetStatusGenerator(mode='all', message_formatter=formatter),
-            WorkerMissingGenerator(workers=['local1'], message_formatter=formatter_worker),
-        ]
-    else:
-        generators_mail = [
-            BuildStatusGenerator(mode='all'),
-            WorkerMissingGenerator(workers='all'),
-        ]
-        generators_pushover = [
-            BuildStatusGenerator(mode='all', message_formatter=formatter),
-            WorkerMissingGenerator(workers=['local1'], message_formatter=formatter_worker),
-        ]
-
-    c['services'] = [
-        reporters.MailNotifier("bot@foo.com", generators=generators_mail),
-        reporters.PushoverNotifier('1234', 'abcd', generators=generators_pushover)
-    ]
-    return c

--- a/master/buildbot/test/integration/test_notifier.py
+++ b/master/buildbot/test/integration/test_notifier.py
@@ -54,7 +54,7 @@ class NotifierMaster(RunMasterBase):
             self.notification.callback(params)
         self.patch(PushoverNotifier, "sendNotification", sendNotification)
 
-        yield self.setupConfig(masterConfig(build_set_summary=build_set_summary))
+        yield self.setup_master(masterConfig(build_set_summary=build_set_summary))
 
     @defer.inlineCallbacks
     def doTest(self, what):

--- a/master/buildbot/test/integration/test_stop_build.py
+++ b/master/buildbot/test/integration/test_stop_build.py
@@ -22,8 +22,27 @@ from buildbot.test.util.integration import RunMasterBase
 class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers
+
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(name="sched", builderNames=["testy"]),
+            schedulers.ForceScheduler(name="force", builderNames=["testy"])
+        ]
+
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='sleep 100', name='sleep'))
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["local1"], factory=f)
+        ]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
 
         @defer.inlineCallbacks
         def newStepCallback(_, data):
@@ -45,27 +64,3 @@ class ShellMaster(RunMasterBase):
         cancel_log = build['steps'][1]['logs'][-1]
         self.assertEqual(cancel_log['name'], 'cancelled')
         self.assertIn('cancelled by test', cancel_log['contents']['content'])
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["testy"]),
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='sleep 100', name='sleep'))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_stop_build.py
+++ b/master/buildbot/test/integration/test_stop_build.py
@@ -23,7 +23,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
 
         @defer.inlineCallbacks
         def newStepCallback(_, data):

--- a/master/buildbot/test/integration/test_stop_trigger.py
+++ b/master/buildbot/test/integration/test_stop_trigger.py
@@ -133,7 +133,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def testTriggerRunsForever(self):
-        yield self.setupConfig(triggerRunsForever())
+        yield self.setup_master(triggerRunsForever())
         self.higherBuild = None
 
         def newCallback(_, data):
@@ -147,7 +147,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def testTriggerRunsForeverAfterCmdStarted(self):
-        yield self.setupConfig(triggerRunsForever())
+        yield self.setup_master(triggerRunsForever())
         self.higherBuild = None
 
         def newCallback(_, data):
@@ -165,7 +165,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def testTriggeredBuildIsNotCreated(self):
-        yield self.setupConfig(triggeredBuildIsNotCreated())
+        yield self.setup_master(triggeredBuildIsNotCreated())
 
         def newCallback(_, data):
             self.master.data.control("stop", {}, ("builds", data['buildid']))

--- a/master/buildbot/test/integration/test_stop_trigger.py
+++ b/master/buildbot/test/integration/test_stop_trigger.py
@@ -27,80 +27,10 @@ from buildbot.process.factory import BuildFactory
 from buildbot.process.results import CANCELLED
 from buildbot.test.util.integration import RunMasterBase
 
+
 # This integration test creates a master and worker environment,
 # with two builders and a trigger step linking them. the triggered build never ends
 # so that we can reliably stop it recursively
-
-
-# master configurations
-def setupTriggerConfiguration(triggeredFactory, nextBuild=None):
-    c = {}
-
-    c['schedulers'] = [
-        schedulers.Triggerable(
-            name="trigsched",
-            builderNames=["triggered"]),
-        schedulers.AnyBranchScheduler(
-            name="sched",
-            builderNames=["main"])]
-
-    f = BuildFactory()
-    f.addStep(steps.Trigger(schedulerNames=['trigsched'],
-                            waitForFinish=True,
-                            updateSourceStamp=True))
-    f.addStep(steps.ShellCommand(command='echo world'))
-
-    mainBuilder = BuilderConfig(name="main",
-                                workernames=["local1"],
-                                factory=f)
-
-    triggeredBuilderKwargs = {'name': "triggered",
-                              'workernames': ["local1"],
-                              'factory': triggeredFactory}
-
-    if nextBuild is not None:
-        triggeredBuilderKwargs['nextBuild'] = nextBuild
-
-    triggeredBuilder = BuilderConfig(**triggeredBuilderKwargs)
-
-    c['builders'] = [mainBuilder, triggeredBuilder]
-    return c
-
-
-def triggerRunsForever():
-    f2 = BuildFactory()
-
-    # Infinite sleep command.
-    if sys.platform == 'win32':
-        # Ping localhost infinitely.
-        # There are other options, however they either don't work in
-        # non-interactive mode (e.g. 'pause'), or doesn't available on all
-        # Windows versions (e.g. 'timeout' and 'choice' are available
-        # starting from Windows 7).
-        cmd = 'ping -t 127.0.0.1'.split()
-    else:
-        cmd = textwrap.dedent("""\
-            while :
-            do
-              echo "sleeping";
-              sleep 1;
-            done
-            """)
-
-    f2.addStep(steps.ShellCommand(command=cmd))
-
-    return setupTriggerConfiguration(f2)
-
-
-def triggeredBuildIsNotCreated():
-    f2 = BuildFactory()
-    f2.addStep(steps.ShellCommand(command="echo 'hello'"))
-
-    def nextBuild(*args, **kwargs):
-        return defer.succeed(None)
-    return setupTriggerConfiguration(f2, nextBuild=nextBuild)
-
-
 class TriggeringMaster(RunMasterBase):
     timeout = 120
     change = dict(branch="master",
@@ -110,6 +40,74 @@ class TriggeringMaster(RunMasterBase):
                   comments="good stuff",
                   revision="HEAD",
                   project="none")
+
+    @defer.inlineCallbacks
+    def setup_trigger_config(self, triggeredFactory, nextBuild=None):
+        c = {}
+
+        c['schedulers'] = [
+            schedulers.Triggerable(
+                name="trigsched",
+                builderNames=["triggered"]),
+            schedulers.AnyBranchScheduler(
+                name="sched",
+                builderNames=["main"])]
+
+        f = BuildFactory()
+        f.addStep(steps.Trigger(schedulerNames=['trigsched'],
+                                waitForFinish=True,
+                                updateSourceStamp=True))
+        f.addStep(steps.ShellCommand(command='echo world'))
+
+        mainBuilder = BuilderConfig(name="main",
+                                    workernames=["local1"],
+                                    factory=f)
+
+        triggeredBuilderKwargs = {'name': "triggered",
+                                  'workernames': ["local1"],
+                                  'factory': triggeredFactory}
+
+        if nextBuild is not None:
+            triggeredBuilderKwargs['nextBuild'] = nextBuild
+
+        triggeredBuilder = BuilderConfig(**triggeredBuilderKwargs)
+
+        c['builders'] = [mainBuilder, triggeredBuilder]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
+    def setup_config_trigger_runs_forever(self):
+        f2 = BuildFactory()
+
+        # Infinite sleep command.
+        if sys.platform == 'win32':
+            # Ping localhost infinitely.
+            # There are other options, however they either don't work in
+            # non-interactive mode (e.g. 'pause'), or doesn't available on all
+            # Windows versions (e.g. 'timeout' and 'choice' are available
+            # starting from Windows 7).
+            cmd = 'ping -t 127.0.0.1'.split()
+        else:
+            cmd = textwrap.dedent("""\
+                while :
+                do
+                  echo "sleeping";
+                  sleep 1;
+                done
+                """)
+
+        f2.addStep(steps.ShellCommand(command=cmd))
+
+        yield self.setup_trigger_config(f2)
+
+    @defer.inlineCallbacks
+    def setup_config_triggered_build_not_created(self):
+        f2 = BuildFactory()
+        f2.addStep(steps.ShellCommand(command="echo 'hello'"))
+
+        def nextBuild(*args, **kwargs):
+            return defer.succeed(None)
+        yield self.setup_trigger_config(f2, nextBuild=nextBuild)
 
     def assertBuildIsCancelled(self, b):
         self.assertTrue(b['complete'])
@@ -133,7 +131,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def testTriggerRunsForever(self):
-        yield self.setup_master(triggerRunsForever())
+        yield self.setup_config_trigger_runs_forever()
         self.higherBuild = None
 
         def newCallback(_, data):
@@ -147,7 +145,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def testTriggerRunsForeverAfterCmdStarted(self):
-        yield self.setup_master(triggerRunsForever())
+        yield self.setup_config_trigger_runs_forever()
         self.higherBuild = None
 
         def newCallback(_, data):
@@ -165,7 +163,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def testTriggeredBuildIsNotCreated(self):
-        yield self.setup_master(triggeredBuildIsNotCreated())
+        yield self.setup_config_triggered_build_not_created()
 
         def newCallback(_, data):
             self.master.data.control("stop", {}, ("builds", data['buildid']))

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -53,7 +53,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_trigger(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
 
         build = yield self.doForceBuild(wantSteps=True, useChange=self.change, wantLogs=True)
 
@@ -72,7 +72,7 @@ class TriggeringMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_trigger_failure(self):
-        yield self.setupConfig(masterConfig(addFailure=True))
+        yield self.setup_master(masterConfig(addFailure=True))
 
         build = yield self.doForceBuild(wantSteps=True, useChange=self.change, wantLogs=True)
 

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -93,13 +93,43 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
         return self.jobdir
 
     @defer.inlineCallbacks
+    def setup_config(self, extra_config):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.buildstep import BuildStep
+        from buildbot.process.factory import BuildFactory
+        from buildbot.process import results
+
+        class MyBuildStep(BuildStep):
+
+            def run(self):
+                return results.SUCCESS
+
+        c['change_source'] = []
+        c['schedulers'] = []  # filled in above
+        f1 = BuildFactory()
+        f1.addStep(MyBuildStep(name='one'))
+        f1.addStep(MyBuildStep(name='two'))
+        c['builders'] = [
+            BuilderConfig(name="a", workernames=["local1"], factory=f1),
+        ]
+        c['title'] = "test"
+        c['titleURL'] = "test"
+        c['buildbotURL'] = "http://localhost:8010/"
+        c['mq'] = {'debug': True}
+        # test wants to influence the config, but we still return a new config
+        # each time
+        c.update(extra_config)
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def startMaster(self, sch):
         extra_config = {
             'schedulers': [sch],
         }
         self.sch = sch
 
-        yield self.setup_master(masterConfig(extra_config))
+        yield self.setup_config(extra_config)
 
         # wait until the scheduler is active
         yield waitFor(lambda: self.sch.active)
@@ -271,33 +301,3 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
         ])
         buildsets = yield self.master.db.buildsets.getBuildsets()
         self.assertEqual(len(buildsets), 1)
-
-
-def masterConfig(extra_config):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.buildstep import BuildStep
-    from buildbot.process.factory import BuildFactory
-    from buildbot.process import results
-
-    class MyBuildStep(BuildStep):
-
-        def run(self):
-            return results.SUCCESS
-
-    c['change_source'] = []
-    c['schedulers'] = []  # filled in above
-    f1 = BuildFactory()
-    f1.addStep(MyBuildStep(name='one'))
-    f1.addStep(MyBuildStep(name='two'))
-    c['builders'] = [
-        BuilderConfig(name="a", workernames=["local1"], factory=f1),
-    ]
-    c['title'] = "test"
-    c['titleURL'] = "test"
-    c['buildbotURL'] = "http://localhost:8010/"
-    c['mq'] = {'debug': True}
-    # test wants to influence the config, but we still return a new config
-    # each time
-    c.update(extra_config)
-    return c

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -99,7 +99,7 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
         }
         self.sch = sch
 
-        yield self.setupConfig(masterConfig(extra_config))
+        yield self.setup_master(masterConfig(extra_config))
 
         # wait until the scheduler is active
         yield waitFor(lambda: self.sch.active)

--- a/master/buildbot/test/integration/test_try_client_e2e.py
+++ b/master/buildbot/test/integration/test_try_client_e2e.py
@@ -28,7 +28,7 @@ class TryClientE2E(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
 
         def trigger_callback():
             port = self.master.pbmanager.dispatchers['tcp:0'].port.getHost().port

--- a/master/buildbot/test/integration/test_try_client_e2e.py
+++ b/master/buildbot/test/integration/test_try_client_e2e.py
@@ -27,8 +27,29 @@ class TryClientE2E(RunMasterBase):
     timeout = 15
 
     @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers
+
+        c['schedulers'] = [
+            schedulers.Try_Userpass(name="try",
+                                    builderNames=["testy"],
+                                    port='tcp:0',
+                                    userpass=[("alice", "pw1")])
+        ]
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
 
         def trigger_callback():
             port = self.master.pbmanager.dispatchers['tcp:0'].port.getHost().port
@@ -41,25 +62,3 @@ class TryClientE2E(RunMasterBase):
         build = yield self.doForceBuild(wantSteps=True, triggerCallback=trigger_callback,
                                         wantLogs=True, wantProperties=True)
         self.assertEqual(build['buildid'], 1)
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.Try_Userpass(name="try",
-                                builderNames=["testy"],
-                                port='tcp:0',
-                                userpass=[("alice", "pw1")])
-    ]
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_usePty.py
+++ b/master/buildbot/test/integration/test_usePty.py
@@ -27,10 +27,32 @@ from buildbot.test.util.integration import RunMasterBase
 # with one builder and a shellcommand step, which use usePTY
 class ShellMaster(RunMasterBase):
 
+    @defer.inlineCallbacks
+    def setup_config(self, usePTY):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(
+            command='if [ -t 1 ] ; then echo in a terminal; else echo "not a terminal"; fi',
+            usePTY=usePTY))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        yield self.setup_master(c)
+
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
     def test_usePTY(self):
-        yield self.setup_master(masterConfig(usePTY=True))
+        yield self.setup_config(usePTY=True)
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -50,32 +72,9 @@ class ShellMaster(RunMasterBase):
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
     def test_NOusePTY(self):
-        yield self.setup_master(masterConfig(usePTY=False))
+        yield self.setup_config(usePTY=False)
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         res = yield self.checkBuildStepLogExist(build, "not a terminal", onlyStdout=True)
         self.assertTrue(res)
-
-
-# master configuration
-def masterConfig(usePTY):
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(
-        command='if [ -t 1 ] ; then echo in a terminal; else echo "not a terminal"; fi',
-        usePTY=usePTY))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_usePty.py
+++ b/master/buildbot/test/integration/test_usePty.py
@@ -30,7 +30,7 @@ class ShellMaster(RunMasterBase):
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
     def test_usePTY(self):
-        yield self.setupConfig(masterConfig(usePTY=True))
+        yield self.setup_master(masterConfig(usePTY=True))
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
@@ -50,7 +50,7 @@ class ShellMaster(RunMasterBase):
     @skipUnlessPlatformIs('posix')
     @defer.inlineCallbacks
     def test_NOusePTY(self):
-        yield self.setupConfig(masterConfig(usePTY=False))
+        yield self.setup_master(masterConfig(usePTY=False))
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)

--- a/master/buildbot/test/integration/test_virtual_builder.py
+++ b/master/buildbot/test/integration/test_virtual_builder.py
@@ -25,8 +25,33 @@ from buildbot.test.util.integration import RunMasterBase
 class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
+    def setup_config(self):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          properties={
+                              'virtual_builder_name': 'virtual_testy',
+                              'virtual_builder_description': 'I am a virtual builder',
+                              'virtual_builder_tags': ['virtual'],
+                          },
+                          factory=f)]
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setup_master(masterConfig())
+        yield self.setup_config()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         builders = yield self.master.data.get(("builders",))
@@ -35,29 +60,3 @@ class ShellMaster(RunMasterBase):
             'masterids': [], 'tags': ['virtual', '_virtual_'],
             'description': 'I am a virtual builder', 'name': 'virtual_testy', 'builderid': 2})
         self.assertEqual(build['builderid'], builders[1]['builderid'])
-
-
-# master configuration
-def masterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      properties={
-                          'virtual_builder_name': 'virtual_testy',
-                          'virtual_builder_description': 'I am a virtual builder',
-                          'virtual_builder_tags': ['virtual'],
-                      },
-                      factory=f)]
-    return c

--- a/master/buildbot/test/integration/test_virtual_builder.py
+++ b/master/buildbot/test/integration/test_virtual_builder.py
@@ -26,7 +26,7 @@ class ShellMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_shell(self):
-        yield self.setupConfig(masterConfig())
+        yield self.setup_master(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         builders = yield self.master.data.get(("builders",))

--- a/master/buildbot/test/integration/test_worker_kubernetes.py
+++ b/master/buildbot/test/integration/test_worker_kubernetes.py
@@ -63,7 +63,7 @@ class KubernetesMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_trigger(self):
-        yield self.setupConfig(
+        yield self.setup_master(
             masterConfig(num_concurrent=NUM_CONCURRENT), startWorker=False)
         yield self.doForceBuild()
 

--- a/master/buildbot/test/integration/test_worker_kubernetes.py
+++ b/master/buildbot/test/integration/test_worker_kubernetes.py
@@ -62,9 +62,58 @@ class KubernetesMaster(RunMasterBase):
                 "Make sure that you're spawned worker can callback this IP")
 
     @defer.inlineCallbacks
+    def setup_config(self, num_concurrent, extra_steps=None):
+        if extra_steps is None:
+            extra_steps = []
+        c = {}
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(name="force", builderNames=["testy"])
+        ]
+        triggereables = []
+        for i in range(num_concurrent):
+            c['schedulers'].append(
+                schedulers.Triggerable(
+                    name="trigsched" + str(i), builderNames=["build"]))
+            triggereables.append("trigsched" + str(i))
+
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        f.addStep(
+            steps.Trigger(
+                schedulerNames=triggereables,
+                waitForFinish=True,
+                updateSourceStamp=True))
+        f.addStep(steps.ShellCommand(command='echo world'))
+        f2 = BuildFactory()
+        f2.addStep(steps.ShellCommand(command='echo ola'))
+        for step in extra_steps:
+            f2.addStep(step)
+        c['builders'] = [
+            BuilderConfig(name="testy", workernames=["kubernetes0"], factory=f),
+            BuilderConfig(
+                name="build",
+                workernames=["kubernetes" + str(i) for i in range(num_concurrent)],
+                factory=f2)
+        ]
+        masterFQDN = os.environ.get('masterFQDN')
+        c['workers'] = [
+            kubernetes.KubeLatentWorker(
+                'kubernetes' + str(i),
+                'buildbot/buildbot-worker',
+                kube_config=kubeclientservice.KubeCtlProxyConfigLoader(
+                    namespace=os.getenv("KUBE_NAMESPACE", "default")),
+                masterFQDN=masterFQDN) for i in range(num_concurrent)
+        ]
+        # un comment for debugging what happens if things looks locked.
+        # c['www'] = {'port': 8080}
+        c['protocols'] = {"pb": {"port": "tcp:9989"}}
+
+        yield self.setup_master(c, startWorker=False)
+
+    @defer.inlineCallbacks
     def test_trigger(self):
-        yield self.setup_master(
-            masterConfig(num_concurrent=NUM_CONCURRENT), startWorker=False)
+        yield self.setup_config(num_concurrent=NUM_CONCURRENT)
         yield self.doForceBuild()
 
         builds = yield self.master.data.get(("builds", ))
@@ -78,54 +127,3 @@ class KubernetesMasterTReq(KubernetesMaster):
     def setup(self):
         super().setUp()
         self.patch(kubernetes.KubeClientService, 'PREFER_TREQ', True)
-
-
-# master configuration
-def masterConfig(num_concurrent, extra_steps=None):
-    if extra_steps is None:
-        extra_steps = []
-    c = {}
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(name="force", builderNames=["testy"])
-    ]
-    triggereables = []
-    for i in range(num_concurrent):
-        c['schedulers'].append(
-            schedulers.Triggerable(
-                name="trigsched" + str(i), builderNames=["build"]))
-        triggereables.append("trigsched" + str(i))
-
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    f.addStep(
-        steps.Trigger(
-            schedulerNames=triggereables,
-            waitForFinish=True,
-            updateSourceStamp=True))
-    f.addStep(steps.ShellCommand(command='echo world'))
-    f2 = BuildFactory()
-    f2.addStep(steps.ShellCommand(command='echo ola'))
-    for step in extra_steps:
-        f2.addStep(step)
-    c['builders'] = [
-        BuilderConfig(name="testy", workernames=["kubernetes0"], factory=f),
-        BuilderConfig(
-            name="build",
-            workernames=["kubernetes" + str(i) for i in range(num_concurrent)],
-            factory=f2)
-    ]
-    masterFQDN = os.environ.get('masterFQDN')
-    c['workers'] = [
-        kubernetes.KubeLatentWorker(
-            'kubernetes' + str(i),
-            'buildbot/buildbot-worker',
-            kube_config=kubeclientservice.KubeCtlProxyConfigLoader(
-                namespace=os.getenv("KUBE_NAMESPACE", "default")),
-            masterFQDN=masterFQDN) for i in range(num_concurrent)
-    ]
-    # un comment for debugging what happens if things looks locked.
-    # c['www'] = {'port': 8080}
-    c['protocols'] = {"pb": {"port": "tcp:9989"}}
-
-    return c

--- a/master/buildbot/test/integration/test_worker_marathon.py
+++ b/master/buildbot/test/integration/test_worker_marathon.py
@@ -54,8 +54,71 @@ class MarathonMaster(RunMasterBase):
                 " is with url to Marathon api ")
 
     @defer.inlineCallbacks
+    def setup_config(self, num_concurrent, extra_steps=None):
+        if extra_steps is None:
+            extra_steps = []
+        c = {}
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+        triggereables = []
+        for i in range(num_concurrent):
+            c['schedulers'].append(
+                schedulers.Triggerable(
+                    name="trigsched" + str(i),
+                    builderNames=["build"]))
+            triggereables.append("trigsched" + str(i))
+
+        f = BuildFactory()
+        f.addStep(steps.ShellCommand(command='echo hello'))
+        f.addStep(steps.Trigger(schedulerNames=triggereables,
+                                waitForFinish=True,
+                                updateSourceStamp=True))
+        f.addStep(steps.ShellCommand(command='echo world'))
+        f2 = BuildFactory()
+        f2.addStep(steps.ShellCommand(command='echo ola'))
+        for step in extra_steps:
+            f2.addStep(step)
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["marathon0"],
+                          factory=f),
+            BuilderConfig(name="build",
+                          workernames=["marathon" + str(i)
+                                       for i in range(num_concurrent)],
+                          factory=f2)]
+        url = os.environ.get('BBTEST_MARATHON_URL')
+        creds = os.environ.get('BBTEST_MARATHON_CREDS')
+        if creds is not None:
+            user, password = creds.split(":")
+        else:
+            user = password = None
+        masterFQDN = os.environ.get('masterFQDN')
+        marathon_extra_config = {
+        }
+        c['workers'] = [
+            MarathonLatentWorker('marathon' + str(i), url, user, password,
+                                 'buildbot/buildbot-worker:master',
+                                 marathon_extra_config=marathon_extra_config,
+                                 masterFQDN=masterFQDN)
+            for i in range(num_concurrent)
+        ]
+        # un comment for debugging what happens if things looks locked.
+        # c['www'] = {'port': 8080}
+        # if the masterFQDN is forced (proxy case), then we use 9989 default port
+        # else, we try to find a free port
+        if masterFQDN is not None:
+            c['protocols'] = {"pb": {"port": "tcp:9989"}}
+        else:
+            c['protocols'] = {"pb": {"port": "tcp:0"}}
+
+        yield self.setup_master(c, startWorker=False)
+
+    @defer.inlineCallbacks
     def test_trigger(self):
-        yield self.setup_master(masterConfig(num_concurrent=NUM_CONCURRENT), startWorker=False)
+        yield self.setup_master(num_concurrent=NUM_CONCURRENT)
         yield self.doForceBuild()
 
         builds = yield self.master.data.get(("builds",))
@@ -63,67 +126,3 @@ class MarathonMaster(RunMasterBase):
         self.assertEqual(len(builds), 1 + NUM_CONCURRENT)
         for b in builds:
             self.assertEqual(b['results'], SUCCESS)
-
-
-# master configuration
-def masterConfig(num_concurrent, extra_steps=None):
-    if extra_steps is None:
-        extra_steps = []
-    c = {}
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-    triggereables = []
-    for i in range(num_concurrent):
-        c['schedulers'].append(
-            schedulers.Triggerable(
-                name="trigsched" + str(i),
-                builderNames=["build"]))
-        triggereables.append("trigsched" + str(i))
-
-    f = BuildFactory()
-    f.addStep(steps.ShellCommand(command='echo hello'))
-    f.addStep(steps.Trigger(schedulerNames=triggereables,
-                            waitForFinish=True,
-                            updateSourceStamp=True))
-    f.addStep(steps.ShellCommand(command='echo world'))
-    f2 = BuildFactory()
-    f2.addStep(steps.ShellCommand(command='echo ola'))
-    for step in extra_steps:
-        f2.addStep(step)
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["marathon0"],
-                      factory=f),
-        BuilderConfig(name="build",
-                      workernames=["marathon" + str(i)
-                                   for i in range(num_concurrent)],
-                      factory=f2)]
-    url = os.environ.get('BBTEST_MARATHON_URL')
-    creds = os.environ.get('BBTEST_MARATHON_CREDS')
-    if creds is not None:
-        user, password = creds.split(":")
-    else:
-        user = password = None
-    masterFQDN = os.environ.get('masterFQDN')
-    marathon_extra_config = {
-    }
-    c['workers'] = [
-        MarathonLatentWorker('marathon' + str(i), url, user, password,
-                             'buildbot/buildbot-worker:master',
-                             marathon_extra_config=marathon_extra_config,
-                             masterFQDN=masterFQDN)
-        for i in range(num_concurrent)
-    ]
-    # un comment for debugging what happens if things looks locked.
-    # c['www'] = {'port': 8080}
-    # if the masterFQDN is forced (proxy case), then we use 9989 default port
-    # else, we try to find a free port
-    if masterFQDN is not None:
-        c['protocols'] = {"pb": {"port": "tcp:9989"}}
-    else:
-        c['protocols'] = {"pb": {"port": "tcp:0"}}
-
-    return c

--- a/master/buildbot/test/integration/test_worker_marathon.py
+++ b/master/buildbot/test/integration/test_worker_marathon.py
@@ -55,7 +55,7 @@ class MarathonMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_trigger(self):
-        yield self.setupConfig(masterConfig(num_concurrent=NUM_CONCURRENT), startWorker=False)
+        yield self.setup_master(masterConfig(num_concurrent=NUM_CONCURRENT), startWorker=False)
         yield self.doForceBuild()
 
         builds = yield self.master.data.get(("builds",))

--- a/master/buildbot/test/integration/test_worker_proxy.py
+++ b/master/buildbot/test/integration/test_worker_proxy.py
@@ -154,9 +154,9 @@ class RunMasterBehindProxy(RunMasterBase):
             os.unlink(get_log_path())
 
     @defer.inlineCallbacks
-    def setupConfig(self, config_dict, startWorker=True):
+    def setup_master(self, config_dict, startWorker=True):
         proxy_connection_string = f"tcp:127.0.0.1:{self.target_port}"
-        yield RunMasterBase.setupConfig(self, config_dict, startWorker,
+        yield RunMasterBase.setup_master(self, config_dict, startWorker,
                                         proxy_connection_string=proxy_connection_string)
 
 

--- a/master/buildbot/test/integration/test_worker_proxy.py
+++ b/master/buildbot/test/integration/test_worker_proxy.py
@@ -156,8 +156,8 @@ class RunMasterBehindProxy(RunMasterBase):
     @defer.inlineCallbacks
     def setup_master(self, config_dict, startWorker=True):
         proxy_connection_string = f"tcp:127.0.0.1:{self.target_port}"
-        yield RunMasterBase.setup_master(self, config_dict, startWorker,
-                                        proxy_connection_string=proxy_connection_string)
+        yield super().setup_master(config_dict, startWorker,
+                                   proxy_connection_string=proxy_connection_string)
 
 
 # Use interoperability test cases to test the HTTP proxy tunneling.

--- a/master/buildbot/test/integration/test_worker_upcloud.py
+++ b/master/buildbot/test/integration/test_worker_upcloud.py
@@ -49,7 +49,7 @@ class UpcloudMaster(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_trigger(self):
-        yield self.setupConfig(masterConfig(num_concurrent=1), startWorker=False)
+        yield self.setup_master(masterConfig(num_concurrent=1), startWorker=False)
         yield self.doForceBuild()
 
         builds = yield self.master.data.get(("builds",))

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -212,6 +212,7 @@ class RunMasterBase(unittest.TestCase):
             config_dict['protocols'] = proto
 
         m = yield getMaster(self, reactor, config_dict)
+        self.master_config_dict = config_dict
         self.master = m
         self.assertFalse(stop.called,
                          "startService tried to stop the reactor; check logs")

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -185,7 +185,7 @@ class RunMasterBase(unittest.TestCase):
         skip = "buildbot-worker package is not installed"
 
     @defer.inlineCallbacks
-    def setupConfig(self, config_dict, startWorker=True, **worker_kwargs):
+    def setup_master(self, config_dict, startWorker=True, **worker_kwargs):
         """
         Setup and start a master configured
         by the function configFunc defined in the test module.


### PR DESCRIPTION
Currently integration tests have two ways to be implemented: by deriving RunMasterBase or deriving RunFakeMasterTestCase which work a bit differently. However, the way the actual tests are written is also different, which makes it harder to understand the tests as on the surface all integration tests work similarly. This commit makes the tests more consistent between themselves.