### PR TITLE
Improve Nigthly scheduler flexibility when there are no changes 

### DIFF
--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -42,7 +42,7 @@ from buildbot.util.codebase import AbsoluteSourceStampsMixin
 # `last_build` means on what time build was scheduled to run ignoring the fact if it actually ran or
 # not.
 # Value of these state keys affects the decision whether to run a build.
-
+#
 # When deciding whether to run the build or to skip it, several factors and their interactions are
 # evaluated:
 # - the value of `onlyIfChanged` (default is False);
@@ -50,13 +50,13 @@ from buildbot.util.codebase import AbsoluteSourceStampsMixin
 # - whether this would be first build (True if `last_build` value was not detected). If there
 # already were builds in the past, it indicates that the scheduler is existing;
 # - were there any important changes after the last build.
-
+#
 # If `onlyIfChanged` is not set or its setting changes to False, builds will always run on the time
 # set, ignoring the status of `last_only_if_changed` and `last_build` regardless of what the state
 # is or anything else.
-
+#
 # If `onlyIfChanged` is True, then builds will be run when there are relevant changes.
-
+#
 # If `onlyIfChanged` is True and even when there were no relevant changes, builds will run for the
 # the first time on specified time as well when the following condition holds:
 # - `last_only_if_changed` was set to False on previous build. This ensures that any changes that
@@ -65,7 +65,7 @@ from buildbot.util.codebase import AbsoluteSourceStampsMixin
 # `onlyIfChanged` is adjusted;
 # - `last_build` does not have a value yet meaning that it is a new scheduler and we should have
 # initial build to set a baseline.
-
+#
 # There is an edge case, when upgrading to v3.5.0 and new object status variable
 # `last_only_if_changed` is introduced. If scheduler exists and had builds before
 # (`last_build` has a value), build should only be started if there are relevant changes.

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -207,8 +207,13 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
 
         last_only_if_changed = yield self.getState('last_only_if_changed', True)
 
-        if last_only_if_changed and self.onlyIfChanged and not any(classifications.values()) and \
-                not self.is_first_build:
+        if (
+            last_only_if_changed
+            and self.onlyIfChanged
+            and not any(classifications.values())
+            and not self.is_first_build
+            and not self.maybe_force_build_on_unimportant_changes(self.lastActuated)
+        ):
             log.msg(("{} scheduler <{}>: skipping build " +
                      "- No important changes").format(self.__class__.__name__, self.name))
             self.is_first_build = False
@@ -265,6 +270,13 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
         @returns: Deferred
         """
         return self.actuationLock.run(self._scheduleNextBuild_locked)
+
+    def maybe_force_build_on_unimportant_changes(self, current_actuation_time):
+        """
+        Allows forcing a build in cases when there are no important changes and onlyIfChanged is
+        enabled.
+        """
+        return False
 
     # utilities
 
@@ -345,10 +357,26 @@ class Periodic(Timed):
 
 
 class NightlyBase(Timed):
-    compare_attrs = ('minute', 'hour', 'dayOfMonth', 'month', 'dayOfWeek')
+    compare_attrs = (
+        "minute",
+        "hour",
+        "dayOfMonth",
+        "month",
+        "dayOfWeek",
+        "force_at_minute",
+        "force_at_hour",
+        "force_at_day_of_month",
+        "force_at_month",
+        "force_at_day_of_week",
+    )
 
     def __init__(self, name, builderNames, minute=0, hour='*',
                  dayOfMonth='*', month='*', dayOfWeek='*',
+                 force_at_minute=None,
+                 force_at_hour=None,
+                 force_at_day_of_month=None,
+                 force_at_month=None,
+                 force_at_day_of_week=None,
                  **kwargs):
         super().__init__(name, builderNames, **kwargs)
 
@@ -357,6 +385,25 @@ class NightlyBase(Timed):
         self.dayOfMonth = dayOfMonth
         self.month = month
         self.dayOfWeek = dayOfWeek
+
+        self.force_at_enabled = (
+            force_at_minute is not None
+            or force_at_hour is not None
+            or force_at_day_of_month is not None
+            or force_at_month is not None
+            or force_at_day_of_week is not None
+        )
+
+        def default_if_none(value, default):
+            if value is None:
+                return default
+            return value
+
+        self.force_at_minute = default_if_none(force_at_minute, 0)
+        self.force_at_hour = default_if_none(force_at_hour, "*")
+        self.force_at_day_of_month = default_if_none(force_at_day_of_month, "*")
+        self.force_at_month = default_if_none(force_at_month, "*")
+        self.force_at_day_of_week = default_if_none(force_at_day_of_week, "*")
 
     def _timeToCron(self, time, isDayOfWeek=False):
         if isinstance(time, int):
@@ -389,20 +436,50 @@ class NightlyBase(Timed):
 
         return ','.join([str(s) for s in time])  # Convert the list to a string
 
-    def getNextBuildTime(self, lastActuated):
-        ts = lastActuated or self.now()
-        sched = (f'{self._timeToCron(self.minute)} {self._timeToCron(self.hour)} '
-                 f'{self._timeToCron(self.dayOfMonth)} {self._timeToCron(self.month)} '
-                 f'{self._timeToCron(self.dayOfWeek, True)}')
+    def _times_to_cron_line(self, minute, hour, day_of_month, month, day_of_week):
+        return " ".join([
+            str(self._timeToCron(minute)),
+            str(self._timeToCron(hour)),
+            str(self._timeToCron(day_of_month)),
+            str(self._timeToCron(month)),
+            str(self._timeToCron(day_of_week, True)),
+        ])
 
+    def _time_to_croniter_tz_time(self, ts):
         # By default croniter interprets input timestamp in UTC timezone. However, the scheduler
         # works in local timezone, so appropriate timezone information needs to be passed
         tz = datetime.timezone(datetime.timedelta(seconds=self.current_utc_offset(ts)))
-        dt_with_tz = datetime.datetime.fromtimestamp(ts, tz)
+        return datetime.datetime.fromtimestamp(ts, tz)
 
-        cron = croniter.croniter(sched, dt_with_tz)
+    def getNextBuildTime(self, lastActuated):
+        ts = lastActuated or self.now()
+        sched = self._times_to_cron_line(
+            self.minute,
+            self.hour,
+            self.dayOfMonth,
+            self.month,
+            self.dayOfWeek,
+        )
+
+        cron = croniter.croniter(sched, self._time_to_croniter_tz_time(ts))
         nextdate = cron.get_next(float)
         return defer.succeed(nextdate)
+
+    def maybe_force_build_on_unimportant_changes(self, current_actuation_time):
+        if not self.force_at_enabled:
+            return False
+        cron_string = self._times_to_cron_line(
+            self.force_at_minute,
+            self.force_at_hour,
+            self.force_at_day_of_month,
+            self.force_at_month,
+            self.force_at_day_of_week,
+        )
+
+        return croniter.croniter.match(
+            cron_string,
+            self._time_to_croniter_tz_time(current_actuation_time)
+        )
 
 
 class Nightly(NightlyBase):
@@ -410,10 +487,20 @@ class Nightly(NightlyBase):
     def __init__(self, name, builderNames, minute=0, hour='*',
                  dayOfMonth='*', month='*', dayOfWeek='*',
                  reason="The Nightly scheduler named '%(name)s' triggered this build",
+                 force_at_minute=None,
+                 force_at_hour=None,
+                 force_at_day_of_month=None,
+                 force_at_month=None,
+                 force_at_day_of_week=None,
                  **kwargs):
         super().__init__(name=name, builderNames=builderNames,
                          minute=minute, hour=hour, dayOfMonth=dayOfMonth,
                          month=month, dayOfWeek=dayOfWeek, reason=reason,
+                         force_at_minute=force_at_minute,
+                         force_at_hour=force_at_hour,
+                         force_at_day_of_month=force_at_day_of_month,
+                         force_at_month=force_at_month,
+                         force_at_day_of_week=force_at_day_of_week,
                          **kwargs)
 
 
@@ -423,10 +510,20 @@ class NightlyTriggerable(NightlyBase):
     def __init__(self, name, builderNames, minute=0, hour='*',
                  dayOfMonth='*', month='*', dayOfWeek='*',
                  reason="The NightlyTriggerable scheduler named '%(name)s' triggered this build",
+                 force_at_minute=None,
+                 force_at_hour=None,
+                 force_at_day_of_month=None,
+                 force_at_month=None,
+                 force_at_day_of_week=None,
                  **kwargs):
         super().__init__(name=name, builderNames=builderNames,
                          minute=minute, hour=hour, dayOfMonth=dayOfMonth,
                          month=month, dayOfWeek=dayOfWeek, reason=reason,
+                         force_at_minute=force_at_minute,
+                         force_at_hour=force_at_hour,
+                         force_at_day_of_month=force_at_day_of_month,
+                         force_at_month=force_at_month,
+                         force_at_day_of_week=force_at_day_of_week,
                          **kwargs)
 
         self._lastTrigger = None

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -274,7 +274,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         d = sched.deactivate()
         return d
 
-    def do_test_iterations_onlyIfChanged(self, *changes_at, last_only_if_changed,
+    def do_test_iterations_onlyIfChanged(self, changes_at, last_only_if_changed,
                                          is_new_scheduler=False, **kwargs):
         fII = mock.Mock(name='fII')
         self.makeScheduler(name='test', builderNames=['test'], branch=None,
@@ -287,10 +287,10 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         if last_only_if_changed is not None:
             self.db.state.set_fake_state(self.sched, 'last_only_if_changed', last_only_if_changed)
 
-        return self.do_test_iterations_onlyIfChanged_test(fII, *changes_at)
+        return self.do_test_iterations_onlyIfChanged_test(fII, changes_at)
 
     @defer.inlineCallbacks
-    def do_test_iterations_onlyIfChanged_test(self, fII, *changes_at):
+    def do_test_iterations_onlyIfChanged_test(self, fII, changes_at):
         yield self.sched.activate()
 
         # check that the scheduler has started to consume changes
@@ -299,7 +299,6 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
         # manually run the clock forward through a half-hour, allowing any
         # excitement to take place
-        changes_at = list(changes_at)
         self.reactor.advance(0)  # let it trigger the first build
         while self.reactor.seconds() < self.time_offset + 30 * 60:
             # inject any new changes..
@@ -314,7 +313,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_no_changes_new_scheduler(self):
-        yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=None,
+        yield self.do_test_iterations_onlyIfChanged([], last_only_if_changed=None,
                                                     is_new_scheduler=True)
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
@@ -332,7 +331,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_no_changes_existing_scheduler(self):
-        yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=True)
+        yield self.do_test_iterations_onlyIfChanged([], last_only_if_changed=True)
         self.assertEqual(self.addBuildsetCalls, [])
         self.db.state.assertStateByClass('test', 'Nightly',
                                          last_build=1500 + self.time_offset)
@@ -348,7 +347,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         # Because onlyIfChanged was False possibly important change will be missed.
         # Therefore the first build should start immediately.
 
-        yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=False)
+        yield self.do_test_iterations_onlyIfChanged([], last_only_if_changed=False)
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
@@ -367,7 +366,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     def test_iterations_onlyIfChanged_no_changes_existing_scheduler_update_to_v3_5_0(self):
         # v3.4.0 have not had a variable last_only_if_changed yet therefore this case is tested
         # separately
-        yield self.do_test_iterations_onlyIfChanged(last_only_if_changed=None)
+        yield self.do_test_iterations_onlyIfChanged([], last_only_if_changed=None)
         self.assertEqual(self.addBuildsetCallTimes, [])
         self.assertEqual(self.addBuildsetCalls, [])
         self.db.state.assertStateByClass('test', 'Nightly',
@@ -377,10 +376,14 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_unimp_changes_calls_for_new_scheduler(self):
         yield self.do_test_iterations_onlyIfChanged(
-            (60, mock.Mock(), False),
-            (600, mock.Mock(), False),
+            [
+                (60, mock.Mock(), False),
+                (600, mock.Mock(), False),
+            ],
             last_only_if_changed=None,
-            is_new_scheduler=True)
+            is_new_scheduler=True,
+        )
+
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
@@ -399,9 +402,13 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_unimp_changes_existing_sched_changed_only_if_changed(self):
         yield self.do_test_iterations_onlyIfChanged(
-            (60, mock.Mock(), False),
-            (600, mock.Mock(), False),
-            last_only_if_changed=False)
+            [
+                (60, mock.Mock(), False),
+                (600, mock.Mock(), False),
+            ],
+            last_only_if_changed=False
+        )
+
         self.assertEqual(self.addBuildsetCalls, [
             ('addBuildsetForSourceStampsWithDefaults', {
                 'builderNames': None,
@@ -420,9 +427,13 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_unimp_changes_existing_sched_same_only_if_changed(self):
         yield self.do_test_iterations_onlyIfChanged(
-            (60, mock.Mock(), False),
-            (600, mock.Mock(), False),
-            last_only_if_changed=True)
+            [
+                (60, mock.Mock(), False),
+                (600, mock.Mock(), False),
+            ],
+            last_only_if_changed=True
+        )
+
         self.assertEqual(self.addBuildsetCalls, [])
 
         self.db.state.assertStateByClass('test', 'Nightly',
@@ -434,11 +445,13 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         # v3.4.0 have not had a variable last_only_if_changed yet therefore this case is tested
         # separately
         yield self.do_test_iterations_onlyIfChanged(
-            (120, self.makeFakeChange(number=1, branch=None), False),
-            (1200, self.makeFakeChange(number=2, branch=None), True),
-            (1201, self.makeFakeChange(number=3, branch=None), False),
+            [
+                (120, self.makeFakeChange(number=1, branch=None), False),
+                (1200, self.makeFakeChange(number=2, branch=None), True),
+                (1201, self.makeFakeChange(number=3, branch=None), False),
+            ],
             last_only_if_changed=None,
-            )
+        )
 
         self.assertEqual(self.addBuildsetCallTimes, [1500])
         self.assertEqual(self.addBuildsetCalls, [(
@@ -459,9 +472,13 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_off_branch_changes(self):
         yield self.do_test_iterations_onlyIfChanged(
-            (60, self.makeFakeChange(number=1, branch='testing'), True),
-            (1700, self.makeFakeChange(number=2, branch='staging'), True),
-            last_only_if_changed=True)
+            [
+                (60, self.makeFakeChange(number=1, branch='testing'), True),
+                (1700, self.makeFakeChange(number=2, branch='staging'), True),
+            ],
+            last_only_if_changed=True
+        )
+
         self.assertEqual(self.addBuildsetCalls, [])
         self.db.state.assertStateByClass('test', 'Nightly',
                                          last_build=1500 + self.time_offset)
@@ -470,12 +487,15 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_iterations_onlyIfChanged_mixed_changes(self):
         yield self.do_test_iterations_onlyIfChanged(
-            (120, self.makeFakeChange(number=3, branch=None), False),
-            (130, self.makeFakeChange(number=4, branch='offbranch'), True),
-            (1200, self.makeFakeChange(number=5, branch=None), True),
-            (1201, self.makeFakeChange(number=6, branch=None), False),
-            (1202, self.makeFakeChange(number=7, branch='offbranch'), True),
-            last_only_if_changed=True)
+            [
+                (120, self.makeFakeChange(number=3, branch=None), False),
+                (130, self.makeFakeChange(number=4, branch='offbranch'), True),
+                (1200, self.makeFakeChange(number=5, branch=None), True),
+                (1201, self.makeFakeChange(number=6, branch=None), False),
+                (1202, self.makeFakeChange(number=7, branch='offbranch'), True),
+            ],
+            last_only_if_changed=True
+        )
 
         # note that the changeid list includes the unimportant changes, but not the
         # off-branch changes, and note that no build took place at 300s, as no important
@@ -499,12 +519,14 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         # Test createAbsoluteSourceStamps=True when only one codebase has
         # changed
         yield self.do_test_iterations_onlyIfChanged(
-            (120, self.makeFakeChange(
-                number=3, codebase='a', revision='2345:bcd'), True),
+            [
+                (120, self.makeFakeChange(number=3, codebase='a', revision='2345:bcd'), True),
+            ],
             codebases={'a': {'repository': "", 'branch': 'master'},
                        'b': {'repository': "", 'branch': 'master'}},
             createAbsoluteSourceStamps=True,
-            last_only_if_changed=True)
+            last_only_if_changed=True
+        )
         self.db.state.assertStateByClass('test', 'Nightly',
                                          last_build=1500 + self.time_offset)
         # addBuildsetForChanges calls getCodebase, so this isn't too
@@ -546,8 +568,12 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             }
         })
 
-        change = self.makeFakeChange(number=3, codebase='a', revision='2345:bcd')
-        yield self.do_test_iterations_onlyIfChanged_test(fII, (120, change, True))
+        yield self.do_test_iterations_onlyIfChanged_test(
+            fII,
+            [
+                (120, self.makeFakeChange(number=3, codebase='a', revision='2345:bcd'), True),
+            ]
+        )
 
         self.db.state.assertStateByClass('test', 'Nightly',
                                          last_build=1500 + self.time_offset)
@@ -573,14 +599,16 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     def test_iterations_onlyIfChanged_createAbsoluteSourceStamps_bothChanged(self):
         # Test createAbsoluteSourceStamps=True when both codebases have changed
         yield self.do_test_iterations_onlyIfChanged(
-            (120, self.makeFakeChange(
-                number=3, codebase='a', revision='2345:bcd'), True),
-            (122, self.makeFakeChange(
-                number=4, codebase='b', revision='1234:abc'), True),
+            [
+                (120, self.makeFakeChange(number=3, codebase='a', revision='2345:bcd'), True),
+                (122, self.makeFakeChange(number=4, codebase='b', revision='1234:abc'), True),
+            ],
             codebases={'a': {'repository': "", 'branch': 'master'},
                        'b': {'repository': "", 'branch': 'master'}},
             last_only_if_changed=None,
-            createAbsoluteSourceStamps=True)
+            createAbsoluteSourceStamps=True
+        )
+
         self.db.state.assertStateByClass('test', 'Nightly',
                                          last_build=1500 + self.time_offset)
         # addBuildsetForChanges calls getCodebase, so this isn't too

--- a/master/docs/manual/configuration/schedulers.rst
+++ b/master/docs/manual/configuration/schedulers.rst
@@ -649,7 +649,8 @@ The full list of parameters is:
 ``dayOfMonth`` (optional)
 
     The day of the month to start a build.
-    This defaults to ``*``, meaning every day or ``L`` for last day.
+    This defaults to ``*``, meaning every day.
+    Use ``L`` to specify last day of the month.
     Last day option respects leap years.
 
 ``month`` (optional)
@@ -664,6 +665,48 @@ The full list of parameters is:
     This defaults to ``*``, meaning every day of the week or nth weekday of month.
     Like first Monday of month ``1#1``, last Monday of month ``L1``,
     Monday + Friday ``mon,fri`` or ranges Monday to Friday ``mon-fri``.
+
+Forcing builds when there are no changes
+........................................
+
+Nightly scheduler supports scheduling builds even in there were no important changes and ``onlyIfChanged`` was set to ``True``.
+This is controlled by ``force_at_*`` parameters.
+The feature is enabled if least one of them is set.
+
+The time interval identified by ``force_at_minute``, ``force_at_hour``, ``force_at_day_of_month``, ``force_at_month`` and ``force_at_day_of_week`` must be subset of time interval identified by ``minute``, ``hour``, ``dayOfMonth``, ``month``, ``dayOfWeek``.
+
+``force_at_minute`` (optional)
+
+    The minute of the hour on which to start the build even if there were no important changes and ``onlyIfChanged`` was set to ``True``.
+    The default is ``None`` meaning this feature is disabled.
+    If the feature is enabled by setting another ``force_at_*`` parameter, then the default value is ``0`` meaning builds will run every hour.
+
+``force_at_hour`` (optional)
+
+    The hour of the day on which to start the build even if there were no important changes and ``onlyIfChanged`` was set to ``True``.
+    The default is ``None`` meaning this feature is disabled.
+    If the feature is enabled by setting another ``force_at_*`` parameter, then the default value is ``*`` meaning builds will run each hour.
+
+``force_at_day_of_month`` (optional)
+
+    The day of the month on which to start the build even if there were no important changes and ``onlyIfChanged`` was set to ``True``.
+    The default is ``None`` meaning this feature is disabled.
+    If the feature is enabled by setting another ``force_at_*`` parameter, then the default value is ``*`` meaning builds will run each day.
+
+``force_at_month`` (optional)
+
+    The month of the year on which to start the build even if there were no important changes and ``onlyIfChanged`` was set to ``True``.
+    The default is ``None`` meaning this feature is disabled.
+    If the feature is enabled by setting another ``force_at_*`` parameter, then the default value is ``*`` meaning builds will run each month.
+
+``force_at_day_of_week`` (optional)
+
+    The day of the week on which to start the build even if there were no important changes and ``onlyIfChanged`` was set to ``True``.
+    The default is ``None`` meaning this feature is disabled.
+    If the feature is enabled by setting another ``force_at_*`` parameter, then the default value is ``*`` meaning builds will run each day of the week.
+
+Example
+.......
 
 For example, the following :file:`master.cfg` clause will cause a build to be started every night at 3:00am:
 

--- a/newsfragments/nightly-force-at-times.feature
+++ b/newsfragments/nightly-force-at-times.feature
@@ -1,0 +1,1 @@
+``Nightly`` scheduler now supports forcing builds at specific times even if ``onlyIfChanged`` parameter was true and there were no important changes.


### PR DESCRIPTION
Additional set of cron parameters is introduced which define a subset of the configured scheduler times. A build will be forced at these times even if there were no important changes when onlyIfChanged is set to True.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
