### PR TITLE
e2e: Increase assertion timeout for React tests

### DIFF
--- a/smokes-react/playwright.config.ts
+++ b/smokes-react/playwright.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
     testIdAttribute: 'data-bb-test-id'
   },
 
+  expect: {
+    timeout: 15000
+  },
+
   /* Configure projects for major browsers */
   projects: [
     {


### PR DESCRIPTION
This should reduce test instability. The instability is otherwise normal because the tests are run on machines with oversubscribed CPU. 