### PR TITLE
bugfix: add change files in BitbucketPullrequestPoller

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -17,6 +17,8 @@
 import time
 from datetime import datetime
 
+from unidiff import PatchSet
+
 from twisted.internet import defer
 from twisted.python import log
 
@@ -159,6 +161,18 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
                     revision = commit_json['hash']
                     revlink = commit_json['links']['html']['href']
 
+                    # Retrieve the list of added/modified files in the commit
+                    response = yield self._http.get(
+                        str(commit_json['links']['diff']['href'])
+                    )
+                    content = yield response.content()
+                    patchset = PatchSet(content.decode())
+                    files = [
+                        file.path
+                        for file in patchset
+                        if file.is_added_file or file.is_modified_file
+                    ]
+
                     # parse repo api page
                     response = yield self._http.get(
                         str(pr['source']['repository']['links']['self']['href'])
@@ -185,6 +199,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
                                     **self.extractProperties(pr),
                                     },
                         src='bitbucket',
+                        files=files,
                     )
 
     def _getCurrentRev(self, pr_id):

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -31,11 +31,13 @@ class SourceRest():
     """https://api.bitbucket.org/2.0/repositories/{owner}/{slug}"""
     template = """\
 {
-
     "hash": "%(hash)s",
     "links": {
         "html": {
             "href": "https://bitbucket.org/%(owner)s/%(slug)s/commits/%(short_hash)s"
+        },
+        "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/%(owner)s/%(slug)s/diff/%(hash)s"
         }
     },
     "repository": {
@@ -79,6 +81,17 @@ class SourceRest():
             "owner": self.owner,
             "slug": self.slug,
         }
+
+    def diff_response(self):
+        return """
+diff --git a/path/to/a/file.txt b/path/to/a/file.txt
+index 3e59caa..be38dcf 100644
+--- a/path/to/a/file.txt
++++ b/path/to/a/file.txt
+@@ -1 +1 @@
+-// header
++// Header
+"""
 
 
 class PullRequestRest():
@@ -377,6 +390,12 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/1111111111111111111111111111111111111111', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response()
+        )
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=self.rest_src.repo_response())
 
@@ -389,7 +408,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'category': None,
             'codebase': None,
             'comments': 'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-            'files': None,
+            'files': ['path/to/a/file.txt'],
             'project': '',
             'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
             'repository': 'https://bitbucket.org/contributor/slug',
@@ -420,6 +439,12 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/1111111111111111111111111111111111111111', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response()
+        )
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=self.rest_src.repo_response())
 
@@ -437,7 +462,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'category': None,
             'codebase': None,
             'comments': 'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-            'files': None,
+            'files': ['path/to/a/file.txt'],
             'project': '',
             'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
             'repository': 'https://bitbucket.org/contributor/slug',
@@ -493,6 +518,12 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/1111111111111111111111111111111111111111', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response()
+        )
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=self.rest_src.repo_response())
 
@@ -513,6 +544,11 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/2222222222222222222222222222222222222222', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response())
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=rest_src2.repo_response())
 
@@ -525,7 +561,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'category': None,
             'codebase': None,
             'comments': 'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-            'files': None,
+            'files': ['path/to/a/file.txt'],
             'project': '',
             'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
             'repository': 'https://bitbucket.org/contributor/slug',
@@ -547,7 +583,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
                 'codebase': None,
                 'comments':
                     'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-                'files': None,
+                'files': ['path/to/a/file.txt'],
                 'project': '',
                 'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
                 'repository': 'https://bitbucket.org/contributor/slug',
@@ -564,7 +600,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
                 'codebase': None,
                 'comments':
                     'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-                'files': None,
+                'files': ['path/to/a/file.txt'],
                 'project': '',
                 'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
                 'repository': 'https://bitbucket.org/contributor/slug',
@@ -615,6 +651,12 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/1111111111111111111111111111111111111111', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response()
+        )
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=self.rest_src.repo_response())
 
@@ -627,7 +669,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'category': None,
             'codebase': None,
             'comments': 'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-            'files': None,
+            'files': ['path/to/a/file.txt'],
             'project': '',
             'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
             'repository': 'https://bitbucket.org/contributor/slug',
@@ -658,6 +700,12 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/1111111111111111111111111111111111111111', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response()
+        )
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=self.rest_src.repo_response())
 
@@ -671,7 +719,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'category': None,
             'codebase': None,
             'comments': 'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-            'files': None,
+            'files': ['path/to/a/file.txt'],
             'project': '',
             'properties': {'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1'},
             'repository': 'https://bitbucket.org/contributor/slug',
@@ -703,6 +751,12 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
 
         self._http.expect(
             'get',
+            'https://api.bitbucket.org/2.0/repositories/contributor/slug/diff/1111111111111111111111111111111111111111', # noqa pylint: disable=line-too-long
+            content=self.rest_src.diff_response()
+        )
+
+        self._http.expect(
+            'get',
             'https://api.bitbucket.org/2.0/repositories/contributor/slug',
             content=self.rest_src.repo_response())
 
@@ -714,7 +768,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin,
             'category': None,
             'codebase': None,
             'comments': 'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
-            'files': None,
+            'files': ['path/to/a/file.txt'],
             'project': '',
             'properties': {
                 'pullrequesturl': 'https://bitbucket.org/owner/slug/pull-request/1',

--- a/master/setup.py
+++ b/master/setup.py
@@ -486,7 +486,8 @@ setup_args['install_requires'] = [
     "txaio >= 2.2.2",
     "autobahn >= 0.16.0",
     'PyJWT',
-    'pyyaml'
+    'pyyaml',
+    'unidiff >= 0.7.5',
 ]
 
 # buildbot_windows_service needs pywin32

--- a/newsfragments/bitbucket-pull-request-poller.bugfix
+++ b/newsfragments/bitbucket-pull-request-poller.bugfix
@@ -1,0 +1,1 @@
+``buildbot.changes.bitbucket.BitbucketPullrequestPoller`` has been updated to emit the change files.


### PR DESCRIPTION
This is a port of https://github.com/buildbot/buildbot/pull/7062 with a trivial issue fixed.

This commit adds support for passing the modified files to the emitted change. There isn't a direct way to do this in the Bitbucket RESET API so this fix grabs the commit diff and parses that.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
