### PR TITLE
remove duplicate entry of autobahn==22.7.1 from CI req

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,6 @@ buildbot-www==3.6.0
 
 autobahn==22.7.1
 boto3==1.24.60
-autobahn==22.7.1
 flake8==5.0.4
 msgpack==1.0.4
 pylint==2.14.5


### PR DESCRIPTION



## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
