### PR TITLE
config: Deprecate alternative config dict keys

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -38,6 +38,7 @@ from buildbot.util import ComparableMixin
 from buildbot.util import identifiers as util_identifiers
 from buildbot.util import service as util_service
 from buildbot.warnings import ConfigWarning
+from buildbot.warnings import warn_deprecated
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www.authz import authz
@@ -296,6 +297,10 @@ class MasterConfig(util.ComparableMixin):
             if name in config_dict:
                 v = config_dict[name]
             elif alt_key and alt_key in config_dict:
+                warn_deprecated(
+                    "3.9.0",
+                    f"Configuration dictionary key {alt_key} is deprecated. Use {name} instead."
+                )
                 v = config_dict[alt_key]
             else:
                 return

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -417,8 +417,19 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         with assertProducesWarning(ConfigWarning, message_pattern=r"Title is too long"):
             self.do_test_load_global(dict(title="Very very very very very long title"))
 
+    def test_load_global_projectName(self):
+        with assertProducesWarning(
+            DeprecatedApiWarning,
+            message_pattern=r"Configuration dictionary key projectName is deprecated"
+        ):
+            self.do_test_load_global(dict(projectName='hey'), title='hey')
+
     def test_load_global_projectURL(self):
-        self.do_test_load_global(dict(projectName='hey'), title='hey')
+        with assertProducesWarning(
+            DeprecatedApiWarning,
+            message_pattern=r"Configuration dictionary key projectURL is deprecated"
+        ):
+            self.do_test_load_global(dict(projectURL='hey'), titleURL='hey')
 
     def test_load_global_titleURL(self):
         self.do_test_load_global(dict(titleURL='hi'), titleURL='hi')

--- a/newsfragments/config-dict-key.removal
+++ b/newsfragments/config-dict-key.removal
@@ -1,0 +1,1 @@
+Deprecated ``projectName`` and ``projectURL`` configuration dictionary keys.


### PR DESCRIPTION
This deprecates "projectName" and "projectURL" keys. These have not been documented for a long time, but there may still be Buildbot instances using these legacy names.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
