### PR TITLE
www: Log viewer fixes

### DIFF
--- a/www/react-base/src/components/LogViewer/LogTextManager.ts
+++ b/www/react-base/src/components/LogViewer/LogTextManager.ts
@@ -59,10 +59,22 @@ export class LogTextManager {
 
   dataGetter: (offset: number, limit: number) => CancellablePromise<any>;
   logType: string;
+
+  // Controls the number of additional downloaded lines that are maintained outside the visible
+  // range. If the number of additional lines becomes lower, a download is initiated.
   downloadInitiateOverscanRowCount: number;
+
+  // Controls the number of additional lines that are downloaded outside the visible range if a
+  // download is requested. This number is usually greater than downloadInitiateOverscanRowCount
+  // so that if a download is requested it retrieves more lines than needed.
   downloadOverscanRowCount: number;
+
+  // How many lines outside the visible range are cached in downloaded form.
   cachedDownloadOverscanRowCount: number;
+
+  // How many lines outside the visible range are cached as rendered form.
   cacheRenderedOverscanRowCount: number;
+
   onStateChange: () => void;
 
   logNumLines = 0; // kept up to date
@@ -507,7 +519,7 @@ export class LogTextManager {
   }
 
   maybeMergeChunkSearchResults(mergeIndex: number, prepend: boolean) {
-    if (this.searchString !== null) {
+    if (this.searchString === null) {
       return;
     }
     const prevResult = this.chunkSearchResults[mergeIndex];

--- a/www/react-base/src/components/LogViewer/LogTextManager.ts
+++ b/www/react-base/src/components/LogViewer/LogTextManager.ts
@@ -670,6 +670,7 @@ export class LogTextManager {
       this.addChunk(chunk);
       this.onStateChange();
       this.pendingRequest = null;
+      this.maybeUpdatePendingRequest(this.currVisibleStartIndex, this.currVisibleEndIndex);
     }).catch((e: Error) => {
       if (e.name === "CanceledError") {
         return;

--- a/www/react-base/src/components/LogViewer/LogViewerText.scss
+++ b/www/react-base/src/components/LogViewer/LogViewerText.scss
@@ -87,6 +87,10 @@
   color: black;
 }
 
+.bb-logviewer-result.bb-logviewer-result-current {
+  background-color: yellow;
+}
+
 .bb-logviewer-result-begin {
   border-top-left-radius: 0.3rem;
   border-bottom-left-radius: 0.3rem;

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -16,7 +16,7 @@
 */
 
 import './LogViewerText.scss'
-import {forwardRef, useRef, useState} from 'react';
+import {forwardRef, useEffect, useRef, useState} from 'react';
 import {generateStyleElement} from "../../util/AnsiEscapeCodes";
 import {observer} from "mobx-react";
 import {Log, useDataAccessor} from "buildbot-data-js";
@@ -108,7 +108,11 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
   const currentSearchResultLine = manager.getCurrentSearchResultLine();
   if (currentSearchResultLineRef.current !== currentSearchResultLine && listRef.current !== null) {
     currentSearchResultLineRef.current = currentSearchResultLine;
-    listRef.current.scrollToItem(currentSearchResultLine);
+    setRenderCounter(c => {
+      // scrollToItem will
+      listRef.current!.scrollToItem(currentSearchResultLine);
+      return c + 1;
+    });
   }
 
   const LogTextArea: React.FC<Size> = ({height, width}) => (

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -18,7 +18,7 @@
 import './LogViewerText.scss'
 import {forwardRef, useRef, useState} from 'react';
 import {generateStyleElement} from "../../util/AnsiEscapeCodes";
-import {observer, useLocalObservable} from "mobx-react";
+import {observer} from "mobx-react";
 import {Log, useDataAccessor} from "buildbot-data-js";
 import {ListOnItemsRenderedProps} from 'react-window';
 import AutoSizer, {Size} from "react-virtualized-auto-sizer";
@@ -57,10 +57,14 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
   const accessor = useDataAccessor([]);
   const [, setRenderCounter] = useState(0);
 
-  const manager = useLocalObservable(() =>
-    new LogTextManager(accessor, log.logid, log.type, downloadInitiateOverscanRowCount,
-      downloadOverscanRowCount, cachedDownloadOverscanRowCount, cacheRenderedOverscanRowCount,
-      maxChunkLinesCount, () => setRenderCounter(c => c + 1)));
+  const managerRef = useRef<LogTextManager|null>(null);
+  if (managerRef.current === null) {
+    managerRef.current = new LogTextManager(
+        accessor, log.logid, log.type, downloadInitiateOverscanRowCount,
+        downloadOverscanRowCount, cachedDownloadOverscanRowCount, cacheRenderedOverscanRowCount,
+        maxChunkLinesCount, () => setRenderCounter(c => c + 1));
+  }
+  const manager = managerRef.current!;
 
   manager.setLogNumLines(log.num_lines);
 

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -60,7 +60,11 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
   const managerRef = useRef<LogTextManager|null>(null);
   if (managerRef.current === null) {
     managerRef.current = new LogTextManager(
-        accessor, log.logid, log.type, downloadInitiateOverscanRowCount,
+        (offset, limit) => accessor.getRaw(`logs/${log.logid}/contents`, {
+          offset: offset,
+          limit: limit,
+        }),
+        log.type, downloadInitiateOverscanRowCount,
         downloadOverscanRowCount, cachedDownloadOverscanRowCount, cacheRenderedOverscanRowCount,
         maxChunkLinesCount, () => setRenderCounter(c => c + 1));
   }


### PR DESCRIPTION
This PR fixes several problems with the current React-based log viewer:
 - occasional wrong renders resulting in black screen
 - search does not work on larger logs consisting of more than one log
 - the current search result is now highlighted separately