### PR TITLE
master: Pin Twisted to 22.10 or older

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -487,7 +487,7 @@ if 'a' in version or 'b' in version:
         if parse_version(pip_dist.version) < parse_version('1.4'):
             raise RuntimeError(VERSION_MSG)
 
-twisted_ver = ">= 18.7.0"
+twisted_ver = ">= 18.7.0, <=22.10.0"
 
 bundle_version = version.split("-")[0]
 

--- a/newsfragments/pin-twisted.bugfix
+++ b/newsfragments/pin-twisted.bugfix
@@ -1,0 +1,1 @@
+Work around requirements parsing error for the Twisted dependency by pinning Twisted to 22.10 or older.


### PR DESCRIPTION
This works around the following exception:

Unhandled error in Deferred:

Traceback (most recent call last):
  File "/.../site-packages/buildbot/scripts/create_master.py", line 84, in createDB
    master = BuildMaster(config['basedir'])
  File "/.../site-packages/buildbot/master.py", line 102, in __init__
    self._services_d = self.create_child_services()
  File "/.../site-packages/twisted/internet/defer.py", line 2245, in unwindGenerator
    return _cancellableInlineCallbacks(gen)
  File "/.../site-packages/twisted/internet/defer.py", line 2157, in _cancellableInlineCallbacks
    _inlineCallbacks(None, gen, status, _copy_context())
--- <exception caught here> ---
  File "/.../site-packages/twisted/internet/defer.py", line 1997, in _inlineCallbacks
    result = context.run(gen.send, result)
  File "/.../site-packages/buildbot/master.py", line 188, in create_child_services
    self.www = wwwservice.WWWService()
  File "/.../site-packages/buildbot/www/service.py", line 196, in __init__
    self.apps = get_plugins('www', None, load_now=True)
  File "/.../site-packages/buildbot/plugins/db.py", line 356, in get_plugins
    return _DB.add_namespace(namespace, interface, check_extras, load_now)
  File "/.../site-packages/buildbot/plugins/db.py", line 306, in add_namespace
    tempo.load()
  File "/.../site-packages/buildbot/plugins/db.py", line 242, in load
    self._tree.load()
  File "/.../site-packages/buildbot/plugins/db.py", line 112, in load
    child.load()
  File "/.../site-packages/buildbot/plugins/db.py", line 45, in load
    self._value = self._loader(self._entry)
  File "/.../site-packages/buildbot/plugins/db.py", line 214, in _load_entry
    raise PluginDBError('Requirements are not satisfied '
buildbot.errors.PluginDBError: Requirements are not satisfied for buildbot.www:base: The 'zope-interface>=5' distribution was not found and is required by Twisted
