### PR TITLE
www: Do not complain about JWT token decoding error

### DIFF
--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -84,6 +84,10 @@ class BuildbotSession(server.Session):
                                  SESSION_SECRET_ALGORITHM])
         except jwt.exceptions.ExpiredSignatureError as e:
             raise KeyError(str(e)) from e
+        except jwt.exceptions.InvalidSignatureError as e:
+            log.msg(e, "Web request has been rejected."
+                    "Signature verification failed while decoding JWT.")
+            raise KeyError(str(e)) from e
         except Exception as e:
             log.err(e, "while decoding JWT session")
             raise KeyError(str(e)) from e

--- a/newsfragments/jwt_decoding_not_error_6872.bugfix
+++ b/newsfragments/jwt_decoding_not_error_6872.bugfix
@@ -1,0 +1,1 @@
+No longer complain about JWT token decoding error (:bug: `6872`).


### PR DESCRIPTION
Users get excessive log errors about rejected request from client. This is benign and not an error in buildbot.

* [ not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed ] I have updated the appropriate documentation
