### PR TITLE
worker: Allow Solaris OS to run cp command without option -v

### DIFF
--- a/newsfragments/solaris-doesnt-know-cp-v.bugfix
+++ b/newsfragments/solaris-doesnt-know-cp-v.bugfix
@@ -1,0 +1,1 @@
+Fixed exception thrown when worker copies directories in Solaris operating system (:issue:`6870`).

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import glob
 import os
+import platform
 import shutil
 import sys
 
@@ -194,7 +195,11 @@ class CopyDirectory(base.Command):
                 log.msg(("cp target '{0}' already exists -- cp will not do what you think!"
                          ).format(to_path))
 
-            command = ['cp', '-R', '-P', '-p', '-v', from_path, to_path]
+            if platform.system().lower().find('solaris') >= 0:
+                command = ['cp', '-R', '-P', '-p', from_path, to_path]
+            else:
+                command = ['cp', '-R', '-P', '-p', '-v', from_path, to_path]
+
             c = runprocess.RunProcess(command, self.protocol_command.worker_basedir,
                                       self.protocol_command.unicode_encoding,
                                       self.protocol_command.send_update,


### PR DESCRIPTION
This PR allows buildbot to run 'cp' command on Solaris operating system.

* [not needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
