### PR TITLE
appveyor: Update to Python39-x64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   matrix:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python
-    - PYTHON: "C:\\Python39"
+    - PYTHON: "C:\\Python39-x64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"


### PR DESCRIPTION
This PR updates to Python39-x64 in order for Pillow 10.0.0 to work on Windows.
Pillow 10.0.0 does not have pre-built packages for 32 bits Windows.

## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
