### PR TITLE
requirements: Update flake8 to 6.0.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,7 +8,7 @@ autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: ignore
 autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
 boto3==1.24.60
-flake8==5.0.4
+flake8==6.0.0;  python_version >= "3.8.1"
 msgpack==1.0.5
 Markdown==3.3.4
 pylint==2.14.5
@@ -56,6 +56,8 @@ hvac==0.11.2
 hyperlink==21.0.0
 idna==2.10  # pyup: ignore (conflicts with moto on master)
 imagesize==1.4.1
+importlib-metadata==4.13.0;  python_version < "3.8"
+importlib-resources==5.12.0;  python_version < "3.8"
 incremental==22.10.0
 ipaddress==1.0.23
 isort==4.3.21   # pyup: ignore (until https://github.com/PyCQA/pylint/pull/3725 is merged)
@@ -86,10 +88,10 @@ pyaml==21.10.1;  python_version < "3.8"  # pyup: ignore
 pyaml==23.7.0;  python_version >= "3.8"
 pyasn1-modules==0.3.0
 pyasn1==0.5.0
-pycodestyle==2.9.1
+pycodestyle==2.10.0;  python_version >= "3.8.1"
 pycparser==2.21
 pyenchant==3.2.2
-pyflakes==2.5.0
+pyflakes==3.0.1;  python_version >= "3.8.1"
 PyJWT==2.7.0
 pyOpenSSL==23.0.0
 pyparsing==3.1.0
@@ -101,6 +103,7 @@ PyYAML==6.0
 requests==2.31.0
 responses==0.23.1
 ruamel.yaml==0.17.32
+ruamel.yaml.clib==0.2.7
 s3transfer==0.6.1
 scandir==1.10.0
 service-identity==21.1.0;  python_version < "3.8"  # pyup: ignore


### PR DESCRIPTION
This PR updates flake8 to 6.0.0 and its dependencies.

## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
