### PR TITLE
Catch UploadDirectory exception when directory is not available in worker

### DIFF
--- a/newsfragments/catch-unwanted-worker-error.bugfix
+++ b/newsfragments/catch-unwanted-worker-error.bugfix
@@ -1,0 +1,1 @@
+Fix worker to fail a step uploadDirectory instead of throwing an exception when directory is not available. (:issue:`5878`)

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import io
 import os
+import re
 import shutil
 import sys
 import tarfile
@@ -360,6 +361,40 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
             'write(s)', 'unpack',
             ('rc', 1)
         ])
+
+
+class TestWorkerDirectoryUploadNoDir(CommandTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpCommand()
+        self.fakemaster = FakeMasterMethods(self.add_update)
+
+    def tearDown(self):
+        self.tearDownCommand()
+
+    @defer.inlineCallbacks
+    def test_directory_not_available(self):
+        path = os.path.join(self.basedir, 'workdir', os.path.expanduser('data'))
+
+        self.make_command(transfer.WorkerDirectoryUploadCommand, {
+            'path': path,
+            'workersrc': 'data',
+            'writer': FakeRemote(self.fakemaster),
+            'maxsize': None,
+            'blocksize': 512,
+            'compress': None
+        })
+
+        yield self.run_command()
+
+        updates = self.get_updates()
+        self.assertEqual(updates[0], ('rc', 1))
+        self.assertEqual(updates[1][0], "stderr")
+
+        error_msg = updates[1][1]
+        pattern = re.compile("Cannot read directory (.*?) for upload: (.*?)")
+        match = pattern.match(error_msg)
+        self.assertNotEqual(error_msg, match)
 
 
 class TestDownloadFile(CommandTestMixin, unittest.TestCase):


### PR DESCRIPTION
Step transfer.directoryUpload fails with exception when expected directory is not available in worker. This PR handles the exception gracefully, and the step just fails instead of causing an exception.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
