### PR TITLE
Dependency update to support Python 3.10 and 3.11 on Windows

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -41,7 +41,8 @@ cryptography==39.0.2
 decorator==5.1.1
 dicttoxml==1.7.4
 dill==0.3.6
-docker==5.0.3
+docker==5.0.3;  python_version < "3.7" # pyup: ignore (6.0.0 droppeded support for < Python 3.7 see: https://docker-py.readthedocs.io/en/stable/change-log.html#id8)
+docker==6.1.2;  python_version >= "3.7"
 docutils==0.17.1  # pyup: ignore (sphinx-rtd-theme 1.0.0 requires docutils<0.18)
 extras==1.0.0
 fixtures==4.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -78,7 +78,7 @@ pbr==5.10.0
 pep8==1.7.1
 Pillow==9.3.0
 platformdirs==2.5.2
-psutil==5.9.1
+psutil==5.9.5
 pyaml==21.10.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -18,7 +18,7 @@ parameterized==0.8.1
 pbr==5.10.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
-psutil==5.9.1
+psutil==5.9.5
 pycparser==2.21;  python_version >= "3.6"
 six==1.16.0
 Twisted==22.4.0;  python_version >= "3.6"

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -48,7 +48,7 @@ msgpack==1.0.4
 packaging==21.3
 parameterized==0.8.1
 pep8==1.7.1
-psutil==5.9.1
+psutil==5.9.5
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.7.0


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
