### PR TITLE
Fix deprecated Twisted resource.ForbiddenResource

### DIFF
--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -23,7 +23,6 @@ from twisted.trial import unittest
 from twisted.web.error import Error
 from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
-from twisted.web.resource import ForbiddenResource
 from twisted.web.resource import IResource
 
 from buildbot.test.reactor import TestReactorMixin
@@ -144,7 +143,7 @@ class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             self.fail("403 expected")
 
     def test_get_login_resource_does_not_throw(self):
-        self.assertIsInstance(self.auth.getLoginResource(), ForbiddenResource)
+        self.auth.getLoginResource()
 
 
 class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):


### PR DESCRIPTION
This PR allows using older and newer Twisted versions since twisted.web.resource.ForbiddenResource was deprecated in Twisted 22.10.0. 

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
