### PR TITLE
www: Implement support for displaying large logs (>1M lines)

### DIFF
--- a/www/react-base/src/components/LogViewer/LogTextManager.test.ts
+++ b/www/react-base/src/components/LogViewer/LogTextManager.test.ts
@@ -48,79 +48,89 @@ const createRecordingGetFakeData = () : [DataRequest[], GetFakeDataFn] => {
 describe('LogTextManager', () => {
   describe('selectChunkDownloadRange', () => {
     it('empty downloaded range', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 150, 160, 0, 200))
         .toEqual([100, 200]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 20, 20, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 20, 20, 150, 160, 0, 200))
         .toEqual([100, 200]);
     });
     it('empty downloaded range exceeds chunk limit', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 155, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 155, 160, 0, 10))
         .toEqual([152, 162]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 150, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 150, 160, 0, 10))
         .toEqual([150, 160]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 140, 170, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 140, 170, 0, 10))
         .toEqual([150, 160]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 10, 30, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 10, 30, 0, 10))
         .toEqual([100, 110]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 220, 240, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 0, 220, 240, 0, 10))
         .toEqual([190, 200]);
     });
     it('non-overlapping ranges', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 20, 30, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 20, 30, 150, 160, 0, 200))
         .toEqual([100, 200]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 200, 230, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 200, 230, 150, 160, 0, 200))
         .toEqual([100, 200]);
     });
+    it('non-overlapping ranges, but overlaps caching', () => {
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 20, 30, 150, 160, 200, 200))
+        .toEqual([30, 200]);
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 20, 30, 150, 160, 200, 10))
+        .toEqual([30, 40]);
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 200, 230, 150, 160, 200, 200))
+        .toEqual([100, 200]);
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 200, 230, 150, 160, 200, 10))
+        .toEqual([190, 200]);
+    });
     it('non-overlapping ranges, range exceeds chunk limit', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 155, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 155, 160, 0, 10))
         .toEqual([152, 162]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 150, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 150, 160, 0, 10))
         .toEqual([150, 160]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 140, 170, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 140, 170, 0, 10))
         .toEqual([150, 160]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 10, 30, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 10, 30, 0, 10))
         .toEqual([100, 110]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 220, 240, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 0, 10, 220, 240, 0, 10))
         .toEqual([190, 200]);
     });
     it('download range in downloaded', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 230, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 230, 150, 160, 0, 200))
         .toEqual([0, 0]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 100, 230, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 100, 230, 150, 160, 0, 200))
         .toEqual([0, 0]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 200, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 200, 150, 160, 0, 200))
         .toEqual([0, 0]);
     });
     it('ranges partially overlap', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 140, 210, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 140, 210, 150, 160, 0, 200))
         .toEqual([100, 140]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 160, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 160, 150, 160, 0, 200))
         .toEqual([160, 200]);
     });
     it('ranges partially overlap, download range exceeds chunk limit', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 140, 210, 150, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 140, 210, 150, 160, 0, 10))
         .toEqual([130, 140]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 160, 150, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 90, 160, 150, 160, 0, 10))
         .toEqual([160, 170]);
     });
     it('downloaded range in middle', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 150, 160, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 150, 160, 0, 200))
         .toEqual([180, 200]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 175, 195, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 175, 195, 0, 200))
         .toEqual([180, 200]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 125, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 125, 0, 200))
         .toEqual([100, 120]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 195, 200))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 195, 0, 200))
         .toEqual([180, 200]);
     });
     it('downloaded range in middle, parts exceed limit', () => {
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 150, 160, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 150, 160, 0, 10))
         .toEqual([180, 190]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 175, 195, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 175, 195, 0, 10))
         .toEqual([180, 190]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 125, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 125, 0, 10))
         .toEqual([110, 120]);
-      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 195, 10))
+      expect(LogTextManager.selectChunkDownloadRange(100, 200, 120, 180, 105, 195, 0, 10))
         .toEqual([180, 190]);
     });
   });

--- a/www/react-base/src/components/LogViewer/LogTextManager.ts
+++ b/www/react-base/src/components/LogViewer/LogTextManager.ts
@@ -344,6 +344,13 @@ export class LogTextManager {
     return true;
   }
 
+  clearCache() {
+    this.renderedLines = [];
+    this.renderedLines[this.renderedLines.length] = undefined; // preallocate
+    this.renderedLinesForSearch = [];
+    this.renderedLinesForSearch[this.renderedLines.length] = undefined; // preallocate
+  }
+
   getRenderedLineContent(index: number, style: React.CSSProperties,
                          renderer: LineRenderer, emptyRenderer: EmptyLineRenderer) {
     if (this.searchString !== null) {

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -139,6 +139,7 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
         width={width}
         itemSize={18}
         getRangeToRenderOverride={getRangeToRenderOverride}
+        onCacheClear={() => manager.clearCache()}
         outerElementType={outerElementType}
       >
         {({index, style}) => (

--- a/www/react-ui/src/components/FixedSizeList/FixedSizeList.test.tsx
+++ b/www/react-ui/src/components/FixedSizeList/FixedSizeList.test.tsx
@@ -563,7 +563,7 @@ describe('FixedSizeList', () => {
       ref.current!.scrollToItem(15);
       await waitForAnimationFrame();
 
-      expect(itemRenderer.mock.calls[0][0].isScrolling).toBe(false);
+      expect(itemRenderer.mock.calls[itemRenderer.mock.calls.length - 1][0].isScrolling).toBe(false);
     });
 
     it('should ignore indexes less than zero', async () => {

--- a/www/react-ui/src/components/FixedSizeList/__snapshots__/FixedSizeList.test.tsx.snap
+++ b/www/react-ui/src/components/FixedSizeList/__snapshots__/FixedSizeList.test.tsx.snap
@@ -589,19 +589,6 @@ Array [
 ]
 `;
 
-exports[`FixedSizeList should render a list of columns 1`] = `
-Array [
-  Array [
-    Object {
-      "overscanStartIndex": 0,
-      "overscanStopIndex": 3,
-      "visibleStartIndex": 0,
-      "visibleStopIndex": 1,
-    },
-  ],
-]
-`;
-
 exports[`FixedSizeList should render a list of rows 1`] = `
 Array [
   Array [


### PR DESCRIPTION
The current implementation creates a HTML element of height line_height * line_count. This is problematic, because browsers do not properly support scrolling for elements above certain size. This makes it impossible to show logs larger than million of lines or so.

Note, however, that the limit of a HTML element size is browser-dependent. Some browsers may have maximum HTML element size such that the maximum size of displayed log can be as small as 100 thousand lines.

To work around this, scrolling is done in a smaller HTML element. The scroll offset and the rows are positioned in such a way that it appears scrolling is done on a much larger HTML element.