### PR TITLE
www/react: Fix logout link

### DIFF
--- a/www/react-base/src/components/Loginbar/Loginbar.tsx
+++ b/www/react-base/src/components/Loginbar/Loginbar.tsx
@@ -92,11 +92,9 @@ export const Loginbar = () => {
     <Nav className="bb-loginbar-dropdown-nav">
       <NavDropdown title={dropdownToggle} id="bb-loginbar-dropdown">
         {userDropdownHeader}
-        <NavDropdown.Item>
-          <a href={"auth/logout?redirect=" + encodeURI(redirect)}>
-            <FaSignOutAlt/>
-            Logout
-          </a>
+        <NavDropdown.Item href={"auth/logout?redirect=" + encodeURI(redirect)}>
+          <FaSignOutAlt/>
+          Logout
         </NavDropdown.Item>
       </NavDropdown>
     </Nav>


### PR DESCRIPTION
NavDropdown.Item is already an `<a>` element. Nesting `<a>` makes the actual link unclickable.