### PR TITLE
Display buildrequest priority on web UI

### DIFF
--- a/www/base/src/app/builders/builder/builder.tpl.jade
+++ b/www/base/src/app/builders/builder/builder.tpl.jade
@@ -9,13 +9,16 @@
         table.table.table-hover.table-striped.table-condensed(ng-show='buildrequests.length>0')
           tr
             td(width='100px') #
+            td(width='100px') Priority
             td(width='150px') Submitted At
             td(width='150px') Owners
             td Properties
-          tr(ng-repeat='br in buildrequests | orderBy:"-submitted_at"', ng-if="br.claimed==false" )
+          tr(ng-repeat='br in buildrequests | orderBy:["-priority","-submitted_at"]', ng-if="br.claimed==false" )
               td
                 a(ui-sref="buildrequest({buildrequest:br.buildrequestid})")
                   span.badge-status {{br.buildrequestid}}
+              td
+                span {{br.priority}}
               td
                 span(title="{{br.submitted_at | dateformat:'LLL'}}")
                   | {{br.submitted_at | timeago }}

--- a/www/base/src/app/buildrequests/pendingbuildrequests.controller.js
+++ b/www/base/src/app/buildrequests/pendingbuildrequests.controller.js
@@ -9,7 +9,7 @@ class Pendingbuildrequests {
         const buildrequestFetchLimit = $scope.settings.buildrequestFetchLimit.value;
 
         const data = dataService.open().closeOnDestroy($scope);
-        $scope.buildrequests = data.getBuildrequests({limit: buildrequestFetchLimit, order:'-submitted_at', claimed:false});
+        $scope.buildrequests = data.getBuildrequests({limit: buildrequestFetchLimit, order:'-priority', claimed:false});
         $scope.properties = {};
         $scope.buildrequests.onNew = function(buildrequest) {
             restService.get(`buildsets/${buildrequest.buildsetid}/properties`).then(function(response) {

--- a/www/base/src/app/buildrequests/pendingbuildrequests.tpl.jade
+++ b/www/base/src/app/buildrequests/pendingbuildrequests.tpl.jade
@@ -7,16 +7,19 @@
       tr
         td(width='100px') #
         td(width='150px') Builder
+        td(width='100px') Priority
         td(width='150px') Submitted At
         td(width='150px') Owner
         td(ng-repeat="(k,v) in properties") {{k}}
-      tr(ng-repeat='br in buildrequests | orderBy:"-submitted_at"' )
+      tr(ng-repeat='br in buildrequests | orderBy:["-priority","-submitted_at"]' )
           td
             a(ui-sref="buildrequest({buildrequest:br.buildrequestid})")
               span.badge-status {{br.buildrequestid}}
           td
             a(ui-sref="builder({builder:br.builderid})")
               span {{br.builder.name}}
+          td
+            span {{br.priority}}
           td
             span(title="{{br.submitted_at | dateformat:'LLL'}}")
               | {{br.submitted_at | timeago }}


### PR DESCRIPTION
Add the priority to the tables on Pending Buildrequets and on each individual builder. Use the  priority for sorting as well.

Unfortunately, I'm having issues building the frontend on my machine, but the changes are simple enough that I felt confident opening this PR. I'm not a node/js developer so not 100% sure about the orderBy syntax but I think it's correct.

## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
