### PR TITLE
www/react: fix BasicDataMultiCollection getRelatedOfFiltered when filteredIds arg is an empty array

### DIFF
--- a/www/react-data-module/src/data/BasicDataMultiCollection.ts
+++ b/www/react-data-module/src/data/BasicDataMultiCollection.ts
@@ -26,7 +26,7 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
   accessor: IDataAccessor;
   parentArray: IObservableArray<ParentDataType> | null;
   parentArrayMap: ObservableMap<string, DataCollection<ParentDataType>> | null;
-  parentFilteredIds: IObservableArray<string>;
+  parentFilteredIds: IObservableArray<string> | null;
 
   @observable byParentId = observable.map<string, Collection>();
   @observable sortedParentIds = observable.array<string>();
@@ -43,14 +43,14 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
     this.accessor = accessor;
     this.parentArray = parentArray;
     this.parentArrayMap = parentArrayMap;
-    this.parentFilteredIds = parentFilteredIds ?? observable([]);
+    this.parentFilteredIds = parentFilteredIds;
 
     this.callback = callback;
     if (parentArray !== null) {
       this.disposer = autorun(() => {
         const newParentIds = new Set<string>();
         for (let parent of this.parentArray!) {
-          if (this.parentFilteredIds.length > 0 && this.parentFilteredIds.indexOf(parent.id) < 0) {
+          if (this.parentFilteredIds !== null && this.parentFilteredIds.indexOf(parent.id) < 0) {
             continue;
           }
 
@@ -71,7 +71,7 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
         const newParentIds = new Set<string>();
         for (const parentList of this.parentArrayMap!.values()) {
           for (const parent of parentList.array) {
-            if (this.parentFilteredIds.length > 0 && this.parentFilteredIds.indexOf(parent.id) < 0) {
+            if (this.parentFilteredIds !== null && this.parentFilteredIds.indexOf(parent.id) < 0) {
               continue;
             }
 


### PR DESCRIPTION
#7099 fixed getRelatedOfFiltered but I was a bit too quick and didn't notice another issue.
When provided with an empty array (which can happen easily), it should not query any child.
Default value for `filteredIds` is now `null`.

## Contributor Checklist:

* [X] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
