### PR TITLE
Drop python 3.7

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -46,8 +46,6 @@ matrix:
     # that the codecov.io service would wait until this build is finished before creating report.
     - python: "3.9"
       env: TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
-    - python: "3.7"
-      env: TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - python: "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -207,7 +207,6 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         return branch
 
     def _trackerBranch(self, branch):
-        # manually quote tilde for Python 3.7
         url = urlquote(self.repourl, '').replace('~', '%7E')
         return f"refs/buildbot/{url}/{self._removeHeads(branch)}"
 

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -71,7 +71,7 @@ sqlite3: http://www.sqlite.org
   Version 3.7.0 or higher is recommended, although Buildbot will run down to 3.6.16 -- at the risk of "Database is locked" errors.
   The minimum version is 3.4.0, below which parallel database queries and schema introspection fail.
 
-  Please note that Python ships with sqlite3 by default since Python 2.6.
+  Please note that Python ships with sqlite3 by default.
 
   If you configure a different database engine, then SQLite is not required.
   however note that Buildbot's own unit tests require SQLite.

--- a/master/setup.py
+++ b/master/setup.py
@@ -152,7 +152,6 @@ setup_args = {
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -465,10 +464,10 @@ setup_args = {
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
-py_36 = sys.version_info[0] > 3 or (
-    sys.version_info[0] == 3 and sys.version_info[1] >= 7)
-if not py_36:
-    raise RuntimeError("Buildbot master requires at least Python-3.7")
+py_38 = sys.version_info[0] > 3 or (
+    sys.version_info[0] == 3 and sys.version_info[1] >= 8)
+if not py_38:
+    raise RuntimeError("Buildbot master requires at least Python-3.8")
 
 # pip<1.4 doesn't have the --pre flag, and will thus attempt to install alpha
 # and beta versions of Buildbot.  Prevent that from happening.

--- a/newsfragments/README.txt
+++ b/newsfragments/README.txt
@@ -8,6 +8,8 @@ towncrier has a few standard types of news fragments, signified by the file exte
 .bugfix: Signifying a bug fix.
 .doc: Signifying a documentation improvement.
 .removal: Signifying a deprecation or removal of public API.
+.change: Signifying a change of behavior
+.misc: Miscellaneous change
 
 The core of the filename can be the fixed issue number of any unique text relative to your work.
 Buildbot project does not require a tracking ticket to be made for each contribution even if this is appreciated.

--- a/newsfragments/min-python-3.8.removal
+++ b/newsfragments/min-python-3.8.removal
@@ -1,0 +1,2 @@
+Buildbot Master now requires Python 3.8 or newer.
+Python 3.7 is no longer supported.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,8 +5,7 @@
 buildbot-www==3.9.0
 
 autobahn==23.6.2;  python_version >= "3.9"
-autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: ignore
-autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
+autobahn==22.7.1;  python_version < "3.9"
 boto3==1.28.3
 flake8==6.1.0;  python_version >= "3.8.1"
 msgpack==1.0.5
@@ -35,21 +34,16 @@ chardet==5.2.0
 charset-normalizer==3.2.0
 click-default-group==1.2.4
 click==8.1.7
-configparser==5.2.0;  python_version < "3.7" # pyup: ignore (see: https://configparser.readthedocs.io/en/latest/history.html)
-configparser==5.3.0;  python_version >= "3.7" and python_version < "3.8" # pyup: ignore (see: https://configparser.readthedocs.io/en/latest/history.html)
-configparser==6.0.0;  python_version >= "3.8"
+configparser==6.0.0
 constantly==15.1.0
 cookies==2.2.1
-coverage==7.2.7;  python_version < "3.8"  # pyup: ignore (see: https://github.com/nedbat/coveragepy/releases/tag/7.3.0)
-coverage==7.3.0;  python_version >= "3.8"
+coverage==7.3.0
 croniter==1.4.1
 cryptography==41.0.3
 decorator==5.1.1
 dicttoxml==1.7.16
-dill==0.3.6;  python_version < "3.7" # pyup: ignore (see: https://github.com/uqfoundation/dill/releases/tag/dill-0.3.7)
-dill==0.3.7;  python_version >= "3.7"
-docker==5.0.3;  python_version < "3.7" # pyup: ignore (6.0.0 droppeded support for < Python 3.7 see: https://docker-py.readthedocs.io/en/stable/change-log.html#id8)
-docker==6.1.3;  python_version >= "3.7"
+dill==0.3.7
+docker==6.1.3
 docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
 extras==1.0.0
 fixtures==4.1.0
@@ -61,9 +55,7 @@ hvac==1.1.1
 hyperlink==21.0.0
 idna==2.10  # pyup: ignore (conflicts with moto on master)
 imagesize==1.4.1
-importlib-metadata==4.13.0;  python_version < "3.8"  # pyup: ignore
-importlib-metadata==6.8.0;  python_version >= "3.8"
-importlib-resources==5.12.0;  python_version < "3.8"
+importlib-metadata==6.8.0
 incremental==22.10.0
 ipaddress==1.0.23
 isort==4.3.21   # pyup: ignore (until https://github.com/PyCQA/pylint/pull/3725 is merged)
@@ -77,8 +69,7 @@ Mako==1.2.4
 markdown2==2.4.10
 MarkupSafe==2.1.3
 mccabe==0.7.0
-more-itertools==9.1.0;  python_version < "3.8" # pyup: ignore (see: https://pyup.io/packages/pypi/more-itertools/changelog)
-more-itertools==10.1.0;  python_version >= "3.8"
+more-itertools==10.1.0
 moto==4.1.14
 olefile==0.46
 packaging==23.1
@@ -86,19 +77,16 @@ parameterized==0.9.0
 pathlib2==2.3.7.post1
 pbr==5.11.1
 pep8==1.7.1
-Pillow==9.3.0;  python_version < "3.8"  # pyup: ignore
-Pillow==10.0.0;  python_version >= "3.8"
+Pillow==10.0.0
 platformdirs==3.10.0
 psutil==5.9.5
-pyaml==21.10.1;  python_version < "3.8"  # pyup: ignore
-pyaml==23.7.0;  python_version >= "3.8"
+pyaml==23.7.0
 pyasn1-modules==0.3.0
 pyasn1==0.5.0
 pycodestyle==2.11.0;  python_version >= "3.8.1"
 pycparser==2.21
 pyenchant==3.2.2
-pyflakes==3.0.1;  python_version < "3.8" # pyup: ignore (see: https://pyup.io/packages/pypi/pyflakes/changelog)
-pyflakes==3.1.0;  python_version >= "3.8"
+pyflakes==3.1.0
 PyJWT==2.8.0
 pyOpenSSL==23.2.0
 pyparsing==3.1.1
@@ -113,8 +101,7 @@ ruamel.yaml==0.17.32
 ruamel.yaml.clib==0.2.7
 s3transfer==0.6.2
 scandir==1.10.0
-service-identity==21.1.0;  python_version < "3.8"  # pyup: ignore
-service-identity==23.1.0;  python_version >= "3.8"
+service-identity==23.1.0
 setuptools-trial==0.6.0
 singledispatch==4.0.0
 six==1.16.0
@@ -139,8 +126,7 @@ unidiff==0.7.5
 urllib3==1.26.11  # pyup: ignore
 webcolors==1.13
 websocket-client==1.6.1
-Werkzeug==2.2.3;  python_version < "3.8"  # pyup: ignore
-Werkzeug==2.3.7;  python_version >= "3.8"
+Werkzeug==2.3.7
 wrapt==1.15.0
 xmltodict==0.13.0
 zope.interface==6.0


### PR DESCRIPTION
This removes support for Debian Buster which was released 2019-07-06, more than 4 years ago. Ubuntu 20.04 LTS has Python 3.8, Ubuntu 18.04 LTS has Python 3.6 which is alreay not supported and other popular
distributions have much newer versions of Python.

On non-Linux OS'es people install Python themselves most of the time, so this change does not affect them significantly.