### PR TITLE
Fix unnecessary nightly scheduler build

### DIFF
--- a/master/buildbot/test/fakedb/state.py
+++ b/master/buildbot/test/fakedb/state.py
@@ -94,15 +94,17 @@ class FakeStateComponent(FakeDBComponent):
 
     # fake methods
 
-    def set_fake_state(self, object, **kwargs):
+    def set_fake_state(self, object, name, value):
         state_key = (object.name, object.__class__.__name__)
         if state_key in self.objects:
             id = self.objects[state_key]
         else:
             id = self.objects[state_key] = self._newId()
 
-        self.states[id] = dict((k, json.dumps(v))
-                               for k, v in kwargs.items())
+        if id in self.states:
+            self.states[id][name] = json.dumps(value)
+        else:
+            self.states[id] = {name: json.dumps(value)}
         return id
 
     # assertions

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -1493,8 +1493,7 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.stopService()
 
         self.master.db.state.set_fake_state(
-            self.poller,
-            lastRev={"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"},
+            self.poller, 'lastRev', {"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"}
         )
 
         yield self.poller.startService()

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -348,7 +348,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         yield self.sched.deactivate()
 
     @defer.inlineCallbacks
-    def test_iterations_onlyIfChanged_unimp_changes_existing_scheduler(self):
+    def test_iterations_onlyIfChanged_unimp_changes_existing_sched_changed_only_if_changed(self):
         yield self.do_test_iterations_onlyIfChanged(
             (60, mock.Mock(), False),
             (600, mock.Mock(), False),
@@ -368,7 +368,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         yield self.sched.deactivate()
 
     @defer.inlineCallbacks
-    def test_iterations_onlyIfChanged_unimp_changes_existing_scheduler_setting_changed(self):
+    def test_iterations_onlyIfChanged_unimp_changes_existing_sched_same_only_if_changed(self):
         yield self.do_test_iterations_onlyIfChanged(
             (60, mock.Mock(), False),
             (600, mock.Mock(), False),

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -246,7 +246,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         d = sched.deactivate()
         return d
 
-    def do_test_iterations_onlyIfChanged(self, *changes_at, last_only_if_changed=None,
+    def do_test_iterations_onlyIfChanged(self, *changes_at, last_only_if_changed,
                                          is_new_scheduler=False, **kwargs):
         fII = mock.Mock(name='fII')
         self.makeScheduler(name='test', builderNames=['test'], branch=None,
@@ -286,7 +286,8 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_no_changes_new_scheduler(self):
-        yield self.do_test_iterations_onlyIfChanged(is_new_scheduler=True)
+        yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=None,
+                                                    is_new_scheduler=True)
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
@@ -336,7 +337,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     def test_iterations_onlyIfChanged_no_changes_existing_scheduler_update_to_v3_5_0(self):
         # v3.4.0 have not had a variable last_only_if_changed yet therefore this case is tested
         # separately
-        yield self.do_test_iterations_onlyIfChanged()
+        yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=None)
         self.assertEqual(self.addBuildsetCallTimes, [])
         self.assertEqual(self.addBuildsetCalls, [])
         self.db.state.assertStateByClass('test', 'Nightly',
@@ -348,6 +349,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         yield self.do_test_iterations_onlyIfChanged(
             (60, mock.Mock(), False),
             (600, mock.Mock(), False),
+            last_only_if_changed=None,
             is_new_scheduler=True)
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
@@ -403,6 +405,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             (120, self.makeFakeChange(number=1, branch=None), False),
             (1200, self.makeFakeChange(number=2, branch=None), True),
             (1201, self.makeFakeChange(number=3, branch=None), False),
+            last_only_if_changed=None,
             )
 
         self.assertEqual(self.addBuildsetCallTimes, [1500])
@@ -537,6 +540,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 number=4, codebase='b', revision='1234:abc'), True),
             codebases={'a': {'repository': "", 'branch': 'master'},
                        'b': {'repository': "", 'branch': 'master'}},
+            last_only_if_changed=None,
             createAbsoluteSourceStamps=True)
         self.db.state.assertStateByClass('test', 'Nightly',
                                          last_build=1500 + self.localtime_offset)

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -306,6 +306,14 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_no_changes_existing_scheduler_setting_changed(self):
+        # When onlyIfChanged==False, builds are run every time on the time set
+        # (changes or no changes). Changes are being recognized but do not have any effect on
+        # starting builds.
+        # It might happen that onlyIfChanged was False, then change happened, then setting was
+        # changed to onlyIfChanged==True.
+        # Because onlyIfChanged was False possibly important change will be missed.
+        # Therefore the first build should start immediately.
+
         yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=False)
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -253,7 +253,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                            fileIsImportant=fII, **kwargs)
 
         if last_only_if_changed is not None:
-            self.db.state.set_fake_state(self.sched, last_only_if_changed=last_only_if_changed)
+            self.db.state.set_fake_state(self.sched, 'last_only_if_changed', last_only_if_changed)
 
         return self.do_test_iterations_onlyIfChanged_test(fII, *changes_at)
 
@@ -448,7 +448,8 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                                       'b': {'repository': "", 'branch': 'master'}},
                            createAbsoluteSourceStamps=True)
 
-        self.db.state.set_fake_state(self.sched, last_only_if_changed=True, lastCodebases={
+        self.db.state.set_fake_state(self.sched, 'last_only_if_changed', True)
+        self.db.state.set_fake_state(self.sched, 'lastCodebases', {
             'b': {
                 'branch': 'master',
                 'repository': 'B',

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -62,7 +62,7 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_getCodebaseDict_existing(self):
-        self.db.state.set_fake_state(self.object, lastCodebases={'a': {
+        self.db.state.set_fake_state(self.object, 'lastCodebases', {'a': {
             'repository': 'A',
             'revision': '1234:abc',
             'branch': 'master',
@@ -83,7 +83,7 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_recordChange_older(self):
-        self.db.state.set_fake_state(self.object, lastCodebases={'a': {
+        self.db.state.set_fake_state(self.object, 'lastCodebases', {'a': {
             'repository': 'A',
             'revision': '2345:bcd',
             'branch': 'master',
@@ -97,7 +97,7 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_recordChange_newer(self):
-        self.db.state.set_fake_state(self.object, lastCodebases={'a': {
+        self.db.state.set_fake_state(self.object, 'lastCodebases', {'a': {
             'repository': 'A',
             'revision': '1234:abc',
             'branch': 'master',

--- a/master/buildbot/test/unit/util/test_state.py
+++ b/master/buildbot/test/unit/util/test_state.py
@@ -39,7 +39,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getState(self):
-        self.master.db.state.set_fake_state(self.object, fav_color=['red', 'purple'])
+        self.master.db.state.set_fake_state(self.object, 'fav_color', ['red', 'purple'])
         res = yield self.object.getState('fav_color')
 
         self.assertEqual(res, ['red', 'purple'])
@@ -51,7 +51,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
         self.assertEqual(res, 'black')
 
     def test_getState_KeyError(self):
-        self.master.db.state.set_fake_state(self.object, fav_color=['red', 'purple'])
+        self.master.db.state.set_fake_state(self.object, 'fav_color', ['red', 'purple'])
         d = self.object.getState('fav_book')
 
         def cb(_):
@@ -72,7 +72,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_setState_existing(self):
-        self.master.db.state.set_fake_state(self.object, x=13)
+        self.master.db.state.set_fake_state(self.object, 'x', 13)
         yield self.object.setState('x', 14)
 
         self.master.db.state.assertStateByClass('fake-name', 'FakeObject',

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -87,15 +87,25 @@ class SchedulerMixin(interfaces.InterfaceTests):
         db.insert_test_data(rows)
 
         if overrideBuildsetMethods:
-            for method in (
-                    'addBuildsetForSourceStampsWithDefaults',
-                    'addBuildsetForChanges',
-                    'addBuildsetForSourceStamps'):
-                actual = getattr(scheduler, method)
-                fake = getattr(self, f'fake_{method}')
+            self.assertArgSpecMatches(
+                scheduler.addBuildsetForSourceStampsWithDefaults,
+                self.fake_addBuildsetForSourceStampsWithDefaults
+            )
+            scheduler.addBuildsetForSourceStampsWithDefaults = \
+                self.fake_addBuildsetForSourceStampsWithDefaults
 
-                self.assertArgSpecMatches(actual, fake)
-                setattr(scheduler, method, fake)
+            self.assertArgSpecMatches(
+                scheduler.addBuildsetForChanges,
+                self.fake_addBuildsetForChanges
+            )
+            scheduler.addBuildsetForChanges = self.fake_addBuildsetForChanges
+
+            self.assertArgSpecMatches(
+                scheduler.addBuildsetForSourceStamps,
+                self.fake_addBuildsetForSourceStamps
+            )
+            scheduler.addBuildsetForSourceStamps = self.fake_addBuildsetForSourceStamps
+
             self.addBuildsetCalls = []
             self._bsidGenerator = iter(range(500, 999))
             self._bridGenerator = iter(range(100, 999))

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -587,6 +587,7 @@ offline
 ok
 Ok
 online
+onlyIfChanged
 optimiselogs
 org
 os

--- a/newsfragments/nightly-scheduler-unnecessary-build.bugfix
+++ b/newsfragments/nightly-scheduler-unnecessary-build.bugfix
@@ -1,0 +1,1 @@
+Fixed unnecessary build started under the following conditions: there is an existing Nightly scheduler, onlyIfChanged is set to true and there is version upgrade from v3.4.0 (:issue:`6793`).


### PR DESCRIPTION
This PR fixes unnecessary nightly scheduler build introduced by commit b5f8b7688723db5768d2f17630cd8bdfa542bcbf when upgrading to v3.5.0.
Fixes #6793.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
