### PR TITLE
Sort requests and builders by priority

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -197,6 +197,22 @@ class Builder(util_service.ReconfigurableServiceMixin,
         else:
             return None
 
+    @defer.inlineCallbacks
+    def get_highest_priority(self):
+        """Returns the priority of the highest priority unclaimed build request
+        for this builder, or None if there are no build requests.
+
+        @returns: priority or None, via Deferred
+        """
+        bldrid = yield self.getBuilderId()
+        unclaimed = yield self.master.data.get(
+            ('builders', bldrid, 'buildrequests'),
+            [resultspec.Filter('claimed', 'eq', [False])],
+            order=['-priority'], limit=1)
+        if unclaimed:
+            return unclaimed[0]['priority']
+        return None
+
     def getBuild(self, number):
         for b in self.building:
             if b.number == number:

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -230,8 +230,9 @@ class BasicBuildChooser(BuildChooserBase):
                         f"from _getNextUnclaimedBuildRequest for builder '{self.bldr}'")
                 nextBreq = None
         else:
-            # otherwise just return the first build
-            brdict = self.unclaimedBrdicts[0]
+            # otherwise just return the build with highest priority
+            brdict = sorted(self.unclaimedBrdicts.data,
+                            key=lambda b: b['priority'], reverse=True)[0]
             nextBreq = yield self._getBuildRequestForBrdict(brdict)
 
         return nextBreq

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -595,8 +595,7 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
         self.assertEqual(rqtime, None)
 
 
-class TestGetHighestPriority(TestReactorMixin, BuilderMixin,
-                               unittest.TestCase):
+class TestGetHighestPriority(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -595,6 +595,52 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
         self.assertEqual(rqtime, None)
 
 
+class TestGetHighestPriority(TestReactorMixin, BuilderMixin,
+                               unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setup_test_reactor()
+        self.setUpBuilderMixin()
+
+        # a collection of rows that would otherwise clutter up every test
+        master_id = fakedb.FakeBuildRequestsComponent.MASTER_ID
+        self.base_rows = [
+            fakedb.SourceStamp(id=21),
+            fakedb.Buildset(id=11, reason='because'),
+            fakedb.BuildsetSourceStamp(buildsetid=11, sourcestampid=21),
+            fakedb.Builder(id=77, name='bldr1'),
+            fakedb.Builder(id=78, name='bldr2'),
+            fakedb.BuildRequest(id=111, submitted_at=1000,
+                                builderid=77, buildsetid=11, priority=0),
+            fakedb.BuildRequest(id=222, submitted_at=2000,
+                                builderid=77, buildsetid=11, priority=10),
+            fakedb.BuildRequestClaim(brid=222, masterid=master_id,
+                                     claimed_at=2001),
+            fakedb.BuildRequest(id=333, submitted_at=3000,
+                                builderid=77, buildsetid=11, priority=5),
+            fakedb.BuildRequest(id=444, submitted_at=3001,
+                                builderid=77, buildsetid=11, priority=3),
+            fakedb.BuildRequest(id=555, submitted_at=2500,
+                                builderid=78, buildsetid=11),
+            fakedb.BuildRequestClaim(brid=555, masterid=master_id,
+                                     claimed_at=2501),
+        ]
+        yield self.db.insert_test_data(self.base_rows)
+
+    @defer.inlineCallbacks
+    def test_ghp_unclaimed(self):
+        yield self.makeBuilder(name='bldr1')
+        priority = yield self.bldr.get_highest_priority()
+        self.assertEqual(priority, 5)
+
+    @defer.inlineCallbacks
+    def test_ghp_all_claimed(self):
+        yield self.makeBuilder(name='bldr2')
+        priority = yield self.bldr.get_highest_priority()
+        self.assertEqual(priority, None)
+
+
 class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     """Tests that a reconfig properly updates all attributes"""

--- a/newsfragments/priority-sort.feature
+++ b/newsfragments/priority-sort.feature
@@ -1,0 +1,4 @@
+Build requests are now sorted according to their buildrequest. Request time is now used as a secondary sort key.
+Builders are sorted according to the highest priority among all of its unclaimed build requests, with the age of the oldest unclaimed request as the secondary key.
+Since all requests are created with priority 0 by default, this does not change default behaviour.
+Higher priorities means run before.


### PR DESCRIPTION
This is another priority PR, after #7008 and #7010.

Now that priorities are no longer always 0, let's use them.

This PR changes the default "nextBuild" and "prioritizeBuilders" to use the priority as the primary sorting key, using the oldest unclaimed build request as the secondary sorting keys.

Note that this does not change default behavior, as by default build requests are created with priority 0 and they are sorted using python's sort() functions, which are [guaranteed to be stable](https://docs.python.org/3/howto/sorting.html#sort-stability-and-complex-sorts).

This PR uses higher priority number to mean higher priority (i.e., run before). Some other places prefer lower numbers to mean higher priority. If the maintainers would prefer, I can invert the meaning.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
