### PR TITLE
statusToString should be used in all places where we need to get a string representation of the Results.

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -50,7 +50,7 @@ from buildbot.process.results import RETRY
 from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
-from buildbot.process.results import Results
+from buildbot.process.results import statusToString
 from buildbot.util import bytes2unicode
 from buildbot.util import debounce
 from buildbot.util import flatten
@@ -370,7 +370,7 @@ class BuildStep(results.ResultComputingConfigMixin,
             stepsumm = 'finished'
 
         if self.results != SUCCESS:
-            stepsumm += f' ({Results[self.results]})'
+            stepsumm += f' ({statusToString(self.results)})'
 
         return {'step': stepsumm}
 
@@ -958,7 +958,7 @@ class ShellMixin:
         summary = util.command_to_string(self.command)
         if summary:
             if self.results != SUCCESS:
-                summary += f' ({Results[self.results]})'
+                summary += f' ({statusToString(self.results)})'
             return {'step': summary}
         return super().getResultSummary()
 

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -23,7 +23,7 @@ from buildbot.process import logobserver
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
-from buildbot.process.results import Results
+from buildbot.process.results import statusToString
 
 
 class BuildEPYDoc(buildstep.ShellMixin, buildstep.BuildStep):
@@ -60,7 +60,7 @@ class BuildEPYDoc(buildstep.ShellMixin, buildstep.BuildStep):
         if self.errors:
             summary += f" err={self.errors}"
         if self.results != SUCCESS:
-            summary += f' ({Results[self.results]})'
+            summary += f' ({statusToString(self.results)})'
         return {'step': summary}
 
     @defer.inlineCallbacks
@@ -156,7 +156,7 @@ class PyFlakes(buildstep.ShellMixin, buildstep.BuildStep):
                 summary += f" {m}={self.counts[m]}"
 
         if self.results != SUCCESS:
-            summary += f' ({Results[self.results]})'
+            summary += f' ({statusToString(self.results)})'
 
         return {'step': summary}
 
@@ -298,7 +298,7 @@ class PyLint(buildstep.ShellMixin, buildstep.BuildStep):
                 summary += f" {fullmsg}={self.counts[msg]}"
 
         if self.results != SUCCESS:
-            summary += f' ({Results[self.results]})'
+            summary += f' ({statusToString(self.results)})'
 
         return {'step': summary}
 
@@ -421,7 +421,7 @@ class Sphinx(buildstep.ShellMixin, buildstep.BuildStep):
         summary = f'{self.name} {len(self.warnings)} warnings'
 
         if self.results != SUCCESS:
-            summary += f' ({Results[self.results]})'
+            summary += f' ({statusToString(self.results)})'
 
         return {'step': summary}
 

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -28,7 +28,7 @@ from buildbot.process.properties import WithProperties
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
-from buildbot.process.results import Results
+from buildbot.process.results import statusToString
 from buildbot.process.results import worst_status
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util import join_list
@@ -517,7 +517,7 @@ class Test(WarningCountingShellCommand):
             if description:
                 summary = join_list(description)
                 if self.results != SUCCESS:
-                    summary += f' ({Results[self.results]})'
+                    summary += f' ({statusToString(self.results)})'
                 return {'step': summary}
 
         return super().getResultSummary()

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -23,7 +23,7 @@ from buildbot.process import buildstep
 from buildbot.process import logobserver
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
-from buildbot.process.results import Results
+from buildbot.process.results import statusToString
 
 
 class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
@@ -167,6 +167,6 @@ class SubunitShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
         # TODO: expectedFailures/unexpectedSuccesses
 
         if self.results != SUCCESS:
-            summary += f' ({Results[self.results]})'
+            summary += f' ({statusToString(self.results)})'
 
         return {'step': summary}

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -194,7 +194,7 @@ class VisualStudio(buildstep.ShellMixin, buildstep.BuildStep):
     def getResultSummary(self):
         if self.logobserver is None:
             # step was skipped or log observer was not created due to another reason
-            return {"step": results.Results[self.results]}
+            return {"step": results.statusToString(self.results)}
 
         description = (f'compile {self.logobserver.nbProjects} projects {self.logobserver.nbFiles} '
                        'files')
@@ -205,7 +205,7 @@ class VisualStudio(buildstep.ShellMixin, buildstep.BuildStep):
             description += f' {self.logobserver.nbErrors} errors'
 
         if self.results != results.SUCCESS:
-            description += f' ({results.Results[self.results]})'
+            description += f' ({results.statusToString(self.results)})'
 
         return {'step': description}
 


### PR DESCRIPTION
For instance this helps to properly handle cases when Results is still None for not yet finished steps.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
