### PR TITLE
Implement support for supplying markdown descriptions

### DIFF
--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from buildbot.config.checks import check_markdown_support
 from buildbot.config.checks import check_param_length
 from buildbot.config.checks import check_param_str_none
 from buildbot.config.errors import error
@@ -139,8 +140,13 @@ class BuilderConfig(util_config.ConfiguredMixin):
             "description_format"
         )
 
-        if self.description_format is not None:
-            error("builder description type must be None")
+        if self.description_format is None:
+            pass
+        elif self.description_format == "markdown":
+            if not check_markdown_support(self.__class__):  # pragma: no cover
+                self.description_format = None
+        else:
+            error("builder description format must be None or \"markdown\"")
             self.description_format = None
 
     def getConfigDict(self):

--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -32,6 +32,7 @@ class BuilderConfig(util_config.ConfiguredMixin):
                  tags=None,
                  nextWorker=None, nextBuild=None, locks=None, env=None,
                  properties=None, collapseRequests=None, description=None,
+                 description_format=None,
                  canStartBuild=None, defaultProperties=None, project=None
                  ):
         # name is required, and can't start with '_'
@@ -132,6 +133,15 @@ class BuilderConfig(util_config.ConfiguredMixin):
         self.collapseRequests = collapseRequests
 
         self.description = check_param_str_none(description, self.__class__, "description")
+        self.description_format = check_param_str_none(
+            description_format,
+            self.__class__,
+            "description_format"
+        )
+
+        if self.description_format is not None:
+            error("builder description type must be None")
+            self.description_format = None
 
     def getConfigDict(self):
         # note: this method will disappear eventually - put your smarts in the
@@ -163,4 +173,6 @@ class BuilderConfig(util_config.ConfiguredMixin):
             rv['collapseRequests'] = self.collapseRequests
         if self.description:
             rv['description'] = self.description
+            if self.description_format:
+                rv['description_format'] = self.description_format
         return rv

--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -15,6 +15,7 @@
 
 
 from buildbot.config.checks import check_param_length
+from buildbot.config.checks import check_param_str_none
 from buildbot.config.errors import error
 from buildbot.db.model import Model
 from buildbot.util import bytes2unicode
@@ -130,7 +131,7 @@ class BuilderConfig(util_config.ConfiguredMixin):
 
         self.collapseRequests = collapseRequests
 
-        self.description = description
+        self.description = check_param_str_none(description, self.__class__, "description")
 
     def getConfigDict(self):
         # note: this method will disappear eventually - put your smarts in the

--- a/master/buildbot/config/checks.py
+++ b/master/buildbot/config/checks.py
@@ -45,3 +45,14 @@ def check_param_str(value, class_inst, name):
 
 def check_param_str_none(value, class_inst, name):
     return check_param_type(value, "(unknown)", class_inst, name, (str, type(None)), "str or None")
+
+
+def check_markdown_support(class_inst):
+    try:
+        import markdown  # pylint: disable=import-outside-toplevel
+        [markdown]
+        return True
+    except ImportError:  # pragma: no cover
+        error(f"{class_inst.__name__}: Markdown library is required in order to use "
+              "markdown format ('pip install Markdown')")
+        return False

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -183,7 +183,6 @@ class MasterConfig(util.ComparableMixin):
             authz=authz.Authz(),
             avatar_methods=avatar.AvatarGravatar(),
             logfileName='http.log',
-            descriptions_are_html=False,
         )
         self.services = {}
 
@@ -704,7 +703,6 @@ class MasterConfig(util.ComparableMixin):
             'custom_templates_dir',
             'debug',
             'default_page',
-            'descriptions_are_html',
             'json_cache_seconds',
             'jsonp',
             'logRotateLength',

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -45,6 +45,8 @@ class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
                     name=bdict['name'],
                     masterids=bdict['masterids'],
                     description=bdict['description'],
+                    description_format=bdict["description_format"],
+                    description_html=bdict["description_html"],
                     projectid=bdict['projectid'],
                     tags=bdict['tags'])
 
@@ -69,6 +71,8 @@ class BuildersEndpoint(base.Endpoint):
                      name=bd['name'],
                      masterids=bd['masterids'],
                      description=bd['description'],
+                     description_format=bd['description_format'],
+                     description_html=bd['description_html'],
                      projectid=bd['projectid'],
                      tags=bd['tags'])
                for bd in bdicts]
@@ -95,6 +99,8 @@ class Builder(base.ResourceType):
         name = types.Identifier(70)
         masterids = types.List(of=types.Integer())
         description = types.NoneOk(types.String())
+        description_format = types.NoneOk(types.String())
+        description_html = types.NoneOk(types.String())
         projectid = types.NoneOk(types.Integer())
         tags = types.List(of=types.String())
     entityType = EntityType(name, 'Builder')
@@ -110,9 +116,10 @@ class Builder(base.ResourceType):
 
     @base.updateMethod
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, projectid, tags):
+    def updateBuilderInfo(self, builderid, description, description_format, description_html,
+                          projectid, tags):
         ret = yield self.master.db.builders.updateBuilderInfo(
-            builderid, description, projectid, tags
+            builderid, description, description_format, description_html, projectid, tags
         )
         yield self.generateEvent(builderid, "update")
         return ret

--- a/master/buildbot/data/projects.py
+++ b/master/buildbot/data/projects.py
@@ -26,6 +26,8 @@ def project_db_to_data(dbdict):
         "name": dbdict["name"],
         "slug": dbdict["slug"],
         "description": dbdict["description"],
+        "description_format": dbdict["description_format"],
+        "description_html": dbdict["description_html"],
     }
 
 
@@ -82,6 +84,8 @@ class Project(base.ResourceType):
         name = types.Identifier(70)
         slug = types.Identifier(70)
         description = types.NoneOk(types.String())
+        description_format = types.NoneOk(types.String())
+        description_html = types.NoneOk(types.String())
     entityType = EntityType(name, 'Project')
 
     @defer.inlineCallbacks
@@ -95,6 +99,19 @@ class Project(base.ResourceType):
 
     @base.updateMethod
     @defer.inlineCallbacks
-    def update_project_info(self, projectid, slug, description):
-        yield self.master.db.projects.update_project_info(projectid, slug, description)
+    def update_project_info(
+        self,
+        projectid,
+        slug,
+        description,
+        description_format,
+        description_html
+    ):
+        yield self.master.db.projects.update_project_info(
+            projectid,
+            slug,
+            description,
+            description_format,
+            description_html
+        )
         yield self.generate_event(projectid, "update")

--- a/master/buildbot/db/migrations/versions/061_2023-06-03_add_builder_description_format.py
+++ b/master/buildbot/db/migrations/versions/061_2023-06-03_add_builder_description_format.py
@@ -1,0 +1,44 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""add builder description format
+
+Revision ID: 061
+Revises: 060
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '061'
+down_revision = '060'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("builders") as batch_op:
+        batch_op.add_column(
+            sa.Column('description_format', sa.Text, nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column('description_html', sa.Text, nullable=True),
+        )
+
+
+def downgrade():
+    op.drop_column("builders", "description_format")
+    op.drop_column("builders", "description_html")

--- a/master/buildbot/db/migrations/versions/062_2023-06-03_add_project_description_format.py
+++ b/master/buildbot/db/migrations/versions/062_2023-06-03_add_project_description_format.py
@@ -1,0 +1,44 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""add project description format
+
+Revision ID: 062
+Revises: 061
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '062'
+down_revision = '061'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(
+            sa.Column('description_format', sa.Text, nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column('description_html', sa.Text, nullable=True),
+        )
+
+
+def downgrade():
+    op.drop_column("projects", "description_format")
+    op.drop_column("projects", "description_html")

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -597,6 +597,10 @@ class Model(base.DBConnectorComponent):
         sa.Column('slug', sa.String(50), nullable=False),
         # project description
         sa.Column('description', sa.Text, nullable=True),
+        # the format of project description
+        sa.Column('description_format', sa.Text, nullable=True),
+        # project description rendered as html if description_format is not NULL
+        sa.Column('description_html', sa.Text, nullable=True),
     )
 
     # Tables related to builders

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -609,6 +609,10 @@ class Model(base.DBConnectorComponent):
         sa.Column('name', sa.Text, nullable=False),
         # builder's description
         sa.Column('description', sa.Text, nullable=True),
+        # the format of builder description
+        sa.Column('description_format', sa.Text, nullable=True),
+        # builder description rendered as html if description_format is not NULL
+        sa.Column('description_html', sa.Text, nullable=True),
         # builder's project
         sa.Column('projectid', sa.Integer,
                   sa.ForeignKey('projects.id', name="fk_builders_projectid",

--- a/master/buildbot/db/projects.py
+++ b/master/buildbot/db/projects.py
@@ -59,12 +59,25 @@ class ProjectsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns a value
-    def update_project_info(self, projectid, slug, description):
+    def update_project_info(
+        self,
+        projectid,
+        slug,
+        description,
+        description_format,
+        description_html
+    ):
         def thd(conn):
             q = self.db.model.projects.update(
                 whereclause=(self.db.model.projects.c.id == projectid)
             )
-            conn.execute(q, slug=slug, description=description).close()
+            conn.execute(
+                q,
+                slug=slug,
+                description=description,
+                description_format=description_format,
+                description_html=description_html,
+            ).close()
         return self.db.pool.do(thd)
 
     def _project_dict_from_row(self, row):
@@ -72,5 +85,7 @@ class ProjectsConnectorComponent(base.DBConnectorComponent):
             "id": row.id,
             "name": row.name,
             "slug": row.slug,
-            "description": row.description
+            "description": row.description,
+            "description_format": row.description_format,
+            "description_html": row.description_html,
         }

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -25,6 +25,7 @@ from buildbot.process.results import CANCELLED
 from buildbot.process.results import RETRY
 from buildbot.process.workerforbuilder import States
 from buildbot.util import service
+from buildbot.util.render_description import render_description
 
 
 class LockRetrieverMixin:
@@ -264,7 +265,10 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
                 project_config.slug,
                 project_config.description,
                 project_config.description_format,
-                None
+                render_description(
+                    project_config.description,
+                    project_config.description_format
+                ),
             )
 
     @defer.inlineCallbacks

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -259,8 +259,13 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
     def reconfigProjects(self, new_config):
         for project_config in new_config.projects:
             projectid = yield self.master.data.updates.find_project_id(project_config.name)
-            yield self.master.data.updates.update_project_info(projectid, project_config.slug,
-                                                               project_config.description)
+            yield self.master.data.updates.update_project_info(
+                projectid,
+                project_config.slug,
+                project_config.description,
+                project_config.description_format,
+                None
+            )
 
     @defer.inlineCallbacks
     def reconfigServiceBuilders(self, new_config):

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -286,8 +286,9 @@ class Build(properties.PropertiesMixin):
                     tags.append('_virtual_')
 
                 projectid = yield self.builder.find_project_id(project)
-                self.master.data.updates.updateBuilderInfo(self._builderid, description,
-                                                           projectid, tags)
+                # Note: not waiting for updateBuilderInfo to complete
+                self.master.data.updates.updateBuilderInfo(self._builderid, description, None,
+                                                           None, projectid, tags)
 
             else:
                 self._builderid = yield self.builder.getBuilderId()

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -110,6 +110,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
             projectid = yield self.find_project_id(builder_config.project)
             yield self.master.data.updates.updateBuilderInfo(builderid,
                                                              builder_config.description,
+                                                             builder_config.description_format,
+                                                             None,
                                                              projectid,
                                                              builder_config.tags)
 
@@ -123,6 +125,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
         if old_config is None:
             return True
         if old_config.description != new_config.description:
+            return True
+        if old_config.description_format != new_config.description_format:
             return True
         if old_config.project != new_config.project:
             return True

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -31,6 +31,7 @@ from buildbot.process.results import RETRY
 from buildbot.util import bytes2unicode
 from buildbot.util import epoch2datetime
 from buildbot.util import service as util_service
+from buildbot.util.render_description import render_description
 
 
 def enforceChosenWorker(bldr, workerforbuilder, breq):
@@ -108,12 +109,18 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         if self._has_updated_config_info(old_config, builder_config):
             projectid = yield self.find_project_id(builder_config.project)
-            yield self.master.data.updates.updateBuilderInfo(builderid,
-                                                             builder_config.description,
-                                                             builder_config.description_format,
-                                                             None,
-                                                             projectid,
-                                                             builder_config.tags)
+
+            yield self.master.data.updates.updateBuilderInfo(
+                builderid,
+                builder_config.description,
+                builder_config.description_format,
+                render_description(
+                    builder_config.description,
+                    builder_config.description_format
+                ),
+                projectid,
+                builder_config.tags
+            )
 
         # if we have any workers attached which are no longer configured,
         # drop them.

--- a/master/buildbot/process/project.py
+++ b/master/buildbot/process/project.py
@@ -21,12 +21,19 @@ from buildbot.config.checks import check_param_str_none
 
 class Project(util.ComparableMixin):
 
-    compare_attrs = ("name", "slug", "description")
+    compare_attrs = (
+        "name",
+        "slug",
+        "description",
+        "description_format",
+    )
 
-    def __init__(self, name, slug=None, description=None):
+    def __init__(self, name, slug=None, description=None, description_format=None):
         if slug is None:
             slug = name
 
         self.name = check_param_str(name, self.__class__, "name")
         self.slug = check_param_str(slug, self.__class__, "slug")
         self.description = check_param_str_none(description, self.__class__, "description")
+        self.description_format = \
+            check_param_str_none(description_format, self.__class__, "description_format")

--- a/master/buildbot/process/project.py
+++ b/master/buildbot/process/project.py
@@ -21,7 +21,7 @@ from buildbot.config.checks import check_param_str_none
 
 class Project(util.ComparableMixin):
 
-    compare_attls = ("name", "slug", "description")
+    compare_attrs = ("name", "slug", "description")
 
     def __init__(self, name, slug=None, description=None):
         if slug is None:

--- a/master/buildbot/process/project.py
+++ b/master/buildbot/process/project.py
@@ -15,8 +15,10 @@
 
 
 from buildbot import util
+from buildbot.config.checks import check_markdown_support
 from buildbot.config.checks import check_param_str
 from buildbot.config.checks import check_param_str_none
+from buildbot.config.errors import error
 
 
 class Project(util.ComparableMixin):
@@ -37,3 +39,11 @@ class Project(util.ComparableMixin):
         self.description = check_param_str_none(description, self.__class__, "description")
         self.description_format = \
             check_param_str_none(description_format, self.__class__, "description_format")
+        if self.description_format is None:
+            pass
+        elif self.description_format == "markdown":
+            if not check_markdown_support(self.__class__):  # pragma: no cover
+                self.description_format = None
+        else:
+            error("project description format must be None or \"markdown\"")
+            self.description_format = None

--- a/master/buildbot/spec/types/project.raml
+++ b/master/buildbot/spec/types/project.raml
@@ -2,23 +2,6 @@
 description: |
     This resource type describes a project.
 
-    Update Methods
-    --------------
-
-    All update methods are available as attributes of ``master.data.updates``.
-
-    .. py:class:: buildbot.data.projects.Project
-
-        .. py:method:: updateBuilderList(masterid, builderNames)
-
-            :param integer masterid: this master's master ID
-            :param list builderNames: list of names of currently-configured builders (unicode strings)
-            :returns: Deferred
-
-            Record the given builders as the currently-configured set of builders on this master.
-            Masters should call this every time the list of configured builders changes.
-
-
 properties:
     projectid:
         description: the ID of this project

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -143,3 +143,7 @@ warnings.filterwarnings('ignore', ".*'urllib3.contrib.pyopenssl' module is depre
 # pipes is still used in astroid and buildbot_worker in default installation
 warnings.filterwarnings('ignore', "'pipes' is deprecated and slated for removal in Python 3.13",
                         category=DeprecationWarning)
+
+# shown on Python 3.7 on Windows
+warnings.filterwarnings('ignore', "SelectableGroups dict interface is deprecated. Use select.",
+                        category=DeprecationWarning)

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -211,8 +211,21 @@ class FakeUpdates(service.AsyncService):
         return defer.succeed(None)
 
     @defer.inlineCallbacks
-    def update_project_info(self, projectid, slug, description):
-        yield self.master.db.projects.update_project_info(projectid, slug, description)
+    def update_project_info(
+        self,
+        projectid,
+        slug,
+        description,
+        description_format,
+        description_html,
+    ):
+        yield self.master.db.projects.update_project_info(
+            projectid,
+            slug,
+            description,
+            description_format,
+            description_html
+        )
 
     def find_project_id(self, name):
         validation.verifyType(self.testcase, 'project name', name,

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -227,8 +227,10 @@ class FakeUpdates(service.AsyncService):
         return defer.succeed(None)
 
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, projectid, tags):
-        yield self.master.db.builders.updateBuilderInfo(builderid, description, projectid, tags)
+    def updateBuilderInfo(self, builderid, description, description_format, description_html,
+                          projectid, tags):
+        yield self.master.db.builders.updateBuilderInfo(builderid, description, description_format,
+                                                        description_html, projectid, tags)
 
     def masterDeactivated(self, masterid):
         return defer.succeed(None)

--- a/master/buildbot/test/fakedb/builders.py
+++ b/master/buildbot/test/fakedb/builders.py
@@ -26,10 +26,25 @@ class Builder(Row):
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
 
-    def __init__(self, id=None, name='some:builder', name_hash=None, projectid=None,
-                 description=None):
-        super().__init__(id=id, name=name, name_hash=name_hash, projectid=projectid,
-                         description=description)
+    def __init__(
+        self,
+        id=None,
+        name='some:builder',
+        name_hash=None,
+        projectid=None,
+        description=None,
+        description_format=None,
+        description_html=None
+    ):
+        super().__init__(
+            id=id,
+            name=name,
+            name_hash=name_hash,
+            projectid=projectid,
+            description=description,
+            description_format=description_format,
+            description_html=description_html,
+        )
 
 
 class BuilderMaster(Row):
@@ -63,11 +78,14 @@ class FakeBuildersComponent(FakeDBComponent):
     def insert_test_data(self, rows):
         for row in rows:
             if isinstance(row, Builder):
-                self.builders[row.id] = dict(
-                    id=row.id,
-                    name=row.name,
-                    projectid=row.projectid,
-                    description=row.description)
+                self.builders[row.id] = {
+                    "id": row.id,
+                    "name": row.name,
+                    "projectid": row.projectid,
+                    "description": row.description,
+                    "description_format": row.description_format,
+                    "description_html": row.description_html,
+                }
             if isinstance(row, BuilderMaster):
                 self.builder_masters[row.id] = \
                     (row.builderid, row.masterid)
@@ -83,12 +101,15 @@ class FakeBuildersComponent(FakeDBComponent):
         if not autoCreate:
             return defer.succeed(None)
         id = len(self.builders) + 1
-        self.builders[id] = dict(
-            id=id,
-            name=name,
-            description=None,
-            projectid=None,
-            tags=[])
+        self.builders[id] = {
+            "id": id,
+            "name": name,
+            "description": None,
+            "description_format": None,
+            "description_html": None,
+            "projectid": None,
+            "tags": []
+        }
         return defer.succeed(id)
 
     def addBuilderMaster(self, builderid=None, masterid=None):
@@ -137,10 +158,13 @@ class FakeBuildersComponent(FakeDBComponent):
         ])
 
     @defer.inlineCallbacks
-    def updateBuilderInfo(self, builderid, description, projectid, tags):
+    def updateBuilderInfo(self, builderid, description, description_format, description_html,
+                          projectid, tags):
         if builderid in self.builders:
             tags = tags if tags else []
             self.builders[builderid]['description'] = description
+            self.builders[builderid]['description_format'] = description_format
+            self.builders[builderid]['description_html'] = description_html
             self.builders[builderid]['projectid'] = projectid
 
             # add tags

--- a/master/buildbot/test/fakedb/projects.py
+++ b/master/buildbot/test/fakedb/projects.py
@@ -26,10 +26,27 @@ class Project(Row):
     id_column = 'id'
     hashedColumns = [('name_hash', ('name',))]
 
-    def __init__(self, id=None, name='fake_project', name_hash=None, slug=None, description=None):
+    def __init__(
+        self,
+        id=None,
+        name='fake_project',
+        name_hash=None,
+        slug=None,
+        description=None,
+        description_format=None,
+        description_html=None,
+    ):
         if slug is None:
             slug = name
-        super().__init__(id=id, name=name, name_hash=name_hash, slug=slug, description=description)
+        super().__init__(
+            id=id,
+            name=name,
+            name_hash=name_hash,
+            slug=slug,
+            description=description,
+            description_format=description_format,
+            description_html=description_html
+        )
 
 
 class FakeProjectsComponent(FakeDBComponent):
@@ -44,7 +61,9 @@ class FakeProjectsComponent(FakeDBComponent):
                     "id": row.id,
                     "name": row.name,
                     "slug": row.slug,
-                    "description": row.description
+                    "description": row.description,
+                    "description_format": row.description_format,
+                    "description_html": row.description_html,
                 }
 
     # Returns Deferred that yields a number
@@ -60,6 +79,8 @@ class FakeProjectsComponent(FakeDBComponent):
             "name": name,
             "slug": name,
             "description": None,
+            "description_format": None,
+            "description_html": None,
         }
         return defer.succeed(id)
 
@@ -74,12 +95,21 @@ class FakeProjectsComponent(FakeDBComponent):
             rv.append(self._row2dict(project))
         return rv
 
-    def update_project_info(self, projectid, slug, description):
+    def update_project_info(
+        self,
+        projectid,
+        slug,
+        description,
+        description_format,
+        description_html
+    ):
         if projectid not in self.projects:
             return defer.succeed(None)
         project = self.projects[projectid]
         project['slug'] = slug
         project['description'] = description
+        project["description_format"] = description_format
+        project["description_html"] = description_html
         return defer.succeed(None)
 
     def _row2dict(self, row):

--- a/master/buildbot/test/integration/test_virtual_builder.py
+++ b/master/buildbot/test/integration/test_virtual_builder.py
@@ -60,5 +60,10 @@ class ShellMaster(RunMasterBase):
         self.assertEqual(builders[1], {
             'masterids': [], 'tags': ['virtual', '_virtual_'],
             'projectid': 1,
-            'description': 'I am a virtual builder', 'name': 'virtual_testy', 'builderid': 2})
+            'description': 'I am a virtual builder',
+            'description_format': None,
+            'description_html': None,
+            'name': 'virtual_testy',
+            'builderid': 2
+        })
         self.assertEqual(build['builderid'], builders[1]['builderid'])

--- a/master/buildbot/test/unit/config/test_builder.py
+++ b/master/buildbot/test/unit/config/test_builder.py
@@ -156,6 +156,11 @@ class BuilderConfigTests(ConfigErrorsMixin, unittest.TestCase):
             BuilderConfig(name="a", workernames=['a'], factory=self.factory,
                           defaultProperties={'a' * 257: 'value'})
 
+    def test_description_wrong_format(self):
+        with self.assertRaisesConfigError("builder description format must be None"):
+            BuilderConfig(name="a", workernames=['a'], factory=self.factory,
+                          description_format="unknown")
+
     def test_getConfigDict(self):
         ns = lambda: 'ns'
         nb = lambda: 'nb'

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -66,7 +66,6 @@ global_defaults = dict(
     www=dict(port=None, plugins={},
              auth={'name': 'NoAuth'}, authz={},
              avatar_methods={'name': 'gravatar'},
-             descriptions_are_html=False,
              logfileName='http.log'),
 )
 
@@ -877,7 +876,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=None,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
-                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -887,7 +885,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=9888,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
-                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -898,7 +895,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     plugins={'waterfall': {'foo': 'bar'}},
                                     auth={'name': 'NoAuth'},
                                     authz={},
-                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -909,7 +905,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     allowed_origins=['a', 'b'],
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
-                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http.log'))
 
@@ -919,7 +914,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=None,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
-                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http-access.log'))
 
@@ -933,7 +927,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertResults(www=dict(port=None,
                                     plugins={}, auth={'name': 'NoAuth'},
                                     authz={},
-                                    descriptions_are_html=False,
                                     avatar_methods={'name': 'gravatar'},
                                     versions=custom_versions,
                                     logfileName='http.log'))

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -217,7 +217,8 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     def test_signature_updateBuilderInfo(self):
         @self.assertArgSpecMatches(self.master.data.updates.updateBuilderInfo)
-        def updateBuilderInfo(self, builderid, description, projectid, tags):
+        def updateBuilderInfo(self, builderid, description, description_format, description_html,
+                              projectid, tags):
             pass
 
     def test_signature_updateBuilderList(self):
@@ -231,11 +232,21 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     def test_updateBuilderList(self):
         # add one builder master
         yield self.rtype.updateBuilderList(13, ['somebuilder'])
-        self.assertEqual(sorted((yield self.master.db.builders.getBuilders())),
-                         sorted([
-                             dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None, projectid=None, tags=[]),
-                         ]))
+        self.assertEqual(
+            sorted((yield self.master.db.builders.getBuilders())),
+            sorted([
+                {
+                    "id": 1,
+                    "masterids": [13],
+                    "name": "somebuilder",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+            ]
+        ))
         self.master.mq.assertProductions([(('builders', '1', 'started'),
                                            {'builderid': 1, 'masterid': 13,
                                             'name': 'somebuilder'})])
@@ -246,39 +257,92 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         def builderKey(builder):
             return builder['id']
 
-        self.assertEqual(sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
-                         sorted([
-                             dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None, projectid=None, tags=[]),
-                             dict(id=2, masterids=[13],
-                                  name='another', description=None, projectid=None, tags=[]),
-                         ], key=builderKey))
+        self.assertEqual(
+            sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
+            sorted([
+                {
+                    "id": 1,
+                    "masterids": [13],
+                    "name": "somebuilder",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+                {
+                    "id": 2,
+                    "masterids": [13],
+                    "name": "another",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+            ], key=builderKey
+        ))
         self.master.mq.assertProductions([(('builders', '2', 'started'),
                                            {'builderid': 2, 'masterid': 13, 'name': 'another'})])
 
         # add one for another master
         yield self.rtype.updateBuilderList(14, ['another'])
-        self.assertEqual(sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
-                         sorted([
-                             dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None, projectid=None, tags=[]),
-                             dict(id=2, masterids=[13, 14],
-                                  name='another', description=None, projectid=None, tags=[]),
-                         ], key=builderKey))
+        self.assertEqual(
+            sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
+            sorted([
+                {
+                    "id": 1,
+                    "masterids": [13],
+                    "name": "somebuilder",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+                {
+                    "id": 2,
+                    "masterids": [13, 14],
+                    "name": "another",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+            ], key=builderKey
+        ))
         self.master.mq.assertProductions([(('builders', '2', 'started'),
                                            {'builderid': 2, 'masterid': 14, 'name': 'another'})])
 
         # remove both for the first master
         yield self.rtype.updateBuilderList(13, [])
-        self.assertEqual(sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
-                         sorted([
-                             dict(
-                                 id=1, masterids=[], name='somebuilder', description=None,
-                                 projectid=None, tags=[]),
-                             dict(
-                                 id=2, masterids=[14], name='another', description=None,
-                                 projectid=None, tags=[]),
-                         ], key=builderKey))
+        self.assertEqual(
+            sorted((yield self.master.db.builders.getBuilders()), key=builderKey),
+            sorted([
+                {
+                    "id": 1,
+                    "masterids": [],
+                    "name": "somebuilder",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+                {
+                    "id": 2,
+                    "masterids": [14],
+                    "name": "another",
+                    "description": None,
+                    "description_html": None,
+                    "description_format": None,
+                    "projectid": None,
+                    "tags": []
+                },
+            ], key=builderKey
+        ))
+
         self.master.mq.assertProductions([
             (('builders', '1', 'stopped'),
              {'builderid': 1, 'masterid': 13, 'name': 'somebuilder'}),

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -122,16 +122,31 @@ class Project(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     def test_signature_update_project_info(self):
         @self.assertArgSpecMatches(self.master.data.updates.update_project_info)
-        def update_project_info(self, projectid, slug, description):
+        def update_project_info(
+            self,
+            projectid,
+            slug,
+            description,
+            description_format,
+            description_html
+        ):
             pass
 
     @defer.inlineCallbacks
     def test_update_project_info(self):
-        yield self.master.data.updates.update_project_info(13, 'slug13', 'project13 desc')
+        yield self.master.data.updates.update_project_info(
+            13,
+            "slug13",
+            "project13 desc",
+            "format",
+            "html desc",
+        )
         projects = yield self.master.db.projects.get_projects()
         self.assertEqual(projects, [{
             "id": 13,
             "name": "fake_project",
             "slug": "slug13",
             "description": "project13 desc",
+            "description_format": "format",
+            "description_html": "html desc",
         }])

--- a/master/buildbot/test/unit/db/test_builders.py
+++ b/master/buildbot/test/unit/db/test_builders.py
@@ -65,7 +65,8 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_updateBuilderInfo(self):
         @self.assertArgSpecMatches(self.db.builders.updateBuilderInfo)
-        def updateBuilderInfo(self, builderid, description, projectid, tags):
+        def updateBuilderInfo(self, builderid, description, description_format, description_html,
+                              projectid, tags):
             pass
 
     @defer.inlineCallbacks
@@ -77,23 +78,54 @@ class Tests(interfaces.InterfaceTests):
             fakedb.Builder(id=8, name='some:builder8'),
         ])
 
-        yield self.db.builders.updateBuilderInfo(7, 'a string which describe the builder',
-                                                 123, ['cat1', 'cat2'])
-        yield self.db.builders.updateBuilderInfo(8, 'a string which describe the builder',
-                                                 124, [])
+        yield self.db.builders.updateBuilderInfo(
+            7,
+            'a string which describe the builder',
+            None,
+            None,
+            123,
+            ['cat1', 'cat2']
+        )
+        yield self.db.builders.updateBuilderInfo(
+            8,
+            'a string which describe the builder',
+            None,
+            None,
+            124,
+            []
+        )
         builderdict7 = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict7)
         builderdict7['tags'].sort()  # order is unspecified
-        self.assertEqual(builderdict7,
-                         dict(id=7, name='some:builder7', tags=['cat1', 'cat2'],
-                              masterids=[], description='a string which describe the builder',
-                              projectid=123))
+        self.assertEqual(
+            builderdict7,
+            {
+                "id": 7,
+                "name": 'some:builder7',
+                "tags": ["cat1", "cat2"],
+                "masterids": [],
+                "description": "a string which describe the builder",
+                "description_format": None,
+                "description_html": None,
+                "projectid": 123,
+            }
+        )
+
         builderdict8 = yield self.db.builders.getBuilder(8)
         validation.verifyDbDict(self, 'builderdict', builderdict8)
-        self.assertEqual(builderdict8,
-                         dict(id=8, name='some:builder8', tags=[],
-                              masterids=[], description='a string which describe the builder',
-                              projectid=124))
+        self.assertEqual(
+            builderdict8,
+            {
+                "id": 8,
+                "name": 'some:builder8',
+                "tags": [],
+                "masterids": [],
+                "description": "a string which describe the builder",
+                "description_format": None,
+                "description_html": None,
+                "projectid": 124,
+            }
+        )
 
     @defer.inlineCallbacks
     def test_update_builder_info_tags_case(self):
@@ -102,7 +134,7 @@ class Tests(interfaces.InterfaceTests):
             fakedb.Builder(id=7, name='some:builder7', projectid=107),
         ])
 
-        yield self.db.builders.updateBuilderInfo(7, 'builder_desc', 107, ['Cat', 'cat'])
+        yield self.db.builders.updateBuilderInfo(7, 'builder_desc', None, None, 107, ['Cat', 'cat'])
         builder_dict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builder_dict)
         builder_dict['tags'].sort()  # order is unspecified
@@ -112,6 +144,8 @@ class Tests(interfaces.InterfaceTests):
             'tags': ['Cat', 'cat'],
             'masterids': [],
             'description': 'builder_desc',
+            'description_format': None,
+            'description_html': None,
             'projectid': 107,
         })
 
@@ -119,9 +153,19 @@ class Tests(interfaces.InterfaceTests):
     def test_findBuilderId_new(self):
         id = yield self.db.builders.findBuilderId('some:builder')
         builderdict = yield self.db.builders.getBuilder(id)
-        self.assertEqual(builderdict,
-                         dict(id=id, name='some:builder', tags=[],
-                              masterids=[], description=None, projectid=None))
+        self.assertEqual(
+            builderdict,
+            {
+                "id": id,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            }
+        )
 
     @defer.inlineCallbacks
     def test_findBuilderId_new_no_autoCreate(self):
@@ -147,9 +191,19 @@ class Tests(interfaces.InterfaceTests):
         yield self.db.builders.addBuilderMaster(builderid=7, masterid=9)
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
-        self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder', tags=[],
-                              masterids=[9, 10], description=None, projectid=None))
+        self.assertEqual(
+            builderdict,
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [9, 10],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            }
+        )
 
     @defer.inlineCallbacks
     def test_addBuilderMaster_already_present(self):
@@ -162,9 +216,19 @@ class Tests(interfaces.InterfaceTests):
         yield self.db.builders.addBuilderMaster(builderid=7, masterid=9)
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
-        self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder', tags=[],
-                              masterids=[9], description=None, projectid=None))
+        self.assertEqual(
+            builderdict,
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [9],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            }
+        )
 
     @defer.inlineCallbacks
     def test_removeBuilderMaster(self):
@@ -178,9 +242,19 @@ class Tests(interfaces.InterfaceTests):
         yield self.db.builders.removeBuilderMaster(builderid=7, masterid=9)
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
-        self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder', tags=[],
-                              masterids=[10], description=None, projectid=None))
+        self.assertEqual(
+            builderdict,
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [10],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            }
+        )
 
     @defer.inlineCallbacks
     def test_getBuilder_no_masters(self):
@@ -189,9 +263,19 @@ class Tests(interfaces.InterfaceTests):
         ])
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
-        self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder', tags=[],
-                              masterids=[], description=None, projectid=None))
+        self.assertEqual(
+            builderdict,
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            }
+        )
 
     @defer.inlineCallbacks
     def test_getBuilder_with_masters(self):
@@ -204,9 +288,19 @@ class Tests(interfaces.InterfaceTests):
         ])
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
-        self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder', tags=[],
-                              masterids=[3, 4], description=None, projectid=None))
+        self.assertEqual(
+            builderdict,
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [3, 4],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            }
+        )
 
     @defer.inlineCallbacks
     def test_getBuilder_missing(self):
@@ -229,12 +323,36 @@ class Tests(interfaces.InterfaceTests):
         for builderdict in builderlist:
             validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(sorted(builderlist, key=builderKey), sorted([
-            dict(id=7, name='some:builder', masterids=[
-                 3], tags=[], description=None, projectid=None),
-            dict(id=8, name='other:builder', masterids=[
-                 3, 4], tags=[], description=None, projectid=None),
-            dict(id=9, name='third:builder',
-                 masterids=[], tags=[], description=None, projectid=None),
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [3],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            },
+            {
+                "id": 8,
+                "name": 'other:builder',
+                "tags": [],
+                "masterids": [3, 4],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            },
+            {
+                "id": 9,
+                "name": 'third:builder',
+                "tags": [],
+                "masterids": [],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            },
         ], key=builderKey))
 
     @defer.inlineCallbacks
@@ -253,10 +371,26 @@ class Tests(interfaces.InterfaceTests):
         for builderdict in builderlist:
             validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(sorted(builderlist, key=builderKey), sorted([
-            dict(id=7, name='some:builder', masterids=[
-                 3], tags=[], description=None, projectid=None),
-            dict(id=8, name='other:builder', masterids=[
-                 3, 4], tags=[], description=None, projectid=None),
+            {
+                "id": 7,
+                "name": 'some:builder',
+                "tags": [],
+                "masterids": [3],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            },
+            {
+                "id": 8,
+                "name": 'other:builder',
+                "tags": [],
+                "masterids": [3, 4],
+                "description": None,
+                "description_format": None,
+                "description_html": None,
+                "projectid": None
+            },
         ], key=builderKey))
 
     @defer.inlineCallbacks
@@ -285,6 +419,8 @@ class Tests(interfaces.InterfaceTests):
                 "masterids": [3],
                 "tags": [],
                 "description": None,
+                "description_format": None,
+                "description_html": None,
                 "projectid": 201,
             },
             {
@@ -293,6 +429,8 @@ class Tests(interfaces.InterfaceTests):
                 "masterids": [4],
                 "tags": [],
                 "description": None,
+                "description_format": None,
+                "description_html": None,
                 "projectid": 201,
             },
         ], key=builderKey))

--- a/master/buildbot/test/unit/db/test_projects.py
+++ b/master/buildbot/test/unit/db/test_projects.py
@@ -46,7 +46,14 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_update_project_info(self):
         @self.assertArgSpecMatches(self.db.projects.update_project_info)
-        def update_project_info(self, projectid, slug, description):
+        def update_project_info(
+            self,
+            projectid,
+            slug,
+            description,
+            description_format,
+            description_html,
+        ):
             pass
 
     @defer.inlineCallbacks
@@ -55,7 +62,13 @@ class Tests(interfaces.InterfaceTests):
             fakedb.Project(id=7, name='fake_project7'),
         ])
 
-        yield self.db.projects.update_project_info(7, 'slug7', 'project7 desc')
+        yield self.db.projects.update_project_info(
+            7,
+            "slug7",
+            "project7 desc",
+            "format",
+            "html desc"
+        )
         dbdict = yield self.db.projects.get_project(7)
         validation.verifyDbDict(self, 'projectdict', dbdict)
         self.assertEqual(dbdict, {
@@ -63,6 +76,8 @@ class Tests(interfaces.InterfaceTests):
             "name": "fake_project7",
             "slug": "slug7",
             "description": "project7 desc",
+            "description_format": "format",
+            "description_html": "html desc",
         })
 
     @defer.inlineCallbacks
@@ -74,6 +89,8 @@ class Tests(interfaces.InterfaceTests):
             "name": "fake_project",
             "slug": "fake_project",
             "description": None,
+            "description_format": None,
+            "description_html": None,
         })
 
     @defer.inlineCallbacks
@@ -101,6 +118,8 @@ class Tests(interfaces.InterfaceTests):
             "name": "fake_project",
             "slug": "fake_project",
             "description": None,
+            "description_format": None,
+            "description_html": None,
         })
 
     @defer.inlineCallbacks
@@ -124,18 +143,24 @@ class Tests(interfaces.InterfaceTests):
                 "name": "fake_project7",
                 "slug": "fake_project7",
                 "description": None,
+                "description_format": None,
+                "description_html": None,
             },
             {
                 "id": 8,
                 "name": "fake_project8",
                 "slug": "fake_project8",
                 "description": None,
+                "description_format": None,
+                "description_html": None,
             },
             {
                 "id": 9,
                 "name": "fake_project9",
                 "slug": "fake_project9",
                 "description": None,
+                "description_format": None,
+                "description_html": None,
             },
         ], key=project_key))
 

--- a/master/buildbot/test/unit/db_migrate/test_versions_061_add_builder_description_format.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_061_add_builder_description_format.py
@@ -1,0 +1,81 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import hashlib
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.Text, nullable=False),
+            sa.Column('description', sa.Text, nullable=True),
+            sa.Column('projectid', sa.Integer, nullable=True),
+            sa.Column('name_hash', sa.String(40), nullable=False),
+        )
+        builders.create()
+
+        conn.execute(builders.insert(), [{
+            "id": 3,
+            "name": "foo",
+            "description": "foo_description",
+            "projectid": None,
+            "name_hash": hashlib.sha1(b'foo').hexdigest()
+        }])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            builders = sautils.Table('builders', metadata, autoload=True)
+            self.assertIsInstance(builders.c.description_format.type, sa.Text)
+            self.assertIsInstance(builders.c.description_html.type, sa.Text)
+
+            q = sa.select([
+                builders.c.name,
+                builders.c.description_format,
+                builders.c.description_html
+            ])
+
+            num_rows = 0
+            for row in conn.execute(q):
+                self.assertIsNone(row.description_format)
+                self.assertIsNone(row.description_html)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+        return self.do_test_migration('060', '061', setup_thd, verify_thd)

--- a/master/buildbot/test/unit/db_migrate/test_versions_062_add_project_description_format.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_062_add_project_description_format.py
@@ -1,0 +1,85 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import hashlib
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        hash_length = 40
+
+        projects = sautils.Table(
+            'projects', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.Text, nullable=False),
+            sa.Column('name_hash', sa.String(hash_length), nullable=False),
+            sa.Column('slug', sa.String(50), nullable=False),
+            sa.Column('description', sa.Text, nullable=True),
+        )
+        projects.create()
+
+        conn.execute(projects.insert(), [{
+            "id": 4,
+            "name": "foo",
+            "description": "foo_description",
+            "description_html": None,
+            "description_format": None,
+            "slug": "foo",
+            "name_hash": hashlib.sha1(b'foo').hexdigest()
+        }])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            projects = sautils.Table('projects', metadata, autoload=True)
+            self.assertIsInstance(projects.c.description_format.type, sa.Text)
+            self.assertIsInstance(projects.c.description_html.type, sa.Text)
+
+            q = sa.select([
+                projects.c.name,
+                projects.c.description_format,
+                projects.c.description_html
+            ])
+
+            num_rows = 0
+            for row in conn.execute(q):
+                self.assertIsNone(row.description_format)
+                self.assertIsNone(row.description_html)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+        return self.do_test_migration('061', '062', setup_thd, verify_thd)

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -650,11 +650,11 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
         builder_updates = []
         self.master.data.updates.updateBuilderInfo = \
-            lambda builderid, desc, projectid, tags: \
-            builder_updates.append((builderid, desc, projectid, tags))
+            lambda builderid, desc, desc_format, desc_html, projectid, tags: \
+            builder_updates.append((builderid, desc, desc_format, desc_html, projectid, tags))
 
         yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
-        self.assertEqual(builder_updates, [(1, new_desc, expect_project_id, new_tags)])
+        self.assertEqual(builder_updates, [(1, new_desc, None, None, expect_project_id, new_tags)])
 
     @defer.inlineCallbacks
     def test_does_not_reconfig_identical(self):
@@ -666,8 +666,8 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
         builder_updates = []
         self.master.data.updates.updateBuilderInfo = \
-            lambda builderid, desc, projectid, tags: \
-            builder_updates.append((builderid, desc, projectid, tags))
+            lambda builderid, desc, desc_format, desc_html, projectid, tags: \
+            builder_updates.append((builderid, desc, desc_format, desc_html, projectid, tags))
 
         yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
         self.assertEqual(builder_updates, [])

--- a/master/buildbot/test/unit/process/test_project.py
+++ b/master/buildbot/test/unit/process/test_project.py
@@ -1,0 +1,27 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.trial import unittest
+
+from buildbot.process.project import Project
+from buildbot.test.util.config import ConfigErrorsMixin
+
+
+class ProjectConfigTests(ConfigErrorsMixin, unittest.TestCase):
+
+    def test_description_wrong_format(self):
+        with self.assertRaisesConfigError("project description format must be None"):
+            Project(name="a", description_format="unknown")

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -167,6 +167,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                 'builder': {
                     'builderid': 80,
                     'description': None,
+                    'description_format': None,
+                    'description_html': None,
                     'projectid': None,
                     'masterids': [],
                     'name': 'Builder1',
@@ -269,6 +271,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                 'builder': {
                     'builderid': 80,
                     'description': None,
+                    'description_format': None,
+                    'description_html': None,
                     'projectid': None,
                     'masterids': [],
                     'name': 'Builder1',

--- a/master/buildbot/test/unit/util/test_render_description.py
+++ b/master/buildbot/test/unit/util/test_render_description.py
@@ -1,0 +1,32 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.trial import unittest
+
+from buildbot.util.render_description import render_description
+
+
+class TestRaml(unittest.TestCase):
+
+    def test_plain(self):
+        self.assertIsNone(render_description("description", None))
+
+    def test_unknown(self):
+        with self.assertRaises(Exception):
+            render_description("description", "unknown")
+
+    def test_markdown(self):
+        self.assertEqual(render_description("# description\ntext", "markdown"),
+                         "<h1>description</h1>\n<p>text</p>")

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -375,6 +375,8 @@ dbdict['projectdict'] = DictValidator(
     name=StringValidator(),
     slug=StringValidator(),
     description=NoneOk(StringValidator()),
+    description_format=NoneOk(StringValidator()),
+    description_html=NoneOk(StringValidator()),
 )
 
 # builder

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -394,6 +394,8 @@ dbdict['builderdict'] = DictValidator(
     masterids=ListValidator(IntValidator()),
     name=StringValidator(),
     description=NoneOk(StringValidator()),
+    description_format=NoneOk(StringValidator()),
+    description_html=NoneOk(StringValidator()),
     projectid=NoneOk(IntValidator()),
     tags=ListValidator(StringValidator()),
 )

--- a/master/buildbot/util/render_description.py
+++ b/master/buildbot/util/render_description.py
@@ -1,0 +1,23 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+def render_description(description, format):
+    if format is None:
+        return None
+    if format == "markdown":
+        import markdown
+        return markdown.markdown(description)
+    raise Exception(f"Unsupported description format {format}")

--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -162,6 +162,12 @@ Other optional keys may be set on each ``BuilderConfig``:
 
     A builder may be given an arbitrary description, which will show up in the web status on the builder's page.
 
+``description_format``
+    (string, optional)
+
+    The format of the ``description`` parameter.
+    By default, it is ``None`` and corresponds to plain text format.
+
 .. index:: Builds; merging
 
 .. _Collapsing-Build-Requests:

--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -167,6 +167,7 @@ Other optional keys may be set on each ``BuilderConfig``:
 
     The format of the ``description`` parameter.
     By default, it is ``None`` and corresponds to plain text format.
+    Allowed values: ``None``, ``markdown``.
 
 .. index:: Builds; merging
 

--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -42,28 +42,37 @@ However, there is a simpler way to use it and it looks like this:
 Other optional keys may be set on each ``BuilderConfig``:
 
 ``builddir``
+    (string, optional).
+
     Specifies the name of a subdirectory of the master's basedir in which everything related to this builder will be stored.
     This holds build status information.
     If not set, this parameter defaults to the builder name, with some characters escaped.
     Each builder must have a unique build directory.
 
 ``workerbuilddir``
+    (string, optional).
+
     Specifies the name of a subdirectory (under the worker's configured base directory) in which everything related to this builder will be placed on the worker.
     This is where checkouts, compilations, and tests are run.
     If not set, defaults to ``builddir``.
     If a worker is connected to multiple builders that share the same ``workerbuilddir``, make sure the worker is set to run one build at a time or ensure this is fine to run multiple builds from the same directory simultaneously.
 
 ``tags``
-    If provided, this is a list of strings that identifies tags for the builder.
-    Status clients can limit themselves to a subset of the available tags.
+    (list of strings, optional).
+
+    Identifies tags for the builder.
     A common use for this is to add new builders to your setup (for a new module or a new worker) that do not work correctly yet and allow you to integrate them with the active builders.
     You can tag these new builders with a ``test`` tag, make your main status clients ignore them, and have only private status clients pick them up.
     As soon as they work, you can move them over to the active tag.
 
 ``project``
+    (string, optional).
+
     If provided, the builder will be associated with the specific project.
 
 ``nextWorker``
+     (function, optional).
+
      If provided, this is a function that controls which worker will be assigned future jobs.
      The function is passed three arguments, the :class:`Builder` object which is assigning a new job, a list of :class:`WorkerForBuilder` objects and the :class:`BuildRequest`.
      The function should return one of the :class:`WorkerForBuilder` objects, or ``None`` if none of the available workers should be used.
@@ -71,12 +80,16 @@ Other optional keys may be set on each ``BuilderConfig``:
      The function can optionally return a Deferred, which should fire with the same results.
 
 ``nextBuild``
+    (function, optional).
+
     If provided, this is a function that controls which build request will be handled next.
     The function is passed two arguments, the :class:`Builder` object which is assigning a new job, and a list of :class:`BuildRequest` objects of pending builds.
     The function should return one of the :class:`BuildRequest` objects, or ``None`` if none of the pending builds should be started.
     This function can optionally return a Deferred which should fire with the same results.
 
 ``canStartBuild``
+    (boolean, optional).
+
     If provided, this is a function that can veto whether a particular worker should be used for a given build request.
     The function is passed three arguments: the :class:`Builder`, a :class:`Worker`, and a :class:`BuildRequest`.
     The function should return ``True`` if the combination is acceptable, or ``False`` otherwise.
@@ -85,7 +98,9 @@ Other optional keys may be set on each ``BuilderConfig``:
     See :ref:`canStartBuild-Functions` for a concrete example.
 
 ``locks``
-    A list of ``Locks`` (instances of :class:`buildbot.locks.WorkerLock` or :class:`buildbot.locks.MasterLock`) that should be acquired before starting a :class:`Build` from this :class:`Builder`.
+    (list of instances of :class:`buildbot.locks.WorkerLock` or :class:`buildbot.locks.MasterLock`, optional).
+
+    Specifies the locks that should be acquired before starting a :class:`Build` from this :class:`Builder`.
     Alternatively, this could be a renderable that returns this list depending on properties related to the build that is just about to be created.
     This lets you defer picking the locks to acquire until it is known which :class:`Worker` a build would get assigned to.
     The properties available to the renderable include all properties that are set to the build before its first step excluding the properties that come from the build itself and the ``builddir`` property that comes from worker.
@@ -95,6 +110,8 @@ Other optional keys may be set on each ``BuilderConfig``:
     See :ref:`Interlocks`.
 
 ``env``
+    (dictionary of strings, optional).
+
     A Builder may be given a dictionary of environment variables in this parameter.
     The variables are used in :bb:step:`ShellCommand` steps in builds created by this builder.
     The environment variables will override anything in the worker's environment.
@@ -120,21 +137,29 @@ Other optional keys may be set on each ``BuilderConfig``:
 .. index:: Builds; merging
 
 ``collapseRequests``
+    (boolean, optional)
+
     Specifies how build requests for this builder should be collapsed.
     See :ref:`Collapsing-Build-Requests`, below.
 
 .. index:: Properties; builder
 
 ``properties``
+    (dictionary of strings, optional)
+
     A builder may be given a dictionary of :ref:`Build-Properties` specific for this builder in this parameter.
     Those values can be used later on like other properties.
     :ref:`Interpolate`.
 
 ``defaultProperties``
+    (dictionary of strings, optional)
+
     Similar to the ``properties`` parameter.
     But ``defaultProperties`` will only be added to :ref:`Build-Properties` if they are not already set by :ref:`another source <Properties>`.
 
 ``description``
+    (string, optional).
+
     A builder may be given an arbitrary description, which will show up in the web status on the builder's page.
 
 .. index:: Builds; merging

--- a/master/docs/manual/configuration/projects.rst
+++ b/master/docs/manual/configuration/projects.rst
@@ -33,6 +33,7 @@ The following arguments are optional:
 
     The format of the ``description`` parameter.
     By default, it is ``None`` and corresponds to plain text format.
+    Allowed values: ``None``, ``markdown``.
 
 Example
 ~~~~~~~

--- a/master/docs/manual/configuration/projects.rst
+++ b/master/docs/manual/configuration/projects.rst
@@ -21,10 +21,18 @@ For more information on the Project function in Buildbot, see :ref:`the Concepts
 The following arguments are optional:
 
 ``slug``
+    (string, optional)
     A short string that is used to refer to the project in the URLs of the Buildbot web UI.
 
 ``description``
+    (string, optional)
     A description of the project that appears in the Buildbot web UI.
+
+``description_format``
+    (string, optional)
+
+    The format of the ``description`` parameter.
+    By default, it is ``None`` and corresponds to plain text format.
 
 Example
 ~~~~~~~

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -48,11 +48,6 @@ This server is configured with the ``www`` configuration key, which specifies a 
     If true, then debugging information will be output to the browser.
     This is best set to false (the default) on production systems, to avoid the possibility of information leakage.
 
-``descriptions_are_html``
-    If ``True``, then builder and project descriptions are interpreted and rendered as HTML.
-    Use only if the builder and project descriptions are coming from a trusted source.
-    Otherwise this option introduces cross site scripting security vulnerability.
-
 ``allowed_origins``
     This gives a list of origins which are allowed to access the Buildbot API (including control via JSONRPC 2.0).
     It implements cross-origin request sharing (CORS), allowing pages at origins other than the Buildbot UI to use the API.

--- a/master/setup.py
+++ b/master/setup.py
@@ -524,6 +524,7 @@ test_deps = [
     'boto3',
     'moto',
     'mock>=2.0.0',
+    "Markdown>=3.0.0",
     'parameterized',
 ]
 if sys.platform != 'win32':

--- a/master/setup.py
+++ b/master/setup.py
@@ -489,8 +489,6 @@ if 'a' in version or 'b' in version:
             raise RuntimeError(VERSION_MSG)
 
 twisted_ver = ">= 18.7.0"
-autobahn_ver = ">= 0.16.0"
-txaio_ver = ">= 2.2.2"
 
 bundle_version = version.split("-")[0]
 
@@ -505,8 +503,8 @@ setup_args['install_requires'] = [
     'sqlalchemy >= 1.3.0, < 1.5',
     'alembic >= 1.6.0',
     'python-dateutil>=1.5',
-    'txaio ' + txaio_ver,
-    'autobahn ' + autobahn_ver,
+    "txaio >= 2.2.2",
+    "autobahn >= 0.16.0",
     'PyJWT',
     'pyyaml'
 ]

--- a/newsfragments/markdown-descriptions.feature
+++ b/newsfragments/markdown-descriptions.feature
@@ -1,0 +1,1 @@
+Added support for specifying builder descriptions in markdown which is later rendered to HTML for presentation in the web frontend.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,6 +8,7 @@ autobahn==22.7.1
 boto3==1.24.60
 flake8==5.0.4
 msgpack==1.0.4
+Markdown==3.3.4
 pylint==2.14.5
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
+++ b/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
@@ -60,7 +60,7 @@ export const ProjectDescriptionWidget = observer(({projectid}: ProjectDescriptio
     <Card>
       <Card.Body>
         <h5>Description</h5>
-        {renderDescription(project === null ? "..." : project.description!)}
+        {project === null ? <>...</> : renderDescription(project)}
       </Card.Body>
     </Card>
   );

--- a/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
+++ b/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
@@ -15,7 +15,6 @@
   Copyright Buildbot Team Members
 */
 
-import {useContext} from "react";
 import {observer} from "mobx-react";
 import {Card} from "react-bootstrap";
 import {
@@ -23,7 +22,6 @@ import {
   useDataAccessor,
   useDataApiQuery,
 } from "buildbot-data-js";
-import {ConfigContext} from "buildbot-ui";
 import {TableHeading} from "../TableHeading/TableHeading";
 
 export type ProjectDescriptionWidgetProps = {
@@ -32,21 +30,22 @@ export type ProjectDescriptionWidgetProps = {
 
 export const ProjectDescriptionWidget = observer(({projectid}: ProjectDescriptionWidgetProps) => {
   const accessor = useDataAccessor([]);
-  const config = useContext(ConfigContext);
 
   const projectQuery = useDataApiQuery(() => Project.getAll(accessor, {query: {
       projectid: projectid
     }}));
   const project = projectQuery.getNthOrNull(0);
 
-  const renderDescription = (description: string) => {
-    if (config.descriptions_are_html) {
+  const renderDescription = (project: Project) => {
+    if (project.description_format === null && project.description_html !== null) {
       return (
-        <div dangerouslySetInnerHTML={{__html: description}}/>
-      );
+          <div><TableHeading>Description:</TableHeading>
+            <div dangerouslySetInnerHTML={{__html: project.description_html}}/>
+          </div>
+      )
     } else {
       return (
-        <div><TableHeading>Description:</TableHeading>{description}</div>
+          <div><TableHeading>Description:</TableHeading>{project.description}</div>
       );
     }
   };

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -16,7 +16,7 @@
 */
 
 import {observer} from "mobx-react";
-import {useContext, useState} from "react";
+import {useState} from "react";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
@@ -29,7 +29,7 @@ import {
   useDataApiQuery,
   useDataApiSingleElementQuery
 } from "buildbot-data-js";
-import {TopbarAction, useTopbarItems, useTopbarActions, ConfigContext} from "buildbot-ui";
+import {TopbarAction, useTopbarItems, useTopbarActions, TopbarItem} from "buildbot-ui";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {BuildRequestsTable} from "../../components/BuildrequestsTable/BuildrequestsTable";
 import {useNavigate, useParams} from "react-router-dom";
@@ -94,7 +94,6 @@ const buildTopbarActions = (builds: DataCollection<Build>,
 export const BuilderView = observer(() => {
   const builderid = Number.parseInt(useParams<"builderid">().builderid ?? "");
   const navigate = useNavigate();
-  const config = useContext(ConfigContext);
 
   const accessor = useDataAccessor([builderid]);
 
@@ -178,16 +177,16 @@ export const BuilderView = observer(() => {
     }
   };
 
-  const renderDescription = (description: string) => {
-    if (config.descriptions_are_html) {
+  const renderDescription = (builder: Builder) => {
+    if (builder.description_format === null && builder.description_html !== null) {
       return (
         <div><TableHeading>Description:</TableHeading>
-          <div dangerouslySetInnerHTML={{__html: description}}/>
+          <div dangerouslySetInnerHTML={{__html: builder.description_html}}/>
         </div>
       )
     } else {
       return (
-        <div><TableHeading>Description:</TableHeading>{description}</div>
+        <div><TableHeading>Description:</TableHeading>{builder.description}</div>
       );
     }
   };
@@ -196,7 +195,7 @@ export const BuilderView = observer(() => {
     <div className="container">
       <AlertNotification text={errorMsg}/>
       {builder !== null && builder.description !== null
-        ? renderDescription(builder.description)
+        ? renderDescription(builder)
         : <></>
       }
       <BuildRequestsTable buildrequests={buildrequests}/>

--- a/www/react-data-module/src/data/classes/Builder.ts
+++ b/www/react-data-module/src/data/classes/Builder.ts
@@ -19,6 +19,8 @@ import {Master, masterDescriptor} from "./Master";
 export class Builder extends BaseClass {
   @observable builderid!: number;
   @observable description!: string|null;
+  @observable description_format!: string|null;
+  @observable description_html!: string|null;
   @observable masterids!: string[];
   @observable name!: string;
   @observable tags!: string[];
@@ -33,6 +35,8 @@ export class Builder extends BaseClass {
   @action update(object: any) {
     this.builderid = object.builderid;
     this.description = object.description;
+    this.description_format = object.description_format;
+    this.description_html = object.description_html;
     this.masterids = object.masterids;
     this.name = object.name;
     this.tags = object.tags;

--- a/www/react-data-module/src/data/classes/Project.ts
+++ b/www/react-data-module/src/data/classes/Project.ts
@@ -15,6 +15,8 @@ import {RequestQuery} from "../DataQuery";
 export class Project extends BaseClass {
   @observable projectid!: number;
   @observable description!: string|null;
+  @observable description_format!: string|null;
+  @observable description_html!: string|null;
   @observable slug!: string[];
   @observable name!: string;
 
@@ -29,6 +31,8 @@ export class Project extends BaseClass {
     this.name = object.name;
     this.slug = object.slug;
     this.description = object.description;
+    this.description_format = object.description_format;
+    this.description_html = object.description_html;
   }
 
   toObject() {

--- a/www/react-ui/src/contexts/Config.ts
+++ b/www/react-ui/src/contexts/Config.ts
@@ -45,7 +45,6 @@ export type Config = {
   titleURL: string;
   buildbotURL: string;
   buildbotURLs?: string[];
-  descriptions_are_html: boolean;
   multiMaster: boolean;
   ui_default_config: {[key: string]: any};
   versions: string[][];


### PR DESCRIPTION
This is useful in cases there is a need to display more information about a Builder or Project in their pages, which requires more extensive syntax capabilities.  