### PR TITLE
Implement a way to group builders by project

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1089,6 +1089,7 @@ produceevent
 programmatically
 progressmetrics
 proj
+projectid
 projectname
 proto
 prs

--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -31,7 +31,7 @@ class BuilderConfig(util_config.ConfiguredMixin):
                  tags=None,
                  nextWorker=None, nextBuild=None, locks=None, env=None,
                  properties=None, collapseRequests=None, description=None,
-                 canStartBuild=None, defaultProperties=None
+                 canStartBuild=None, defaultProperties=None, project=None
                  ):
         # name is required, and can't start with '_'
         if not name or type(name) not in (bytes, str):
@@ -43,6 +43,11 @@ class BuilderConfig(util_config.ConfiguredMixin):
             self.name = bytes2unicode(name, encoding="ascii")
         except UnicodeDecodeError:
             error("builder names must be unicode or ASCII")
+
+        if not isinstance(project, (type(None), str)):
+            error("builder project must be None or str")
+            project = None
+        self.project = project
 
         # factory is required
         if factory is None:
@@ -137,6 +142,8 @@ class BuilderConfig(util_config.ConfiguredMixin):
             'builddir': self.builddir,
             'workerbuilddir': self.workerbuilddir,
         }
+        if self.project:
+            rv['project'] = self.project
         if self.tags:
             rv['tags'] = self.tags
         if self.nextWorker:

--- a/master/buildbot/config/checks.py
+++ b/master/buildbot/config/checks.py
@@ -30,3 +30,18 @@ def check_param_length(value, name, max_length):
         if len(shortest_value) > max_length:
             error(f"{name} '{value}' (shortest interpolation) exceeds maximum length of "
                   f"{max_length}")
+
+
+def check_param_type(value, default_value, class_inst, name, types, types_msg):
+    if isinstance(value, types):
+        return value
+    error(f"{class_inst.__name__} argument {name} must be an instance of {types_msg}")
+    return default_value
+
+
+def check_param_str(value, class_inst, name):
+    return check_param_type(value, "(unknown)", class_inst, name, (str,), "str")
+
+
+def check_param_str_none(value, class_inst, name):
+    return check_param_type(value, "(unknown)", class_inst, name, (str, type(None)), "str or None")

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -156,8 +156,7 @@ class Endpoint:
 class BuildNestingMixin:
 
     """
-    A mixin for methods to decipher the many ways a build, step, or log can be
-    specified.
+    A mixin for methods to decipher the many ways a various entities can be specified.
     """
 
     @defer.inlineCallbacks
@@ -198,6 +197,12 @@ class BuildNestingMixin:
         if 'buildername' in kwargs:
             return self.master.db.builders.findBuilderId(kwargs['buildername'], autoCreate=False)
         return defer.succeed(kwargs['builderid'])
+
+    # returns Deferred that yields a number
+    def get_project_id(self, kwargs):
+        if "projectname" in kwargs:
+            return self.master.db.projects.find_project_id(kwargs["projectname"], auto_create=False)
+        return defer.succeed(kwargs["projectid"])
 
 
 class ListResult(UserList):

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -45,6 +45,7 @@ class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
                     name=bdict['name'],
                     masterids=bdict['masterids'],
                     description=bdict['description'],
+                    projectid=bdict['projectid'],
                     tags=bdict['tags'])
 
 
@@ -65,6 +66,7 @@ class BuildersEndpoint(base.Endpoint):
                      name=bd['name'],
                      masterids=bd['masterids'],
                      description=bd['description'],
+                     projectid=bd['projectid'],
                      tags=bd['tags'])
                for bd in bdicts]
 
@@ -90,6 +92,7 @@ class Builder(base.ResourceType):
         name = types.Identifier(70)
         masterids = types.List(of=types.Integer())
         description = types.NoneOk(types.String())
+        projectid = types.NoneOk(types.Integer())
         tags = types.List(of=types.String())
     entityType = EntityType(name, 'Builder')
 
@@ -104,8 +107,10 @@ class Builder(base.ResourceType):
 
     @base.updateMethod
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, tags):
-        ret = yield self.master.db.builders.updateBuilderInfo(builderid, description, tags)
+    def updateBuilderInfo(self, builderid, description, projectid, tags):
+        ret = yield self.master.db.builders.updateBuilderInfo(
+            builderid, description, projectid, tags
+        )
         yield self.generateEvent(builderid, "update")
         return ret
 

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -56,12 +56,15 @@ class BuildersEndpoint(base.Endpoint):
     pathPatterns = """
         /builders
         /masters/n:masterid/builders
+        /projects/n:projectid/builders
     """
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
         bdicts = yield self.master.db.builders.getBuilders(
-            masterid=kwargs.get('masterid', None))
+            masterid=kwargs.get('masterid', None),
+            projectid=kwargs.get('projectid', None)
+        )
         return [dict(builderid=bd['id'],
                      name=bd['name'],
                      masterids=bd['masterids'],

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -56,6 +56,7 @@ class DataConnector(service.AsyncService):
         'buildbot.data.schedulers',
         'buildbot.data.forceschedulers',
         'buildbot.data.root',
+        'buildbot.data.projects',
         'buildbot.data.properties',
         'buildbot.data.test_results',
         'buildbot.data.test_result_sets',

--- a/master/buildbot/data/projects.py
+++ b/master/buildbot/data/projects.py
@@ -1,0 +1,100 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+
+from buildbot.data import base
+from buildbot.data import types
+
+
+def project_db_to_data(dbdict):
+    return {
+        "projectid": dbdict["id"],
+        "name": dbdict["name"],
+        "slug": dbdict["slug"],
+        "description": dbdict["description"],
+    }
+
+
+class ProjectEndpoint(base.BuildNestingMixin, base.Endpoint):
+
+    isCollection = False
+    pathPatterns = """
+        /projects/n:projectid
+        /projects/i:projectname
+    """
+
+    @defer.inlineCallbacks
+    def get(self, result_spec, kwargs):
+        projectid = yield self.get_project_id(kwargs)
+        if projectid is None:
+            return None
+
+        dbdict = yield self.master.db.projects.get_project(projectid)
+        if not dbdict:
+            return None
+        return project_db_to_data(dbdict)
+
+
+class ProjectsEndpoint(base.Endpoint):
+
+    isCollection = True
+    rootLinkName = 'projects'
+    pathPatterns = """
+        /projects
+    """
+
+    @defer.inlineCallbacks
+    def get(self, result_spec, kwargs):
+        dbdicts = yield self.master.db.projects.get_projects()
+        return [project_db_to_data(dbdict) for dbdict in dbdicts]
+
+    def get_kwargs_from_graphql(self, parent, resolve_info, args):
+        return {}
+
+
+class Project(base.ResourceType):
+
+    name = "project"
+    plural = "projects"
+    endpoints = [ProjectEndpoint, ProjectsEndpoint]
+    keyField = 'projectid'
+    eventPathPatterns = """
+        /projects/:projectid
+    """
+    subresources = ["Builder"]
+
+    class EntityType(types.Entity):
+        projectid = types.Integer()
+        name = types.Identifier(70)
+        slug = types.Identifier(70)
+        description = types.NoneOk(types.String())
+    entityType = EntityType(name, 'Project')
+
+    @defer.inlineCallbacks
+    def generate_event(self, _id, event):
+        project = yield self.master.data.get(('projects', str(_id)))
+        self.produceEvent(project, event)
+
+    @base.updateMethod
+    def find_project_id(self, name):
+        return self.master.db.projects.find_project_id(name)
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def update_project_info(self, projectid, slug, description):
+        yield self.master.db.projects.update_project_info(projectid, slug, description)
+        yield self.generate_event(projectid, "update")

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -37,7 +37,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             ), autoCreate=autoCreate)
 
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, tags):
+    def updateBuilderInfo(self, builderid, description, projectid, tags):
         # convert to tag IDs first, as necessary
         def toTagid(tag):
             if isinstance(tag, type(1)):
@@ -57,7 +57,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
 
             q = builders_tbl.update(
                 whereclause=(builders_tbl.c.id == builderid))
-            conn.execute(q, description=description).close()
+            conn.execute(q, description=description, projectid=projectid).close()
             # remove previous builders_tags
             conn.execute(builders_tags_tbl.delete(
                 whereclause=((builders_tags_tbl.c.builderid == builderid)))).close()
@@ -119,7 +119,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                            onclause=(bldr_tbl.c.id == limiting_bm_tbl.c.builderid))
             q = sa.select(
                 [bldr_tbl.c.id, bldr_tbl.c.name,
-                    bldr_tbl.c.description, bm_tbl.c.masterid],
+                    bldr_tbl.c.description, bldr_tbl.c.projectid, bm_tbl.c.masterid],
                 from_obj=[j],
                 order_by=[bldr_tbl.c.id, bm_tbl.c.masterid])
             if masterid is not None:
@@ -143,7 +143,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                 # pylint: disable=unsubscriptable-object
                 if not last or row['id'] != last['id']:
                     last = dict(id=row.id, name=row.name, masterids=[], description=row.description,
-                                tags=bldr_id_to_tags[row.id])
+                                projectid=row.projectid, tags=bldr_id_to_tags[row.id])
                     rv.append(last)
                 if row['masterid']:
                     last['masterids'].append(row['masterid'])

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -102,7 +102,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                              (tbl.c.masterid == masterid))))
         return self.db.pool.do(thd)
 
-    def getBuilders(self, masterid=None, _builderid=None):
+    def getBuilders(self, masterid=None, projectid=None, _builderid=None):
         def thd(conn):
             bldr_tbl = self.db.model.builders
             bm_tbl = self.db.model.builder_masters
@@ -125,6 +125,8 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             if masterid is not None:
                 # filter the masterid from the limiting table
                 q = q.where(limiting_bm_tbl.c.masterid == masterid)
+            if projectid is not None:
+                q = q.where(bldr_tbl.c.projectid == projectid)
             if _builderid is not None:
                 q = q.where(bldr_tbl.c.id == _builderid)
 

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -34,6 +34,7 @@ from buildbot.db import logs
 from buildbot.db import masters
 from buildbot.db import model
 from buildbot.db import pool
+from buildbot.db import projects
 from buildbot.db import schedulers
 from buildbot.db import sourcestamps
 from buildbot.db import state
@@ -102,6 +103,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
         self.users = users.UsersConnectorComponent(self)
         self.masters = masters.MastersConnectorComponent(self)
         self.builders = builders.BuildersConnectorComponent(self)
+        self.projects = projects.ProjectsConnectorComponent(self)
         self.steps = steps.StepsConnectorComponent(self)
         self.tags = tags.TagsConnectorComponent(self)
         self.logs = logs.LogsConnectorComponent(self)

--- a/master/buildbot/db/migrations/versions/060_2023-04-15_add_builder_projects.py
+++ b/master/buildbot/db/migrations/versions/060_2023-04-15_add_builder_projects.py
@@ -1,0 +1,61 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""add builder projects
+
+Revision ID: 060
+Revises: 059
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '060'
+down_revision = '059'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    hash_length = 40
+
+    op.create_table(
+        "projects",
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.Text, nullable=False),
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
+        sa.Column('slug', sa.String(50), nullable=False),
+        sa.Column('description', sa.Text, nullable=True),
+        mysql_DEFAULT_CHARSET='utf8',
+    )
+
+    with op.batch_alter_table("builders") as batch_op:
+        batch_op.add_column(
+            sa.Column('projectid', sa.Integer,
+                      sa.ForeignKey('projects.id', name="fk_builders_projectid",
+                                    ondelete='SET NULL'),
+                      nullable=True),
+        )
+
+    op.create_index('builders_projectid', "builders", ["projectid"])
+    op.create_index('projects_name_hash', "projects", ["name_hash"], unique=True)
+
+
+def downgrade():
+    op.drop_index("builders_projectid")
+    op.drop_column("builders", "project")
+    op.drop_table("projects")
+    op.drop_index("projects_name_hash")

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -583,6 +583,22 @@ class Model(base.DBConnectorComponent):
         sa.Column('important', sa.Integer),
     )
 
+    # Tables related to projects
+    # --------------------------
+
+    projects = sautils.Table(
+        'projects', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        # project name
+        sa.Column('name', sa.Text, nullable=False),
+        # sha1 of name; used for a unique index
+        sa.Column('name_hash', sa.String(hash_length), nullable=False),
+        # project slug, potentially shown in the URLs
+        sa.Column('slug', sa.String(50), nullable=False),
+        # project description
+        sa.Column('description', sa.Text, nullable=True),
+    )
+
     # Tables related to builders
     # --------------------------
 
@@ -593,6 +609,11 @@ class Model(base.DBConnectorComponent):
         sa.Column('name', sa.Text, nullable=False),
         # builder's description
         sa.Column('description', sa.Text, nullable=True),
+        # builder's project
+        sa.Column('projectid', sa.Integer,
+                  sa.ForeignKey('projects.id', name="fk_builders_projectid",
+                                ondelete='SET NULL'),
+                  nullable=True),
         # sha1 of name; used for a unique index
         sa.Column('name_hash', sa.String(hash_length), nullable=False),
     )
@@ -864,7 +885,9 @@ class Model(base.DBConnectorComponent):
     sa.Index('scheduler_changes_changeid', scheduler_changes.c.changeid)
     sa.Index('scheduler_changes_unique', scheduler_changes.c.schedulerid,
              scheduler_changes.c.changeid, unique=True)
+    sa.Index('projects_name_hash', projects.c.name_hash, unique=True)
     sa.Index('builder_name_hash', builders.c.name_hash, unique=True)
+    sa.Index('builders_projectid', builders.c.projectid)
     sa.Index('builder_masters_builderid', builder_masters.c.builderid)
     sa.Index('builder_masters_masterid', builder_masters.c.masterid)
     sa.Index('builder_masters_identity',

--- a/master/buildbot/db/projects.py
+++ b/master/buildbot/db/projects.py
@@ -1,0 +1,76 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+
+from buildbot.db import base
+
+
+class ProjectsConnectorComponent(base.DBConnectorComponent):
+
+    def find_project_id(self, name, auto_create=True):
+        name_hash = self.hashColumns(name)
+        return self.findSomethingId(
+            tbl=self.db.model.projects,
+            whereclause=(self.db.model.projects.c.name_hash == name_hash),
+            insert_values={
+                "name": name,
+                "slug": name,
+                "name_hash": name_hash,
+            }, autoCreate=auto_create)
+
+    @defer.inlineCallbacks
+    def get_project(self, projectid):
+        def thd(conn):
+            q = self.db.model.projects.select(
+                whereclause=(self.db.model.projects.c.id == projectid)
+            )
+            res = conn.execute(q)
+            row = res.fetchone()
+
+            rv = None
+            if row:
+                rv = self._project_dict_from_row(row)
+            res.close()
+            return rv
+        return (yield self.db.pool.do(thd))
+
+    # returns a Deferred that returns a value
+    def get_projects(self):
+        def thd(conn):
+            tbl = self.db.model.projects
+            q = tbl.select()
+            q = q.order_by(tbl.c.name)
+            res = conn.execute(q)
+            return [self._project_dict_from_row(row) for row in res.fetchall()]
+        return self.db.pool.do(thd)
+
+    # returns a Deferred that returns a value
+    def update_project_info(self, projectid, slug, description):
+        def thd(conn):
+            q = self.db.model.projects.update(
+                whereclause=(self.db.model.projects.c.id == projectid)
+            )
+            conn.execute(q, slug=slug, description=description).close()
+        return self.db.pool.do(thd)
+
+    def _project_dict_from_row(self, row):
+        return {
+            "id": row.id,
+            "name": row.name,
+            "slug": row.slug,
+            "description": row.description
+        }

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -243,7 +243,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
         timer = metrics.Timer("BotMaster.reconfigServiceWithBuildbotConfig")
         timer.start()
 
-        # reconfigure builders
+        yield self.reconfigProjects(new_config)
         yield self.reconfigServiceBuilders(new_config)
 
         # call up
@@ -254,6 +254,13 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
         self.maybeStartBuildsForAllBuilders()
 
         timer.stop()
+
+    @defer.inlineCallbacks
+    def reconfigProjects(self, new_config):
+        for project_config in new_config.projects:
+            projectid = yield self.master.data.updates.find_project_id(project_config.name)
+            yield self.master.data.updates.update_project_info(projectid, project_config.slug,
+                                                               project_config.description)
 
     @defer.inlineCallbacks
     def reconfigServiceBuilders(self, new_config):

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -62,6 +62,7 @@ class Build(properties.PropertiesMixin):
 
     VIRTUAL_BUILDERNAME_PROP = "virtual_builder_name"
     VIRTUAL_BUILDERDESCRIPTION_PROP = "virtual_builder_description"
+    VIRTUAL_BUILDER_PROJECT_PROP = "virtual_builder_project"
     VIRTUAL_BUILDERTAGS_PROP = "virtual_builder_tags"
     workdir = "build"
     reason = "changes"
@@ -275,15 +276,18 @@ class Build(properties.PropertiesMixin):
                 description = self.getProperty(
                     self.VIRTUAL_BUILDERDESCRIPTION_PROP,
                     self.builder.config.description)
+                project = self.getProperty(
+                    self.VIRTUAL_BUILDER_PROJECT_PROP,
+                    self.builder.config.project)
                 tags = self.getProperty(
                     self.VIRTUAL_BUILDERTAGS_PROP,
                     self.builder.config.tags)
                 if type(tags) == type([]) and '_virtual_' not in tags:
                     tags.append('_virtual_')
 
-                self.master.data.updates.updateBuilderInfo(self._builderid,
-                                                           description,
-                                                           tags)
+                projectid = yield self.builder.find_project_id(project)
+                self.master.data.updates.updateBuilderInfo(self._builderid, description,
+                                                           projectid, tags)
 
             else:
                 self._builderid = yield self.builder.getBuilderId()

--- a/master/buildbot/process/project.py
+++ b/master/buildbot/process/project.py
@@ -1,0 +1,32 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from buildbot import util
+from buildbot.config.checks import check_param_str
+from buildbot.config.checks import check_param_str_none
+
+
+class Project(util.ComparableMixin):
+
+    compare_attls = ("name", "slug", "description")
+
+    def __init__(self, name, slug=None, description=None):
+        if slug is None:
+            slug = name
+
+        self.name = check_param_str(name, self.__class__, "name")
+        self.slug = check_param_str(slug, self.__class__, "slug")
+        self.description = check_param_str_none(description, self.__class__, "description")

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -373,6 +373,11 @@ types:
         get:
             is:
             - bbget: {bbtype: project}
+        /builders:
+            description: This path selects all builders for a project
+            get:
+                is:
+                - bbget: {bbtype: builder}
 
 /buildrequests:
     /{buildrequestid}:

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -54,6 +54,7 @@ types:
     log: !include types/log.raml
     logchunk: !include types/logchunk.raml
     master: !include types/master.raml
+    project: !include types/project.raml
     rootlink: !include types/rootlink.raml
     scheduler: !include types/scheduler.raml
     sourcedproperties: !include types/sourcedproperties.raml
@@ -356,6 +357,22 @@ types:
             get:
                 is:
                 - bbget: {bbtype: string}
+
+/projects:
+    description: This path selects all projects
+    get:
+        is:
+        - bbget: {bbtype: project}
+
+    /{projectid_or_projectname}:
+        uriParameters:
+            projectid_or_projectname:
+                type: number|identifier
+                description: the ID or name of the project
+        description: This path selects a single project
+        get:
+            is:
+            - bbget: {bbtype: project}
 
 /buildrequests:
     /{buildrequestid}:

--- a/master/buildbot/spec/types/project.raml
+++ b/master/buildbot/spec/types/project.raml
@@ -1,0 +1,35 @@
+#%RAML 1.0 DataType
+description: |
+    This resource type describes a project.
+
+    Update Methods
+    --------------
+
+    All update methods are available as attributes of ``master.data.updates``.
+
+    .. py:class:: buildbot.data.projects.Project
+
+        .. py:method:: updateBuilderList(masterid, builderNames)
+
+            :param integer masterid: this master's master ID
+            :param list builderNames: list of names of currently-configured builders (unicode strings)
+            :returns: Deferred
+
+            Record the given builders as the currently-configured set of builders on this master.
+            Masters should call this every time the list of configured builders changes.
+
+
+properties:
+    projectid:
+        description: the ID of this project
+        type: integer
+    name:
+        description: project name
+        type: identifier
+    slug:
+        description: project slug
+        type: identifier
+    description?:
+        description: description of the project
+        type: string
+type: object

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -210,6 +210,15 @@ class FakeUpdates(service.AsyncService):
     def rebuildBuildrequest(self, buildrequest):
         return defer.succeed(None)
 
+    @defer.inlineCallbacks
+    def update_project_info(self, projectid, slug, description):
+        yield self.master.db.projects.update_project_info(projectid, slug, description)
+
+    def find_project_id(self, name):
+        validation.verifyType(self.testcase, 'project name', name,
+                              validation.StringValidator())
+        return self.master.db.projects.find_project_id(name)
+
     def updateBuilderList(self, masterid, builderNames):
         self.testcase.assertEqual(masterid, self.master.masterid)
         for n in builderNames:
@@ -218,8 +227,8 @@ class FakeUpdates(service.AsyncService):
         return defer.succeed(None)
 
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, tags):
-        yield self.master.db.builders.updateBuilderInfo(builderid, description, tags)
+    def updateBuilderInfo(self, builderid, description, projectid, tags):
+        yield self.master.db.builders.updateBuilderInfo(builderid, description, projectid, tags)
 
     def masterDeactivated(self, masterid):
         return defer.succeed(None)

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -41,7 +41,7 @@ class FakeUpdates(service.AsyncService):
         self.maybeBuildsetCompleteCalls = 0
         self.masterStateChanges = []  # dictionaries
         self.schedulerIds = {}  # { name : id }; users can add schedulers here
-        self.builderIds = {}  # { name : id }; users can add schedulers here
+        self.builderIds = {}  # { name : id }; users can add builders here
         self.schedulerMasters = {}  # { schedulerid : masterid }
         self.changesourceMasters = {}  # { changesourceid : masterid }
         self.workerIds = {}  # { name : id }; users can add workers here

--- a/master/buildbot/test/fakedb/__init__.py
+++ b/master/buildbot/test/fakedb/__init__.py
@@ -50,6 +50,8 @@ from .logs import Log
 from .logs import LogChunk
 from .masters import FakeMastersComponent
 from .masters import Master
+from .projects import FakeProjectsComponent
+from .projects import Project
 from .schedulers import FakeSchedulersComponent
 from .schedulers import Scheduler
 from .schedulers import SchedulerChange
@@ -109,6 +111,7 @@ __all__ = [
     'FakeDBConnector',
     'FakeLogsComponent',
     'FakeMastersComponent',
+    'FakeProjectsComponent',
     'FakeSchedulersComponent',
     'FakeSourceStampsComponent',
     'FakeStateComponent',
@@ -124,6 +127,7 @@ __all__ = [
     'Object',
     'ObjectState',
     'Patch',
+    'Project',
     'Scheduler',
     'SchedulerChange',
     'SchedulerMaster',

--- a/master/buildbot/test/fakedb/builders.py
+++ b/master/buildbot/test/fakedb/builders.py
@@ -114,7 +114,7 @@ class FakeBuildersComponent(FakeDBComponent):
             return defer.succeed(self._row2dict(bldr))
         return defer.succeed(None)
 
-    def getBuilders(self, masterid=None):
+    def getBuilders(self, masterid=None, projectid=None):
         rv = []
         for builderid, bldr in self.builders.items():
             masterids = [bm[1] for bm in self.builder_masters.values()
@@ -125,6 +125,8 @@ class FakeBuildersComponent(FakeDBComponent):
         if masterid is not None:
             rv = [bd for bd in rv
                   if masterid in bd['masterids']]
+        if projectid is not None:
+            rv = [bd for bd in rv if bd['projectid'] == projectid]
         return defer.succeed(rv)
 
     def addTestBuilder(self, builderid, name=None):

--- a/master/buildbot/test/fakedb/builders.py
+++ b/master/buildbot/test/fakedb/builders.py
@@ -26,8 +26,10 @@ class Builder(Row):
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
 
-    def __init__(self, id=None, name='some:builder', name_hash=None, description=None):
-        super().__init__(id=id, name=name, name_hash=name_hash, description=description)
+    def __init__(self, id=None, name='some:builder', name_hash=None, projectid=None,
+                 description=None):
+        super().__init__(id=id, name=name, name_hash=name_hash, projectid=projectid,
+                         description=description)
 
 
 class BuilderMaster(Row):
@@ -64,6 +66,7 @@ class FakeBuildersComponent(FakeDBComponent):
                 self.builders[row.id] = dict(
                     id=row.id,
                     name=row.name,
+                    projectid=row.projectid,
                     description=row.description)
             if isinstance(row, BuilderMaster):
                 self.builder_masters[row.id] = \
@@ -84,6 +87,7 @@ class FakeBuildersComponent(FakeDBComponent):
             id=id,
             name=name,
             description=None,
+            projectid=None,
             tags=[])
         return defer.succeed(id)
 
@@ -131,10 +135,11 @@ class FakeBuildersComponent(FakeDBComponent):
         ])
 
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, tags):
+    def updateBuilderInfo(self, builderid, description, projectid, tags):
         if builderid in self.builders:
             tags = tags if tags else []
             self.builders[builderid]['description'] = description
+            self.builders[builderid]['projectid'] = projectid
 
             # add tags
             tagids = []

--- a/master/buildbot/test/fakedb/connector.py
+++ b/master/buildbot/test/fakedb/connector.py
@@ -24,6 +24,7 @@ from buildbot.test.fakedb.changes import FakeChangesComponent
 from buildbot.test.fakedb.changesources import FakeChangeSourcesComponent
 from buildbot.test.fakedb.logs import FakeLogsComponent
 from buildbot.test.fakedb.masters import FakeMastersComponent
+from buildbot.test.fakedb.projects import FakeProjectsComponent
 from buildbot.test.fakedb.row import Row
 from buildbot.test.fakedb.schedulers import FakeSchedulersComponent
 from buildbot.test.fakedb.sourcestamps import FakeSourceStampsComponent
@@ -82,6 +83,8 @@ class FakeDBConnector(service.AsyncMultiService):
         self.users = comp = FakeUsersComponent(self, testcase)
         self._components.append(comp)
         self.masters = comp = FakeMastersComponent(self, testcase)
+        self._components.append(comp)
+        self.projects = comp = FakeProjectsComponent(self, testcase)
         self._components.append(comp)
         self.builders = comp = FakeBuildersComponent(self, testcase)
         self._components.append(comp)

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -88,7 +88,7 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
         table_names = [
             'objects', 'object_state', 'masters',
             'workers', 'configured_workers', 'connected_workers',
-            'builder_masters', 'builders'
+            'builder_masters', 'builders', 'projects',
         ]
 
         master = fakemaster.make_master(self, wantRealReactor=True)

--- a/master/buildbot/test/integration/test_virtual_builder.py
+++ b/master/buildbot/test/integration/test_virtual_builder.py
@@ -44,6 +44,7 @@ class ShellMaster(RunMasterBase):
                           properties={
                               'virtual_builder_name': 'virtual_testy',
                               'virtual_builder_description': 'I am a virtual builder',
+                              'virtual_builder_project': 'virtual_project',
                               'virtual_builder_tags': ['virtual'],
                           },
                           factory=f)]
@@ -58,5 +59,6 @@ class ShellMaster(RunMasterBase):
         self.assertEqual(len(builders), 2)
         self.assertEqual(builders[1], {
             'masterids': [], 'tags': ['virtual', '_virtual_'],
+            'projectid': 1,
             'description': 'I am a virtual builder', 'name': 'virtual_testy', 'builderid': 2})
         self.assertEqual(build['builderid'], builders[1]['builderid'])

--- a/master/buildbot/test/unit/config/test_checks.py
+++ b/master/buildbot/test/unit/config/test_checks.py
@@ -39,5 +39,5 @@ class TestCheckParamLength(unittest.TestCase, config.ConfigErrorsMixin):
         check_param_length(Interpolate('123456%(prop:xy)s7890', kw='arg'), 'Step name', 10)
 
     def test_long_interpolate(self):
-        with self.assertRaisesConfigError("xceeds maximum length of 10"):
+        with self.assertRaisesConfigError("exceeds maximum length of 10"):
             check_param_length(Interpolate('123456%(prop:xy)s78901'), 'Step name', 10)

--- a/master/buildbot/test/unit/config/test_checks.py
+++ b/master/buildbot/test/unit/config/test_checks.py
@@ -16,6 +16,8 @@
 from twisted.trial import unittest
 
 from buildbot.config.checks import check_param_length
+from buildbot.config.checks import check_param_str
+from buildbot.config.checks import check_param_str_none
 from buildbot.process.properties import Interpolate
 from buildbot.test.util import config
 
@@ -41,3 +43,23 @@ class TestCheckParamLength(unittest.TestCase, config.ConfigErrorsMixin):
     def test_long_interpolate(self):
         with self.assertRaisesConfigError("exceeds maximum length of 10"):
             check_param_length(Interpolate('123456%(prop:xy)s78901'), 'Step name', 10)
+
+
+class TestCheckParamType(unittest.TestCase, config.ConfigErrorsMixin):
+
+    def test_str(self):
+        check_param_str('abc', self.__class__, 'param')
+
+    def test_str_wrong(self):
+        msg = "TestCheckParamType argument param must be an instance of str"
+        with self.assertRaisesConfigError(msg):
+            check_param_str(1, self.__class__, 'param')
+
+    def test_str_none(self):
+        check_param_str_none('abc', self.__class__, 'param')
+        check_param_str_none(None, self.__class__, 'param')
+
+    def test_str_none_wrong(self):
+        msg = "TestCheckParamType argument param must be an instance of str or None"
+        with self.assertRaisesConfigError(msg):
+            check_param_str_none(1, self.__class__, 'param')

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -91,11 +91,13 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         self.setUpEndpoint()
         return self.db.insert_test_data([
+            fakedb.Project(id=201, name='project201'),
+            fakedb.Project(id=202, name='project202'),
             fakedb.Builder(id=1, name='buildera'),
             fakedb.Builder(id=2, name='builderb'),
-            fakedb.Builder(id=3, name='builderTagA'),
-            fakedb.Builder(id=4, name='builderTagB'),
-            fakedb.Builder(id=5, name='builderTagAB'),
+            fakedb.Builder(id=3, name='builderTagA', projectid=201),
+            fakedb.Builder(id=4, name='builderTagB', projectid=201),
+            fakedb.Builder(id=5, name='builderTagAB', projectid=202),
             fakedb.Tag(id=3, name="tagA"),
             fakedb.Tag(id=4, name="tagB"),
             fakedb.BuildersTags(builderid=3, tagid=3),
@@ -128,6 +130,16 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
         self.assertEqual(sorted([b['builderid'] for b in builders]),
                          [2])
+
+    @defer.inlineCallbacks
+    def test_get_projectid(self):
+        builders = yield self.callGet(('projects', 201, 'builders'))
+
+        for b in builders:
+            self.validateData(b)
+
+        self.assertEqual(sorted([b['builderid'] for b in builders]),
+                         [3, 4])
 
     @defer.inlineCallbacks
     def test_get_masterid_missing(self):

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -205,7 +205,7 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     def test_signature_updateBuilderInfo(self):
         @self.assertArgSpecMatches(self.master.data.updates.updateBuilderInfo)
-        def updateBuilderInfo(self, builderid, description, tags):
+        def updateBuilderInfo(self, builderid, description, projectid, tags):
             pass
 
     def test_signature_updateBuilderList(self):
@@ -222,7 +222,7 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders())),
                          sorted([
                              dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None, tags=[]),
+                                  name='somebuilder', description=None, projectid=None, tags=[]),
                          ]))
         self.master.mq.assertProductions([(('builders', '1', 'started'),
                                            {'builderid': 1, 'masterid': 13,
@@ -237,9 +237,9 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
                          sorted([
                              dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None, tags=[]),
+                                  name='somebuilder', description=None, projectid=None, tags=[]),
                              dict(id=2, masterids=[13],
-                                  name='another', description=None, tags=[]),
+                                  name='another', description=None, projectid=None, tags=[]),
                          ], key=builderKey))
         self.master.mq.assertProductions([(('builders', '2', 'started'),
                                            {'builderid': 2, 'masterid': 13, 'name': 'another'})])
@@ -249,9 +249,9 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
                          sorted([
                              dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None, tags=[]),
+                                  name='somebuilder', description=None, projectid=None, tags=[]),
                              dict(id=2, masterids=[13, 14],
-                                  name='another', description=None, tags=[]),
+                                  name='another', description=None, projectid=None, tags=[]),
                          ], key=builderKey))
         self.master.mq.assertProductions([(('builders', '2', 'started'),
                                            {'builderid': 2, 'masterid': 14, 'name': 'another'})])
@@ -261,9 +261,11 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
                          sorted([
                              dict(
-                                 id=1, masterids=[], name='somebuilder', description=None, tags=[]),
+                                 id=1, masterids=[], name='somebuilder', description=None,
+                                 projectid=None, tags=[]),
                              dict(
-                                 id=2, masterids=[14], name='another', description=None, tags=[]),
+                                 id=2, masterids=[14], name='another', description=None,
+                                 projectid=None, tags=[]),
                          ], key=builderKey))
         self.master.mq.assertProductions([
             (('builders', '1', 'stopped'),

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -1,0 +1,137 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.data import projects
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.util import endpoint
+from buildbot.test.util import interfaces
+
+
+class ProjectEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = projects.ProjectEndpoint
+    resourceTypeClass = projects.Project
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpEndpoint()
+        yield self.db.insert_test_data([
+            fakedb.Project(id=1, name='project1'),
+            fakedb.Project(id=2, name='project2'),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @defer.inlineCallbacks
+    def test_get_existing_id(self):
+        project = yield self.callGet(('projects', 2))
+
+        self.validateData(project)
+        self.assertEqual(project['name'], 'project2')
+
+    @defer.inlineCallbacks
+    def test_get_existing_name(self):
+        project = yield self.callGet(('projects', 'project2'))
+
+        self.validateData(project)
+        self.assertEqual(project['name'], 'project2')
+
+    @defer.inlineCallbacks
+    def test_get_missing(self):
+        project = yield self.callGet(('projects', 99))
+
+        self.assertIsNone(project)
+
+    @defer.inlineCallbacks
+    def test_get_missing_with_name(self):
+        project = yield self.callGet(('projects', 'project99'))
+
+        self.assertIsNone(project)
+
+
+class ProjectsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = projects.ProjectsEndpoint
+    resourceTypeClass = projects.Project
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpEndpoint()
+        yield self.db.insert_test_data([
+            fakedb.Project(id=1, name='project1'),
+            fakedb.Project(id=2, name='project2'),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @defer.inlineCallbacks
+    def test_get(self):
+        projects = yield self.callGet(('projects',))
+
+        for b in projects:
+            self.validateData(b)
+
+        self.assertEqual(sorted([b['projectid'] for b in projects]), [1, 2])
+
+
+class Project(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setup_test_reactor()
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
+        self.rtype = projects.Project(self.master)
+        yield self.master.db.insert_test_data([
+            fakedb.Project(id=13, name="fake_project"),
+        ])
+
+    def test_signature_find_project_id(self):
+        @self.assertArgSpecMatches(
+            self.master.data.updates.find_project_id,  # fake
+            self.rtype.find_project_id)  # real
+        def find_project_id(self, name):
+            pass
+
+    def test_find_project_id(self):
+        # this just passes through to the db method, so test that
+        rv = defer.succeed(None)
+        self.master.db.projects.find_project_id = mock.Mock(return_value=rv)
+        self.assertIdentical(self.rtype.find_project_id('foo'), rv)
+
+    def test_signature_update_project_info(self):
+        @self.assertArgSpecMatches(self.master.data.updates.update_project_info)
+        def update_project_info(self, projectid, slug, description):
+            pass
+
+    @defer.inlineCallbacks
+    def test_update_project_info(self):
+        yield self.master.data.updates.update_project_info(13, 'slug13', 'project13 desc')
+        projects = yield self.master.db.projects.get_projects()
+        self.assertEqual(projects, [{
+            "id": 13,
+            "name": "fake_project",
+            "slug": "slug13",
+            "description": "project13 desc",
+        }])

--- a/master/buildbot/test/unit/db/test_build_data.py
+++ b/master/buildbot/test/unit/db/test_build_data.py
@@ -232,7 +232,7 @@ class TestRealDB(unittest.TestCase,
     def setUp(self):
         yield self.setUpConnectorComponent(
             table_names=['builds', 'builders', 'masters', 'buildrequests', 'buildsets',
-                         'workers', 'build_data'])
+                         'workers', 'build_data', "projects"])
 
         self.db.build_data = build_data.BuildDataConnectorComponent(self.db)
 

--- a/master/buildbot/test/unit/db/test_builders.py
+++ b/master/buildbot/test/unit/db/test_builders.py
@@ -60,7 +60,7 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_getBuilders(self):
         @self.assertArgSpecMatches(self.db.builders.getBuilders)
-        def getBuilders(self, masterid=None):
+        def getBuilders(self, masterid=None, projectid=None):
             pass
 
     def test_signature_updateBuilderInfo(self):
@@ -257,6 +257,44 @@ class Tests(interfaces.InterfaceTests):
                  3], tags=[], description=None, projectid=None),
             dict(id=8, name='other:builder', masterids=[
                  3, 4], tags=[], description=None, projectid=None),
+        ], key=builderKey))
+
+    @defer.inlineCallbacks
+    def test_getBuilders_projectid(self):
+        yield self.insert_test_data([
+            fakedb.Project(id=201, name="p201"),
+            fakedb.Project(id=202, name="p202"),
+            fakedb.Builder(id=101, name="b101"),
+            fakedb.Builder(id=102, name="b102", projectid=201),
+            fakedb.Builder(id=103, name="b103", projectid=201),
+            fakedb.Builder(id=104, name="b104", projectid=202),
+            fakedb.Master(id=3, name='m1'),
+            fakedb.Master(id=4, name='m2'),
+            fakedb.BuilderMaster(builderid=101, masterid=3),
+            fakedb.BuilderMaster(builderid=102, masterid=3),
+            fakedb.BuilderMaster(builderid=103, masterid=4),
+            fakedb.BuilderMaster(builderid=104, masterid=4),
+        ])
+        builderlist = yield self.db.builders.getBuilders(projectid=201)
+        for builderdict in builderlist:
+            validation.verifyDbDict(self, 'builderdict', builderdict)
+        self.assertEqual(sorted(builderlist, key=builderKey), sorted([
+            {
+                "id": 102,
+                "name": "b102",
+                "masterids": [3],
+                "tags": [],
+                "description": None,
+                "projectid": 201,
+            },
+            {
+                "id": 103,
+                "name": "b103",
+                "masterids": [4],
+                "tags": [],
+                "description": None,
+                "projectid": 201,
+            },
         ], key=builderKey))
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/db/test_builders.py
+++ b/master/buildbot/test/unit/db/test_builders.py
@@ -65,38 +65,44 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_updateBuilderInfo(self):
         @self.assertArgSpecMatches(self.db.builders.updateBuilderInfo)
-        def updateBuilderInfo(self, builderid, description, tags):
+        def updateBuilderInfo(self, builderid, description, projectid, tags):
             pass
 
     @defer.inlineCallbacks
     def test_updateBuilderInfo(self):
         yield self.insert_test_data([
+            fakedb.Project(id=123, name="fake_project123"),
+            fakedb.Project(id=124, name="fake_project124"),
             fakedb.Builder(id=7, name='some:builder7'),
             fakedb.Builder(id=8, name='some:builder8'),
         ])
 
         yield self.db.builders.updateBuilderInfo(7, 'a string which describe the builder',
-                                                 ['cat1', 'cat2'])
-        yield self.db.builders.updateBuilderInfo(8, 'a string which describe the builder', [])
+                                                 123, ['cat1', 'cat2'])
+        yield self.db.builders.updateBuilderInfo(8, 'a string which describe the builder',
+                                                 124, [])
         builderdict7 = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict7)
         builderdict7['tags'].sort()  # order is unspecified
         self.assertEqual(builderdict7,
                          dict(id=7, name='some:builder7', tags=['cat1', 'cat2'],
-                              masterids=[], description='a string which describe the builder'))
+                              masterids=[], description='a string which describe the builder',
+                              projectid=123))
         builderdict8 = yield self.db.builders.getBuilder(8)
         validation.verifyDbDict(self, 'builderdict', builderdict8)
         self.assertEqual(builderdict8,
                          dict(id=8, name='some:builder8', tags=[],
-                              masterids=[], description='a string which describe the builder'))
+                              masterids=[], description='a string which describe the builder',
+                              projectid=124))
 
     @defer.inlineCallbacks
     def test_update_builder_info_tags_case(self):
         yield self.insert_test_data([
-            fakedb.Builder(id=7, name='some:builder7'),
+            fakedb.Project(id=107, name='fake_project'),
+            fakedb.Builder(id=7, name='some:builder7', projectid=107),
         ])
 
-        yield self.db.builders.updateBuilderInfo(7, 'builder_desc', ['Cat', 'cat'])
+        yield self.db.builders.updateBuilderInfo(7, 'builder_desc', 107, ['Cat', 'cat'])
         builder_dict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builder_dict)
         builder_dict['tags'].sort()  # order is unspecified
@@ -105,7 +111,8 @@ class Tests(interfaces.InterfaceTests):
             'name': 'some:builder7',
             'tags': ['Cat', 'cat'],
             'masterids': [],
-            'description': 'builder_desc'
+            'description': 'builder_desc',
+            'projectid': 107,
         })
 
     @defer.inlineCallbacks
@@ -114,7 +121,7 @@ class Tests(interfaces.InterfaceTests):
         builderdict = yield self.db.builders.getBuilder(id)
         self.assertEqual(builderdict,
                          dict(id=id, name='some:builder', tags=[],
-                              masterids=[], description=None))
+                              masterids=[], description=None, projectid=None))
 
     @defer.inlineCallbacks
     def test_findBuilderId_new_no_autoCreate(self):
@@ -142,7 +149,7 @@ class Tests(interfaces.InterfaceTests):
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
                          dict(id=7, name='some:builder', tags=[],
-                              masterids=[9, 10], description=None))
+                              masterids=[9, 10], description=None, projectid=None))
 
     @defer.inlineCallbacks
     def test_addBuilderMaster_already_present(self):
@@ -157,7 +164,7 @@ class Tests(interfaces.InterfaceTests):
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
                          dict(id=7, name='some:builder', tags=[],
-                              masterids=[9], description=None))
+                              masterids=[9], description=None, projectid=None))
 
     @defer.inlineCallbacks
     def test_removeBuilderMaster(self):
@@ -173,7 +180,7 @@ class Tests(interfaces.InterfaceTests):
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
                          dict(id=7, name='some:builder', tags=[],
-                              masterids=[10], description=None))
+                              masterids=[10], description=None, projectid=None))
 
     @defer.inlineCallbacks
     def test_getBuilder_no_masters(self):
@@ -184,7 +191,7 @@ class Tests(interfaces.InterfaceTests):
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
                          dict(id=7, name='some:builder', tags=[],
-                              masterids=[], description=None))
+                              masterids=[], description=None, projectid=None))
 
     @defer.inlineCallbacks
     def test_getBuilder_with_masters(self):
@@ -199,7 +206,7 @@ class Tests(interfaces.InterfaceTests):
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
                          dict(id=7, name='some:builder', tags=[],
-                              masterids=[3, 4], description=None))
+                              masterids=[3, 4], description=None, projectid=None))
 
     @defer.inlineCallbacks
     def test_getBuilder_missing(self):
@@ -223,11 +230,11 @@ class Tests(interfaces.InterfaceTests):
             validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(sorted(builderlist, key=builderKey), sorted([
             dict(id=7, name='some:builder', masterids=[
-                 3], tags=[], description=None),
+                 3], tags=[], description=None, projectid=None),
             dict(id=8, name='other:builder', masterids=[
-                 3, 4], tags=[], description=None),
+                 3, 4], tags=[], description=None, projectid=None),
             dict(id=9, name='third:builder',
-                 masterids=[], tags=[], description=None),
+                 masterids=[], tags=[], description=None, projectid=None),
         ], key=builderKey))
 
     @defer.inlineCallbacks
@@ -247,9 +254,9 @@ class Tests(interfaces.InterfaceTests):
             validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(sorted(builderlist, key=builderKey), sorted([
             dict(id=7, name='some:builder', masterids=[
-                 3], tags=[], description=None),
+                 3], tags=[], description=None, projectid=None),
             dict(id=8, name='other:builder', masterids=[
-                 3, 4], tags=[], description=None),
+                 3, 4], tags=[], description=None, projectid=None),
         ], key=builderKey))
 
     @defer.inlineCallbacks
@@ -279,7 +286,7 @@ class TestRealDB(unittest.TestCase,
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpConnectorComponent(
-            table_names=['builders', 'masters', 'builder_masters',
+            table_names=['projects', 'builders', 'masters', 'builder_masters',
                          'builders_tags', 'tags'])
 
         self.db.builders = builders.BuildersConnectorComponent(self.db)

--- a/master/buildbot/test/unit/db/test_buildrequests.py
+++ b/master/buildbot/test/unit/db/test_buildrequests.py
@@ -650,7 +650,7 @@ class TestRealDB(unittest.TestCase,
             table_names=['patches', 'changes', 'builders',
                          'buildsets', 'buildset_properties', 'buildrequests',
                          'buildset_sourcestamps', 'masters', 'buildrequest_claims',
-                         'sourcestamps', 'sourcestampsets', 'builds', 'workers',
+                         'sourcestamps', 'sourcestampsets', 'builds', 'workers', "projects",
                          ])
 
         self.db.buildrequests = \

--- a/master/buildbot/test/unit/db/test_builds.py
+++ b/master/buildbot/test/unit/db/test_builds.py
@@ -507,7 +507,7 @@ class TestRealDB(unittest.TestCase,
         yield self.setUpConnectorComponent(
             table_names=['builds', 'builders', 'masters', 'buildrequests',
                          'buildsets', 'workers', 'build_properties', 'changes',
-                         'sourcestamps', 'buildset_sourcestamps', 'patches'])
+                         'sourcestamps', 'buildset_sourcestamps', 'patches', "projects"])
 
         self.db.builds = builds.BuildsConnectorComponent(self.db)
 

--- a/master/buildbot/test/unit/db/test_buildsets.py
+++ b/master/buildbot/test/unit/db/test_buildsets.py
@@ -507,7 +507,7 @@ class TestRealDB(db.TestCase,
             table_names=['patches', 'buildsets', 'buildset_properties',
                          'objects', 'buildrequests', 'sourcestamps',
                          'buildset_sourcestamps', 'builders',
-                         'builds', 'masters', 'workers'])
+                         'builds', 'masters', 'workers', "projects"])
 
         self.db.buildsets = buildsets.BuildsetsConnectorComponent(self.db)
         yield self.setUpTests()

--- a/master/buildbot/test/unit/db/test_changes.py
+++ b/master/buildbot/test/unit/db/test_changes.py
@@ -767,7 +767,7 @@ class TestRealDB(unittest.TestCase,
                          'sourcestampsets', 'sourcestamps', 'patches', 'change_users',
                          'users', 'buildsets', 'workers', 'builders', 'masters',
                          'buildrequests', 'builds', 'buildset_sourcestamps',
-                         'workers'])
+                         'workers', "projects"])
 
         self.db.changes = changes.ChangesConnectorComponent(self.db)
         self.db.builds = builds.BuildsConnectorComponent(self.db)

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -42,7 +42,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin,
             'changes', 'change_properties', 'change_files', 'patches',
             'sourcestamps', 'buildset_properties', 'buildsets',
             'sourcestampsets', 'builds', 'builders', 'masters',
-            'buildrequests', 'workers'])
+            'buildrequests', 'workers', "projects"])
 
         self.master = fakemaster.make_master(self)
         self.master.config = MasterConfig()

--- a/master/buildbot/test/unit/db/test_logs.py
+++ b/master/buildbot/test/unit/db/test_logs.py
@@ -588,7 +588,7 @@ class TestRealDB(unittest.TestCase,
         yield self.setUpConnectorComponent(
             table_names=['logs', 'logchunks', 'steps', 'builds', 'builders',
                          'masters', 'buildrequests', 'buildsets',
-                         'workers'])
+                         'workers', "projects"])
 
         self.db.logs = logs.LogsConnectorComponent(self.db)
 

--- a/master/buildbot/test/unit/db/test_projects.py
+++ b/master/buildbot/test/unit/db/test_projects.py
@@ -1,0 +1,175 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.db import projects
+from buildbot.test import fakedb
+from buildbot.test.util import connector_component
+from buildbot.test.util import interfaces
+from buildbot.test.util import validation
+
+
+def project_key(builder):
+    return builder['id']
+
+
+class Tests(interfaces.InterfaceTests):
+
+    def test_signature_find_project_id(self):
+        @self.assertArgSpecMatches(self.db.projects.find_project_id)
+        def find_project_id(self, name, auto_create=True):
+            pass
+
+    def test_signature_get_project(self):
+        @self.assertArgSpecMatches(self.db.projects.get_project)
+        def get_project(self, projectid):
+            pass
+
+    def test_signature_get_projects(self):
+        @self.assertArgSpecMatches(self.db.projects.get_projects)
+        def get_projects(self):
+            pass
+
+    def test_signature_update_project_info(self):
+        @self.assertArgSpecMatches(self.db.projects.update_project_info)
+        def update_project_info(self, projectid, slug, description):
+            pass
+
+    @defer.inlineCallbacks
+    def test_update_project_info(self):
+        yield self.insert_test_data([
+            fakedb.Project(id=7, name='fake_project7'),
+        ])
+
+        yield self.db.projects.update_project_info(7, 'slug7', 'project7 desc')
+        dbdict = yield self.db.projects.get_project(7)
+        validation.verifyDbDict(self, 'projectdict', dbdict)
+        self.assertEqual(dbdict, {
+            "id": 7,
+            "name": "fake_project7",
+            "slug": "slug7",
+            "description": "project7 desc",
+        })
+
+    @defer.inlineCallbacks
+    def test_find_project_id_new(self):
+        id = yield self.db.projects.find_project_id('fake_project')
+        dbdict = yield self.db.projects.get_project(id)
+        self.assertEqual(dbdict, {
+            "id": id,
+            "name": "fake_project",
+            "slug": "fake_project",
+            "description": None,
+        })
+
+    @defer.inlineCallbacks
+    def test_find_project_id_new_no_auto_create(self):
+        id = yield self.db.projects.find_project_id('fake_project', auto_create=False)
+        self.assertIsNone(id)
+
+    @defer.inlineCallbacks
+    def test_find_project_id_exists(self):
+        yield self.insert_test_data([
+            fakedb.Project(id=7, name='fake_project'),
+        ])
+        id = yield self.db.projects.find_project_id('fake_project')
+        self.assertEqual(id, 7)
+
+    @defer.inlineCallbacks
+    def test_get_project(self):
+        yield self.insert_test_data([
+            fakedb.Project(id=7, name='fake_project'),
+        ])
+        dbdict = yield self.db.projects.get_project(7)
+        validation.verifyDbDict(self, 'projectdict', dbdict)
+        self.assertEqual(dbdict, {
+            "id": 7,
+            "name": "fake_project",
+            "slug": "fake_project",
+            "description": None,
+        })
+
+    @defer.inlineCallbacks
+    def test_get_project_missing(self):
+        dbdict = yield self.db.projects.get_project(7)
+        self.assertIsNone(dbdict)
+
+    @defer.inlineCallbacks
+    def test_get_projects(self):
+        yield self.insert_test_data([
+            fakedb.Project(id=7, name="fake_project7"),
+            fakedb.Project(id=8, name="fake_project8"),
+            fakedb.Project(id=9, name="fake_project9"),
+        ])
+        dblist = yield self.db.projects.get_projects()
+        for dbdict in dblist:
+            validation.verifyDbDict(self, 'projectdict', dbdict)
+        self.assertEqual(sorted(dblist, key=project_key), sorted([
+            {
+                "id": 7,
+                "name": "fake_project7",
+                "slug": "fake_project7",
+                "description": None,
+            },
+            {
+                "id": 8,
+                "name": "fake_project8",
+                "slug": "fake_project8",
+                "description": None,
+            },
+            {
+                "id": 9,
+                "name": "fake_project9",
+                "slug": "fake_project9",
+                "description": None,
+            },
+        ], key=project_key))
+
+    @defer.inlineCallbacks
+    def test_get_projects_empty(self):
+        dblist = yield self.db.projects.get_projects()
+        self.assertEqual(dblist, [])
+
+
+class RealTests(Tests):
+
+    # tests that only "real" implementations will pass
+
+    pass
+
+
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent()
+
+
+class TestRealDB(unittest.TestCase,
+                 connector_component.ConnectorComponentMixin,
+                 RealTests):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent(table_names=['projects'])
+
+        self.db.projects = projects.ProjectsConnectorComponent(self.db)
+        self.master = self.db.master
+        self.master.db = self.db
+
+    def tearDown(self):
+        return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/db/test_sourcestamps.py
+++ b/master/buildbot/test/unit/db/test_sourcestamps.py
@@ -378,6 +378,7 @@ class TestRealDB(unittest.TestCase,
         yield self.setUpConnectorComponent(
             table_names=['sourcestamps',
                          'patches',
+                         "projects",
                          'masters',
                          'workers',
                          'buildsets',

--- a/master/buildbot/test/unit/db/test_steps.py
+++ b/master/buildbot/test/unit/db/test_steps.py
@@ -351,7 +351,7 @@ class TestRealDB(unittest.TestCase,
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpConnectorComponent(
-            table_names=['steps', 'builds', 'builders', 'masters',
+            table_names=['steps', 'builds', 'builders', 'masters', "projects",
                          'buildrequests', 'buildsets', 'workers'])
 
         self.db.steps = steps.StepsConnectorComponent(self.db)

--- a/master/buildbot/test/unit/db/test_test_result_sets.py
+++ b/master/buildbot/test/unit/db/test_test_result_sets.py
@@ -231,7 +231,7 @@ class TestRealDB(unittest.TestCase,
     def setUp(self):
         yield self.setUpConnectorComponent(
             table_names=['steps', 'builds', 'builders', 'masters', 'buildrequests', 'buildsets',
-                         'workers', 'test_result_sets'])
+                         'workers', 'test_result_sets', "projects"])
 
         self.db.test_result_sets = test_result_sets.TestResultSetsConnectorComponent(self.db)
 

--- a/master/buildbot/test/unit/db/test_test_results.py
+++ b/master/buildbot/test/unit/db/test_test_results.py
@@ -170,8 +170,8 @@ class TestRealDB(unittest.TestCase,
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpConnectorComponent(
-            table_names=['steps', 'builds', 'builders', 'masters', 'buildrequests', 'buildsets',
-                         'workers', 'test_names', 'test_code_paths', 'test_results',
+            table_names=['steps', 'builds', "projects", 'builders', 'masters', 'buildrequests',
+                         'buildsets', 'workers', 'test_names', 'test_code_paths', 'test_results',
                          'test_result_sets'])
 
         self.db.test_results = test_results.TestResultsConnectorComponent(self.db)

--- a/master/buildbot/test/unit/db/test_workers.py
+++ b/master/buildbot/test/unit/db/test_workers.py
@@ -663,7 +663,7 @@ class TestRealDB(unittest.TestCase,
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpConnectorComponent(
-            table_names=['workers', 'masters', 'builders',
+            table_names=['workers', 'masters', 'projects', 'builders',
                          'builder_masters', 'connected_workers',
                          'configured_workers'])
 

--- a/master/buildbot/test/unit/db_migrate/test_versions_060_add_builder_projects.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_060_add_builder_projects.py
@@ -1,0 +1,97 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import hashlib
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.Text, nullable=False),
+            sa.Column('description', sa.Text, nullable=True),
+            sa.Column('name_hash', sa.String(40), nullable=False),
+        )
+        builders.create()
+
+        conn.execute(builders.insert(), [{
+            "id": 3,
+            "name": "foo",
+            "description": "foo_description",
+            "name_hash": hashlib.sha1(b'foo').hexdigest()
+        }])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            # check that projects table has been added
+            projects = sautils.Table('projects', metadata, autoload=True)
+
+            q = sa.select([
+                projects.c.id,
+                projects.c.name,
+                projects.c.name_hash,
+                projects.c.slug,
+                projects.c.description,
+            ])
+            self.assertEqual(conn.execute(q).fetchall(), [])
+
+            # check that builders.projectid has been added
+            builders = sautils.Table('builders', metadata, autoload=True)
+            self.assertIsInstance(builders.c.projectid.type, sa.Integer)
+
+            q = sa.select([builders.c.name, builders.c.projectid])
+            num_rows = 0
+            for row in conn.execute(q):
+                # verify that the default value was set correctly
+                self.assertIsNone(row.projectid)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+            # check that new indexes have been added
+            insp = sa.inspect(conn)
+
+            indexes = insp.get_indexes('projects')
+            index_names = [item['name'] for item in indexes]
+            self.assertTrue('projects_name_hash' in index_names)
+
+            indexes = insp.get_indexes('builders')
+            index_names = [item['name'] for item in indexes]
+            self.assertTrue('builders_projectid' in index_names)
+
+        return self.do_test_migration('059', '060', setup_thd, verify_thd)

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -164,6 +164,8 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):
         # check that reconfigServiceBuilders is called.
+        self.patch(self.botmaster, 'reconfigProjects',
+                   mock.Mock(side_effect=lambda c: defer.succeed(None)))
         self.patch(self.botmaster, 'reconfigServiceBuilders',
                    mock.Mock(side_effect=lambda c: defer.succeed(None)))
         self.patch(self.botmaster, 'maybeStartBuildsForAllBuilders',
@@ -172,8 +174,8 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
         new_config = mock.Mock()
         yield self.botmaster.reconfigServiceWithBuildbotConfig(new_config)
 
-        self.botmaster.reconfigServiceBuilders.assert_called_with(
-            new_config)
+        self.botmaster.reconfigServiceBuilders.assert_called_with(new_config)
+        self.botmaster.reconfigProjects.assert_called_with(new_config)
         self.assertTrue(
             self.botmaster.maybeStartBuildsForAllBuilders.called)
 

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -124,6 +124,9 @@ class FakeBuilder:
     def getBuilderIdForName(self, name):
         return defer.succeed(self._builders.get(name, None) or self.builderid)
 
+    def find_project_id(self, name):
+        return defer.succeed(None)
+
 
 @implementer(interfaces.IBuildStepFactory)
 class FakeStepFactory:

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -167,6 +167,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                 'builder': {
                     'builderid': 80,
                     'description': None,
+                    'projectid': None,
                     'masterids': [],
                     'name': 'Builder1',
                     'tags': []
@@ -268,6 +269,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                 'builder': {
                     'builderid': 80,
                     'description': None,
+                    'projectid': None,
                     'masterids': [],
                     'name': 'Builder1',
                     'tags': []

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -135,7 +135,7 @@ class TestCleanupDbRealDb(db.RealDatabaseWithConnectorMixin, TestCleanupDb):
         yield super().setUp()
 
         table_names = [
-            'logs', 'logchunks', 'steps', 'builds', 'builders',
+            'logs', 'logchunks', 'steps', 'builds', 'projects', 'builders',
             'masters', 'buildrequests', 'buildsets', 'workers'
         ]
 

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from twisted import trial
 from twisted.internet import defer
 
 from buildbot.data import base
@@ -100,9 +101,14 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
     # interface tests
 
     def test_get_spec(self):
-        @self.assertArgSpecMatches(self.ep.get)
-        def get(self, resultSpec, kwargs):
-            pass
+        try:
+            @self.assertArgSpecMatches(self.ep.get)
+            def get(self, resultSpec, kwargs):
+                pass
+        except trial.unittest.FailTest:
+            @self.assertArgSpecMatches(self.ep.get)
+            def get(self, result_spec, kwargs):
+                pass
 
     def test_control_spec(self):
         @self.assertArgSpecMatches(self.ep.control)

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -369,6 +369,14 @@ dbdict['ssdict'] = DictValidator(
     created_at=DateTimeValidator(),
 )
 
+# project
+dbdict['projectdict'] = DictValidator(
+    id=IntValidator(),
+    name=StringValidator(),
+    slug=StringValidator(),
+    description=NoneOk(StringValidator()),
+)
+
 # builder
 
 message['builders'] = Selector()
@@ -386,6 +394,7 @@ dbdict['builderdict'] = DictValidator(
     masterids=ListValidator(IntValidator()),
     name=StringValidator(),
     description=NoneOk(StringValidator()),
+    projectid=NoneOk(IntValidator()),
     tags=ListValidator(StringValidator()),
 )
 

--- a/master/docs/developer/database/builders.rst
+++ b/master/docs/developer/database/builders.rst
@@ -51,10 +51,12 @@ Builders connector
 
         Get the indicated builder.
 
-    .. py:method:: getBuilders(masterid=None)
+    .. py:method:: getBuilders(masterid=None, projectid=None)
 
         :param integer masterid: ID of the master to which the results should be limited
+        :param integer masterid: ID of the project to which the results should be limited
         :returns: list of Builder dicts via Deferred
 
         Get all builders (in unspecified order).
-        If ``masterid`` is given, then only builders configured on that master are returned.
+        If ``masterid`` is specified, then only builders configured on that master are returned.
+        If ``projectid`` is specified, then only builders for a particular project are returned.

--- a/master/docs/developer/raml/index.rst
+++ b/master/docs/developer/raml/index.rst
@@ -21,6 +21,7 @@ This section documents the available REST APIs according to the RAML specificati
     log
     master
     patch
+    project
     rootlink
     scheduler
     sourcedproperties

--- a/master/docs/developer/raml/project.rst
+++ b/master/docs/developer/raml/project.rst
@@ -1,0 +1,2 @@
+.. jinja:: data_api_project
+    :file: templates/raml.jinja

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -14,6 +14,7 @@ You'll need to understand how Buildbot sees the world to configure it properly.
 .. index: source stamp
 
 .. _Source-Stamps:
+.. _Concepts-Project:
 
 Source identification
 ---------------------
@@ -147,6 +148,8 @@ This level of concurrency may be controlled by various kinds of :ref:`Interlocks
 At a low level, each builder has its own exclusive directory on the build master and one exclusive directory on each of the workers it is attached to.
 The directory on the master is used for keeping status information.
 The directories on the workers are used as a location where the actual checkout, compilation and testing steps happen.
+
+For easier management in the Web UI related builders may be grouped into projects.
 
 .. _Concepts-Build:
 

--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -60,6 +60,9 @@ Other optional keys may be set on each ``BuilderConfig``:
     You can tag these new builders with a ``test`` tag, make your main status clients ignore them, and have only private status clients pick them up.
     As soon as they work, you can move them over to the active tag.
 
+``project``
+    If provided, the builder will be associated with the specific project.
+
 ``nextWorker``
      If provided, this is a function that controls which worker will be assigned future jobs.
      The function is passed three arguments, the :class:`Builder` object which is assigning a new job, a list of :class:`WorkerForBuilder` objects and the :class:`BuildRequest`.
@@ -210,6 +213,8 @@ The virtual builder metadata is configured with the following properties:
 * ``virtual_builder_name``: The name of the virtual builder.
 
 * ``virtual_builder_description``: The description of the virtual builder.
+
+* ``virtual_builder_project``: The project of the virtual builder.
 
 * ``virtual_builder_tags``: The tags for the virtual builder.
 

--- a/master/docs/manual/configuration/index.rst
+++ b/master/docs/manual/configuration/index.rst
@@ -18,6 +18,7 @@ The next section, :doc:`../customization`, describes this approach, with frequen
     schedulers
     workers
     builders
+    projects
     buildfactories
     buildsets
     properties

--- a/master/docs/manual/configuration/projects.rst
+++ b/master/docs/manual/configuration/projects.rst
@@ -1,0 +1,42 @@
+.. bb:cfg:: projects
+
+.. _Project-Configuration:
+
+Projects
+--------
+
+.. contents::
+    :depth: 1
+    :local:
+
+The :bb:cfg:`projects` configuration key is a list of objects holding the configuration of the Projects.
+For more information on the Project function in Buildbot, see :ref:`the Concepts chapter <Concepts-Project>`.
+
+``Project`` takes the following keyword arguments:
+
+``name``
+    The name of the Project.
+    Builders are associated to the Project using this string as their ``project`` parameter.
+
+The following arguments are optional:
+
+``slug``
+    A short string that is used to refer to the project in the URLs of the Buildbot web UI.
+
+``description``
+    A description of the project that appears in the Buildbot web UI.
+
+Example
+~~~~~~~
+
+The following is a demonstration of defining several Projects in the Buildbot configuration
+
+.. code-block:: python
+
+    from buildbot.plugins import util
+    c['projects'] = [
+        util.Project(name="example",
+                     description="An application to build example widgets"),
+        util.Project(name="example-utils",
+                     description="Utilities for the example project"),
+    ]

--- a/master/setup.py
+++ b/master/setup.py
@@ -389,6 +389,7 @@ setup_args = {
                 'BuildFactory', 'GNUAutoconf', 'CPAN', 'Distutils', 'Trial',
                 'BasicBuildFactory', 'QuickBuildFactory', 'BasicSVN']),
             ('buildbot.process.logobserver', ['LogLineObserver']),
+            ('buildbot.process.project', ['Project']),
             ('buildbot.process.properties', [
                 'FlattenList', 'Interpolate', 'Property', 'Transform',
                 'WithProperties', 'renderer', 'Secret']),

--- a/newsfragments/builder-projects.feature
+++ b/newsfragments/builder-projects.feature
@@ -1,0 +1,5 @@
+Introduce a way to group builders by project.
+A new ``projects`` list is added to the configuration dictionary.
+Builders can be associated to the entries in that list by the new ``project`` argument.
+
+Grouping builders by project allows to significantly clean up the UI in larger Buildbot installations that contain hundreds or thousands of builders for a smaller number of unrelated codebases.


### PR DESCRIPTION
Introduce a way to group builders by project. A new ``projects`` list is added to the configuration dictionary. Builders can be associated to the entries in that list by the new ``project`` argument.

Grouping builders by project allows to significantly clean up the UI in larger Buildbot installations that contain hundreds or thousands of builders for a smaller number of unrelated codebases.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
