### PR TITLE
Use old behavior with no warning after hvac update to v3.0.0

### DIFF
--- a/master/buildbot/test/unit/test_secret_in_hvac.py
+++ b/master/buildbot/test/unit/test_secret_in_hvac.py
@@ -57,7 +57,7 @@ class FakeHvacKvV1:
 class FakeHvacKvV2:
     token = None
 
-    def read_secret_version(self, path, mount_point):
+    def read_secret_version(self, path, mount_point, raise_on_deleted_version=True):
         if self.token is None:
             raise hvac.exceptions.Unauthorized(message="Fake Unauthorized exception")
         if path == "wrong/path":


### PR DESCRIPTION
This PR avoids appearing warning after `hvac` is update to v3.0.0 as `raise_on_deleted_version` parameter will change its default value to `False`. The current default of `True` will preserve previous behavior. To use the old behavior with no warning, explicitly set this value to `True`.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
