### PR TITLE
data: Add missing buildset keys to the buildset/*/complete events

### DIFF
--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -248,7 +248,9 @@ class Buildset(base.ResourceType):
             "submitted_at": bsdict['submitted_at'],
             "complete": True,
             "complete_at": complete_at,
-            "results": cumulative_results
+            "results": cumulative_results,
+            "parent_buildid": bsdict["parent_buildid"],
+            "parent_relationship": bsdict["parent_relationship"],
         }
         # TODO: properties=properties)
         self.produceEvent(msg, "complete")

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -243,7 +243,9 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests,
             "reason": reason,
             "results": results,
             "submitted_at": submitted_at,
-            "sourcestamps": [ssmap[ssid] for ssid in sourcestampids]
+            "sourcestamps": [ssmap[ssid] for ssid in sourcestampids],
+            "parent_buildid": None,
+            "parent_relationship": None,
         })
 
     def test_addBuildset_two_builderNames(self):

--- a/newsfragments/data-api-buildset-complete-missing-keys.bugfix
+++ b/newsfragments/data-api-buildset-complete-missing-keys.bugfix
@@ -1,0 +1,1 @@
+Added missing ``parent_buildid`` and ``parent_relationship`` keys to the buildset completion event in the Data API.


### PR DESCRIPTION
This fixes a frontend crash when forcing a build and waiting for its completion.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
