### PR TITLE
db: Fix performance of changes queries with custom filter

### DIFF
--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -48,7 +48,19 @@ class FixerMixin:
                 del change['sourcestampid']
         return change
     fieldMapping = {
+        'author': 'changes.author',
+        'branch': 'changes.branch',
+        'category': 'changes.category',
         'changeid': 'changes.changeid',
+        'codebase': 'changes.codebase',
+        'comments': 'changes.comments',
+        'committer': 'changes.committer',
+        'project': 'changes.project',
+        'repository': 'changes.repository',
+        'revision': 'changes.revision',
+        'revlink': 'changes.revlink',
+        'sourcestampid': 'changes.sourcestampid',
+        'when_timestamp': 'changes.when_timestamp',
     }
 
 

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -249,11 +249,12 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
         def thd(conn):
             # get the changeids from the 'changes' table
             changes_tbl = self.db.model.changes
-            q = sa.select([changes_tbl.c.changeid])
 
             if resultSpec is not None:
+                q = changes_tbl.select()
                 return reversed(resultSpec.thd_execute(conn, q, self._getDataFromRow))
 
+            q = sa.select([changes_tbl.c.changeid])
             rp = conn.execute(q)
             changeids = [self._getDataFromRow(row) for row in rp]
             rp.close()

--- a/newsfragments/optimize-changse-queries.bugfix
+++ b/newsfragments/optimize-changse-queries.bugfix
@@ -1,0 +1,1 @@
+Fixed performance of changes queries with custom filters.


### PR DESCRIPTION
Currently the following REST query will result in pathological behavior:

`api/v2/changes?limit=50&project__eq=test`

The database wrapper notices that there is a filter on a field and selects code path that handles ResultSpecs. Unfortunately, that code path does not actually support any fields within changes table, so it will load whole table one by one without any filtering and do filtering on application side.
