### PR TITLE
www: Highlight current most related tab in the sidebar

### DIFF
--- a/www/react-base/src/components/PageWithSidebar/PageWithSidebar.scss
+++ b/www/react-base/src/components/PageWithSidebar/PageWithSidebar.scss
@@ -15,8 +15,16 @@ $gl-sidebar-width: 600px;
   /* theme */
   .sidebar.sidebar-blue {
     background: #30426a;
-    ul .sidebar-main, .sidebar-footer, a:hover, button:hover {
+    ul .sidebar-main, .sidebar-footer {
       background: #273759;
+    }
+    li.current a,
+    li.current button {
+      background: #273759;
+    }
+    a:hover,
+    button:hover {
+      background: #1b263d;
     }
     ul .sidebar-title {
       color: #627cb7;
@@ -149,6 +157,15 @@ $gl-sidebar-width: 600px;
           line-height: 40px;
           >svg {
             margin-left: -1em;
+          }
+        }
+        &.current {
+          a, button {
+            border-left: 3px solid #8c5e10;
+            text-indent: 22px;
+          }
+          .menu-icon {
+            text-indent: 25px;
           }
         }
         a:hover,

--- a/www/react-base/src/components/PageWithSidebar/PageWithSidebar.tsx
+++ b/www/react-base/src/components/PageWithSidebar/PageWithSidebar.tsx
@@ -18,9 +18,12 @@
 import './PageWithSidebar.scss';
 import {observer} from "mobx-react";
 import {FaAngleRight, FaBars, FaThumbtack} from "react-icons/fa";
-import {GlobalMenuSettings} from "../../plugins/GlobalMenuSettings";
+import {
+  getBestMatchingSettingsGroupRoute,
+  GlobalMenuSettings
+} from "../../plugins/GlobalMenuSettings";
 import {SidebarStore} from "../../stores/SidebarStore";
-import {Link} from "react-router-dom";
+import {Link, useLocation} from "react-router-dom";
 
 type PageWithSidebarProps = {
   menuSettings: GlobalMenuSettings,
@@ -47,11 +50,14 @@ export const PageWithSidebar = observer(({menuSettings, sidebarStore, children}:
     );
   }
 
+  const matchingGroupRoute = getBestMatchingSettingsGroupRoute(useLocation().pathname, groups);
+
   const groupElements = groups.map((group, groupIndex) => {
     if (group.subGroups.length > 0) {
       const subGroups = group.subGroups.map(subGroup => {
           const subClassName = "sidebar-list subitem" +
-            (sidebarStore.activeGroup === group.name ? " active": "");
+            (sidebarStore.activeGroup === group.name ? " active": "") +
+            (subGroup.route === matchingGroupRoute ? " current": "");
 
           return (
             <li key={`group-${subGroup.name}`} className={subClassName}>
@@ -78,8 +84,12 @@ export const PageWithSidebar = observer(({menuSettings, sidebarStore, children}:
     if (groupIndex > 0) {
       elements.push(<li key={`groupsep-${group.name}`} className="sidebar-separator"></li>);
     }
+
+    const groupClassName = "sidebar-list" +
+        (group.route === matchingGroupRoute ? " current": "");
+
     elements.push(
-      <li key={`group-${group.name}`} className="sidebar-list">
+      <li key={`group-${group.name}`} className={groupClassName}>
         {group.route === null
           ? <button onClick={() => sidebarStore.toggleGroup(group.name)}>{group.caption}
             <span className="menu-icon">{group.icon}</span>

--- a/www/react-base/src/plugins/GlobalMenuSettings.test.ts
+++ b/www/react-base/src/plugins/GlobalMenuSettings.test.ts
@@ -15,7 +15,11 @@
   Copyright Buildbot Team Members
 */
 
-import {GlobalMenuSettings} from "./GlobalMenuSettings";
+import {
+  getBestMatchingSettingsGroupRoute,
+  GlobalMenuSettings,
+  ResolvedGroupSettings
+} from "./GlobalMenuSettings";
 
 describe('GlobalMenuSettings', () => {
   it("group sorting", () => {
@@ -211,5 +215,53 @@ describe('GlobalMenuSettings', () => {
           }
         ]
       }]);
+  });
+
+  describe('getBestMatchingSettingsGroupRoute', () => {
+    const buildGroup = (route: string|null,
+                        subGroups: ResolvedGroupSettings[]) : ResolvedGroupSettings => {
+      return {
+        name: '',
+        caption: '',
+        route: route,
+        order: 0,
+        subGroups: subGroups
+      }
+    };
+
+    it('no groups', () => {
+      expect(getBestMatchingSettingsGroupRoute('/path', [])).toBeNull();
+    });
+
+    it('not matching groups', () => {
+      expect(getBestMatchingSettingsGroupRoute('/path', [
+        buildGroup('/', []),
+        buildGroup('/pa', []),
+        buildGroup('/path2', []),
+      ])).toBeNull();
+    });
+
+    it('matching group', () => {
+      expect(getBestMatchingSettingsGroupRoute('/path/path2/path3', [
+        buildGroup('/path', []),
+        buildGroup('/path/path2', []),
+        buildGroup('/path/path2/path3', []),
+      ])).toEqual('/path/path2/path3');
+
+      expect(getBestMatchingSettingsGroupRoute('/path/path2/path3', [
+        buildGroup('/path/path2/path3', []),
+        buildGroup('/path/path2', []),
+        buildGroup('/path', []),
+      ])).toEqual('/path/path2/path3');
+    });
+
+    it('matching sub group', () => {
+      expect(getBestMatchingSettingsGroupRoute('/path/path2/path3', [
+        buildGroup('/path', []),
+        buildGroup('/path/path2', [
+          buildGroup('/path/path2/path3', []),
+        ]),
+      ])).toEqual('/path/path2/path3');
+    });
   });
 });

--- a/www/react-base/src/plugins/GlobalMenuSettings.ts
+++ b/www/react-base/src/plugins/GlobalMenuSettings.ts
@@ -118,3 +118,23 @@ export class GlobalMenuSettings {
 };
 
 export const globalMenuSettings = new GlobalMenuSettings();
+
+export function getBestMatchingSettingsGroupRoute(path: string, groups: ResolvedGroupSettings[]) {
+  let bestRoute: string|null = null;
+
+  const checkGroup = (group: ResolvedGroupSettings) => {
+    if (group.route !== null && path.startsWith(group.route) &&
+        (path.length === group.route.length || path[group.route.length] === "/")) {
+      if (bestRoute === null || group.route.length > bestRoute.length) {
+        bestRoute = group.route;
+      }
+    }
+  }
+
+  groups.map(group => {
+    group.subGroups.map(subGroup => checkGroup(subGroup));
+    checkGroup(group);
+  });
+
+  return bestRoute;
+}


### PR DESCRIPTION
This way it's clearer to the users where they are in the with regards to sidebar buttons.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
