### PR TITLE
reporter: Prevent Bitbucket status key length exceeding limits

### DIFF
--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import hashlib
 from urllib.parse import urlparse
 
 from twisted.internet import defer
@@ -112,9 +113,16 @@ class BitbucketStatusPush(ReporterBase):
         props = Properties.fromDict(build['properties'])
         props.master = self.master
 
+        def key_hash(key):
+            sha_obj = hashlib.sha1()
+            sha_obj.update(key.encode('utf-8'))
+            return sha_obj.hexdigest()
+
+        status_key = yield props.render(self.status_key)
+
         body = {
             'state': status,
-            'key': (yield props.render(self.status_key)),
+            'key': key_hash(status_key),
             'name': (yield props.render(self.status_name)),
             'description': reports[0]['subject'],
             'url': build['url']

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -73,7 +73,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'INPROGRESS',
-                'key': 'Builder0',
+                'key': '0550a051225ac4ea91a92c9c94d41dfe6fa9f428',  # sha1("Builder0")
                 'name': 'Builder0',
                 'description': '',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -87,7 +87,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'SUCCESSFUL',
-                'key': 'Builder0',
+                'key': '0550a051225ac4ea91a92c9c94d41dfe6fa9f428',  # sha1("Builder0")
                 'name': 'Builder0',
                 'description': '',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -101,7 +101,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'FAILED',
-                'key': 'Builder0',
+                'key': '0550a051225ac4ea91a92c9c94d41dfe6fa9f428',  # sha1("Builder0")
                 'name': 'Builder0',
                 'description': '',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -129,7 +129,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'SUCCESSFUL',
-                'key': 'Builder0',
+                'key': '0550a051225ac4ea91a92c9c94d41dfe6fa9f428',  # sha1("Builder0")
                 'name': 'Builder0',
                 'description': '',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -148,7 +148,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'SUCCESSFUL',
-                'key': 'Builder0',
+                'key': '0550a051225ac4ea91a92c9c94d41dfe6fa9f428',  # sha1("Builder0")
                 'name': 'Builder0',
                 'description': '',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -185,7 +185,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'INPROGRESS',
-                'key': 'Builder0',
+                'key': '0550a051225ac4ea91a92c9c94d41dfe6fa9f428',  # sha1("Builder0")
                 'name': 'Builder0',
                 'description': '',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -264,7 +264,7 @@ class TestBitbucketStatusPushProperties(TestReactorMixin, unittest.TestCase,
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'INPROGRESS',
-                'key': 'Builder0/0',
+                'key': '84f9e75c46896d56da4fd75e096d24ec62f76f33',  # sha1("Builder0/0")
                 'name': 'Builder0-0',
                 'description': 'not finished build',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',
@@ -278,7 +278,7 @@ class TestBitbucketStatusPushProperties(TestReactorMixin, unittest.TestCase,
             '/user/repo/commit/d34db33fd43db33f/statuses/build',
             json={
                 'state': 'SUCCESSFUL',
-                'key': 'Builder0/0',
+                'key': '84f9e75c46896d56da4fd75e096d24ec62f76f33',  # sha1("Builder0/0")
                 'name': 'Builder0-0',
                 'description': 'Build succeeded!',
                 'url': 'http://localhost:8080/#/builders/79/builds/0',

--- a/newsfragments/bitbucket_status-reporter-key-length.bugfix
+++ b/newsfragments/bitbucket_status-reporter-key-length.bugfix
@@ -1,0 +1,1 @@
+Prevent Bitbucket status key length exceeding limits (:issue:`7049`).


### PR DESCRIPTION
This should resolve #7049 .

Since the "key" is not shown in user facing portions of the Bitbucket UI, I think using a hash should be OK.

I do not know whether I have properly used the "yield" keyword here or if I accidentally prevent deferred execution, so it would be great if someone knowing those mechanisms could check whether everything is in order.
`trial buildbot.test.unit.reporters.test_bitbucket` finishes cleanly.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ?] I have updated the appropriate documentation
