### PR TITLE
worker: Add option --connection-string for create-worker

### DIFF
--- a/master/docs/manual/installation/worker.rst
+++ b/master/docs/manual/installation/worker.rst
@@ -175,13 +175,19 @@ To use these, just include them on the ``buildbot-worker create-worker`` command
 
     Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
     If set, the generated connection string starts with ``tls`` instead of with ``tcp``, allowing encrypted connection to the buildmaster.
-    Make sure the worker trusts the buildmasters certificate. If you have an non-authoritative certificate (CA is self-signed) see ``connection_string`` below.
+    Make sure the worker trusts the buildmasters certificate. If you have an non-authoritative certificate (CA is self-signed) see option ``--connection-string`` and also Worker-TLS-Config_ below.
 
 .. option:: --delete-leftover-dirs
 
     Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
     If set, unexpected directories in worker base directory will be removed.
     Otherwise, a warning will be displayed in :file:`twistd.log` so that you can manually remove them.
+
+.. option:: --connection-string
+
+    Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
+    If set, the worker connection to master will be made using this ``connection_string``. See Worker-TLS-Config_ below for more details.
+    Note that this option will override required positional argument ``masterhost[:port]`` and also option ``--use-tls``.
 
 .. option:: --proxy-connection-string
 
@@ -293,5 +299,5 @@ Worker TLS Configuration
 
 
 
-.. _ConnectionStrings: https://twistedmatrix.com/documents/current/core/howto/endpoints.html
-.. _clientFromString: https://twistedmatrix.com/documents/current/api/twisted.internet.endpoints.clientFromString.html
+.. _ConnectionStrings: https://docs.twistedmatrix.com/en/stable/core/howto/endpoints.html
+.. _clientFromString: https://docs.twistedmatrix.com/en/stable/api/twisted.internet.endpoints.html#clientFromString

--- a/newsfragments/create-worker-connection-string.feature
+++ b/newsfragments/create-worker-connection-string.feature
@@ -1,0 +1,2 @@
+Workers can now be created to use ``connection string`` right out of the box when new option ``--connection-string=`` is used.
+

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -132,6 +132,8 @@ class CreateWorkerOptions(MakerBase):
          "Allows the worker to initiate a graceful shutdown. One of "
          "'signal' or 'file'"],
         ["protocol", None, "pb", "Protocol to be used when creating master-worker connection"],
+        ["connection-string", None, None,
+         "Twisted endpoint connection string (this will override master host[:port])"],
         ["proxy-connection-string", None, None,
          "Address of HTTP proxy to tunnel through"]
     ]

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -57,6 +57,7 @@ class TestDefaultOptionsMixin:
         "numcpus": None,
         "protocol": "pb",
         "maxretries": None,
+        "connection-string": None,
         "proxy-connection-string": None,
 
         # arguments
@@ -129,6 +130,7 @@ class TestMakeTAC(TestDefaultOptionsMixin, unittest.TestCase):
             maxRetries=expected_args["maxretries"],
             useTls=expected_args["use-tls"],
             delete_leftover_dirs=expected_args["delete-leftover-dirs"],
+            connection_string=expected_args["connection-string"],
             proxy_connection_string=expected_args["proxy-connection-string"],
             )
 
@@ -330,6 +332,20 @@ class TestMakeTAC(TestDefaultOptionsMixin, unittest.TestCase):
 
         self.assertIn("umask = 0o22", tac_contents)
         options["umask"] = 18
+        self.assert_tac_file_contents(tac_contents, options)
+
+    def test_connection_string(self):
+        """
+        test that when --connection-string options is used, correct tac file
+        is generated.
+        """
+        options = self.options.copy()
+        options["connection-string"] = "TLS:buildbot-master.com:9989"
+
+        tac_contents = create_worker._make_tac(options.copy())
+
+        options["host"] = None
+        options["port"] = None
         self.assert_tac_file_contents(tac_contents, options)
 
 


### PR DESCRIPTION
Using this option will propagate given connection string to worker's `buildbot.tac` file. Required positional arguments host and port will be visible in `buildbot.tac` only as comments.
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
