### PR TITLE
reporters: MailNotifier works correctly when SSL packages are installed

### DIFF
--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -332,11 +332,12 @@ class MailNotifier(ReporterBase):
 
         s = unicode2bytes(s)
         recipients = [parseaddr(r)[1] for r in recipients]
+        hostname = self.relayhost if self.useTls or useAuth else None
         sender_factory = ESMTPSenderFactory(
             unicode2bytes(self.smtpUser), unicode2bytes(self.smtpPassword),
             parseaddr(self.fromaddr)[1], recipients, BytesIO(s),
             result, requireTransportSecurity=self.useTls,
-            requireAuthentication=useAuth, hostname=self.relayhost)
+            requireAuthentication=useAuth, hostname=hostname)
 
         if self.useSmtps:
             reactor.connectSSL(self.relayhost, self.smtpPort,

--- a/newsfragments/mail-notifier-over-tls-only-when-configured-so.bugfix
+++ b/newsfragments/mail-notifier-over-tls-only-when-configured-so.bugfix
@@ -1,0 +1,1 @@
+``MailNotifier`` now works correctly when SSL packages are installed but ``useTls=False`` and auth (``smtpUser``, ``smtpPassword``) is not set. (:issue:`5609`)


### PR DESCRIPTION
``MailNotifier`` didn't work when it was configured to use plan TCP but SSL packages were installed (to support workers over TLS). This was due to creating client context for ``ESMTPSender`` when None was expected.

Fixes #5609



## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
