### PR TITLE
Use upstream croniter

### DIFF
--- a/master/buildbot/util/croniter.py
+++ b/master/buildbot/util/croniter.py
@@ -15,6 +15,8 @@ from time import time
 
 from dateutil.relativedelta import relativedelta
 
+from buildbot.warnings import warn_deprecated
+
 search_re = re.compile(r'^([^-]+)-([^-/]+)(/(.*))?$')
 only_int_re = re.compile(r'^\d+$')
 any_int_re = re.compile(r'^\d+')
@@ -40,6 +42,14 @@ special_day_of_week_or_month_re = re.compile(
 )
 
 __all__ = ('croniter',)
+
+
+warn_deprecated(
+    "3.10.0",
+    "buildbot.util.croniter has been deprecated. Use croniter Pypi package as a replacement. "
+    "Note that croniter assumes that the input times in UTC timezone whereas "
+    "buildbot.util.croniter assumed that the input times are in local timezone."
+)
 
 
 class croniter:

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -762,6 +762,8 @@ In the near future, all uses of this module will be replaced with message-queuei
 :py:mod:`buildbot.util.croniter`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+(deprecated)
+
 This module is a copy of https://github.com/taichino/croniter, and provides support for converting cron-like time specifications to actual times.
 
 :py:mod:`buildbot.util.state`

--- a/master/docs/manual/upgrading/4.0-upgrade.rst
+++ b/master/docs/manual/upgrading/4.0-upgrade.rst
@@ -78,3 +78,14 @@ The ``wantLogs`` argument to message formatters has been removed.
 The equivalent is setting both ``want_logs`` and ``want_logs_content`` to the previous value of ``wantLogs``.
 
 The ``wantSteps`` and ``wantProperties`` arguments have been renamed to ``want_steps`` and ``want_properties`` respectively.
+
+buildbot.util.croniter
+----------------------
+
+``buildbot.util.croniter`` module has been removed.
+The replacement is ``croniter`` package from Pypi.
+
+Migration to ``croniter`` involves ensuring that the input times are passed as time-aware ``datetime`` objects.
+
+The original ``buildbot.util.croniter`` code always assumed the input time is in the current timezone.
+The ``croniter`` package assumes the input time is in UTC timezone.

--- a/master/setup.py
+++ b/master/setup.py
@@ -498,6 +498,7 @@ setup_args['install_requires'] = [
     'Twisted ' + twisted_ver,
     'Jinja2 >= 2.1',
     'msgpack >= 0.6.0',
+    "croniter >= 1.3.0",
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
     'sqlalchemy >= 1.3.0, < 1.5',

--- a/newsfragments/buildbot-util-croniter.removal
+++ b/newsfragments/buildbot-util-croniter.removal
@@ -1,0 +1,1 @@
+``buildbot.util.croniter`` module has been deprecated in favor of using Pypi ``croniter`` package.

--- a/newsfragments/upstream-croniter.bugfix
+++ b/newsfragments/upstream-croniter.bugfix
@@ -1,0 +1,1 @@
+Addressed a number of timing errors in ``Nightly`` scheduler by upgrading ``croniter`` code.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -40,6 +40,7 @@ configparser==6.0.0;  python_version >= "3.8"
 constantly==15.1.0
 cookies==2.2.1
 coverage==7.2.7
+croniter==1.4.1
 cryptography==41.0.3
 decorator==5.1.1
 dicttoxml==1.7.16


### PR DESCRIPTION
This addresses a number of bugs that have been fixed in upstream
croniter package since the code was copied into Buildbot.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
