### PR TITLE
github: Run builds on all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - master
   pull_request:
-    branches:
-    - master
 
 permissions:
   contents: read


### PR DESCRIPTION
Other release branches still needs to have builds.