### PR TITLE
Add a script to copy database across supported database backends

### DIFF
--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -227,7 +227,7 @@ def create_engine(name_or_url, **kwargs):
         u, kwargs, max_conns = special_case_mysql(u, kwargs)
 
     # remove the basedir as it may confuse sqlalchemy
-    basedir = kwargs.pop('basedir')
+    kwargs.pop('basedir')
 
     # calculate the maximum number of connections from the pool parameters,
     # if it hasn't already been specified
@@ -242,6 +242,4 @@ def create_engine(name_or_url, **kwargs):
     # by DBConnector to configure the surrounding thread pool
     engine.optimal_thread_pool_size = max_conns
 
-    # keep the basedir
-    engine.buildbot_basedir = basedir
     return engine

--- a/master/buildbot/scripts/copydb.py
+++ b/master/buildbot/scripts/copydb.py
@@ -1,0 +1,233 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import os
+import queue
+
+import sqlalchemy as sa
+
+from twisted.internet import defer
+
+from buildbot import config as config_module
+from buildbot.db import connector
+from buildbot.db import exceptions
+from buildbot.db import model
+from buildbot.master import BuildMaster
+from buildbot.scripts import base
+from buildbot.util import in_reactor
+from buildbot.util import misc
+
+
+@in_reactor
+def copy_database(config):  # pragma: no cover
+    # we separate the actual implementation to protect unit tests
+    # from @in_reactor which stops the reactor
+    return _copy_database_in_reactor(config)
+
+
+@defer.inlineCallbacks
+def _copy_database_in_reactor(config):
+    if not base.checkBasedir(config):
+        return 1
+
+    print_debug = not config["quiet"]
+
+    def print_log(*args, **kwargs):
+        if print_debug:
+            print(*args, **kwargs)
+
+    config['basedir'] = os.path.abspath(config['basedir'])
+
+    with base.captureErrors((SyntaxError, ImportError),
+                            f"Unable to load 'buildbot.tac' from '{config['basedir']}':"):
+        config_file = base.getConfigFileFromTac(config['basedir'])
+
+    with base.captureErrors(config_module.ConfigErrors,
+                            f"Unable to load '{config_file}' from '{config['basedir']}':"):
+        master_src_cfg = base.loadConfig(config, config_file)
+        master_dst_cfg = base.loadConfig(config, config_file)
+        master_dst_cfg.db["db_url"] = config["destination_url"]
+
+    print_log(f"Copying database ({master_src_cfg.db['db_url']}) to ({config['destination_url']})")
+
+    if not master_src_cfg or not master_dst_cfg:
+        return 1
+
+    master_src = BuildMaster(config['basedir'])
+    master_src.config = master_src_cfg
+    try:
+        yield master_src.db.setup(check_version=True, verbose=not config["quiet"])
+    except exceptions.DatabaseNotReadyError:
+        for l in connector.upgrade_message.format(basedir=config['basedir']).split('\n'):
+            print(l)
+        return 1
+
+    master_dst = BuildMaster(config['basedir'])
+    master_dst.config = master_dst_cfg
+    yield master_dst.db.setup(check_version=False, verbose=not config["quiet"])
+    yield master_dst.db.model.upgrade()
+    yield _copy_database_with_db(master_src.db, master_dst.db, print_log)
+    return 0
+
+
+@defer.inlineCallbacks
+def _copy_single_table(src_db, dst_db, table, table_name, buildset_to_parent_buildid, print_log):
+    column_keys = table.columns.keys()
+
+    rows_queue = queue.Queue(1024)
+    written_count = [0]
+    total_count = [0]
+
+    def thd_write(conn):
+        while True:
+            try:
+                rows = rows_queue.get(timeout=1)
+                if rows is None:
+                    rows_queue.task_done()
+                    return
+
+                row_dicts = [
+                    {k: getattr(row, k) for k in column_keys} for row in rows
+                ]
+
+                if table_name == "buildsets":
+                    for row_dict in row_dicts:
+                        if row_dict["parent_buildid"] is not None:
+                            buildset_to_parent_buildid.append(
+                                (row_dict["id"], row_dict["parent_buildid"])
+                            )
+                        row_dict["parent_buildid"] = None
+
+            except queue.Empty:
+                continue
+
+            try:
+                written_count[0] += len(rows)
+                print_log(f"Copying {len(rows)} items ({written_count[0]}/{total_count[0]}) "
+                          f"for {table_name} table")
+
+                if len(row_dicts) > 0:
+                    conn.execute(table.insert(), row_dicts)
+
+            finally:
+                rows_queue.task_done()
+
+    def thd_read(conn):
+        q = sa.select([sa.sql.func.count()]).select_from(table)
+        total_count[0] = conn.execute(q).scalar()
+
+        rows = []
+        for row in conn.execute(sa.select(table)).fetchall():
+            rows.append(row)
+            if len(rows) >= 10000:
+                rows_queue.put(rows)
+                rows = []
+
+        rows_queue.put(rows)
+        rows_queue.put(None)
+
+    yield src_db.pool.do(thd_read)
+    yield dst_db.pool.do(thd_write)
+
+    rows_queue.join()
+
+
+@defer.inlineCallbacks
+def _copy_database_with_db(src_db, dst_db, print_log):
+    # Tables need to be specified in correct order so that tables that other tables depend on are
+    # copied first.
+    table_names = [
+        # Note that buildsets.parent_buildid introduces circular dependency.
+        # It is handled separately
+        "buildsets",
+        "buildset_properties",
+        "projects",
+        "builders",
+        "changesources",
+        "buildrequests",
+        "workers",
+        "masters",
+        "buildrequest_claims",
+        "changesource_masters",
+        "builder_masters",
+        "configured_workers",
+        "connected_workers",
+        "patches",
+        "sourcestamps",
+        "buildset_sourcestamps",
+        "changes",
+        "change_files",
+        "change_properties",
+        "users",
+        "users_info",
+        "change_users",
+        "builds",
+        "build_properties",
+        "build_data",
+        "steps",
+        "logs",
+        "logchunks",
+        "schedulers",
+        "scheduler_masters",
+        "scheduler_changes",
+        "tags",
+        "builders_tags",
+        "test_result_sets",
+        "test_names",
+        "test_code_paths",
+        "test_results",
+        "objects",
+        "object_state",
+    ]
+
+    metadata = model.Model.metadata
+    assert len(set(table_names)) == len(set(metadata.tables.keys()))
+
+    # Not a dict so that the values are inserted back in predictable order
+    buildset_to_parent_buildid = []
+
+    for table_name in table_names:
+        table = metadata.tables[table_name]
+        _copy_single_table(
+            src_db,
+            dst_db,
+            table,
+            table_name,
+            buildset_to_parent_buildid,
+            print_log
+        )
+
+    def thd_write_buildset_parent_buildid(conn):
+        written_count = 0
+        for rows in misc.chunkify_list(buildset_to_parent_buildid, 10000):
+            q = model.Model.buildsets.update()
+            q = q.where(model.Model.buildsets.c.id == sa.bindparam('_id'))
+            q = q.values({'parent_buildid': sa.bindparam('parent_buildid')})
+
+            written_count += len(rows)
+            print_log(
+                f"Copying {len(rows)} items ({written_count}/{len(buildset_to_parent_buildid)}) "
+                f"for buildset.parent_buildid field"
+            )
+
+            conn.execute(q, [
+                {'_id': buildset_id, 'parent_buildid': parent_buildid}
+                for buildset_id, parent_buildid in rows
+            ])
+
+    yield dst_db.pool.do(thd_write_buildset_parent_buildid)
+
+    print_log("Copy complete")

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -719,6 +719,37 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
     """)
 
 
+class CopyDBOptions(base.BasedirMixin, base.SubcommandOptions):
+    subcommandFunction = "buildbot.scripts.copydb.copy_database"
+
+    optFlags = [
+        ('quiet', 'q', "Don't display error messages or tracebacks"),
+    ]
+
+    def getSynopsis(self):
+        return "Usage:    buildbot copydb <destination_url> [<basedir>]"
+
+    def parseArgs(self, *args):
+        if len(args) == 0:
+            raise usage.UsageError("incorrect number of arguments")
+
+        self['destination_url'] = args[0]
+        args = args[1:]
+        super().parseArgs(*args)
+
+    longdesc = textwrap.dedent("""
+    This command copies all buildbot data from source database configured in the buildbot
+    configuration file to the destination database. The URL of the destination database is
+    specified on the command line.
+
+    The destination database must be empty. The script will initialize it in the same way as if
+    a new Buildbot installation was created.
+
+    Source database must be already upgraded to the current Buildbot version by the "buildbot
+    upgrade-master" command.
+    """)
+
+
 class Options(usage.Options):
     synopsis = "Usage:    buildbot <command> [command options]"
 
@@ -756,7 +787,8 @@ class Options(usage.Options):
          "Output graphql api schema"],
         ['cleanupdb', None, CleanupDBOptions,
          "cleanup the database"
-         ]
+         ],
+        ["copy-db", None, CopyDBOptions, "copy the database"],
     ]
 
     def opt_version(self):

--- a/master/buildbot/test/unit/util/test_misc.py
+++ b/master/buildbot/test/unit/util/test_misc.py
@@ -125,3 +125,44 @@ class TestCancelAfter(TestReactorMixin, unittest.TestCase):
         self.d.errback(RuntimeError("oh noes"))  # ignored
         self.assertTrue(d.called)
         yield self.assertFailure(d, defer.CancelledError)
+
+
+class TestChunkifyList(unittest.TestCase):
+    def test_all(self):
+        self.assertEqual(list(misc.chunkify_list([], 0)), [])
+        self.assertEqual(list(misc.chunkify_list([], 1)), [])
+        self.assertEqual(list(misc.chunkify_list([1], 0)), [[1]])
+        self.assertEqual(list(misc.chunkify_list([1], 1)), [[1]])
+        self.assertEqual(list(misc.chunkify_list([1], 2)), [[1]])
+        self.assertEqual(list(misc.chunkify_list([1, 2], 0)), [[1], [2]])
+        self.assertEqual(list(misc.chunkify_list([1, 2], 1)), [[1], [2]])
+        self.assertEqual(list(misc.chunkify_list([1, 2], 2)), [[1, 2]])
+        self.assertEqual(list(misc.chunkify_list([1, 2], 3)), [[1, 2]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3], 0)), [[1], [2], [3]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3], 1)), [[1], [2], [3]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3], 2)), [[1, 2], [3]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3], 3)), [[1, 2, 3]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3], 4)), [[1, 2, 3]])
+
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0)),
+                         [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1)),
+                         [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2)),
+                         [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3)),
+                         [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 4)),
+                         [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5)),
+                         [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 6)),
+                         [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 7)),
+                         [[1, 2, 3, 4, 5, 6, 7], [8, 9, 10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 8)),
+                         [[1, 2, 3, 4, 5, 6, 7, 8], [9, 10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 9)),
+                         [[1, 2, 3, 4, 5, 6, 7, 8, 9], [10]])
+        self.assertEqual(list(misc.chunkify_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10)),
+                         [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])

--- a/master/buildbot/util/misc.py
+++ b/master/buildbot/util/misc.py
@@ -51,3 +51,8 @@ def writeLocalFile(path, contents, mode=None):  # pragma: no cover
         if mode is not None:
             os.chmod(path, mode)
         file.write(contents)
+
+
+def chunkify_list(l, chunk_size):
+    chunk_size = max(1, chunk_size)
+    return (l[i:i + chunk_size] for i in range(0, len(l), chunk_size))

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -159,6 +159,22 @@ This command is frontend for various database maintenance jobs:
 - optimiselogs: This optimization groups logs into bigger chunks
   to apply higher level of compression.
 
+copy-db
++++++++
+
+.. code-block:: none
+
+    buildbot copy-db {DESTINATION_URL} {BASEDIR} [-q]
+
+This command copies all buildbot data from source database configured in the buildbot configuration file to the destination database.
+The URL of the destination database is specified on the command line.
+The destination database may have different type from the source database.
+
+The destination database must be empty.
+The script will initialize it in the same way as if a new Buildbot installation was created.
+
+Source database must be already upgraded to the current Buildbot version by the ``buildbot upgrade-master`` command.
+
 Developer Tools
 ~~~~~~~~~~~~~~~
 

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -24,6 +24,8 @@ In the default configuration Buildbot uses a file-based SQLite database, stored 
    However, it does not scale well with large numbers of builders, workers and users.
    If you expect your Buildbot to grow over time, it is strongly advised to use a real database server (e.g., MySQL or Postgres).
 
+   A SQLite3 database may be migrated to a real database server using ``buildbot copy-db`` script.
+
    See the :ref:`Database-Server` section for more details.
 
 Override this configuration with the :bb:cfg:`db_url` parameter.

--- a/newsfragments/copy-db.feature
+++ b/newsfragments/copy-db.feature
@@ -1,0 +1,3 @@
+Buildbot now has ``copy-db`` script migrate all data stored in the database from one database to another.
+This may be used to change database engine types.
+For example a sqlite database may be migrated to Postgres or MySQL when the load and data size grows.


### PR DESCRIPTION
This PR adds a ``copy-db`` script to migrate all data stored in the database from one database to another. It may be used to change database engine types. For example a sqlite database may be migrated to Postgres or MySQL when the load and data size grows.