### PR TITLE
util: Fix missed invocations when stop() is called on debounce component

### DIFF
--- a/master/buildbot/test/unit/util/test_debounce.py
+++ b/master/buildbot/test/unit/util/test_debounce.py
@@ -66,6 +66,9 @@ class DebounceTest(unittest.TestCase):
                 db.expCalls += 1
             elif e == 'complete':
                 db.callDeferred.callback(None)
+            elif e == 'complete-and-called':
+                db.callDeferred.callback(None)
+                db.expCalls += 1
             elif e == 'fail':
                 db.callDeferred.errback(failure.Failure(RuntimeError()))
             elif e == 'failure_logged':
@@ -217,7 +220,7 @@ class DebounceTest(unittest.TestCase):
     def test_stop_while_running_queued(self):
         """If the debounced method is stopped while running with another call
         queued, the running call completes, stop returns only after the call
-        completes, the queued call never occurs, and subsequent calls do
+        completes, the queued call still occurs, and subsequent calls do
         nothing."""
         self.scenario([
             (1, 0.0, 'maybe'),
@@ -225,9 +228,10 @@ class DebounceTest(unittest.TestCase):
             (1, 4.5, 'maybe'),
             (1, 5.0, 'stop'),
             (1, 5.0, 'stopNotComplete'),
-            (1, 6.0, 'complete'),
-            (1, 6.0, 'stopComplete'),
-            (1, 6.0, 'maybe'),
+            (1, 6.0, 'complete-and-called'),
+            (1, 6.5, 'complete'),
+            (1, 6.5, 'stopComplete'),
+            (1, 6.5, 'maybe'),
             (1, 10.0, 'check'),  # not called
         ])
 

--- a/master/buildbot/util/debounce.py
+++ b/master/buildbot/util/debounce.py
@@ -42,7 +42,7 @@ class Debouncer:
         # true if this instance is stopped
         self.stopped = False
         # deferreds to fire when the call is complete
-        self.completeDeferreds = None
+        self.completeDeferreds = []
         # for tests
         self.get_reactor = get_reactor
 
@@ -63,7 +63,6 @@ class Debouncer:
 
     def invoke(self):
         self.phase = PH_RUNNING
-        self.completeDeferreds = []
         d = defer.maybeDeferred(self.function)
         d.addErrback(log.err, 'from debounced function:')
 
@@ -71,6 +70,12 @@ class Debouncer:
         def retry(_):
             queued = self.phase == PH_RUNNING_QUEUED
             self.phase = PH_IDLE
+            if queued and self.stopped:
+                # If stop() is called when debouncer is running with additional run queued,
+                # the queued run must still be invoked because the current run may be stale.
+                self.invoke()
+                return
+
             while self.completeDeferreds:
                 self.completeDeferreds.pop(0).callback(None)
             if queued:

--- a/newsfragments/debouncer-stop-during-queued.bugfix
+++ b/newsfragments/debouncer-stop-during-queued.bugfix
@@ -1,0 +1,1 @@
+Fixed missed invocations of methods decorated with ``util.debounce`` when debouncer was being stopped under certain conditions. This caused step and build state string updates to be sometimes missed.


### PR DESCRIPTION
Calling stop() on a debouncer did not invoke any queued runs. This would break the main guarantee of the debouncer that each queued run would get an invocation after it.

Within Buildbot this resulted in step state updates being sometimes lost as the last updateSummary() call before updateSummary.stop() was being ignored.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
