### PR TITLE
Scheduler priority

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -284,7 +284,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
     @defer.inlineCallbacks
     def addBuildsetForSourceStampsWithDefaults(self, reason, sourcestamps=None,
                                                waited_for=False, properties=None, builderNames=None,
-                                               **kw):
+                                               priority=None, **kw):
         if sourcestamps is None:
             sourcestamps = []
 
@@ -329,7 +329,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         rv = yield self.addBuildsetForSourceStamps(
             sourcestamps=stampsWithDefaults, reason=reason,
             waited_for=waited_for, properties=properties,
-            builderNames=builderNames, **kw)
+            builderNames=builderNames, priority=priority, **kw)
         return rv
 
     def getCodebaseDict(self, codebase):

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -387,7 +387,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
     @defer.inlineCallbacks
     def addBuildsetForSourceStamps(self, waited_for=False, sourcestamps=None,
                                    reason='', external_idstring=None, properties=None,
-                                   builderNames=None, priority=0, **kw):
+                                   builderNames=None, priority=None, **kw):
         if sourcestamps is None:
             sourcestamps = []
         # combine properties
@@ -437,6 +437,9 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         # translate properties object into a dict as required by the
         # addBuildset method
         properties_dict = yield properties.render(properties.asDict())
+
+        if priority is None:
+            priority = 0
 
         bsid, brids = yield self.master.data.updates.addBuildset(
             scheduler=self.name, sourcestamps=sourcestamps, reason=reason,

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -131,7 +131,8 @@ class BaseBasicScheduler(base.BaseScheduler):
                 return defer.succeed(None)
             # otherwise, we'll build it right away
             return self.addBuildsetForChanges(reason=self.reason,
-                                              changeids=[change.number])
+                                              changeids=[change.number],
+                                              priority=self.priority)
 
         timer_name = self.getTimerNameForChange(change)
 
@@ -199,7 +200,8 @@ class BaseBasicScheduler(base.BaseScheduler):
 
         changeids = sorted(classifications.keys())
         yield self.addBuildsetForChanges(reason=self.reason,
-                                         changeids=changeids)
+                                         changeids=changeids,
+                                         priority=self.priority)
 
         max_changeid = changeids[-1]  # (changeids are sorted)
         yield self.master.db.schedulers.flushChangeClassifications(

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -107,7 +107,8 @@ class Dependent(base.BaseScheduler):
             if sub_results in (SUCCESS, WARNINGS):
                 yield self.addBuildsetForSourceStamps(
                     sourcestamps=sub_ssids.copy(),
-                    reason='downstream')
+                    reason='downstream',
+                    priority=self.priority)
 
             sub_bsids.append(sub_bsid)
 

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -707,12 +707,6 @@ class ForceScheduler(base.BaseScheduler):
             config.error(f"ForceScheduler '{name}': username must be a StringParameter: "
                          f"{repr(username)}")
 
-        if self.checkIfType(priority, IntParameter):
-            self.priority = priority
-        else:
-            config.error(f"ForceScheduler '{name}': priority must be a IntParameter: "
-                         f"{repr(priority)}")
-
         self.forcedProperties = []
         self.label = name if label is None else label
 
@@ -742,6 +736,12 @@ class ForceScheduler(base.BaseScheduler):
                          builderNames=builderNames,
                          properties={},
                          codebases=codebase_dict)
+
+        if self.checkIfType(priority, IntParameter):
+            self.priority = priority
+        else:
+            config.error(f"ForceScheduler '{name}': priority must be a IntParameter: "
+                         f"{repr(priority)}")
 
         if properties:
             self.forcedProperties.extend(properties)

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -219,7 +219,8 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
         if changeids:
             max_changeid = changeids[-1]  # (changeids are sorted)
             yield self.addBuildsetForChanges(reason=self.reason,
-                                             changeids=changeids)
+                                             changeids=changeids,
+                                             priority=self.priority)
             yield scheds.flushChangeClassifications(self.serviceid,
                                                     less_than=max_changeid + 1)
         else:
@@ -228,7 +229,8 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
             sourcestamps = [{"codebase": cb} for cb in self.codebases]
             yield self.addBuildsetForSourceStampsWithDefaults(
                 reason=self.reason,
-                sourcestamps=sourcestamps)
+                sourcestamps=sourcestamps,
+                priority=self.priority)
         self.is_first_build = False
 
     def getCodebaseDict(self, codebase):
@@ -505,4 +507,5 @@ class NightlyTriggerable(NightlyBase):
             sourcestamps=sourcestamps,
             properties=props,
             parent_buildid=parent_buildid,
-            parent_relationship=parent_relationship)
+            parent_relationship=parent_relationship,
+            priority=self.priority)

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -60,6 +60,7 @@ class Triggerable(base.BaseScheduler):
         idsDeferred = self.addBuildsetForSourceStampsWithDefaults(
             reason,
             sourcestamps, waited_for,
+            priority=self.priority,
             properties=props,
             parent_buildid=parent_buildid,
             parent_relationship=parent_relationship)

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -265,6 +265,7 @@ class Try_Jobdir(TryBase):
             reason=reason,
             external_idstring=bytes2unicode(parsed_job['jobid']),
             builderNames=builderNames,
+            priority=self.priority,
             properties=requested_props)
 
 

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -801,5 +801,5 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
         )
         def addBuildsetForSourceStampsWithDefaults(self, reason, sourcestamps=None,
                                                    waited_for=False, properties=None,
-                                                   builderNames=None, **kw):
+                                                   builderNames=None, priority=None, **kw):
             pass

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -789,7 +789,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
         )
         def addBuildsetForSourceStamps(self, waited_for=False, sourcestamps=None,
                                        reason='', external_idstring=None, properties=None,
-                                       builderNames=None, priority=0, **kw):
+                                       builderNames=None, priority=None, **kw):
             pass
 
     def test_signature_addBuildsetForSourceStampsWithDefaults(self):

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -776,7 +776,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
         )
         def addBuildsetForChanges(self, waited_for=False, reason='',
                                   external_idstring=None, changeids=None, builderNames=None,
-                                  properties=None,
+                                  properties=None, priority=None,
                                   **kw):
             pass
 

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -46,7 +46,7 @@ class CommonStuffMixin:
         @self.assertArgSpecMatches(sched.addBuildsetForChanges)
         def addBuildsetForChanges(
                 waited_for=False, reason='', external_idstring=None, changeids=None,
-                builderNames=None, properties=None, **kw):
+                builderNames=None, properties=None, priority=None, **kw):
             self.assertEqual(external_idstring, None)
             self.assertEqual(reason, sched.reason)
             self.events.append(f"B{repr(changeids).replace(' ', '')}@{int(self.clock.seconds())}")

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -393,6 +393,23 @@ class SingleBranchScheduler(CommonStuffMixin,
             basic.SingleBranchScheduler(name="tsched", treeStableTimer=60,
                                         branches='x')
 
+    def test_constructor_priority_none(self):
+        sched = self.makeScheduler(
+            basic.SingleBranchScheduler, branch="master", priority=None)
+        self.assertEqual(sched.priority, None)
+
+    def test_constructor_priority_int(self):
+        sched = self.makeScheduler(
+            basic.SingleBranchScheduler, branch="master", priority=8)
+        self.assertEqual(sched.priority, 8)
+
+    def test_constructor_priority_function(self):
+        def sched_priority(builderNames, changesByCodebase):
+            return 0
+        sched = self.makeScheduler(
+            basic.SingleBranchScheduler, branch="master", priority=sched_priority)
+        self.assertEqual(sched.priority, sched_priority)
+
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_important(self):
         # this looks suspiciously like the same test above, because SingleBranchScheduler
@@ -504,6 +521,32 @@ class SingleBranchScheduler(CommonStuffMixin,
         cbd = yield sched.getCodebaseDict('a')
         # _lastCodebases is ignored
         self.assertEqual(cbd, {'branch': 'master', 'repository': ''})
+
+    @defer.inlineCallbacks
+    def test_gotChange_with_priority(self):
+        sched = self.makeFullScheduler(name='test', builderNames=['test'],
+                                       branch='master', priority=8)
+        self.db.insert_test_data([
+            fakedb.Object(id=self.OBJECTID, name='test',
+                          class_name='SingleBranchScheduler')])
+
+        yield sched.activate()
+
+        yield sched.gotChange(self.mkch(codebase='a', revision='1234:abc', repository='A',
+                                        number=10),
+                              True)
+
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForChanges', {
+                'waited_for': False,
+                'external_idstring': None,
+                'changeids': [10],
+                'properties': None,
+                'reason': "The SingleBranchScheduler scheduler named 'test' triggered this build",
+                'builderNames': None,
+                'priority': 8})])
+
+        yield sched.deactivate()
 
 
 class AnyBranchScheduler(CommonStuffMixin,

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -154,6 +154,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 {
                     "builderNames": ['a'],
                     "waited_for": False,
+                    "priority": 0,
                     "properties": {
                         'owner': ('user', 'Force Build Form'),
                         'reason': ('because', 'Force Build Form'),
@@ -185,6 +186,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 'addBuildsetForSourceStampsWithDefaults',
                 {
                     'builderNames': ['a'],
+                    'priority': 0,
                     'properties': {'owner': ('user', 'Force Build Form'),
                         'reason': ('because', 'Force Build Form')},
                     'reason': 'user wants it because',
@@ -212,6 +214,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 {
                     "builderNames": ['a', 'b'],
                     "waited_for": False,
+                    "priority": 0,
                     "properties": {
                         'owner': ('user', 'Force Build Form'),
                         'reason': ('because', 'Force Build Form'),
@@ -240,6 +243,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 {
                     "builderNames": ['a', 'b'],
                     "waited_for": False,
+                    "priority": 0,
                     "properties": {
                         'owner': ('user', 'Force Build Form'),
                         'reason': ('because', 'Force Build Form'),
@@ -304,6 +308,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 {
                     "builderNames": ['a'],
                     "waited_for": False,
+                    "priority": 0,
                     "properties": expProperties,
                     "reason": "A build was forced by 'user': because",
                     "sourcestamps": [
@@ -336,6 +341,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 {
                     "builderNames": ['a'],
                     "waited_for": False,
+                    "priority": 0,
                     "properties": expProperties,
                     "reason": "A build was forced by 'user': because",
                     "sourcestamps": [
@@ -442,6 +448,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                 {
                     "builderNames": ['a'],
                     "waited_for": False,
+                    "priority": 0,
                     "properties": expect_props,
                     "reason": "A build was forced by 'user': because",
                     "sourcestamps": [

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -137,6 +137,23 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             name='test', builderNames=['test'], branch='default', month='1')
         self.assertEqual(sched.month, "1")
 
+    def test_constructor_priority_none(self):
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default', priority=None)
+        self.assertEqual(sched.priority, None)
+
+    def test_constructor_priority_int(self):
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default', priority=8)
+        self.assertEqual(sched.priority, 8)
+
+    def test_constructor_priority_function(self):
+        def sched_priority(builderNames, changesByCodebase):
+            return 0
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default', priority=sched_priority)
+        self.assertEqual(sched.priority, sched_priority)
+
     @defer.inlineCallbacks
     def test_enabled_callback(self):
         sched = self.makeScheduler(

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -424,7 +424,9 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'external_idstring': None,
                 'changeids': [1, 2, 3],
-                'properties': None, 'builderNames': None
+                'priority': None,
+                'properties': None,
+                'builderNames': None,
                 }),
             ])
         self.db.state.assertStateByClass('test', 'Nightly',
@@ -461,6 +463,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'builderNames': None,
                 'changeids': [3, 5, 6],
                 'external_idstring': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False})])
@@ -489,6 +492,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'builderNames': None,
                 'changeids': [3],
                 'external_idstring': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False})])
@@ -532,6 +536,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'builderNames': None,
                 'changeids': [3],
                 'external_idstring': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False})])
@@ -563,6 +568,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'builderNames': None,
                 'changeids': [3, 4],
                 'external_idstring': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False})])

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -203,18 +203,21 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
                 'sourcestamps': [{'codebase': ''}],
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False}),
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
                 'sourcestamps': [{'codebase': ''}],
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False}),
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
                 'sourcestamps': [{'codebase': ''}],
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False})])
@@ -238,6 +241,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
                 'sourcestamps': [{'codebase': ''}],
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'waited_for': False})])
@@ -292,6 +296,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'sourcestamps': [{'codebase': ''}],
@@ -324,6 +329,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'sourcestamps': [{'codebase': ''}],
@@ -355,6 +361,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'sourcestamps': [{'codebase': ''}],
@@ -375,6 +382,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': None,
                 'reason': "The Nightly scheduler named 'test' triggered this build",
                 'sourcestamps': [{'codebase': ''}],

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -60,6 +60,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, TestReactorMixin,
                 'addBuildsetForSourceStampsWithDefaults',
                 {
                     "builderNames": None,  # uses the default
+                    "priority": None,
                     "properties": properties,
                     "reason": "The NightlyTriggerable scheduler named 'test' triggered this build",
                     "sourcestamps": sourcestamps,

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -304,6 +304,7 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin,
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': {'scheduler': ('n', 'Scheduler')},
                 'reason': "The Triggerable scheduler named 'n' triggered "
                           "this build",
@@ -329,6 +330,7 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin,
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': {'scheduler': ('n', 'Scheduler')},
                 'reason': "The Triggerable scheduler named 'n' triggered "
                           "this build",
@@ -351,6 +353,7 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin,
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
+                'priority': None,
                 'properties': {'scheduler': ('n', 'Scheduler'), 'reason': ('test1', 'test')},
                 'reason': "test1",
                 'sourcestamps': [],

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -159,6 +159,20 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin,
         sched = self.makeScheduler(reason="Because I said so")
         self.assertEqual(sched.reason, "Because I said so")
 
+    def test_constructor_priority_none(self):
+        sched = self.makeScheduler(priority=None)
+        self.assertEqual(sched.priority, None)
+
+    def test_constructor_priority_int(self):
+        sched = self.makeScheduler(priority=8)
+        self.assertEqual(sched.priority, 8)
+
+    def test_constructor_priority_function(self):
+        def sched_priority(builderNames, changesByCodebase):
+            return 0
+        sched = self.makeScheduler(priority=sched_priority)
+        self.assertEqual(sched.priority, sched_priority)
+
     def test_trigger(self):
         sched = self.makeScheduler(codebases={'cb': {'repository': 'r'}})
         # no subscription should be in place yet

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -245,7 +245,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
 
     def fake_addBuildsetForSourceStamps(self, waited_for=False, sourcestamps=None,
                                         reason='', external_idstring=None, properties=None,
-                                        builderNames=None, priority=0, **kw):
+                                        builderNames=None, priority=None, **kw):
         if sourcestamps is None:
             sourcestamps = []
         properties = properties.asDict() if properties is not None else None

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -224,7 +224,8 @@ class SchedulerMixin(interfaces.InterfaceTests):
         return self._addBuildsetReturnValue(builderNames)
 
     def fake_addBuildsetForChanges(self, waited_for=False, reason='', external_idstring=None,
-                                   changeids=None, builderNames=None, properties=None, **kw):
+                                   changeids=None, builderNames=None, properties=None,
+                                   priority=None, **kw):
         if changeids is None:
             changeids = []
         properties = properties.asDict() if properties is not None else None
@@ -238,6 +239,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
                     "changeids": changeids,
                     "properties": properties,
                     "builderNames": builderNames,
+                    "priority": priority,
                 }
             )
         )

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -209,7 +209,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
 
     def fake_addBuildsetForSourceStampsWithDefaults(self, reason, sourcestamps=None,
                                                     waited_for=False, properties=None,
-                                                    builderNames=None, **kw):
+                                                    builderNames=None, priority=None, **kw):
         properties = properties.asDict() if properties is not None else None
         self.assertIsInstance(sourcestamps, list)
 
@@ -220,7 +220,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
         self.addBuildsetCalls.append(('addBuildsetForSourceStampsWithDefaults',
                                       {"reason": reason, "sourcestamps": sourcestamps,
                                        "waited_for": waited_for, "properties": properties,
-                                       "builderNames": builderNames}))
+                                       "builderNames": builderNames, "priority": priority}))
         return self._addBuildsetReturnValue(builderNames)
 
     def fake_addBuildsetForChanges(self, waited_for=False, reason='', external_idstring=None,

--- a/master/docs/manual/configuration/schedulers.rst
+++ b/master/docs/manual/configuration/schedulers.rst
@@ -208,6 +208,14 @@ There are several common arguments for schedulers, although not all are availabl
     A string that will be used as the reason for the triggered build.
     By default it lists the type and name of the scheduler triggering the build.
 
+.. _Scheduler-Attr-Priority:
+
+``priority`` (optional)
+
+    Specifies the default priority for :class:`BuildRequests` created by this scheduler.
+    It can either be an integer or a function (see :ref:`Scheduler-Priority-Functions`).
+    By default it creates :class:`BuildRequests` with priority 0.
+
 The remaining subsections represent a catalog of the available scheduler types.
 All these schedulers are defined in modules under :mod:`buildbot.schedulers`, and their docstrings are the best source of documentation on the arguments each one takes.
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -254,6 +254,40 @@ The ``nextBuild`` function is passed as parameter to :class:`BuilderConfig`:
 
     ... BuilderConfig(..., nextBuild=nextBuild, ...) ...
 
+.. index:: Schedulers; priority
+
+.. _Scheduler-Priority-Functions:
+
+Scheduler Priority Functions
+----------------------------
+When a :class:`Scheduler` is creating a a new :class:`BuildRequest` from a (list of) :class:`Change` (s),it is possible to set the :class:`BuildRequest` priority.
+This can either be an integer or a function, which receives a list of builder names and a dictionary of :class:`Change`, grouped by their codebase.
+
+A simple implementation might look like this:
+
+.. code-block:: python
+
+   def scheduler_priority(builderNames, changesByCodebase):
+        priority = 0
+
+        for codebase, changes in changesByCodebase.items():
+            for chg in changes:
+                if chg["branch"].startswith("dev/"):
+                        priority = max(priority, 0)
+                elif chg["branch"].startswith("bugfix/"):
+                        priority = max(priority, 5)
+                elif chg["branch"] == "main":
+                        priority = max(priority, 10)
+
+        return priority
+
+The priority function/integer can be passed as a parameter to :class:`Scheduler`:
+
+.. code-block:: python
+
+   ... schedulers.SingleBranchScheduler(..., priority=scheduler_priority, ...) ...
+
+
 .. _canStartBuild-Functions:
 
 ``canStartBuild`` Functions

--- a/newsfragments/scheduler-priority.feature
+++ b/newsfragments/scheduler-priority.feature
@@ -1,0 +1,1 @@
+Schedulers can now set a default priority for the buildrequests that it creates. It can either be an integer or a function.


### PR DESCRIPTION
One more buildrequest priority PR (following #7008, #7010, #7012 and #7016).

The goal of this PR is to allow schedulers to set a default priority for buildrequests it creates. It supports either an integer or a callable, to which we pass the builderNames and the codebases + changes related to that buildrequest. The function must return an integer.

The integer path is pretty straightforward, but for the callable option, should I be passing something else? The `changesByCodebase` is a dictionary whose keys are codebase names and the values is a list of changes (as dictionaries).

Feedback welcome on the design.

I would also like to add more robust tests, the ones I added only check that we set the scheduler.priority to the right value, it doesn't check that buildrequests were actually created with the right priority. But I got a bit confused with the framework/fake changes etc, so help is appreciated.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
