### PR TITLE
www: Add support for specifying builder descriptions being in HTML

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -183,6 +183,7 @@ class MasterConfig(util.ComparableMixin):
             authz=authz.Authz(),
             avatar_methods=avatar.AvatarGravatar(),
             logfileName='http.log',
+            descriptions_are_html=False,
         )
         self.services = {}
 
@@ -703,6 +704,7 @@ class MasterConfig(util.ComparableMixin):
             'custom_templates_dir',
             'debug',
             'default_page',
+            'descriptions_are_html',
             'json_cache_seconds',
             'jsonp',
             'logRotateLength',

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -66,6 +66,7 @@ global_defaults = dict(
     www=dict(port=None, plugins={},
              auth={'name': 'NoAuth'}, authz={},
              avatar_methods={'name': 'gravatar'},
+             descriptions_are_html=False,
              logfileName='http.log'),
 )
 
@@ -876,6 +877,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=None,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
+                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -885,6 +887,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=9888,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
+                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -895,6 +898,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     plugins={'waterfall': {'foo': 'bar'}},
                                     auth={'name': 'NoAuth'},
                                     authz={},
+                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -905,6 +909,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     allowed_origins=['a', 'b'],
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
+                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -914,6 +919,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=None,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
+                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http-access.log'))
 
@@ -927,6 +933,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=None,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
+                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     versions=custom_versions,
                                     logfileName='http.log'))

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -48,6 +48,11 @@ This server is configured with the ``www`` configuration key, which specifies a 
     If true, then debugging information will be output to the browser.
     This is best set to false (the default) on production systems, to avoid the possibility of information leakage.
 
+``descriptions_are_html``
+    If ``True``, then builder and project descriptions are interpreted and rendered as HTML.
+    Use only if the builder and project descriptions are coming from a trusted source.
+    Otherwise this option introduces cross site scripting security vulnerability.
+
 ``allowed_origins``
     This gives a list of origins which are allowed to access the Buildbot API (including control via JSONRPC 2.0).
     It implements cross-origin request sharing (CORS), allowing pages at origins other than the Buildbot UI to use the API.

--- a/newsfragments/www-descriptions-are-html.feature
+++ b/newsfragments/www-descriptions-are-html.feature
@@ -1,0 +1,1 @@
+Added a www configuration parameter ``descriptions_are_html`` to allow setting builder and project descriptions as html.

--- a/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
+++ b/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
@@ -1,0 +1,68 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {useContext} from "react";
+import {observer} from "mobx-react";
+import {Card} from "react-bootstrap";
+import {
+  Project,
+  useDataAccessor,
+  useDataApiQuery,
+} from "buildbot-data-js";
+import {ConfigContext} from "buildbot-ui";
+import {TableHeading} from "../TableHeading/TableHeading";
+
+export type ProjectDescriptionWidgetProps = {
+  projectid: number;
+}
+
+export const ProjectDescriptionWidget = observer(({projectid}: ProjectDescriptionWidgetProps) => {
+  const accessor = useDataAccessor([]);
+  const config = useContext(ConfigContext);
+
+  const projectQuery = useDataApiQuery(() => Project.getAll(accessor, {query: {
+      projectid: projectid
+    }}));
+  const project = projectQuery.getNthOrNull(0);
+
+  const renderDescription = (description: string) => {
+    if (config.descriptions_are_html) {
+      return (
+        <div dangerouslySetInnerHTML={{__html: description}}/>
+      );
+    } else {
+      return (
+        <div><TableHeading>Description:</TableHeading>{description}</div>
+      );
+    }
+  };
+
+  if (project !== null && project.description === null) {
+    return (
+      <></>
+    );
+  }
+
+  return (
+    <Card>
+      <Card.Body>
+        <h5>Description</h5>
+        {renderDescription(project === null ? "..." : project.description!)}
+      </Card.Body>
+    </Card>
+  );
+});

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -16,7 +16,7 @@
 */
 
 import {observer} from "mobx-react";
-import {useState} from "react";
+import {useContext, useState} from "react";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
@@ -29,7 +29,7 @@ import {
   useDataApiQuery,
   useDataApiSingleElementQuery
 } from "buildbot-data-js";
-import {TopbarAction, useTopbarItems, useTopbarActions, TopbarItem} from "buildbot-ui";
+import {TopbarAction, useTopbarItems, useTopbarActions, ConfigContext} from "buildbot-ui";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {BuildRequestsTable} from "../../components/BuildrequestsTable/BuildrequestsTable";
 import {useNavigate, useParams} from "react-router-dom";
@@ -94,6 +94,7 @@ const buildTopbarActions = (builds: DataCollection<Build>,
 export const BuilderView = observer(() => {
   const builderid = Number.parseInt(useParams<"builderid">().builderid ?? "");
   const navigate = useNavigate();
+  const config = useContext(ConfigContext);
 
   const accessor = useDataAccessor([builderid]);
 
@@ -177,11 +178,25 @@ export const BuilderView = observer(() => {
     }
   };
 
+  const renderDescription = (description: string) => {
+    if (config.descriptions_are_html) {
+      return (
+        <div><TableHeading>Description:</TableHeading>
+          <div dangerouslySetInnerHTML={{__html: description}}/>
+        </div>
+      )
+    } else {
+      return (
+        <div><TableHeading>Description:</TableHeading>{description}</div>
+      );
+    }
+  };
+
   return (
     <div className="container">
       <AlertNotification text={errorMsg}/>
       {builder !== null && builder.description !== null
-        ? <div><TableHeading>Description:</TableHeading>{builder.description}</div>
+        ? renderDescription(builder.description)
         : <></>
       }
       <BuildRequestsTable buildrequests={buildrequests}/>

--- a/www/react-base/src/views/ProjectView/ProjectView.tsx
+++ b/www/react-base/src/views/ProjectView/ProjectView.tsx
@@ -35,8 +35,14 @@ import {ProjectChangesWidget} from "../../components/ProjectWidgets/ProjectChang
 import {
   ProjectPendingBuildRequestsWidget
 } from "../../components/ProjectWidgets/ProjectPendingBuildRequestsWidget";
+import {ProjectDescriptionWidget} from "../../components/ProjectWidgets/ProjectDescriptionWidget";
 
-const defaultWidgetsConfig = ["builders", "pending_build_requests", "changes"];
+const defaultWidgetsConfig = [
+  "description",
+  "builders",
+  "pending_build_requests",
+  "changes"
+];
 
 function findProjectWidgetsConfig(config: Config, name: string) {
   if (config.project_widgets === undefined) {
@@ -64,6 +70,9 @@ type KnownWidgetsConfig = {[name: string]: WidgetCallback};
 const knownWidgets: KnownWidgetsConfig = {
   "builders": (projectid, filterManager) => (
     <ProjectBuildersWidget projectid={projectid} filterManager={filterManager}/>
+  ),
+  "description": (projectid, filterManager) => (
+    <ProjectDescriptionWidget projectid={projectid}/>
   ),
   "pending_build_requests": (projectid, filterManager) => (
     <ProjectPendingBuildRequestsWidget projectid={projectid}/>

--- a/www/react-base/src/views/ProjectView/ProjectView.tsx
+++ b/www/react-base/src/views/ProjectView/ProjectView.tsx
@@ -69,16 +69,16 @@ type KnownWidgetsConfig = {[name: string]: WidgetCallback};
 
 const knownWidgets: KnownWidgetsConfig = {
   "builders": (projectid, filterManager) => (
-    <ProjectBuildersWidget projectid={projectid} filterManager={filterManager}/>
+    <ProjectBuildersWidget key="builders" projectid={projectid} filterManager={filterManager}/>
   ),
   "description": (projectid, filterManager) => (
-    <ProjectDescriptionWidget projectid={projectid}/>
+    <ProjectDescriptionWidget key="description" projectid={projectid}/>
   ),
   "pending_build_requests": (projectid, filterManager) => (
-    <ProjectPendingBuildRequestsWidget projectid={projectid}/>
+    <ProjectPendingBuildRequestsWidget key="pending_build_requests" projectid={projectid}/>
   ),
   "changes": (projectid, filterManager) => (
-    <ProjectChangesWidget projectid={projectid}/>
+    <ProjectChangesWidget key="changes" projectid={projectid}/>
   ),
 }
 

--- a/www/react-base/src/views/ProjectsView/ProjectsView.tsx
+++ b/www/react-base/src/views/ProjectsView/ProjectsView.tsx
@@ -48,7 +48,6 @@ export const ProjectsView = observer(() => {
       <Link to={`/projects/${project.projectid}`}>
         <li key={project.projectid} className="list-group-item">
             {project.name}
-          &nbsp;&nbsp;{project.description}
         </li>
       </Link>
     );

--- a/www/react-ui/src/contexts/Config.ts
+++ b/www/react-ui/src/contexts/Config.ts
@@ -45,6 +45,7 @@ export type Config = {
   titleURL: string;
   buildbotURL: string;
   buildbotURLs?: string[];
+  descriptions_are_html: boolean;
   multiMaster: boolean;
   ui_default_config: {[key: string]: any};
   versions: string[][];


### PR DESCRIPTION
It probably makes sense to just support something like markdown, but this PR is the first step.