### PR TITLE
worker: Log error in remote_getWorkerInfo instead of crashing

### DIFF
--- a/newsfragments/get-worker-info.bugfix
+++ b/newsfragments/get-worker-info.bugfix
@@ -1,0 +1,1 @@
+Fix worker not connecting error when there are files in WORKER/info folder that can not be decoded. (:issue:`3585`) (:issue:`4758`) (:issue:`6932`)


### PR DESCRIPTION
Worker lists and reads all file in WORKER/info folder in functin remote_getWorkerInfo. To prevent it from crashing when it encounteres file that can not be decoded we now only report this error to log and continue.

Fixes #3585
Fixes #4758
Fixes #6932

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
