### PR TITLE
www/react/grid-view: fix link to Builder

### DIFF
--- a/newsfragments/react-grid-view-builder-link.bugfix
+++ b/newsfragments/react-grid-view-builder-link.bugfix
@@ -1,0 +1,1 @@
+Fix link to Builder in React Grid View.

--- a/www/react-grid_view/src/views/GridView/GridView.tsx
+++ b/www/react-grid_view/src/views/GridView/GridView.tsx
@@ -294,7 +294,7 @@ export const GridView = observer(() => {
     return (
       <tr key={builder.name}>
         <th>
-          <Link to={`/builders/{builder.builderid}`}>{builder.name}</Link>
+          <Link to={`/builders/${builder.builderid}`}>{builder.name}</Link>
         </th>
         <td>
           {filterManager.getElementsForTags(builder.tags)}


### PR DESCRIPTION
Just noticed a small mistake in a format string.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
