### PR TITLE
www: Remove useless log messages when using RemoteUserAuth

### DIFF
--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -23,6 +23,7 @@ from twisted.trial import unittest
 from twisted.web.error import Error
 from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
+from twisted.web.resource import ForbiddenResource
 from twisted.web.resource import IResource
 
 from buildbot.test.reactor import TestReactorMixin
@@ -141,6 +142,9 @@ class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             self.assertEqual(int(e.status), 403)
         else:
             self.fail("403 expected")
+
+    def test_get_login_resource_does_not_throw(self):
+        self.assertIsInstance(self.auth.getLoginResource(), ForbiddenResource)
 
 
 class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -30,6 +30,7 @@ from twisted.web.error import Error
 from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import DigestCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
+from twisted.web.resource import ForbiddenResource
 from twisted.web.resource import IResource
 from zope.interface import implementer
 
@@ -112,6 +113,9 @@ class RemoteUserAuth(AuthBase):
             self.header = unicode2bytes(header)
         if headerRegex is not None:
             self.headerRegex = re.compile(unicode2bytes(headerRegex))
+
+    def getLoginResource(self):
+        return ForbiddenResource(message="URL is not supported for authentication")
 
     @defer.inlineCallbacks
     def maybeAutoLogin(self, request):

--- a/newsfragments/www-remote-user-auth-exception.bugfix
+++ b/newsfragments/www-remote-user-auth-exception.bugfix
@@ -1,0 +1,1 @@
+Fixed excessive messages in the logs when otherwise unsupported ``/auth/login`` endpoint is accessed when using ``RemoteUserAuth`` authentication plugin.


### PR DESCRIPTION
This removes the following stacktrace when /auth/login is accessed (the page is not otherwise visible in the UI):
```
	Traceback (most recent call last):
	  File ".../site-packages/twisted/protocols/basic.py", line 549, in dataReceived
	    why = self.lineReceived(line)
	  File ".../site-packages/twisted/web/http.py", line 2319, in lineReceived
	    self.allContentReceived()
	  File ".../site-packages/twisted/web/http.py", line 2447, in allContentReceived
	    req.requestReceived(command, path, version)
	  File ".../site-packages/twisted/web/http.py", line 1032, in requestReceived
	    self.process()
	--- <exception caught here> ---
	  File ".../site-packages/twisted/web/server.py", line 222, in process
	    resrc = self.site.getResourceFor(self)
	  File ".../buildbot/master/buildbot/www/service.py", line 162, in getResourceFor
	    return server.Site.getResourceFor(self, request)
	  File ".../site-packages/twisted/web/server.py", line 891, in getResourceFor
	    return resource.getChildForRequest(self.resource, request)
	  File ".../site-packages/twisted/web/resource.py", line 97, in getChildForRequest
	    resource = resource.getChildWithDefault(pathElement, request)
	  File ".../site-packages/twisted/web/resource.py", line 199, in getChildWithDefault
	    return self.getChild(path, request)
	  File ".../buildbot/master/buildbot/www/auth.py", line 47, in getChild
	    return self.master.www.auth.getLoginResource()
	  File ".../buildbot/master/buildbot/www/auth.py", line 65, in getLoginResource
	    raise Error(501, b"not implemented")
	twisted.web.error.Error: 501 not implemented
```
