### PR TITLE
doc: Forget about BrowserID/Persona

### DIFF
--- a/master/docs/developer/auth.rst
+++ b/master/docs/developer/auth.rst
@@ -102,5 +102,4 @@ After this point, any stored authentication information is gone and the user is 
 Future Additions
 ----------------
 
-* Browserid/Persona: This method is very similar to oauth2, and should be implemented in a similar way (i.e. two stage redirect + token-verify)
 * Use the User table in db: This is a very similar to the UserPasswordAuth use cases (form + local db verification). Eventually, this method will require some work on the UI in order to populate the db, add a "register" button, verification email, etc. This has to be done in a ui plugin.


### PR DESCRIPTION
Persona/BrowserID hasn't caught on and doesn't seem to any time soon, with webauthn & friends appearing to have more hype

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

Since this only deletes one line from the docs, I hope it's okay to skip `newsfragments`.