### PR TITLE
Reporters: Serialize only related events

### DIFF
--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -189,19 +189,19 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
 
     @defer.inlineCallbacks
     def test_reports_sent_in_order_despite_slow_generator(self):
-        gen = self.setup_mock_generator([('fake1', None, None)])
+        gen = self.setup_mock_generator([('builds', None, None)])
 
         notifier = yield self.setupNotifier(generators=[gen])
 
         # Handle an event when generate is slow
         gen.generate = slow_generate = mock.Mock(return_value=defer.Deferred())
-        notifier._got_event(('fake1', None, None), None)
+        notifier._got_event(('builds', None, None), {'buildrequestid': 1})
         notifier.sendMessage.assert_not_called()
 
         # Then handle an event when generate is fast
         gen.generate = mock.Mock(return_value=defer.Deferred())
         gen.generate.return_value.callback(2)
-        notifier._got_event(('fake1', None, None), None)
+        notifier._got_event(('builds', None, None), {'buildrequestid': 1})
 
         # sendMessage still not called
         notifier.sendMessage.assert_not_called()
@@ -213,17 +213,102 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
         self.assertEqual(notifier.sendMessage.call_args_list, [mock.call([1]), mock.call([2])])
 
     @defer.inlineCallbacks
-    def test_reconfig_waits_for_pending_events(self):
-        gen = self.setup_mock_generator([('fake1', None, None)])
-        gen.generate = mock.Mock(return_value=defer.Deferred())
+    def test_reports_sent_in_order_despite_multiple_slow_generators(self):
+        gen = self.setup_mock_generator([('buildrequests', None, None)])
+        gen2 = self.setup_mock_generator([('builds', None, None)])
+
+        notifier = yield self.setupNotifier(generators=[gen, gen2])
+
+        # This makes it possible to mock generate calls in arbitrary order
+        mock_generate_calls = {
+            'buildrequests': {
+                1: {
+                    'new': defer.Deferred()
+                }
+            },
+            'builds': {
+                1: {
+                    'new': defer.Deferred(),
+                    'finished': defer.Deferred()
+                }
+            }
+        }
+
+        def mock_generate(_1, _2, key, msg):
+            return mock_generate_calls[key[0]][msg['buildrequestid']][key[2]]
+        gen.generate = mock.Mock(side_effect=mock_generate)
+        gen2.generate = mock.Mock(side_effect=mock_generate)
+
+        # Handle an event when generate is very slow
+        notifier._got_event(('buildrequests', None, 'new'), {'buildrequestid': 1})
+
+        # Handle an event when generate is also slow
+        notifier._got_event(('builds', None, 'new'), {'buildrequestid': 1})
+
+        # Handle an event when generate is fast
+        mock_generate_calls['builds'][1]['finished'].callback(3)
+        notifier._got_event(('builds', None, 'finished'), {'buildrequestid': 1})
+
+        # Finish generate call for second event
+        mock_generate_calls['builds'][1]['new'].callback(2)
+
+        # sendMessage still not called
+        notifier.sendMessage.assert_not_called()
+
+        # Finish generate call for first event
+        mock_generate_calls['buildrequests'][1]['new'].callback(1)
+
+        # Now sendMessage should have been called three times in given order
+        self.assertEqual(
+            notifier.sendMessage.call_args_list,
+            [mock.call([1]), mock.call([2]), mock.call([3])]
+        )
+
+    @defer.inlineCallbacks
+    def test_reports_sent_in_order_and_asap_for_multiple_builds(self):
+        gen = self.setup_mock_generator([('builds', None, None)])
 
         notifier = yield self.setupNotifier(generators=[gen])
-        notifier._got_event(('fake1', None, None), None)
-        self.assertIsNotNone(notifier._pending_got_event_call)
 
-        d = notifier.reconfigService(generators=[gen])
-        self.assertFalse(d.called)
+        # This makes it possible to mock generate calls in arbitrary order
+        mock_generate_calls = {
+            'builds': {
+                1: {
+                    'new': defer.Deferred(),
+                    'finished': defer.Deferred()
+                },
+                2: {
+                    'new': defer.Deferred(),
+                    'finished': defer.Deferred()
+                }
+            }
+        }
 
-        gen.generate.return_value.callback(1)
-        self.assertTrue(d.called)
-        self.assertIsNone(notifier._pending_got_event_call)
+        def mock_generate(_1, _2, key, msg):
+            return mock_generate_calls[key[0]][msg['buildrequestid']][key[2]]
+        gen.generate = mock.Mock(side_effect=mock_generate)
+
+        # Handle an event (for first build) when generate is slow
+        notifier._got_event(('builds', None, 'new'), {'buildrequestid': 1})
+        notifier.sendMessage.assert_not_called()
+
+        # Handle an event (for second build) when generate is fast
+        mock_generate_calls['builds'][2]['new'].callback(21)
+        notifier._got_event(('builds', None, 'new'), {'buildrequestid': 2})
+
+        # Handle an event (for first build) when generate is fast
+        mock_generate_calls['builds'][1]['finished'].callback(12)
+        notifier._got_event(('builds', None, 'finished'), {'buildrequestid': 1})
+
+        # Handle an event (for second build) when generate is fast
+        mock_generate_calls['builds'][2]['finished'].callback(22)
+        notifier._got_event(('builds', None, 'finished'), {'buildrequestid': 2})
+
+        # Finish generate call for first event
+        mock_generate_calls['builds'][1]['new'].callback(11)
+
+        # Now sendMessage should have been called four times in given order
+        self.assertEqual(
+            notifier.sendMessage.call_args_list,
+            [mock.call([21]), mock.call([22]), mock.call([11]), mock.call([12])]
+        )

--- a/newsfragments/reporters-chain-related-envets.feature
+++ b/newsfragments/reporters-chain-related-envets.feature
@@ -1,0 +1,2 @@
+Only related events are now serialized (chained) in ``ReporterBase._got_event`` to preserve correct processing order.
+This can improve performance of reporters on bigger Buildbot instances or reporters with slower generators.


### PR DESCRIPTION
This one is for discussion first IMO.

**Problem**:
Serialization of events processing introduced in https://github.com/buildbot/buildbot/pull/6603 causes **significant** performance reduction.
In our case delays can reach hours as even the smallest delays accumulate (we have large Buildbot instance with single `BitbucketServerCoreAPIStatusPush` reporter) .

**Proposed solution**
I would like to introduce these changes as solution for this problem without compromising the original intention of https://github.com/buildbot/buildbot/pull/6603.

* The idea is to serialize only related events. Keys for grouping such related events are generated by  `_get_chain_key_for_event`. IMO only events related to `buildrequests` (buildrequests, builds) need such serialization and other events can be processes asynchronously.

* I also removed the wait for pending events in `reconfigService` as I find is useless. As far as I can tell it only creates potential for missing (not consuming) events while the reconfig is ongoing. And the pending events will be processed anyway.

---

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
