### PR TITLE
Replace deprecated pkg_resources with importlib-based solutions

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,7 @@
 [settings]
 line_length=110
 known_future_library=__future__,future
-known_standard_library=pkg_resources,html
+known_standard_library=html
 known_twisted=twisted,zope,autobahn,klein,txaio
 known_mock=mock
 known_third_party=migrate,sqlalchemy,ldap3,txrequests,requests,MySQLdb,coverage,jinja2,dateutil,sphinx,setuptools,jwt,flask,docutils,aiohttp

--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -194,25 +194,17 @@ class _Plugins:
     represent plugins within a namespace
     """
 
-    def __init__(self, namespace, interface=None, check_extras=True):
+    def __init__(self, namespace, interface=None):
         if interface is not None:
             assert interface.isOrExtends(IPlugin)
 
         self._group = f'{_NAMESPACE_BASE}.{namespace}'
 
         self._interface = interface
-        self._check_extras = check_extras
-
         self._real_tree = None
 
     def _load_entry(self, entry):
         # pylint: disable=W0703
-        if self._check_extras:
-            try:
-                entry.require()
-            except Exception as e:
-                raise PluginDBError('Requirements are not satisfied '
-                                    f'for {self._group}:{entry.name}: {str(e)}') from e
         try:
             result = entry.load()
         except Exception as e:
@@ -289,8 +281,7 @@ class _PluginDB:
     def __init__(self):
         self._namespaces = {}
 
-    def add_namespace(self, namespace, interface=None, check_extras=True,
-                      load_now=False):
+    def add_namespace(self, namespace, interface=None, load_now=False):
         """
         register given namespace in global database of plugins
 
@@ -299,7 +290,7 @@ class _PluginDB:
         tempo = self._namespaces.get(namespace)
 
         if tempo is None:
-            tempo = _Plugins(namespace, interface, check_extras)
+            tempo = _Plugins(namespace, interface)
             self._namespaces[namespace] = tempo
 
         if load_now:
@@ -349,8 +340,8 @@ def info():
     return _DB.info()
 
 
-def get_plugins(namespace, interface=None, check_extras=True, load_now=False):
+def get_plugins(namespace, interface=None, load_now=False):
     """
     helper to get a direct interface to _Plugins
     """
-    return _DB.add_namespace(namespace, interface, check_extras, load_now)
+    return _DB.add_namespace(namespace, interface, load_now)

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -18,7 +18,8 @@ Push events to Gerrit
 
 import time
 import warnings
-from pkg_resources import parse_version
+
+from packaging.version import parse as parse_version
 
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -17,7 +17,9 @@ HVAC based providers
 """
 
 
-import pkg_resources
+import importlib.metadata
+
+from packaging.version import parse as parse_version
 
 from twisted.internet import defer
 from twisted.internet import threads
@@ -108,7 +110,7 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
         if vault_server.endswith('/'):  # pragma: no cover
             vault_server = vault_server[:-1]
         self.client = hvac.Client(vault_server)
-        self.version = pkg_resources.parse_version(pkg_resources.get_distribution('hvac').version)
+        self.version = parse_version(importlib.metadata.version('hvac'))
         self.client.secrets.kv.default_kv_version = api_version
         return self
 
@@ -144,7 +146,7 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
         if self.api_version == 1:
             return self.client.secrets.kv.v1.read_secret(path=path, mount_point=self.secrets_mount)
         else:
-            if self.version >= pkg_resources.parse_version("1.1.1"):
+            if self.version >= parse_version("1.1.1"):
                 return self.client.secrets.kv.v2.read_secret_version(path=path,
                                                                      mount_point=self.secrets_mount,
                                                                      raise_on_deleted_version=True)

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -105,12 +105,6 @@ warnings.filterwarnings('ignore', ".*time.clock has been deprecated in Python 3.
 warnings.filterwarnings('ignore', ".*The usage of `cmp` is deprecated and will be removed "
                                   "on or after.*", DeprecationWarning)
 
-# ignore a warning emitted by pkg_resources when importing certain namespace packages
-warnings.filterwarnings('ignore', ".*Not importing directory .*/zope: missing __init__",
-                        category=ImportWarning)
-warnings.filterwarnings('ignore', ".*Not importing directory .*/sphinxcontrib: missing __init__",
-                        category=ImportWarning)
-
 # ignore warnings from importing lib2to3 via buildbot_pkg ->
 # setuptools.command.build_py -> setuptools.lib2to3_ex -> lib2to3
 # https://github.com/pypa/setuptools/issues/2086
@@ -136,12 +130,6 @@ warnings.filterwarnings('ignore', "'pipes' is deprecated and slated for removal 
 
 # shown on Python 3.7 on Windows
 warnings.filterwarnings('ignore', "SelectableGroups dict interface is deprecated. Use select.",
-                        category=DeprecationWarning)
-
-# shown on Python 3.11
-warnings.filterwarnings('ignore', ".*pkg_resources is deprecated as an API.*",
-                        category=DeprecationWarning)
-warnings.filterwarnings('ignore', ".*Deprecated call to `pkg_resources.declare_namespace.*",
                         category=DeprecationWarning)
 
 # boto3 shows this warning when on old Python

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -17,8 +17,9 @@
 import importlib
 import inspect
 import os
-import pkg_resources
 import warnings
+
+from packaging.version import parse as parse_version
 
 import twisted
 from twisted.trial import unittest
@@ -96,7 +97,7 @@ class TestSetupPyEntryPoints(unittest.TestCase):
 
     def test_util(self):
         # work around Twisted bug 9384.
-        if pkg_resources.parse_version(twisted.__version__) < pkg_resources.parse_version("18.9.0"):
+        if parse_version(twisted.__version__) < parse_version("18.9.0"):
             raise SkipTest('manhole.py can not be imported on old twisted and new python')
 
         known_not_exported = {

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -221,7 +221,7 @@ class TestSetupPyEntryPoints(unittest.TestCase):
         # Now verify that are no unregistered plugins left.
         existing_classes = self.get_existing_classes(module_name, interface)
 
-        exported_classes = {f'{plugins._get_entry(name)._entry.module_name}.{name}'
+        exported_classes = {f'{plugins._get_entry(name)._entry.module}.{name}'
                             for name in plugins.names}
         if known_not_exported is None:
             known_not_exported = set()

--- a/master/buildbot/test/integration/test_usePty.py
+++ b/master/buildbot/test/integration/test_usePty.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from twisted import __version__ as twistedVersion
 from twisted.internet import defer

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -14,9 +14,10 @@
 # Copyright Buildbot Team Members
 
 import warnings
-from pkg_resources import parse_version
 from unittest.mock import Mock
 from unittest.mock import call
+
+from packaging.version import parse as parse_version
 
 from twisted.internet import defer
 from twisted.internet import error

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -234,12 +234,6 @@ class TestBuildbotPlugins(unittest.TestCase):
         with assertProducesWarning(DeprecationWarning, "test warning"):
             _ = plugins.deep.path
 
-    def test_interface_provided_deps_failed(self):
-        plugins = db.get_plugins('interface_failed', interface=ITestInterface,
-                                 check_extras=True)
-        with self.assertRaises(PluginDBError):
-            plugins.get('good')
-
     def test_required_interface_not_provided(self):
         plugins = db.get_plugins('no_interface_again',
                                  interface=ITestInterface)
@@ -250,11 +244,6 @@ class TestBuildbotPlugins(unittest.TestCase):
     def test_no_interface_provided(self):
         plugins = db.get_plugins('no_interface')
         self.assertFalse(plugins.get('good') is None)
-
-    def test_no_interface_provided_deps_failed(self):
-        plugins = db.get_plugins('no_interface_failed', check_extras=True)
-        with self.assertRaises(PluginDBError):
-            plugins.get('good')
 
     def test_failure_on_dups(self):
         with self.assertRaises(PluginDBError):

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -15,12 +15,9 @@
 
 
 import inspect
-import pkg_resources
 from collections import OrderedDict
-from packaging.version import parse as parse_version
 
 import zope.interface.interface
-from twisted.trial import unittest
 from zope.interface.interface import Attribute
 
 
@@ -89,13 +86,6 @@ class InterfaceTests:
 
     def assertInterfacesImplemented(self, cls):
         "Given a class, assert that the zope.interface.Interfaces are implemented to specification."
-
-        # see if this version of zope.interface is too old to run these tests
-        zi_vers = pkg_resources.working_set.find(
-            pkg_resources.Requirement.parse('zope.interface')).version
-        if parse_version(zi_vers) < parse_version('4.1.1'):
-            raise unittest.SkipTest(
-                "zope.interfaces is too old to run this test")
 
         for interface in zope.interface.implementedBy(cls):
             for attr, template_argspec in interface.namesAndDescriptions():

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -17,6 +17,7 @@
 import inspect
 import pkg_resources
 from collections import OrderedDict
+from packaging.version import parse as parse_version
 
 import zope.interface.interface
 from twisted.trial import unittest
@@ -92,7 +93,7 @@ class InterfaceTests:
         # see if this version of zope.interface is too old to run these tests
         zi_vers = pkg_resources.working_set.find(
             pkg_resources.Requirement.parse('zope.interface')).version
-        if pkg_resources.parse_version(zi_vers) < pkg_resources.parse_version('4.1.1'):
+        if parse_version(zi_vers) < parse_version('4.1.1'):
             raise unittest.SkipTest(
                 "zope.interfaces is too old to run this test")
 

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -15,7 +15,7 @@
 
 import json
 import os
-import pkg_resources
+from importlib.metadata import entry_points
 from io import BytesIO
 from io import StringIO
 from unittest import mock
@@ -123,7 +123,7 @@ class FakeRequest:
 class RequiresWwwMixin:
     # mix this into a TestCase to skip if buildbot-www is not installed
 
-    if not list(pkg_resources.iter_entry_points('buildbot.www', 'base')):
+    if not [ep for ep in entry_points().get('buildbot.www', []) if ep.name == 'base']:
         if 'BUILDBOT_TEST_REQUIRE_WWW' in os.environ:
             raise RuntimeError('$BUILDBOT_TEST_REQUIRE_WWW is set but '
                                'buildbot-www is not installed')

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -14,7 +14,8 @@
 # Copyright Buildbot Team Members
 
 import re
-from pkg_resources import parse_version
+
+from packaging.version import parse as parse_version
 
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -14,10 +14,11 @@
 # Copyright Buildbot Team Members
 
 
-import pkg_resources
 import re
 from abc import ABCMeta
 from abc import abstractmethod
+
+from packaging.version import parse as parse_version
 
 import twisted
 from twisted.cred.checkers import FilePasswordDB
@@ -116,8 +117,8 @@ class RemoteUserAuth(AuthBase):
             self.headerRegex = re.compile(unicode2bytes(headerRegex))
 
     def getLoginResource(self):
-        current_version = pkg_resources.parse_version(twisted.__version__)
-        if current_version < pkg_resources.parse_version("22.10.0"):
+        current_version = parse_version(twisted.__version__)
+        if current_version < parse_version("22.10.0"):
             from twisted.web.resource import ForbiddenResource
             return ForbiddenResource(message="URL is not supported for authentication")
 

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-import importlib.resources
+import importlib_resources
 
 from twisted.web import static
 
@@ -25,9 +25,9 @@ class Application:
 
     def __init__(self, modulename, description, ui=True):
         self.description = description
-        self.version = importlib.resources.files(modulename).joinpath("VERSION")
+        self.version = importlib_resources.files(modulename).joinpath("VERSION")
         self.version = bytes2unicode(self.version.read_bytes())
-        self.static_dir = importlib.resources.files(modulename) / "static"
+        self.static_dir = importlib_resources.files(modulename) / "static"
         self.resource = static.File(self.static_dir)
         self.ui = ui
 

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-import pkg_resources
+import importlib.resources
 
 from twisted.web import static
 
@@ -25,11 +25,9 @@ class Application:
 
     def __init__(self, modulename, description, ui=True):
         self.description = description
-        self.version = pkg_resources.resource_string(
-            modulename, "VERSION").strip()
-        self.version = bytes2unicode(self.version)
-        self.static_dir = pkg_resources.resource_filename(
-            modulename, "static")
+        self.version = importlib.resources.files(modulename).joinpath("VERSION")
+        self.version = bytes2unicode(self.version.read_bytes())
+        self.static_dir = importlib.resources.files(modulename) / "static"
         self.resource = static.File(self.static_dir)
         self.ui = ui
 

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -12,8 +12,8 @@
 # serve to show the default.
 
 
+import importlib.metadata
 import os
-import pkg_resources
 import sys
 import textwrap
 
@@ -33,9 +33,9 @@ except ImportError:
 
 # -- General configuration -----------------------------------------------
 try:
-    pkg_resources.require('docutils>=0.8')
-except pkg_resources.ResolutionError as e:
-    raise RuntimeError("docutils is not installed or has incompatible version. "
+    importlib.metadata.distribution('docutils')
+except importlib.metadata.PackageNotFoundError as e:
+    raise RuntimeError("docutils is not installed. "
                        "Please install documentation dependencies with `pip "
                        "install buildbot[docs]`") from e
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/master/setup.py
+++ b/master/setup.py
@@ -485,6 +485,7 @@ setup_args['install_requires'] = [
     'python-dateutil>=1.5',
     "txaio >= 2.2.2",
     "autobahn >= 0.16.0",
+    'packaging',
     'PyJWT',
     'pyyaml',
     'unidiff >= 0.7.5',

--- a/master/setup.py
+++ b/master/setup.py
@@ -478,6 +478,7 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     'msgpack >= 0.6.0',
     "croniter >= 1.3.0",
+    'importlib-resources >= 5',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
     'sqlalchemy >= 1.3.0, < 1.5',

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -21,7 +21,6 @@ import re
 import shutil
 import subprocess
 import sys
-from pkg_resources import parse_version
 from subprocess import PIPE
 from subprocess import STDOUT
 from subprocess import Popen

--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -29,10 +29,10 @@ class BuildbotWWWPkg(unittest.TestCase):
     epName = "base"
 
     loadTestScript = dedent("""
-        import pkg_resources
+        from importlib.metadata import entry_points
         import re
         apps = {}
-        for ep in pkg_resources.iter_entry_points('buildbot.www'):
+        for ep in entry_points().get('buildbot.www', []):
             apps[ep.name] = ep.load()
 
         print(apps["%(epName)s"])

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -56,6 +56,7 @@ hyperlink==21.0.0
 idna==2.10  # pyup: ignore (conflicts with moto on master)
 imagesize==1.4.1
 importlib-metadata==6.8.0
+importlib-resources==6.0.1
 incremental==22.10.0
 ipaddress==1.0.23
 isort==4.3.21   # pyup: ignore (until https://github.com/PyCQA/pylint/pull/3725 is merged)


### PR DESCRIPTION

This PR solves https://github.com/buildbot/buildbot/issues/7003.

Buildbot is migrating to importlib-based solutions since use of `pkg_resources` is deprecated in favor of [importlib.resources](https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). 

## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
