### PR TITLE
reporter: Prevent possible loss of events during reconfig

### DIFF
--- a/newsfragments/prevent-reporters-events-loss.bugfix
+++ b/newsfragments/prevent-reporters-events-loss.bugfix
@@ -1,0 +1,1 @@
+Prevent possible event loss during reconfig of reporters (:issue:`6982`).


### PR DESCRIPTION
Reconfig now removes consumers for event keys that are no longer wanted and add consumers for newly appeared event keys. There is no longer possibility of losing events for event keys that were unchanged during reconfig.

Fixes #6982

---
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
