### PR TITLE
Add set_priority method to /buildrequests API

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -99,11 +99,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
             return (yield self.db2data(buildrequest))
         return None
 
-    @defer.inlineCallbacks
-    def control(self, action, args, kwargs):
-        if action != "cancel":
-            raise ValueError(f"action: {action} is not supported")
-        brid = kwargs['buildrequestid']
+    def cancel_request(self, brid, args, kwargs):
         # first, try to claim the request; if this fails, then it's too late to
         # cancel the build anyway
         try:
@@ -136,6 +132,22 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
         brdict = yield self.master.db.buildrequests.getBuildRequest(brid)
         self.master.mq.produce(('buildrequests', str(brid), 'cancel'), brdict)
         return None
+
+    def set_request_priority(self, brid, args, kwargs):
+        priority = args['priority']
+        yield self.master.db.buildrequests.set_build_requests_priority(
+                 brids=[brid], priority=priority)
+        return None
+
+    @defer.inlineCallbacks
+    def control(self, action, args, kwargs):
+        brid = kwargs['buildrequestid']
+        if action == "cancel":
+            return self.cancel_request(brid, args, kwargs)
+        elif action == "set_priority":
+            return self.set_request_priority(brid, args, kwargs)
+        else:
+            raise ValueError(f"action: {action} is not supported")
 
 
 class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -223,6 +223,36 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
             transaction.commit()
         yield self.db.pool.do(thd)
 
+    def set_build_requests_priority(self, brids, priority):
+        def thd(conn):
+            transaction = conn.begin()
+
+            # the update here is simple, but a number of conditions are
+            # attached to ensure that we do not update a row inappropriately,
+            # Note that checking that the request is mine would require a
+            # subquery, so for efficiency that is not checked.
+
+            reqs_tbl = self.db.model.buildrequests
+
+            # we'll need to batch the brids into groups of 100, so that the
+            # parameter lists supported by the DBAPI aren't exhausted
+            for batch in self.doBatch(brids, 100):
+
+                q = reqs_tbl.update()
+                q = q.where(reqs_tbl.c.id.in_(batch))
+                q = q.where(reqs_tbl.c.complete != 1)
+                res = conn.execute(q,
+                                   priority=priority)
+
+                # if an incorrect number of rows were updated, then we failed.
+                if res.rowcount != len(batch):
+                    log.msg(f"tried to complete {len(batch)} buildrequests, "
+                            f"but only completed {res.rowcount}")
+                    transaction.rollback()
+                    raise NotClaimedError
+            transaction.commit()
+        return self.db.pool.do(thd)
+
     @staticmethod
     def _brdictFromRow(row, master_masterid):
         claimed = False

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -404,6 +404,17 @@ types:
                                 type: string
                                 required: false
                                 description: The reason why the buildrequest was cancelled
+        /actions/set_priority:
+            post:
+                description: |
+                    Change a buildrequest's priority.
+                body:
+                    application/json:
+                        properties:
+                            priority:
+                                type: int
+                                required: true
+                                description: The new priority for the buildrequest
     get:
         is:
         - bbget: {bbtype: buildrequest}

--- a/newsfragments/buildrequests-set-priority.feature
+++ b/newsfragments/buildrequests-set-priority.feature
@@ -1,0 +1,2 @@
+Buildrequests can now have their priority changed, using the /buildrequests API
+See https://docs.buildbot.net/latest/developer/raml/buildrequest.html.


### PR DESCRIPTION
This is the second PR about buildrequests priority, following #7008.

This adds a new option to change the priority for a pending buildrequest, using the /buildrequest API.

I'm having some trouble getting a unit test for this, though. I'm looking at the existing tests that send a `cancel` action via the /buildrequests API but I can't find any that is simple enough that I could tweak for `set_priority`. I would appreciate some help from the maintainers.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
