### PR TITLE
www/react: Fix queries depending on useDataApiSingleElementQuery()

### DIFF
--- a/www/react-data-module/src/data/BasicDataMultiCollection.ts
+++ b/www/react-data-module/src/data/BasicDataMultiCollection.ts
@@ -92,11 +92,11 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
     }
   }
 
-  isExpired() {
+  isValid() {
     if (this.accessor === undefined) {
       return false;
     }
-    return !this.accessor.isOpen();
+    return this.accessor.isOpen();
   }
 
   isResolved() {

--- a/www/react-data-module/src/data/DataCollection.ts
+++ b/www/react-data-module/src/data/DataCollection.ts
@@ -17,7 +17,10 @@ import {DataPropertiesCollection} from "./DataPropertiesCollection";
 import {DataMultiPropertiesCollection} from "./DataMultiPropertiesCollection";
 
 export interface IDataCollection {
-  isExpired(): boolean;
+  // A valid data collection is one that listens to data changes from the API. The initial set of data objects may
+  // not have been acquired yet, isResolved() tracks this. Invalid data collections are the ones that are constructed
+  // without an accessor and the ones whose accessor has expired.
+  isValid(): boolean;
   isResolved(): boolean;
   subscribe(): Promise<void>;
   initial(data: any[]): void;
@@ -54,11 +57,11 @@ export class DataCollection<DataType extends BaseClass> implements IDataCollecti
     }
   }
 
-  isExpired() {
+  isValid() {
     if (this.accessor === undefined) {
       return false;
     }
-    return !this.accessor.isOpen();
+    return this.accessor.isOpen();
   }
 
   isResolved() {

--- a/www/react-data-module/src/data/DataPropertiesCollection.ts
+++ b/www/react-data-module/src/data/DataPropertiesCollection.ts
@@ -50,11 +50,11 @@ export class DataPropertiesCollection implements IDataCollection {
     }
   }
 
-  isExpired() {
+  isValid() {
     if (this.accessor === undefined) {
       return false;
     }
-    return !this.accessor.isOpen();
+    return this.accessor.isOpen();
   }
 
   isResolved() {

--- a/www/react-data-module/src/data/ReactUtils.ts
+++ b/www/react-data-module/src/data/ReactUtils.ts
@@ -46,8 +46,7 @@ export function useDataAccessor<T>(dependency: (T|null)[]): IDataAccessor {
 export function useDataApiQuery<Collection extends IDataCollection>(
     callback: () => Collection): Collection {
   let storedCollection = useRef<Collection|null>(null);
-  if (storedCollection.current === null ||
-      storedCollection.current.isExpired()) {
+  if (storedCollection.current === null || !storedCollection.current.isValid()) {
     if (storedCollection.current !== null) {
       storedCollection.current.close();
     }
@@ -74,8 +73,8 @@ export function useDataApiDynamicQuery<T, Collection extends IDataCollection>(
   let storedCollection = useRef<Collection|null>(null);
 
   if (storedCollection.current === null ||
-      !arrayElementsEqual(dependency, storedDependency.current) ||
-      storedCollection.current.isExpired()) {
+      !storedCollection.current.isValid() ||
+      !arrayElementsEqual(dependency, storedDependency.current)) {
     if (storedCollection.current !== null) {
       storedCollection.current.close();
     }
@@ -96,8 +95,8 @@ export function useDataApiDynamicQueryResolved<T, Collection extends IDataCollec
   let storedNewCollection = useRef<Collection|null>(null);
 
   if (storedCollection.current === null ||
-    !arrayElementsEqual(dependency, storedDependency.current) ||
-    storedCollection.current.isExpired()) {
+      !storedCollection.current.isValid() ||
+      !arrayElementsEqual(dependency, storedDependency.current)) {
 
     if (storedCollection.current !== null) {
       if (storedNewCollection.current !== null) {


### PR DESCRIPTION
The current implementation returns dummy DataCollection for the first call (while data has not yet arrived) of useDataApiSingleElementQuery() and similar users of useDataApiDynamicQuery(). Once the response data arrives, the data collection stored in useDataApiQuery() is not renewed even though it does not react to any data updates.

The fix is to treat collections with undefined accessor as invalid data collections.