### PR TITLE
master: Remove pkg_resources require()

### DIFF
--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -194,25 +194,17 @@ class _Plugins:
     represent plugins within a namespace
     """
 
-    def __init__(self, namespace, interface=None, check_extras=True):
+    def __init__(self, namespace, interface=None):
         if interface is not None:
             assert interface.isOrExtends(IPlugin)
 
         self._group = f'{_NAMESPACE_BASE}.{namespace}'
 
         self._interface = interface
-        self._check_extras = check_extras
-
         self._real_tree = None
 
     def _load_entry(self, entry):
         # pylint: disable=W0703
-        if self._check_extras:
-            try:
-                entry.require()
-            except Exception as e:
-                raise PluginDBError('Requirements are not satisfied '
-                                    f'for {self._group}:{entry.name}: {str(e)}') from e
         try:
             result = entry.load()
         except Exception as e:
@@ -289,8 +281,7 @@ class _PluginDB:
     def __init__(self):
         self._namespaces = {}
 
-    def add_namespace(self, namespace, interface=None, check_extras=True,
-                      load_now=False):
+    def add_namespace(self, namespace, interface=None, load_now=False):
         """
         register given namespace in global database of plugins
 
@@ -299,7 +290,7 @@ class _PluginDB:
         tempo = self._namespaces.get(namespace)
 
         if tempo is None:
-            tempo = _Plugins(namespace, interface, check_extras)
+            tempo = _Plugins(namespace, interface)
             self._namespaces[namespace] = tempo
 
         if load_now:
@@ -349,8 +340,8 @@ def info():
     return _DB.info()
 
 
-def get_plugins(namespace, interface=None, check_extras=True, load_now=False):
+def get_plugins(namespace, interface=None, load_now=False):
     """
     helper to get a direct interface to _Plugins
     """
-    return _DB.add_namespace(namespace, interface, check_extras, load_now)
+    return _DB.add_namespace(namespace, interface, load_now)

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -234,12 +234,6 @@ class TestBuildbotPlugins(unittest.TestCase):
         with assertProducesWarning(DeprecationWarning, "test warning"):
             _ = plugins.deep.path
 
-    def test_interface_provided_deps_failed(self):
-        plugins = db.get_plugins('interface_failed', interface=ITestInterface,
-                                 check_extras=True)
-        with self.assertRaises(PluginDBError):
-            plugins.get('good')
-
     def test_required_interface_not_provided(self):
         plugins = db.get_plugins('no_interface_again',
                                  interface=ITestInterface)
@@ -250,11 +244,6 @@ class TestBuildbotPlugins(unittest.TestCase):
     def test_no_interface_provided(self):
         plugins = db.get_plugins('no_interface')
         self.assertFalse(plugins.get('good') is None)
-
-    def test_no_interface_provided_deps_failed(self):
-        plugins = db.get_plugins('no_interface_failed', check_extras=True)
-        with self.assertRaises(PluginDBError):
-            plugins.get('good')
 
     def test_failure_on_dups(self):
         with self.assertRaises(PluginDBError):


### PR DESCRIPTION
This is a commit from https://github.com/buildbot/buildbot/pull/7035 in an attempt to fix tests. The tests currently fail with errors similar to what's caused by `https://github.com/jazzband/pip-tools/issues/1576`. The errors are unfortunately harder to reproduce than I have time for. Since we're removing the feature anyway, let's save some time by not investigating the root cause and just removing the feature.

The original description of the commit is below:

----

pkg_resources.require() has no substitute in importlib_metadata, so migration is not possible. Removing this function also requests removing the private member '_check_extras' of class _Plugins, as it has no more use cases and is irrelevant.
