### PR TITLE
copy-db script fixes

### DIFF
--- a/master/buildbot/scripts/copydb.py
+++ b/master/buildbot/scripts/copydb.py
@@ -223,7 +223,7 @@ def _copy_database_with_db(src_db, dst_db, print_log):
 
     for table_name in table_names:
         table = metadata.tables[table_name]
-        _copy_single_table(
+        yield _copy_single_table(
             src_db,
             dst_db,
             table,

--- a/newsfragments/copydb-autoincrement.bugfix
+++ b/newsfragments/copydb-autoincrement.bugfix
@@ -1,0 +1,1 @@
+Fix handling of primary key columns on Postgres in the ``copy-db`` script.

--- a/newsfragments/copydb-tables.bugfix
+++ b/newsfragments/copydb-tables.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition in the ``copy-db`` script which sometimes lead to no data being copied.


### PR DESCRIPTION
This PR fixes several issues found in copy-db script when migrating to Postgres DB.