### PR TITLE
Misc scheduler fixes

### DIFF
--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -41,7 +41,6 @@ class BrDict(dict):
 
 
 class BuildRequestsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     def _saSelectQuery(self):
         reqs_tbl = self.db.model.buildrequests

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -26,7 +26,6 @@ from buildbot.util import epoch2datetime
 
 
 class BuildsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     # returns a Deferred that returns a value
     def _getBuild(self, whereclause):

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -41,7 +41,6 @@ class AlreadyCompleteError(RuntimeError):
 
 
 class BuildsetsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     @defer.inlineCallbacks
     def addBuildset(self, sourcestamps, reason, properties, builderids,

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -34,7 +34,6 @@ class ChDict(dict):
 
 
 class ChangesConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     # returns a Deferred that returns a value
     def getParentChangeIds(self, branch, repository, project, codebase):

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -27,7 +27,6 @@ class ChangeSourceAlreadyClaimedError(Exception):
 
 
 class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     def findChangeSourceId(self, name):
         tbl = self.db.model.changesources

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -27,7 +27,6 @@ class SchedulerAlreadyClaimedError(Exception):
 
 
 class SchedulersConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     # returns a Deferred that returns None
     def enable(self, schedulerid, v):

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -110,8 +110,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
             q = sa.select(
                 [sch_ch_tbl.c.changeid, sch_ch_tbl.c.important],
                 whereclause=wc)
-            return {r.changeid: [False, True][r.important]
-                    for r in conn.execute(q)}
+            return {r.changeid: bool(r.important) for r in conn.execute(q)}
         return self.db.pool.do(thd)
 
     def findSchedulerId(self, name):

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -36,7 +36,6 @@ class SsList(list):
 
 
 class SourceStampsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/database.rst
 
     @defer.inlineCallbacks
     def findSourceStampId(self, branch=None, revision=None, repository=None,

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -31,7 +31,6 @@ class ObjDict(dict):
 
 
 class StateConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     def getObjectId(self, name, class_name):
         # defer to a cached method that only takes one parameter (a tuple)

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -25,7 +25,6 @@ from buildbot.util import epoch2datetime
 
 
 class StepsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
     url_lock = None
 
     @defer.inlineCallbacks

--- a/master/buildbot/db/test_result_sets.py
+++ b/master/buildbot/db/test_result_sets.py
@@ -27,7 +27,6 @@ class TestResultSetAlreadyCompleted(Exception):
 
 
 class TestResultSetsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     @defer.inlineCallbacks
     def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -25,7 +25,6 @@ class TestResultDict(dict):
 
 
 class TestResultsConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     @defer.inlineCallbacks
     def _add_code_paths(self, builderid, paths):

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -26,7 +26,6 @@ class UsDict(dict):
 
 
 class UsersConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/db.rst
 
     # returns a Deferred that returns a value
     def findUserByAttr(self, identifier, attr_type, attr_data, _race_hook=None):

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -22,7 +22,6 @@ from buildbot.util import identifiers
 
 
 class WorkersConnectorComponent(base.DBConnectorComponent):
-    # Documentation is in developer/database.rst
 
     def findWorkerId(self, name):
         tbl = self.db.model.workers

--- a/master/docs/manual/configuration/services/old_build_canceller.rst
+++ b/master/docs/manual/configuration/services/old_build_canceller.rst
@@ -10,7 +10,7 @@ The purpose of this service is to cancel builds on branches as soon as a new com
 This allows to reduce resource usage in projects that use Buildbot to run tests on pull request branches.
 For example, if a developer pushes new commits to the branch, notices and fixes a problem quickly and then pushes again, the builds that have been started on the older commit will be cancelled immediately instead of waiting for builds to finish.
 
-The service may be configured to be track a subset of builds.
+The service may be configured to track a subset of builds.
 This is controlled by the ``filters`` parameter.
 The decision on whether to track a build is done on build startup.
 Configuration changes are ignored for builds that have already started.


### PR DESCRIPTION
This PR fixes a typo in ondBuildCanceller documentation, removes obsolete comments about documentation location and simplifies changes evaluation code in scheduler.

* [not needed] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
