### PR TITLE
Report timeouts

### DIFF
--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -59,6 +59,7 @@ class RemoteCommand(base.RemoteCommandImpl):
         self.stdioLogName = stdioLogName
         self._startTime = None
         self._remoteElapsed = None
+        self.remote_failure_reason = None
         self.remote_command = remote_command
         self.args = args
         self.ignore_updates = ignore_updates
@@ -366,9 +367,11 @@ class RemoteCommand(base.RemoteCommandImpl):
             yield self.add_header_lines(f"program finished with exit code {rc}\n")
         if key == "elapsed":
             self._remoteElapsed = value
+        if key == "failure_reason":
+            self.remote_failure_reason = value
 
         # TODO: these should be handled at the RemoteCommand level
-        if key not in ('stdout', 'stderr', 'header', 'rc'):
+        if key not in ('stdout', 'stderr', 'header', 'rc', "failure_reason"):
             if key not in self.updates:
                 self.updates[key] = []
             self.updates[key].append(value)

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -518,6 +518,8 @@ class Test(WarningCountingShellCommand):
                 summary = join_list(description)
                 if self.results != SUCCESS:
                     summary += f' ({statusToString(self.results)})'
+                    if self.timed_out:
+                        summary += " (timed out)"
                 return {'step': summary}
 
         return super().getResultSummary()

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -168,5 +168,7 @@ class SubunitShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
 
         if self.results != SUCCESS:
             summary += f' ({statusToString(self.results)})'
+            if self.timed_out:
+                summary += " (timed out)"
 
         return {'step': summary}

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -206,6 +206,8 @@ class VisualStudio(buildstep.ShellMixin, buildstep.BuildStep):
 
         if self.results != results.SUCCESS:
             description += f' ({results.statusToString(self.results)})'
+            if self.timed_out:
+                description += " (timed out)"
 
         return {'step': description}
 

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -15,6 +15,8 @@
 
 from unittest import mock
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import reactor
@@ -773,6 +775,16 @@ class TestBuildStep(TestBuildStepMixin, config.ConfigErrorsMixin,
         self.checkSummary((yield st.getBuildResultSummary()), 'fooing (skipped)')
         self.checkSummary(st.getResultSummary(), 'fooing (skipped)')
 
+    @defer.inlineCallbacks
+    def test_getResultSummary_description_failure_timed_out(self):
+        st = buildstep.BuildStep()
+        st.results = FAILURE
+        st.description = "fooing"
+        st.timed_out = True
+        self.checkSummary((yield st.getBuildResultSummary()), "fooing (failure) (timed out)",
+                          "fooing (failure) (timed out)")
+        self.checkSummary(st.getResultSummary(), "fooing (failure) (timed out)")
+
     # Test calling checkWorkerHasCommand() when worker have support for
     # requested remote command.
     def testcheckWorkerHasCommandGood(self):
@@ -1388,6 +1400,18 @@ class TestShellMixin(TestBuildStepMixin,
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="'foo BAR'")
+        yield self.run_step()
+
+    @parameterized.expand(["timeout", "timeout_without_output"])
+    @defer.inlineCallbacks
+    def test_description_timed_out(self, failure_reason):
+        self.setup_step(SimpleShellCommand(command=["foo"]))
+        self.expect_commands(
+            ExpectShell(workdir="wkdir", command=["foo"])
+            .update("failure_reason", failure_reason)
+            .exit(1)
+        )
+        self.expect_outcome(result=FAILURE, state_string="'foo' (failure) (timed out)")
         yield self.run_step()
 
     def test_getResultSummary(self):

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -188,6 +188,10 @@ BuildStep
         If false, then the step is running.
         If true, the step is not running, or has been interrupted.
 
+    .. py:attribute:: timed_out
+
+        If ``True``, then one or more remote commands of the step timed out.
+
     A step can indicate its up-to-the-moment status using a short summary string.
     These methods allow step subclasses to produce such summaries.
 

--- a/master/docs/developer/master-worker-msgpack.rst
+++ b/master/docs/developer/master-worker-msgpack.rst
@@ -824,6 +824,11 @@ Runs a ``shell`` command on the worker.
     If command succeeded, worker sends ``rc`` value 0 as an ``update`` message ``args`` key-value pair.
     It can also send many other ``update`` messages with keys such as ``header``, ``stdout`` or ``stderr`` to inform about command execution.
     If command failed, it sends ``rc`` value with the error number.
+    If command timed out, it sends ``failure_reason`` key.
+    The value of the ``failure_reason`` key can be one of the following:
+
+     - ``timeout`` if the command timed out due to time specified by the ``maxTime`` parameter being exceeded.
+     - ``timeout_without_output`` if the command timed out due to time specified by the ``timeout`` parameter being exceeded.
 
     The basic structure of worker ``update`` message is explained in section :ref:`MsgPack_Keys_And_Values_Message`.
 
@@ -1146,6 +1151,14 @@ Commands may have their own update names so only common ones are described here.
     It represents an exit code of a process.
     0 if the process exit was successful.
     Any other number represents a failure.
+
+``failure_reason``
+
+    Value is a string and describes additional scenarios when a process failed.
+    The value of the ``failure_reason`` key can be one of the following:
+
+     - ``timeout`` if the command timed out due to time specified by the ``maxTime`` parameter being exceeded.
+     - ``timeout_without_output`` if the command timed out due to time specified by the ``timeout`` parameter being exceeded.
 
 ``header``
     Value is a string of a header.

--- a/master/docs/developer/master-worker.rst
+++ b/master/docs/developer/master-worker.rst
@@ -299,6 +299,14 @@ The ``shell`` command sends the following updates:
     0 indicates success and any nonzero value is considered a failure.  No
     further updates should be sent after an ``rc``.
 
+``failure_reason``
+
+    Value is a string and describes additional scenarios when a process failed.
+    The value of the ``failure_reason`` key can be one of the following:
+
+     - ``timeout`` if the command timed out due to time specified by the ``maxTime`` parameter being exceeded.
+     - ``timeout_without_output`` if the command timed out due to time specified by the ``timeout`` parameter being exceeded.
+
 ``log``
 
     This update contains data for a logfile other than stdio.  The data

--- a/newsfragments/step-report-timeout.feature
+++ b/newsfragments/step-report-timeout.feature
@@ -1,0 +1,1 @@
+Improved step result reporting to specify whether step failed due to a time out.

--- a/newsfragments/worker-failure-reason.feature
+++ b/newsfragments/worker-failure-reason.feature
@@ -1,0 +1,1 @@
+Worker now sends `failure_reason` update when the command it was running timed out.

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -26,7 +26,7 @@ from buildbot_worker.exceptions import AbandonChain
 from buildbot_worker.interfaces import IWorkerCommand
 
 # The following identifier should be updated each time this file is changed
-command_version = "3.1"
+command_version = "3.2"
 
 # version history:
 #  >=1.17: commands are interruptable
@@ -70,6 +70,7 @@ command_version = "3.1"
 #    * "slavedest" command argument renamed to "workerdest" in downloadFile
 #      command.
 #  >= 3.1: rmfile command added to remove a file
+#  >= 3.2: shell command now reports failure reason in case the command timed out.
 
 
 @implementer(IWorkerCommand)

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -698,12 +698,14 @@ class RunProcess(object):
         msg = (
             "command timed out: {0} seconds without output running {1}".format(
             self.timeout, self.fake_command))
+        self.send_update([("failure_reason", "timeout_without_output")])
         self.kill(msg)
 
     def doMaxTimeout(self):
         self.maxTimeoutTimer = None
         msg = "command timed out: {0} seconds elapsed running {1}".format(
             self.maxTime, self.fake_command)
+        self.send_update([("failure_reason", "timeout")])
         self.kill(msg)
 
     def isDead(self):

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -306,6 +306,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         self.assertTrue(('stdout', nl('hello\n')) not in self.updates, self.show())
         self.assertTrue(('rc', FATAL_RC) in self.updates, self.show())
+        self.assertTrue(("failure_reason", "timeout_without_output") in self.updates, self.show())
 
     @defer.inlineCallbacks
     def testCommandMaxTime(self):
@@ -320,6 +321,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         self.assertTrue(('stdout', nl('hello\n')) not in self.updates, self.show())
         self.assertTrue(('rc', FATAL_RC) in self.updates, self.show())
+        self.assertTrue(("failure_reason", "timeout") in self.updates, self.show())
 
     @compat.skipUnlessPlatformIs("posix")
     @defer.inlineCallbacks


### PR DESCRIPTION
This PR implements timeout condition reporting from worker up to the build and step status strings in the database and web UI.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
