### PR TITLE
Fix rst markup in wwwhooks documentation

### DIFF
--- a/master/docs/manual/configuration/wwwhooks.rst
+++ b/master/docs/manual/configuration/wwwhooks.rst
@@ -137,7 +137,7 @@ The GitHub hook has the following parameters:
 
 ``token``
     If your GitHub or GitHub Enterprise instance does not allow anonymous communication, you need to provide an access token.
-    Instructions can be found here <https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>
+    Instructions can be found `here <https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>`_.
 
 ``pullrequest_ref`` (default ``merge``)
     Remote ref to test if a pull request is sent to the endpoint.


### PR DESCRIPTION
The rst markup seems incorrect.

The text can be found "GitHub hook" heading.


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
