### PR TITLE
worker: Improved check of "number" options for create-worker

### DIFF
--- a/newsfragments/create-worker-options-check.bugfix
+++ b/newsfragments/create-worker-options-check.bugfix
@@ -1,0 +1,1 @@
+Options for `create-worker` that are converted to numbers are now also checked to be valid Python literals. This will prevent creating invalid worker configurations, e.g.: when using option ``--umask=022`` instead of ``--umask=0o022`` or ``--umask=18``. (:issue:`7047`)

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -217,7 +217,7 @@ class CreateWorkerOptions(MakerBase):
                                        argument))
 
         for argument in ["log-count", "maxretries", "umask", "numcpus"]:
-            if not re.match(r'^(0o)?\d+$', self[argument]) and \
+            if not re.match(r'^((0o)\d+|0|[1-9]\d*)$', self[argument]) and \
                     self[argument] != 'None':
                 raise usage.UsageError("{} parameter needs to be a number"
                                     " or None".format(argument))

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -244,6 +244,11 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
                                "umask parameter needs to be a number or None"):
             self.parse("--umask=X", *self.req_args)
 
+    def test_inv_umask2(self):
+        with self.assertRaisesRegex(usage.UsageError,
+                               "umask parameter needs to be a number or None"):
+            self.parse("--umask=022", *self.req_args)
+
     def test_inv_allow_shutdown(self):
         with self.assertRaisesRegex(usage.UsageError,
                        "allow-shutdown needs to be one of 'signal' or 'file'"):


### PR DESCRIPTION
Options that will be converted to numbers have to be valid Python literals. We now check that such number does not start with 0.

Fixes #7047


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
