### PR TITLE
requirements: Update cryptography to 41.0.2

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,7 +39,7 @@ configparser==5.2.0
 constantly==15.1.0
 cookies==2.2.1
 coverage==6.4.3
-cryptography==39.0.2
+cryptography==41.0.2
 decorator==5.1.1
 dicttoxml==1.7.16
 dill==0.3.6
@@ -93,7 +93,7 @@ pycparser==2.21
 pyenchant==3.2.2
 pyflakes==3.0.1;  python_version >= "3.8.1"
 PyJWT==2.7.0
-pyOpenSSL==23.0.0
+pyOpenSSL==23.2.0
 pyparsing==3.1.0
 pypugjs==5.9.12
 python-dateutil==2.8.2

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -7,7 +7,7 @@ Automat==20.2.0;  python_version < "3.6"  # pyup: ignore
 Automat==22.10.0;  python_version >= "3.6"
 cffi==1.15.1;  python_version >= "3.6"
 constantly==15.1.0
-cryptography==39.0.2;  python_version >= "3.6"
+cryptography==41.0.2;  python_version >= "3.6"
 funcsigs==1.0.2
 future==0.18.3
 hyperlink==21.0.0


### PR DESCRIPTION
This PR updates cryptography to 41.0.2 and its dependencies in requirements files.


## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
