### PR TITLE
GerritChangePoller fixes

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -315,6 +315,9 @@ class GerritChangeSource(GerritChangeSourceBase):
     STREAM_BACKOFF_MAX = 60
     "(seconds) maximum time to wait before retrying a failed connection"
 
+    # The number of gerrit output lines to print in case of a failure
+    MAX_STORED_OUTPUT_DEBUG_LINES = 20
+
     name = None
 
     def checkConfig(self,
@@ -345,9 +348,17 @@ class GerritChangeSource(GerritChangeSourceBase):
         self.process = None
         self.wantProcess = False
         self.streamProcessTimeout = self.STREAM_BACKOFF_MIN
+        self._last_lines_for_debug = []
         return super().reconfigService(**kwargs)
 
+    def _append_line_for_debug(self, line):
+        self._last_lines_for_debug.append(line)
+        while len(self._last_lines_for_debug) > self.MAX_STORED_OUTPUT_DEBUG_LINES:
+            self._last_lines_for_debug.pop(0)
+
     class LocalPP(LineProcessProtocol):
+
+        MAX_STORED_OUTPUT_DEBUG_LINES = 20
 
         def __init__(self, change_source):
             super().__init__()
@@ -358,12 +369,15 @@ class GerritChangeSource(GerritChangeSourceBase):
             if self.change_source.debug:
                 log.msg(f"{self.change_source.name} "
                         f"stdout: {line.decode('utf-8', errors='replace')}")
+
+            self.change_source._append_line_for_debug(line)
             yield self.change_source.lineReceived(line)
 
         def errLineReceived(self, line):
             if self.change_source.debug:
                 log.msg(f"{self.change_source.name} "
                         f"stderr: {line.decode('utf-8', errors='replace')}")
+            self.change_source._append_line_for_debug(line)
 
         def processEnded(self, status):
             super().processEnded(status)
@@ -381,8 +395,13 @@ class GerritChangeSource(GerritChangeSourceBase):
            self.STREAM_GOOD_CONNECTION_TIME:
             # bad startup; start the stream process again after a timeout,
             # and then increase the timeout
+            log_lines = "\n".join([l.decode("utf-8", errors="ignore")
+                                   for l in self._last_lines_for_debug])
+
             log.msg(f"{self.name}: stream-events failed; restarting after "
-                    f"{round(self.streamProcessTimeout)}s")
+                    f"{round(self.streamProcessTimeout)}s.\n"
+                    f"{len(self._last_lines_for_debug)} log lines follow:\n{log_lines}")
+
             self.master.reactor.callLater(
                 self.streamProcessTimeout, self.startStreamProcess)
             self.streamProcessTimeout *= self.STREAM_BACKOFF_EXPONENT
@@ -423,6 +442,7 @@ class GerritChangeSource(GerritChangeSourceBase):
         cmd = self._buildGerritCommand("stream-events")
         self.lastStreamProcessStart = util.now()
         self.process = reactor.spawnProcess(self.LocalPP(self), "ssh", cmd, env=None)
+        self._last_lines_for_debug = []
 
     @defer.inlineCallbacks
     def getFiles(self, change, patchset):

--- a/master/buildbot/config/checks.py
+++ b/master/buildbot/config/checks.py
@@ -47,6 +47,14 @@ def check_param_str_none(value, class_inst, name):
     return check_param_type(value, "(unknown)", class_inst, name, (str, type(None)), "str or None")
 
 
+def check_param_int(value, class_inst, name):
+    return check_param_type(value, 0, class_inst, name, (int,), "int")
+
+
+def check_param_int_none(value, class_inst, name):
+    return check_param_type(value, None, class_inst, name, (int, type(None)), "int or None")
+
+
 def check_markdown_support(class_inst):
     try:
         import markdown  # pylint: disable=import-outside-toplevel

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -496,8 +496,20 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
     def test_startStreamProcess_bytes_output(self):
         s = yield self.newChangeSource('somehost', 'some_choosy_user', debug=True)
 
-        exp_argv = ['ssh', '-o', 'BatchMode=yes', 'some_choosy_user@somehost', '-p', '29418']
-        exp_argv += ['gerrit', 'stream-events']
+        exp_argv = [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+            "some_choosy_user@somehost",
+            "-p",
+            "29418",
+            "gerrit",
+            "stream-events",
+        ]
 
         def spawnProcess(pp, cmd, argv, env):
             self.assertEqual([cmd, argv], [exp_argv[0], exp_argv])
@@ -546,8 +558,23 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
     def test_getFiles(self):
         s = yield self.newChangeSource('host', 'user', gerritport=2222)
         exp_argv = [
-            'ssh', '-o', 'BatchMode=yes', 'user@host', '-p', '2222',
-            'gerrit', 'query', '1000', '--format', 'JSON', '--files', '--patch-sets'
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+            "user@host",
+            "-p",
+            "2222",
+            "gerrit",
+            "query",
+            "1000",
+            "--format",
+            "JSON",
+            "--files",
+            "--patch-sets",
         ]
 
         self.expect_commands(
@@ -568,8 +595,27 @@ class TestGerritChangeSource(MasterRunProcessMixin, changesource.ChangeSourceMix
     @defer.inlineCallbacks
     def test_getFilesFromEvent(self):
         self.expect_commands(
-            ExpectMasterShell(['ssh', '-o', 'BatchMode=yes', 'user@host', '-p', '29418', 'gerrit',
-                          'query', '4321', '--format', 'JSON', '--files', '--patch-sets'])
+            ExpectMasterShell(
+                [
+                    "ssh",
+                    "-o",
+                    "BatchMode=yes",
+                    "-o",
+                    "ServerAliveInterval=15",
+                    "-o",
+                    "ServerAliveCountMax=3",
+                    "user@host",
+                    "-p",
+                    "29418",
+                    "gerrit",
+                    "query",
+                    "4321",
+                    "--format",
+                    "JSON",
+                    "--files",
+                    "--patch-sets",
+                ]
+            )
             .stdout(self.query_files_success)
         )
 

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1285,6 +1285,19 @@ The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
     Populate the `files` attribute of emitted changes (default `False`).
     Buildbot will run an extra query command for each handled event to determine the changed files.
 
+``ssh_server_alive_interval_s``
+    Sets the ``ServerAliveInterval`` option of the ssh client (default `15`).
+    This causes client to emit periodic keepalive messages in case the connection is not otherwise active.
+    If the server does not respond at least ``ssh_server_alive_count_max`` times, a reconnection is forced.
+    This helps to avoid stuck connections in case network link is severed without notification in the TCP layer.
+    Specifying ``None`` will omit the option from the ssh client command line.
+
+``ssh_server_alive_count_max``
+    Sets the ``ServerAliveCountMax`` option of the ssh client (default `3`).
+    If the server does not respond at least ``ssh_server_alive_count_max`` times, a reconnection is forced.
+    This helps to avoid stuck connections in case network link is severed without notification in the TCP layer.
+    Specifying ``None`` will omit the option from the ssh client command line.
+
 ``debug``
     Print Gerrit event in the log (default `False`).
     This allows to debug event content, but will eventually fill your logs with useless Gerrit event logs.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -450,7 +450,7 @@ Json
 jsonable
 JUnit
 kB
-Keepalive
+keepalive
 keepalives
 kerberos
 Kerberos

--- a/newsfragments/gerrit-change-source-reconnect-on-bad-connection.bugfix
+++ b/newsfragments/gerrit-change-source-reconnect-on-bad-connection.bugfix
@@ -1,0 +1,3 @@
+Improved stale connection handling in ``GerritChangeSource``.
+``GerritChangeSource`` will instruct the ssh client to send periodic keepalive messages and will reconnect if the server does not reply for 45 seconds (default).
+``GerritChangeSource`` now has ``ssh_server_alive_interval_s`` and ``ssh_server_alive_count_max`` options to control this behavior.

--- a/newsfragments/gerrit-logging.feature
+++ b/newsfragments/gerrit-logging.feature
@@ -1,0 +1,1 @@
+``GerritChangeSource`` will now log a small number of previous log lines coming from ``ssh`` process in case of connection failure.


### PR DESCRIPTION
GerritChangeSource will now instruct the ssh client to send periodic keepalive messages and will reconnect if the server does not reply for 45 seconds (default).

This PR also improves logging in case of errors so that operators don't need to touch GerritChangeSource to enable debug mode in case of simple failures.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
