### PR TITLE
Improve process killing on Windows

### DIFF
--- a/master/buildbot/util/runprocess.py
+++ b/master/buildbot/util/runprocess.py
@@ -271,10 +271,10 @@ class RunProcess:
                         subprocess.check_call(f"TASKKILL /F /PID {pid} /T")
                         success = True
                 except subprocess.CalledProcessError as e:
-                    # taskkill may return 128 as exit code when the child has already exited.
+                    # taskkill may return 128 or 255 as exit code when the child has already exited.
                     # We can't handle this race condition in any other way than just interpreting
                     # the kill action as successful
-                    if e.returncode == 128:
+                    if e.returncode in (128, 255):
                         log.msg(f"{self} taskkill didn't find pid {pid} to kill")
                         success = True
                     else:

--- a/master/buildbot/util/runprocess.py
+++ b/master/buildbot/util/runprocess.py
@@ -259,15 +259,26 @@ class RunProcess:
         log.msg(f'{self}: killing process using {interrupt_signal}')
 
         if runtime.platformType == "win32":
-            if interrupt_signal is not None and self.process.pid is not None:
-                if interrupt_signal == "TERM":
-                    # TODO: blocks
-                    subprocess.check_call(f"TASKKILL /PID {self.process.pid} /T")
-                    success = True
-                elif interrupt_signal == "KILL":
-                    # TODO: blocks
-                    subprocess.check_call(f"TASKKILL /F /PID {self.process.pid} /T")
-                    success = True
+            pid = self.process.pid
+            if interrupt_signal is not None and pid is not None:
+                try:
+                    if interrupt_signal == "TERM":
+                        # TODO: blocks
+                        subprocess.check_call(f"TASKKILL /PID {pid} /T")
+                        success = True
+                    elif interrupt_signal == "KILL":
+                        # TODO: blocks
+                        subprocess.check_call(f"TASKKILL /F /PID {pid} /T")
+                        success = True
+                except subprocess.CalledProcessError as e:
+                    # taskkill may return 128 as exit code when the child has already exited.
+                    # We can't handle this race condition in any other way than just interpreting
+                    # the kill action as successful
+                    if e.returncode == 128:
+                        log.msg(f"{self} taskkill didn't find pid {pid} to kill")
+                        success = True
+                    else:
+                        raise
 
         # try signalling the process itself (works on Windows too, sorta)
         if not success:

--- a/newsfragments/mastershell-windows-kill.bugfix
+++ b/newsfragments/mastershell-windows-kill.bugfix
@@ -1,0 +1,1 @@
+Fixed handling of occasional errors that happen when attempting to kill a master-side process that has already exited.

--- a/newsfragments/windows-process-killing-taskkill.bugfix
+++ b/newsfragments/windows-process-killing-taskkill.bugfix
@@ -1,0 +1,1 @@
+Fixed occasional errors that happen when killing processes on Windows. TASKKILL command may return code 255 when process has already exited.

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -807,10 +807,10 @@ class RunProcess(object):
             log.msg("taskkill'd pid {0}".format(pid))
 
         except subprocess.CalledProcessError as e:
-            # taskkill may return 128 as exit code when the child has already exited. We can't
-            # handle this race condition in any other way than just interpreting the kill action
-            # as successful
-            if e.returncode == 128:
+            # taskkill may return 128 or 255 as exit code when the child has already exited.
+            # We can't handle this race condition in any other way than just interpreting the kill
+            # action as successful
+            if e.returncode in (128, 255):
                 log.msg("taskkill didn't find pid {0} to kill".format(pid))
             else:
                 log.msg("taskkill failed to kill process {0}: {1}".format(pid, e))


### PR DESCRIPTION
This PR fixes a couple of race conditions:
 - When killing master-side processes, the TASKKILL exit codes 128 and 255 were not interpreted as success.
 - When killing worker-side processes, the TASKKILL exit code 255 was not interpreted as success.