### PR TITLE
p4: use p4client name in sync commands instead of p4base

### DIFF
--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -167,14 +167,14 @@ class P4(Source):
         # Then we need to sync the client
         if self.revision:
             if self.debug:
-                log.msg("P4: full() sync command based on :base:%s changeset:%d",
-                        self._getP4BaseForLog(), int(self.revision))
-            yield self._dovccmd(['sync', f'{self._getP4BaseForCommand()}...@{int(self.revision)}'],
+                log.msg("P4: full() sync command based on :client:%s changeset:%d",
+                        self.p4client, int(self.revision))
+            yield self._dovccmd(['sync', f'//{self.p4client}/...@{int(self.revision)}'],
                                 collectStdout=True)
         else:
             if self.debug:
-                log.msg("P4: full() sync command based on :base:%s no revision",
-                        self._getP4BaseForLog())
+                log.msg("P4: full() sync command based on :client:%s no revision",
+                        self.p4client)
             yield self._dovccmd(['sync'], collectStdout=True)
 
         if self.debug:
@@ -192,18 +192,12 @@ class P4(Source):
         command = ['sync', ]
 
         if self.revision:
-            command.extend([f'{self._getP4BaseForCommand()}...@{int(self.revision)}'])
+            command.extend([f'//{self.p4client}/...@{int(self.revision)}'])
 
         if self.debug:
             log.msg(
                 "P4:incremental() command:%s revision:%s", command, self.revision)
         yield self._dovccmd(command)
-
-    def _getP4BaseForLog(self):
-        return self.p4base or '<custom viewspec>'
-
-    def _getP4BaseForCommand(self):
-        return self.p4base or ''
 
     def _buildVCCommand(self, doCommand):
         assert doCommand, "No command specified"

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -151,7 +151,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-P', ('obfuscated', 'pass', 'XXXXXX'),
-                                 '-c', 'p4_client1', 'sync', '//depot...@100'])
+                                 '-c', 'p4_client1', 'sync', '//p4_client1/...@100'])
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',

--- a/newsfragments/p4-sync-use-client-name.bugfix
+++ b/newsfragments/p4-sync-use-client-name.bugfix
@@ -1,0 +1,1 @@
+- `P4` step now use the rev-spec format `//{p4client}/...@{revision}` when syncing with a revision


### PR DESCRIPTION
p4base is required to not have a trailing slash and no slash was provided between p4base and '...'
Since the client can be created with custom views or a base and branch, easiest way to sync is simply use the client name and let Perforce handle things.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
