### PR TITLE
Fix git shallow submodule fetch in incremental mode

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -114,7 +114,7 @@ class Git(Source, GitStepMixin):
                     bbconfig.error("Git: invalid method for mode 'full'.")
                 if self.shallow and (self.mode != 'full' or self.method != 'clobber'):
                     bbconfig.error(
-                        "Git: shallow only possible with mode 'full' and method 'clobber'.")
+                        "Git: in mode 'full' shallow only possible with method 'clobber'.")
         if not isinstance(self.getDescription, (bool, dict)):
             bbconfig.error("Git: getDescription must be a boolean or a dict.")
 

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -442,7 +442,7 @@ class Git(Source, GitStepMixin):
             cmdArgs = ["submodule", "update", "--init", "--recursive"]
             if self.remoteSubmodules:
                 cmdArgs.append("--remote")
-            if self.shallow:
+            if shallowClone:
                 cmdArgs.extend(["--depth", str(int(shallowClone))])
             res = yield self._dovccmd(cmdArgs, shallowClone)
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -2366,7 +2366,7 @@ class TestGit(sourcesteps.SourceStepMixin,
 
     def test_mode_full_copy_shallow(self):
         with self.assertRaisesConfigError(
-                "shallow only possible with mode 'full' and method 'clobber'"):
+                "in mode 'full' shallow only possible with method 'clobber'"):
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                         mode='full', method='copy', shallow=True)
 

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -37,7 +37,7 @@ The Git step takes the following arguments:
 ``shallow`` (optional)
    Instructs Git to attempt shallow clones (``--depth 1``).
    The depth defaults to 1 and can be changed by passing an integer instead of ``True``.
-   This option can be used only in full builds with clobber method.
+   This option can be used only in incremental builds, or full builds with clobber method.
 
 ``reference`` (optional)
    Use the specified string as a path to a reference repository on the local machine.

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -11,7 +11,7 @@ The :bb:step:`Git` build step clones or updates a `Git <http://git.or.cz/>`_ rep
 
 .. note::
 
-   Buildbot supports Git version 1.2.0 or later. Earlier versions (such as the one shipped in Ubuntu 'Dapper') do not support the :command:`git init` command that Buildbot uses.
+   Buildbot supports Git version 1.2.0 or later.
 
 .. code-block:: python
 

--- a/newsfragments/git-incremental-submodule-shallow.bugfix
+++ b/newsfragments/git-incremental-submodule-shallow.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect git command line parameters when using ``Git`` source step with ``mode="incremental"``, ``shallow=True``, ``submodules=True`` (regression since Buildbot 3.9) (:issue:`7054`).

--- a/newsfragments/git-shallow-incremental.doc
+++ b/newsfragments/git-shallow-incremental.doc
@@ -1,0 +1,1 @@
+Clarified that ``shallow`` option for the ``Git`` source step is also supported in ``incremental`` mode.


### PR DESCRIPTION
Fixes #7054. Also clarifies documentation that shallow option is allowed in incremental mode.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
