### PR TITLE
Future is now

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -50,12 +50,10 @@ matrix:
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.7
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.6
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
-    - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=2.7
 
     # Worker tests on python and twisted package combinations.
     # We support worker on Python 2.7, on which Twisted 20.3.0 is the last version that works
     - env: PYTHON=3.9 TWISTED=18.7.0 SQLALCHEMY=latest TESTS=trial_worker
-    - env: PYTHON=2.7 TWISTED=20.3.0 SQLALCHEMY=latest TESTS=trial_worker
 
     # Configuration when SQLite database is persistent between running tests
     # (by default in other tests in-memory SQLite database is used which is

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 line_length=110
-known_future_library=__future__,future
+known_future_library=__future__
 known_standard_library=html
 known_twisted=twisted,zope,autobahn,klein,txaio
 known_mock=mock

--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-import html  # py2: via future
+import html
 import time
 
 from twisted.internet import defer

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -80,8 +80,6 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
                     tf.extract(inf)
                     prefixes.add(inf.name.split('/', 1)[0])
 
-            # (note that tf.extractall isn't available in py2.4)
-
             # get the top-level dir from the tarball
             assert len(prefixes) == 1, "tarball has multiple top-level dirs!"
             self.basedir = prefixes.pop()

--- a/master/buildbot/worker/upcloud.py
+++ b/master/buildbot/worker/upcloud.py
@@ -14,10 +14,6 @@
 # Copyright Buildbot Team Members
 # -*- Coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import hashlib
 import socket
 

--- a/newsfragments/worker-python27.removal
+++ b/newsfragments/worker-python27.removal
@@ -1,0 +1,2 @@
+Removed Python 2.7 support on the worker. This does not affect compatibility of connecting workers
+running old versions of Buildbot to masters running new versions of Buildbot.

--- a/pyinstaller/buildbot-worker.py
+++ b/pyinstaller/buildbot-worker.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 from buildbot_worker.scripts.runner import run
 
 run()

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -48,7 +48,6 @@ docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
 extras==1.0.0
 fixtures==4.1.0
 funcsigs==1.0.2
-future==0.18.3
 graphql-core==3.2.3
 greenlet==3.0.1
 hvac==1.2.1

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -18,9 +18,6 @@
 # We can't put this method in utility modules, because they import dependency packages
 #
 
-from __future__ import division
-from __future__ import print_function
-
 import datetime
 import os
 import re

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import multiprocessing
 import os.path
 import socket

--- a/worker/buildbot_worker/bot.py
+++ b/worker/buildbot_worker/bot.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from buildbot_worker.null import LocalWorker
 from buildbot_worker.pb import Worker
 

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import glob
 import os
 import platform

--- a/worker/buildbot_worker/commands/registry.py
+++ b/worker/buildbot_worker/commands/registry.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import buildbot_worker.commands.fs
 import buildbot_worker.commands.shell
 import buildbot_worker.commands.transfer

--- a/worker/buildbot_worker/commands/shell.py
+++ b/worker/buildbot_worker/commands/shell.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from buildbot_worker import runprocess
 from buildbot_worker.commands import base
 

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import tarfile
 import tempfile

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -207,29 +207,24 @@ class WorkerDirectoryUploadCommand(WorkerFileUploadCommand):
         # Create temporary archive
         fd, self.tarname = tempfile.mkstemp(prefix='buildbot-transfer-')
         self.fp = os.fdopen(fd, "rb+")
-
         if self.compress == 'bz2':
             mode = 'w|bz2'
         elif self.compress == 'gz':
             mode = 'w|gz'
         else:
             mode = 'w'
-        # TODO: Use 'with' when depending on Python 2.7
-        # Not possible with older versions:
-        # exceptions.AttributeError: 'TarFile' object has no attribute '__exit__'
-        archive = tarfile.open(mode=mode, fileobj=self.fp)
-        try:
-            archive.add(self.path, '')
-        except OSError as e:
-            # if directory does not exist, bail out with an error
-            self.stderr = "Cannot read directory '{0}' for upload: {1}".format(self.path, e)
-            self.rc = 1
-            archive.close()
-            d = defer.succeed(False)
-            d.addCallback(self.finished)
-            return d
 
-        archive.close()
+        with tarfile.open(mode=mode, fileobj=self.fp) as archive:
+            try:
+                archive.add(self.path, '')
+            except OSError as e:
+                # if directory does not exist, bail out with an error
+                self.stderr = "Cannot read directory '{0}' for upload: {1}".format(self.path, e)
+                self.rc = 1
+                archive.close()  # need to close it before self.finished() runs below
+                d = defer.succeed(False)
+                d.addCallback(self.finished)
+                return d
 
         # Transfer it
         self.fp.seek(0)

--- a/worker/buildbot_worker/commands/utils.py
+++ b/worker/buildbot_worker/commands/utils.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 
 from twisted.python import log

--- a/worker/buildbot_worker/commands/utils.py
+++ b/worker/buildbot_worker/commands/utils.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import text_type
 
 import os
 
@@ -67,9 +66,9 @@ if runtime.platformType == 'win32':  # pragma: no cover
         # Thus, if a non-unicode-named dir contains a unicode filename, that filename will get
         # garbled.
         # So force dir to be unicode.
-        if not isinstance(dir, text_type):
+        if not isinstance(dir, str):
             try:
-                dir = text_type(dir, "utf-8")
+                dir = str(dir, "utf-8")
             except UnicodeDecodeError:
                 log.err("rmdirRecursive: decoding from UTF-8 failed (ignoring)")
 

--- a/worker/buildbot_worker/compat.py
+++ b/worker/buildbot_worker/compat.py
@@ -19,16 +19,7 @@ Helpers for handling compatibility differences
 between Python 2 and Python 3.
 """
 
-if str != bytes:
-    # On Python 3 and higher, str and bytes
-    # are not equivalent.  We must use StringIO for
-    # doing io on native strings.
-    from io import StringIO as NativeStringIO
-else:
-    # On Python 2 and older, str and bytes
-    # are equivalent.  We must use BytesIO for
-    # doing io on native strings.
-    from io import BytesIO as NativeStringIO
+from io import StringIO as NativeStringIO
 
 
 def bytes2NativeString(x, encoding='utf-8'):

--- a/worker/buildbot_worker/compat.py
+++ b/worker/buildbot_worker/compat.py
@@ -19,9 +19,6 @@ Helpers for handling compatibility differences
 between Python 2 and Python 3.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 if str != bytes:
     # On Python 3 and higher, str and bytes
     # are not equivalent.  We must use StringIO for

--- a/worker/buildbot_worker/compat.py
+++ b/worker/buildbot_worker/compat.py
@@ -21,7 +21,6 @@ between Python 2 and Python 3.
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import text_type
 
 if str != bytes:
     # On Python 3 and higher, str and bytes
@@ -60,13 +59,12 @@ def unicode2bytes(x, encoding='utf-8', errors='strict'):
     """
     Convert a unicode string to C{bytes}.
 
-    @param x: a unicode string, of type C{unicode} on Python 2,
-              or C{str} on Python 3.
+    @param x: a unicode string, of type C{str}.
     @param encoding: an optional codec, default: 'utf-8'
     @param errors: error handling scheme, default 'strict'
     @return: a string of type C{bytes}
     """
-    if isinstance(x, text_type):
+    if isinstance(x, str):
         x = x.encode(encoding, errors)
     return x
 
@@ -75,16 +73,15 @@ def bytes2unicode(x, encoding='utf-8', errors='strict'):
     """
     Convert a C{bytes} to a unicode string.
 
-    @param x: a unicode string, of type C{unicode} on Python 2,
-              or C{str} on Python 3.
+    @param x: a unicode string, of type C{str}.
     @param encoding: an optional codec, default: 'utf-8'
     @param errors: error handling scheme, default 'strict'
     @return: a unicode string of type C{unicode} on Python 2, or
              C{str} on Python 3.
     """
-    if isinstance(x, (text_type, type(None))):
+    if isinstance(x, (str, type(None))):
         return x
-    return text_type(x, encoding, errors)
+    return str(x, encoding, errors)
 
 
 __all__ = [

--- a/worker/buildbot_worker/exceptions.py
+++ b/worker/buildbot_worker/exceptions.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 
 class AbandonChain(Exception):
 

--- a/worker/buildbot_worker/interfaces.py
+++ b/worker/buildbot_worker/interfaces.py
@@ -18,9 +18,6 @@
 # pylint: disable=no-method-argument
 # pylint: disable=inherit-non-class
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from zope.interface import Interface
 
 

--- a/worker/buildbot_worker/monkeypatches/testcase_assert.py
+++ b/worker/buildbot_worker/monkeypatches/testcase_assert.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import unittest
 
 

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import base64
 
 import msgpack

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet import defer
 
 from buildbot_worker.base import WorkerBase

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os.path
 import shutil
 import signal

--- a/worker/buildbot_worker/pbutil.py
+++ b/worker/buildbot_worker/pbutil.py
@@ -17,9 +17,6 @@
 """Base classes handy for use with PB clients.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.application.internet import backoffPolicy
 from twisted.cred import error
 from twisted.internet import defer

--- a/worker/buildbot_worker/pbutil.py
+++ b/worker/buildbot_worker/pbutil.py
@@ -19,7 +19,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import iteritems
 
 from twisted.application.internet import backoffPolicy
 from twisted.cred import error
@@ -153,6 +152,6 @@ def decode(data, encoding='utf-8', errors='strict'):
         return bytes2unicode(data, encoding, errors)
     if data_type in (dict, list, tuple):
         if data_type == dict:
-            data = iteritems(data)
+            data = data.items()
         return data_type(map(decode, data))
     return data

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -19,10 +19,6 @@ Support for running 'shell commands'
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import PY3
-from future.utils import iteritems
-from future.utils import string_types
-from future.utils import text_type
 
 import os
 import pprint
@@ -324,9 +320,9 @@ class RunProcess(object):
         def to_bytes(cmd):
             if isinstance(cmd, (tuple, list)):
                 for i, a in enumerate(cmd):
-                    if isinstance(a, text_type):
+                    if isinstance(a, str):
                         cmd[i] = a.encode(unicode_encoding)
-            elif isinstance(cmd, text_type):
+            elif isinstance(cmd, str):
                 cmd = cmd.encode(unicode_encoding)
             return cmd
 
@@ -344,7 +340,7 @@ class RunProcess(object):
         if not os.path.exists(workdir):
             os.makedirs(workdir)
         if environ:
-            for key, v in iteritems(environ):
+            for key, v in environ.items():
                 if isinstance(v, list):
                     # Need to do os.pathsep translation.  We could either do that
                     # by replacing all incoming ':'s with os.pathsep, or by
@@ -367,9 +363,9 @@ class RunProcess(object):
                 # environment
                 if key not in environ or environ[key] is not None:
                     newenv[key] = os.environ[key]
-            for key, v in iteritems(environ):
+            for key, v in environ.items():
                 if v is not None:
-                    if not isinstance(v, string_types):
+                    if not isinstance(v, str):
                         raise RuntimeError("'env' values must be strings or "
                                            "lists; key '{0}' is incorrect".format(key))
                     newenv[key] = p.sub(subst, v)
@@ -609,19 +605,12 @@ class RunProcess(object):
         """A cheat that routes around the impedance mismatch between
         twisted and cmd.exe with respect to escaping quotes"""
 
-        # NamedTemporaryFile differs in PY2 and PY3.
-        # In PY2, it needs encoded str and its encoding cannot be specified.
-        # In PY3, it needs str which is unicode and its encoding can be specified.
-        if PY3:
-            tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
-                                    delete=False, encoding=self.unicode_encoding)
-        else:
-            tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
-                                    delete=False)
+        tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
+                                delete=False, encoding=self.unicode_encoding)
 
         # echo off hides this cheat from the log files.
         tf.write(u"@echo off\n")
-        if isinstance(self.command, (string_types, bytes)):
+        if isinstance(self.command, (str, bytes)):
             tf.write(bytes2NativeString(self.command, self.unicode_encoding))
         else:
             tf.write(win32_batch_quote(self.command, self.unicode_encoding))

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -17,9 +17,6 @@
 Support for running 'shell commands'
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import pprint
 import re

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
 workerTACTemplate = [

--- a/worker/buildbot_worker/scripts/logwatcher.py
+++ b/worker/buildbot_worker/scripts/logwatcher.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import platform
 

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -16,10 +16,6 @@
 # N.B.: don't import anything that might pull in a reactor yet. Some of our
 # subcommands want to load modules that need the gtk reactor.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import re
 import sys

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 import time

--- a/worker/buildbot_worker/scripts/stop.py
+++ b/worker/buildbot_worker/scripts/stop.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import signal
 import time

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -64,10 +64,6 @@
 
 # Written by Mark Hammond, 2006.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 import threading

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -67,7 +67,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from future.builtins import range
 
 import os
 import sys

--- a/worker/buildbot_worker/test/fake/protocolcommand.py
+++ b/worker/buildbot_worker/test/fake/protocolcommand.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import pprint
 
 from buildbot_worker.base import ProtocolCommandBase

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet import defer
 
 

--- a/worker/buildbot_worker/test/test_extra_coverage.py
+++ b/worker/buildbot_worker/test/test_extra_coverage.py
@@ -17,9 +17,6 @@
 # included in the coverage because none of the tests import
 # them; this results in a more accurate total coverage percent.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from buildbot_worker.scripts import logwatcher
 
 modules = []  # for the benefit of pyflakes

--- a/worker/buildbot_worker/test/test_util_hangcheck.py
+++ b/worker/buildbot_worker/test/test_util_hangcheck.py
@@ -2,9 +2,6 @@
 Tests for `buildbot_worker.util._hangcheck`.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint

--- a/worker/buildbot_worker/test/unit/runprocess-scripts.py
+++ b/worker/buildbot_worker/test/unit/runprocess-scripts.py
@@ -18,9 +18,6 @@
 # have access to any of the Buildbot source.  Functions here should be kept
 # very simple!
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import select
 import signal

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import multiprocessing
 import os
 import shutil

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 
 import multiprocessing
 import os

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import shutil
 import socket

--- a/worker/buildbot_worker/test/unit/test_commands_base.py
+++ b/worker/buildbot_worker/test/unit/test_commands_base.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import errno
 import os
 import shutil

--- a/worker/buildbot_worker/test/unit/test_commands_registry.py
+++ b/worker/buildbot_worker/test/unit/test_commands_registry.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.trial import unittest
 
 from buildbot_worker.commands import registry

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 
 from twisted.internet import defer

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import io
 import os
 import re

--- a/worker/buildbot_worker/test/unit/test_commands_utils.py
+++ b/worker/buildbot_worker/test/unit/test_commands_utils.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import shutil
 import sys

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import pprint
 import re

--- a/worker/buildbot_worker/test/unit/test_scripts_base.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_base.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import sys
 

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 
 from twisted.trial import unittest

--- a/worker/buildbot_worker/test/unit/test_scripts_restart.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_restart.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.trial import unittest
 
 from buildbot_worker.scripts import restart

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import sys
 

--- a/worker/buildbot_worker/test/unit/test_scripts_start.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_start.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.trial import unittest
 
 from buildbot_worker.scripts import start

--- a/worker/buildbot_worker/test/unit/test_scripts_stop.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_stop.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import errno
 import os
 import signal

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -14,9 +14,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.trial import unittest
 
 from buildbot_worker import util

--- a/worker/buildbot_worker/test/util/command.py
+++ b/worker/buildbot_worker/test/util/command.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -13,33 +13,18 @@
 #
 # Copyright Buildbot Team Members
 
-# We cannot use the builtins module here from Python-Future.
-# We need to use the native __builtin__ module on Python 2,
-# and builtins module on Python 3, because we need to override
-# the actual native open method.
-
+import builtins
 import errno
 import os
 import re
 import shutil
 import sys
 from io import StringIO
+from unittest import mock
 
 from twisted.python import log
 
 from buildbot_worker.scripts import base
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-try:
-    # Python 2
-    import __builtin__ as builtins
-except ImportError:
-    # Python 3
-    import builtins
 
 
 def nl(s):

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -18,9 +18,6 @@
 # and builtins module on Python 3, because we need to override
 # the actual native open method.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import errno
 import os
 import re

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -20,15 +20,12 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import PY3
-from future.utils import string_types
 
 import errno
 import os
 import re
 import shutil
 import sys
-from io import BytesIO
 from io import StringIO
 
 from twisted.python import log
@@ -52,7 +49,7 @@ def nl(s):
     """Convert the given string to the native newline format, assuming it is
     already in normal UNIX newline format (\n).  Use this to create the
     appropriate expectation in an assertEqual"""
-    if not isinstance(s, string_types):
+    if not isinstance(s, str):
         return s
     return s.replace('\n', os.linesep)
 
@@ -227,16 +224,7 @@ class StdoutAssertionsMixin(object):
     """
 
     def setUpStdoutAssertions(self):
-        #
-        # sys.stdout is implemented differently
-        # in Python 2 and Python 3, so we need to
-        # override it differently.
-        # In Python 2, sys.stdout is a byte stream.
-        # In Python 3, sys.stdout is a text stream.
-        if PY3:
-            self.stdout = StringIO()
-        else:
-            self.stdout = BytesIO()
+        self.stdout = StringIO()
         self.patch(sys, 'stdout', self.stdout)
 
     def assertWasQuiet(self):

--- a/worker/buildbot_worker/test/util/sourcecommand.py
+++ b/worker/buildbot_worker/test/util/sourcecommand.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from buildbot_worker.test.util import command
 
 

--- a/worker/buildbot_worker/util/__init__.py
+++ b/worker/buildbot_worker/util/__init__.py
@@ -13,8 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from future.utils import text_type
-
 import itertools
 import textwrap
 import time
@@ -72,7 +70,7 @@ class Obfuscated(object):
 
     @staticmethod
     def to_text(s):
-        if isinstance(s, (text_type, bytes)):
+        if isinstance(s, (str, bytes)):
             return s
         return str(s)
 

--- a/worker/buildbot_worker/util/_hangcheck.py
+++ b/worker/buildbot_worker/util/_hangcheck.py
@@ -7,9 +7,6 @@ server, neither side will talk, leading to a hung connection. This
 wrapper will disconnect in that case, and inform the caller.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet.interfaces import IProtocol
 from twisted.internet.interfaces import IProtocolFactory
 from twisted.python.components import proxyForInterface

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -19,9 +19,6 @@
 Standard setup script.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import sys
 


### PR DESCRIPTION
This PR fixes #6980 - it removes all usages of `__future__` and dependency on `future` library + some other small Python 2/3 fixes.

It's probably not a complete removal of Python 2 code.