### PR TITLE
Pin pip to 23.0.1 in CI to fix test breakage

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -96,7 +96,10 @@ matrix:
 
 # Dependencies installation commands
 install:
-  - pip install -U pip
+  - condition: python == "2.7"
+    cmd: pip install -U pip
+  - condition: python != "2.7"
+    cmd: pip install pip==23.0.1
   - condition: TESTS not in ("minimal_install", "smokes", "trial_worker")
     cmd: pip install -r requirements-ci.txt
   - condition: TESTS == "minimal_install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             env
             python3.7 -m venv .venv
             . .venv/bin/activate
-            pip install -U pip 'setuptools<45.0.0'
+            pip install -U pip setuptools
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
             pip install pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
             env
             python3.7 -m venv .venv
             . .venv/bin/activate
-            pip install -U pip setuptools
+            pip install pip==23.0.1
+            pip install -U setuptools
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
             pip install pyinstaller

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt', 'requirements-cidb.txt') }}
           restore-keys: ${{ runner.os }}-pip-
 
-      - run: pip install -U pip
+      - run: pip install pip==23.0.1
       - run: pip install -r requirements-ci.txt -r requirements-cidb.txt
 
       # run real db tests under coverage to have several merging coverage report
@@ -117,7 +117,8 @@ jobs:
           python -c "import sys; print(sys.exec_prefix)"
           python -c "import sys; print(sys.executable)"
           python -V -V
-          python -m pip install -U pip setuptools
+          python -m pip install pip==23.0.1
+          python -m pip install -U setuptools
           python -m pip install -r requirements-ci.txt
           python -m pip list
           # Check that pywin32 is properly installed

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ docker-buildbot-master:
 
 $(VENV_NAME):
 	virtualenv -p $(VENV_PY_VERSION) $(VENV_NAME)
-	$(PIP) install -U pip setuptools
+	$(PIP) install pip==23.0.1
+	$(PIP) install -U setuptools
 
 # helper for virtualenv creation
 virtualenv: $(VENV_NAME)   # usage: make virtualenv VENV_PY_VERSION=python3.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,8 @@ install:
   - "python -c \"import sys; print(sys.exec_prefix)\""
   - "python -c \"import sys; print(sys.executable)\""
   - "python -V -V"
-  - "python -m pip install -U pip setuptools"
+  - "python -m pip install pip==23.0.1"
+  - "python -m pip install -U setuptools"
   - "python -m pip install -r requirements-ci.txt"
   - "python -m pip list"
   # Check that pywin32 is properly installed


### PR DESCRIPTION
pip 23.1 changed hanged the set of entries in sys.path_importer_cache under the following conditions:

 - there's a package with a submodule (e.g. mypackage.submodule)
- the package is installed in editable mode in a virtualenv created
using python3 -m env (but not virtualenv)
- mypackage.submodule is imported directly as import
mypackage.submodule

In the case of buildbot master installed in editable mode (pip install -e master), the $(pwd)/master directory is not in
sys.path_importer_cache. This breaks module resolution in the trial test runner and produces the following error when attempting to run tests:

builtins.UserWarning: .../buildbot/master (for module buildbot.test) not in path importer cache (PEP 302 violation - check your local configuration).

I've filed a bug in pip https://github.com/pypa/pip/issues/11964. Depending on whether this change of behavior is deemed a regression, a bug may need to be filed in Twisted. In any case, pip will be pinned to 23.0.1 in Buildbot CI for the time being.