### PR TITLE
Release notes for 3.9.2

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -9,6 +9,16 @@ Release Notes
 .. towncrier release notes start
 
 
+Buildbot ``3.9.2`` ( ``2023-09-02`` )
+=====================================
+
+Bug fixes
+---------
+
+- Work around requirements parsing error for the Twisted dependency by pinning Twisted to 22.10 or older.
+  This fixes buildbot crash on startup when newest Twisted is installed.
+
+
 Buildbot ``3.9.1`` ( ``2023-09-02`` )
 =====================================
 

--- a/newsfragments/pin-twisted.bugfix
+++ b/newsfragments/pin-twisted.bugfix
@@ -1,1 +1,0 @@
-Work around requirements parsing error for the Twisted dependency by pinning Twisted to 22.10 or older.


### PR DESCRIPTION
This PR ports release notes for 3.9.2 from 3.9.x branch so that they stay in the documentation.