### PR TITLE
Fix FailingBuildsetCanceller documentation

### DIFF
--- a/master/docs/manual/configuration/services/failing_buildset_canceller.rst
+++ b/master/docs/manual/configuration/services/failing_buildset_canceller.rst
@@ -9,7 +9,7 @@ The purpose of this service is to cancel builds once one build on a buildset fai
 
 This is useful for reducing use of resources in cases when there is no need to gather information from all builds of a buildset once one of them fails.
 
-The service may be configured to be track a subset of builds.
+The service may be configured to track a subset of builds.
 This is controlled by the ``filters`` parameter.
 The decision on whether to cancel a build is done once a build fails.
 


### PR DESCRIPTION
This PR fixes a typo in FailingBuildsetCanceller documentation.
* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
