### PR TITLE
p4: fix got_revision not taking into account changelist only deleting files

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1691,3 +1691,4 @@ yieldmetricsvalue
 za
 zadka
 zope
+ztag

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -146,6 +146,9 @@ class P4(Source):
         if self.use_tickets and self.p4passwd:
             yield self._acquireTicket()
 
+        # First we need to create the client
+        yield self._createClientSpec()
+
         yield self._getAttrGroupMember('mode', self.mode)()
         yield self.parseGotRevision()
         return results.SUCCESS
@@ -154,9 +157,6 @@ class P4(Source):
     def mode_full(self):
         if self.debug:
             log.msg("P4:full()..")
-
-        # First we need to create the client
-        yield self._createClientSpec()
 
         # Then p4 sync #none
         yield self._dovccmd(['sync', '#none'])
@@ -184,9 +184,6 @@ class P4(Source):
     def mode_incremental(self):
         if self.debug:
             log.msg("P4:incremental()")
-
-        # First we need to create the client
-        yield self._createClientSpec()
 
         # and plan to do a checkout
         command = ['sync', ]

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -114,7 +114,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
         self.setup_step(P4(p4port='localhost:12000', mode='incremental',
                           p4base='//depot', p4branch='trunk',
                           p4user='user', p4client='p4_client1', p4passwd='pass'),
-                       {"revision": '100'})
+                       {"revision": '101'})
 
         root_dir = '/home/user/workspace/wkdir'
         if _is_windows:
@@ -151,14 +151,15 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-P', ('obfuscated', 'pass', 'XXXXXX'),
-                                 '-c', 'p4_client1', 'sync', '//p4_client1/...@100'])
+                                 '-c', 'p4_client1', '-ztag', 'changes',
+                                 '-m1', '//p4_client1/...@101'])
+            .stdout("... change 100")
             .exit(0),
             ExpectShell(workdir='wkdir',
                         command=['p4', '-p', 'localhost:12000', '-u', 'user',
                                  '-P', ('obfuscated', 'pass', 'XXXXXX'),
-                                 '-c', 'p4_client1', 'changes', '-m1', '#have'])
-            .stdout("Change 100 on 2013/03/21 by user@machine \'duh\'")
-            .exit(0)
+                                 '-c', 'p4_client1', 'sync', '//p4_client1/...@100'])
+            .exit(0),
         )
         self.expect_outcome(result=SUCCESS)
         self.expect_property('got_revision', '100', 'P4')
@@ -182,17 +183,18 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
             .exit(0),
             ExpectShell(workdir=workdir,
                         timeout=timeout,
-                        command=(['p4', '-p', 'localhost:12000', '-u', 'user',
-                                  '-P', ('obfuscated', 'pass', 'XXXXXX'), '-c', 'p4_client1']
-                                 + extra_args + ['sync']))
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
+                                 '-c', 'p4_client1', '-ztag', 'changes',
+                                 '-m1', '//p4_client1/...#head'])
+            .stdout("... change 100")
             .exit(0),
             ExpectShell(workdir=workdir,
                         timeout=timeout,
-                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
-                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
-                                 '-c', 'p4_client1', 'changes', '-m1', '#have'])
-            .stdout("Change 100 on 2013/03/21 by user@machine \'duh\'")
-            .exit(0)
+                        command=(['p4', '-p', 'localhost:12000', '-u', 'user',
+                                  '-P', ('obfuscated', 'pass', 'XXXXXX'), '-c', 'p4_client1']
+                                 + extra_args + ['sync', '//p4_client1/...@100']))
+            .exit(0),
         )
         self.expect_outcome(result=SUCCESS)
         self.expect_property('got_revision', '100', 'P4')
@@ -511,6 +513,13 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
             .exit(0),
             ExpectShell(workdir=workdir,
                         command=['p4', '-p', 'localhost:12000', '-u', p4user,
+                                 '-P', expected_pass,
+                                 '-c', p4client, '-ztag', 'changes',
+                                 '-m1', f'//{p4client}/...#head'])
+            .stdout("... change 100")
+            .exit(0),
+            ExpectShell(workdir=workdir,
+                        command=['p4', '-p', 'localhost:12000', '-u', p4user,
                                  '-P', expected_pass, '-c', p4client]
                         + extra_args
                         + ['sync', '#none'])
@@ -522,14 +531,8 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
             ExpectShell(workdir=workdir,
                         command=['p4', '-p', 'localhost:12000', '-u', p4user,
                                  '-P', expected_pass, '-c', p4client]
-                        + extra_args + ['sync'])
+                        + extra_args + ['sync', f'//{p4client}/...@100'])
             .exit(0),
-            ExpectShell(workdir=workdir,
-                        command=['p4', '-p', 'localhost:12000', '-u', p4user,
-                                 '-P', expected_pass, '-c', p4client,
-                                 'changes', '-m1', '#have'])
-            .stdout("Change 100 on 2013/03/21 by user@machine \'duh\'")
-            .exit(0)
         )
         self.expect_outcome(result=SUCCESS)
         self.expect_property('got_revision', '100', 'P4')
@@ -1027,14 +1030,15 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin,
                         initial_stdin=client_spec)
             .exit(0),
             ExpectShell(workdir='wkdir',
-                        command=(['p4', '-p', 'localhost:12000', '-u', 'user',
-                                  '-c', 'p4_client1', 'sync']))
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-c', 'p4_client1', '-ztag', 'changes',
+                                 '-m1', '//p4_client1/...#head'])
+            .stdout("... change 100")
             .exit(0),
             ExpectShell(workdir='wkdir',
-                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
-                                 '-c', 'p4_client1', 'changes', '-m1', '#have'])
-            .stdout("Change 100 on 2013/03/21 by user@machine \'duh\'")
-            .exit(0)
+                        command=(['p4', '-p', 'localhost:12000', '-u', 'user',
+                                  '-c', 'p4_client1', 'sync', '//p4_client1/...@100']))
+            .exit(0),
         )
         self.expect_outcome(result=SUCCESS)
         return self.run_step()

--- a/newsfragments/p4-sync-correct-got-revision-on-deletion-changelist.bugfix
+++ b/newsfragments/p4-sync-correct-got-revision-on-deletion-changelist.bugfix
@@ -1,0 +1,1 @@
+- `P4` now reports the correct `got_revision` when syncing a changelist that only delete files


### PR DESCRIPTION
This is built onto #7108 so I'll leave this in draft until it's resolved.

This PR's goal is to fix the `got_revision` in the following situation.

Let's assume a Perforce changelist 99 which does file modification/addition/etc.
And a Changelist 100 which only remove files.

The current code will correctly sync changelist 100.
However, `p4 changes -m1 #have` will return changelist 99 as there is no files from changelist 100 in the client's havelist.

To circumvent this, I retrieve the current change seen by the client specs with `p4 changes -m1 //{p4client}/...` (with an optionally given target revision), then use this to sync at the given revision which will be used to set `got_revision`.

Since I needed a client for this, I moved the client creation out of the `mode_` functions, which could be considered a breaking change. Let me know if this is an issue.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
