### PR TITLE
Add command ID to worker logs

### DIFF
--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -54,6 +54,7 @@ class ProtocolCommandBase:
         self.builder_is_running = builder_is_running
         self.on_command_complete = on_command_complete
         self.on_lost_remote_step = on_lost_remote_step
+        self.command_id = command_id
 
         self.protocol_args_setup(command, args)
 

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -140,9 +140,9 @@ class Command(object):
 
     _reactor = reactor
 
-    def __init__(self, protocol_command, stepId, args):
+    def __init__(self, protocol_command, command_id, args):
         self.protocol_command = protocol_command
-        self.stepId = stepId  # just for logging
+        self.command_id = command_id  # just for logging
         self.args = args
         self.startTime = None
 

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -152,6 +152,9 @@ class Command(object):
                              self.__class__.__name__, ", ".join(missingArgs)))
         self.setup(args)
 
+    def log_msg(self, msg, *args):
+        log.msg(u"(command {0}): {1}".format(self.command_id, msg), *args)
+
     def setup(self, args):
         """Override this in a subclass to extract items from the args dict."""
 
@@ -178,9 +181,9 @@ class Command(object):
     def sendStatus(self, status):
         """Send a status update to the master."""
         if self.debug:
-            log.msg("sendStatus", status)
+            self.log_msg("sendStatus: {0}".format(status))
         if not self.running:
-            log.msg("would sendStatus but not .running")
+            self.log_msg("would sendStatus but not .running")
             return
         self.protocol_command.send_update(status)
 
@@ -197,8 +200,7 @@ class Command(object):
 
     def _abandonOnFailure(self, rc):
         if not isinstance(rc, int):
-            log.msg("weird, _abandonOnFailure was given rc={0} ({1})".format(
-                    rc, type(rc)))
+            self.log_msg("weird, _abandonOnFailure was given rc={0} ({1})".format(rc, type(rc)))
         assert isinstance(rc, int)
         if rc != 0:
             raise AbandonChain(rc)
@@ -208,8 +210,8 @@ class Command(object):
         self.sendStatus([('rc', 0)])
 
     def _checkAbandoned(self, why):
-        log.msg("_checkAbandoned", why)
+        self.log_msg("_checkAbandoned", why)
         why.trap(AbandonChain)
-        log.msg(" abandoning chain", why.value)
+        self.log_msg(" abandoning chain", why.value)
         self.sendStatus([('rc', why.value.args[0])])
         return None

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -107,7 +107,7 @@ class RemoveDirectory(base.Command):
     def _clobber(self, dummy, path, chmodDone=False):
         command = ["rm", "-rf", path]
 
-        c = runprocess.RunProcess(command, self.protocol_command.worker_basedir,
+        c = runprocess.RunProcess(self.command_id, command, self.protocol_command.worker_basedir,
                                   self.protocol_command.unicode_encoding,
                                   self.protocol_command.send_update,
                                   sendRC=0, timeout=self.timeout, maxTime=self.maxTime,
@@ -140,7 +140,7 @@ class RemoveDirectory(base.Command):
             # permission) by running 'find' instead
             command = ["find", path, '-exec', 'chmod', 'u+rwx', '{}', ';']
 
-        c = runprocess.RunProcess(command, self.protocol_command.worker_basedir,
+        c = runprocess.RunProcess(self.command_id, command, self.protocol_command.worker_basedir,
                                   self.protocol_command.unicode_encoding,
                                   self.protocol_command.send_update,
                                   sendRC=0, timeout=self.timeout, maxTime=self.maxTime,
@@ -199,7 +199,8 @@ class CopyDirectory(base.Command):
             else:
                 command = ['cp', '-R', '-P', '-p', '-v', from_path, to_path]
 
-            c = runprocess.RunProcess(command, self.protocol_command.worker_basedir,
+            c = runprocess.RunProcess(self.command_id, command,
+                                      self.protocol_command.worker_basedir,
                                       self.protocol_command.unicode_encoding,
                                       self.protocol_command.send_update,
                                       sendRC=False, timeout=self.timeout,

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -24,7 +24,6 @@ import sys
 
 from twisted.internet import defer
 from twisted.internet import threads
-from twisted.python import log
 from twisted.python import runtime
 
 from buildbot_worker import runprocess
@@ -47,7 +46,7 @@ class MakeDirectory(base.Command):
                 if not os.path.isdir(dirname):
                     os.makedirs(dirname)
             except OSError as e:
-                log.msg("MakeDirectory {0} failed: {1}".format(dirname, e))
+                self.log_msg("MakeDirectory {0} failed: {1}".format(dirname, e))
                 self.sendStatus([
                     ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, dirname)),
                     ('rc', e.errno)
@@ -192,8 +191,8 @@ class CopyDirectory(base.Command):
                 os.makedirs(os.path.dirname(to_path))
             if os.path.exists(to_path):
                 # I don't think this happens, but just in case..
-                log.msg(("cp target '{0}' already exists -- cp will not do what you think!"
-                         ).format(to_path))
+                self.log_msg(("cp target '{0}' already exists -- cp will not do what you think!"
+                              ).format(to_path))
 
             if platform.system().lower().find('solaris') >= 0:
                 command = ['cp', '-R', '-P', '-p', from_path, to_path]
@@ -228,7 +227,7 @@ class StatFile(base.Command):
             stat = os.stat(filename)
             self.sendStatus([('stat', tuple(stat)), ('rc', 0)])
         except OSError as e:
-            log.msg("StatFile {0} failed: {1}".format(filename, e))
+            self.log_msg("StatFile {0} failed: {1}".format(filename, e))
             self.sendStatus([
                 ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, filename)),
                 ('rc', e.errno)
@@ -253,7 +252,7 @@ class GlobPath(base.Command):
                 files = glob.glob(pathname)
             self.sendStatus([('files', files), ('rc', 0)])
         except OSError as e:
-            log.msg("GlobPath {0} failed: {1}".format(pathname, e))
+            self.log_msg("GlobPath {0} failed: {1}".format(pathname, e))
             self.sendStatus([
                 ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, pathname)),
                 ('rc', e.errno)
@@ -274,7 +273,7 @@ class ListDir(base.Command):
             files = os.listdir(dirname)
             self.sendStatus([('files', files), ('rc', 0)])
         except OSError as e:
-            log.msg("ListDir {0} failed: {1}".format(dirname, e))
+            self.log_msg("ListDir {0} failed: {1}".format(dirname, e))
             self.sendStatus([
                 ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, dirname)),
                 ('rc', e.errno)
@@ -295,7 +294,7 @@ class RemoveFile(base.Command):
             os.remove(pathname)
             self.sendStatus([('rc', 0)])
         except OSError as e:
-            log.msg("remove file {0} failed: {1}".format(pathname, e))
+            self.log_msg("remove file {0} failed: {1}".format(pathname, e))
             self.sendStatus([
                 ('header', '{0}: {1}: {2}'.format(self.header, e.strerror, pathname)),
                 ('rc', e.errno)

--- a/worker/buildbot_worker/commands/shell.py
+++ b/worker/buildbot_worker/commands/shell.py
@@ -29,6 +29,7 @@ class WorkerShellCommand(base.Command):
         workdir = args['workdir']
 
         c = runprocess.RunProcess(
+            self.command_id,
             args['command'],
             workdir,
             self.protocol_command.unicode_encoding,

--- a/worker/buildbot_worker/interfaces.py
+++ b/worker/buildbot_worker/interfaces.py
@@ -30,11 +30,11 @@ class IWorkerCommand(Interface):
     subclasses. It specifies how the worker can start, interrupt, and
     query the various Commands running on behalf of the buildmaster."""
 
-    def __init__(builder, stepId, args):
+    def __init__(builder, command_id, args):
         """Create the Command. 'builder' is a reference to the parent
         buildbot_worker.base.WorkerForBuilderBase instance, which will be
         used to send status updates (by calling builder.sendStatus).
-        'stepId' is a random string which helps correlate worker logs with
+        'command_id' is a random string which helps correlate worker logs with
         the master. 'args' is a dict of arguments that comes from the
         master-side BuildStep, with contents that are specific to the
         individual Command subclass.

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -67,7 +67,6 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
                                      builder_is_running, on_command_complete, None, command,
                                      command_id, args)
         self.protocol = protocol
-        self.command_id = command_id
 
     def protocol_args_setup(self, command, args):
         if "want_stdout" in args:

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -289,7 +289,7 @@ class WorkerForBuilderPbLike(WorkerForBuilderBase):
                                                      self.lostRemoteStep, command, command_id, args,
                                                      command_ref)
 
-        log.msg(u" startCommand:{0} [id {1}]".format(command, command_id))
+        log.msg(u"(command {0}): startCommand:{1}".format(command_id, command))
         self.protocol_command.protocol_notify_on_disconnect()
         d = self.protocol_command.command.doStart()
         d.addCallback(lambda res: None)
@@ -298,7 +298,7 @@ class WorkerForBuilderPbLike(WorkerForBuilderBase):
 
     def remote_interruptCommand(self, command_id, why):
         """Halt the current step."""
-        log.msg("asked to interrupt current command: {0}".format(why))
+        log.msg("(command {0}): asked to interrupt: reason {1}".format(command_id, why))
         if not self.protocol_command:
             # TODO: just log it, a race could result in their interrupting a
             # command that wasn't actually running

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -56,13 +56,13 @@ class UnknownCommand(pb.Error):
 class ProtocolCommandPb(ProtocolCommandBase):
     def __init__(self, unicode_encoding, worker_basedir, basedir, buffer_size, buffer_timeout,
                  max_line_length, newline_re, builder_is_running, on_command_complete,
-                 on_lost_remote_step, command, stepId, args, command_ref):
+                 on_lost_remote_step, command, command_id, args, command_ref):
         self.basedir = basedir
         self.command_ref = command_ref
         ProtocolCommandBase.__init__(self, unicode_encoding, worker_basedir, buffer_size,
                                      buffer_timeout, max_line_length, newline_re,
                                      builder_is_running, on_command_complete, on_lost_remote_step,
-                                     command, stepId, args)
+                                     command, command_id, args)
 
     def protocol_args_setup(self, command, args):
         if command == "mkdir":
@@ -262,7 +262,7 @@ class WorkerForBuilderPbLike(WorkerForBuilderBase):
         """This is invoked before the first step of any new build is run.  It
         doesn't do much, but masters call it so it's still here."""
 
-    def remote_startCommand(self, command_ref, stepId, command, args):
+    def remote_startCommand(self, command_ref, command_id, command, args):
         """
         This gets invoked by L{buildbot.process.step.RemoteCommand.start}, as
         part of various master-side BuildSteps, to start various commands
@@ -270,7 +270,7 @@ class WorkerForBuilderPbLike(WorkerForBuilderBase):
         .commandComplete() to notify the master-side RemoteCommand that I'm
         done.
         """
-        stepId = decode(stepId)
+        command_id = decode(command_id)
         command = decode(command)
         args = decode(args)
 
@@ -286,17 +286,17 @@ class WorkerForBuilderPbLike(WorkerForBuilderBase):
                                                      self.buffer_timeout, self.max_line_length,
                                                      self.newline_re, self.running,
                                                      on_command_complete,
-                                                     self.lostRemoteStep, command, stepId, args,
+                                                     self.lostRemoteStep, command, command_id, args,
                                                      command_ref)
 
-        log.msg(u" startCommand:{0} [id {1}]".format(command, stepId))
+        log.msg(u" startCommand:{0} [id {1}]".format(command, command_id))
         self.protocol_command.protocol_notify_on_disconnect()
         d = self.protocol_command.command.doStart()
         d.addCallback(lambda res: None)
         d.addBoth(self.protocol_command.command_complete)
         return None
 
-    def remote_interruptCommand(self, stepId, why):
+    def remote_interruptCommand(self, command_id, why):
         """Halt the current step."""
         log.msg("asked to interrupt current command: {0}".format(why))
         if not self.protocol_command:

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -281,7 +281,7 @@ class RunProcess(object):
     # Then changes to the system clock during a run wouldn't effect the "elapsed
     # time" results.
 
-    def __init__(self, command, workdir, unicode_encoding, send_update, environ=None,
+    def __init__(self, command_id, command, workdir, unicode_encoding, send_update, environ=None,
                  sendStdout=True, sendStderr=True, sendRC=True,
                  timeout=None, maxTime=None, sigtermTime=None,
                  initialStdin=None, keepStdout=False, keepStderr=False,
@@ -300,6 +300,8 @@ class RunProcess(object):
         @param useProcGroup: (default True) use a process group for non-PTY
             process invocations
         """
+        self.command_id = command
+
         if logfiles is None:
             logfiles = {}
 

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -107,7 +107,7 @@ class LogFileWatcher(object):
         decoderFactory = getincrementaldecoder(self.command.unicode_encoding)
         self.logDecode = decoderFactory(errors='replace')
 
-        log.msg("LogFileWatcher created to watch {0}".format(logfile))
+        self.command.log_msg("LogFileWatcher created to watch {0}".format(logfile))
         # we are created before the ShellCommand starts. If the logfile we're
         # supposed to be watching already exists, record its size and
         # ctime/mtime so we can tell when it starts to change.
@@ -208,37 +208,36 @@ class RunProcessPP(protocol.ProcessProtocol):
 
     def connectionMade(self):
         if self.debug:
-            log.msg("RunProcessPP.connectionMade")
+            self.command.log_msg("RunProcessPP.connectionMade")
 
         if self.command.useProcGroup:
             if self.debug:
-                log.msg(" recording pid {0} as subprocess pgid".format(
-                    self.transport.pid))
+                self.command.log_msg("pid {0} set as subprocess pgid".format(self.transport.pid))
             self.transport.pgid = self.transport.pid
 
         if self.pending_stdin:
             if self.debug:
-                log.msg(" writing to stdin")
+                self.command.log_msg("writing to stdin")
             self.transport.write(self.pending_stdin)
         if self.debug:
-            log.msg(" closing stdin")
+            self.command.log_msg("closing stdin")
         self.transport.closeStdin()
 
     def outReceived(self, data):
         if self.debug:
-            log.msg("RunProcessPP.outReceived")
+            self.command.log_msg("RunProcessPP.outReceived")
         decodedData = self.stdoutDecode.decode(data)
         self.command.addStdout(decodedData)
 
     def errReceived(self, data):
         if self.debug:
-            log.msg("RunProcessPP.errReceived")
+            self.command.log_msg("RunProcessPP.errReceived")
         decodedData = self.stderrDecode.decode(data)
         self.command.addStderr(decodedData)
 
     def processEnded(self, status_object):
         if self.debug:
-            log.msg("RunProcessPP.processEnded", status_object)
+            self.command.log_msg("RunProcessPP.processEnded {0}".format(status_object))
         # status_object is a Failure wrapped around an
         # error.ProcessTerminated or and error.ProcessDone.
         # requires twisted >= 1.0.4 to overcome a bug in process.py
@@ -249,8 +248,7 @@ class RunProcessPP(protocol.ProcessProtocol):
         # a zero exit status.  So we force it.  See
         # http://stackoverflow.com/questions/2061735/42-passed-to-terminateprocess-sometimes-getexitcodeprocess-returns-0
         if self.killed and rc == 0:
-            log.msg(
-                "process was killed, but exited with status 0; faking a failure")
+            self.command.log_msg("process was killed, but exited with status 0; faking a failure")
             # windows returns '1' even for signalled failures, while POSIX
             # returns -1
             if runtime.platformType == 'win32':
@@ -428,6 +426,9 @@ class RunProcess(object):
                                follow=follow)
             self.logFileWatchers.append(w)
 
+    def log_msg(self, msg):
+        log.msg(u"(command {0}): {1}".format(self.command_id, msg))
+
     def __repr__(self):
         return "<{0} '{1}'>".format(self.__class__.__name__, self.fake_command)
 
@@ -454,7 +455,7 @@ class RunProcess(object):
         # ensure workdir exists
         if not os.path.isdir(self.workdir):
             os.makedirs(self.workdir)
-        log.msg("RunProcess._startCommand")
+        self.log_msg("RunProcess._startCommand")
 
         self.pp = RunProcessPP(self)
 
@@ -505,7 +506,7 @@ class RunProcess(object):
 
         # self.stdin is handled in RunProcessPP.connectionMade
 
-        log.msg(u" " + display)
+        self.log_msg(u" " + display)
         self.send_update([(u'header', display + u"\n")])
 
         # then comes the secondary information
@@ -522,16 +523,16 @@ class RunProcess(object):
             else:
                 unit = u"secs"
             msg += u" (maxTime {0} {1})".format(self.maxTime, unit)
-        log.msg(u" " + msg)
+        self.log_msg(u" " + msg)
         self.send_update([(u'header', msg + u"\n")])
 
         msg = " watching logfiles {0}".format(self.logfiles)
-        log.msg(" " + msg)
+        self.log_msg(" " + msg)
         self.send_update([('header', msg + u"\n")])
 
         # then the obfuscated command array for resolving unambiguity
         msg = u" argv: {0}".format(self.fake_command)
-        log.msg(u" " + msg)
+        self.log_msg(u" " + msg)
         self.send_update([('header', msg + u"\n")])
 
         # then the environment, since it sometimes causes problems
@@ -543,16 +544,16 @@ class RunProcess(object):
                                                            encoding=self.unicode_encoding),
                                              bytes2unicode(self.environ[name],
                                                            encoding=self.unicode_encoding))
-            log.msg(u" environment:\n{0}".format(pprint.pformat(self.environ)))
+            self.log_msg(u" environment:\n{0}".format(pprint.pformat(self.environ)))
             self.send_update([(u'header', msg)])
 
         if self.initialStdin:
             msg = u" writing {0} bytes to stdin".format(len(self.initialStdin))
-            log.msg(u" " + msg)
+            self.log_msg(u" " + msg)
             self.send_update([(u'header', msg + u"\n")])
 
         msg = u" using PTY: {0}".format(bool(self.usePTY))
-        log.msg(u" " + msg)
+        self.log_msg(u" " + msg)
         self.send_update([(u'header', msg + u"\n")])
 
         # put data into stdin and close it, if necessary.  This will be
@@ -665,8 +666,8 @@ class RunProcess(object):
 
     def finished(self, sig, rc):
         self.elapsedTime = util.now(self._reactor) - self.startTime
-        log.msg("command finished with signal {0}, exit code {1}, elapsedTime: {2:0.6f}".format(
-            sig, rc, self.elapsedTime))
+        self.log_msg(("command finished with signal {0}, exit code {1}, " +
+                      "elapsedTime: {2:0.6f}").format(sig, rc, self.elapsedTime))
         for w in self.logFileWatchers:
             # this will send the final updates
             w.stop()
@@ -683,17 +684,17 @@ class RunProcess(object):
         if d:
             d.callback(rc)
         else:
-            log.msg("Hey, command {0} finished twice".format(self))
+            self.log_msg("Hey, command {0} finished twice".format(self))
 
     def failed(self, why):
-        log.msg("RunProcess.failed: command failed: {0}".format(why))
+        self.log_msg("RunProcess.failed: command failed: {0}".format(why))
         self._cancelTimers()
         d = self.deferred
         self.deferred = None
         if d:
             d.errback(why)
         else:
-            log.msg("Hey, command {0} finished twice".format(self))
+            self.log_msg("Hey, command {0} finished twice".format(self))
 
     def doTimeout(self):
         self.ioTimeoutTimer = None
@@ -730,7 +731,7 @@ class RunProcess(object):
 
     def cleanUp(self, hit):
         if not hit:
-            log.msg("signalProcess/os.kill failed both times")
+            self.log_msg("signalProcess/os.kill failed both times")
 
         if runtime.platformType == "posix":
             # we only do this under posix because the win32eventreactor
@@ -751,28 +752,27 @@ class RunProcess(object):
             sig = getattr(signal, "SIG" + interruptSignal, None)
 
             if sig is None:
-                log.msg("signal module is missing SIG{0}".format(interruptSignal))
+                self.log_msg("signal module is missing SIG{0}".format(interruptSignal))
             elif not hasattr(os, "kill"):
-                log.msg("os module is missing the 'kill' function")
+                self.log_msg("os module is missing the 'kill' function")
             elif self.process.pgid is None:
-                log.msg("self.process has no pgid")
+                self.log_msg("self.process has no pgid")
             else:
-                log.msg("trying to kill process group {0}".format(
-                        self.process.pgid))
+                self.log_msg("trying to kill process group {0}".format(self.process.pgid))
                 try:
                     os.killpg(self.process.pgid, sig)
-                    log.msg(" signal {0} sent successfully".format(sig))
+                    self.log_msg(" signal {0} sent successfully".format(sig))
                     self.process.pgid = None
                     hit = 1
                 except OSError:
-                    log.msg('failed to kill process group (ignored): {0}'.format(
+                    self.log_msg('failed to kill process group (ignored): {0}'.format(
                             (sys.exc_info()[1])))
                     # probably no-such-process, maybe because there is no process
                     # group
 
         elif runtime.platformType == "win32":
             if interruptSignal is None:
-                log.msg("interruptSignal==None, only pretending to kill child")
+                self.log_msg("interruptSignal==None, only pretending to kill child")
             elif self.process.pid is not None:
                 if interruptSignal == "TERM":
                     self._taskkill(self.process.pid, force=False)
@@ -784,16 +784,15 @@ class RunProcess(object):
         # try signalling the process itself (works on Windows too, sorta)
         if not hit:
             try:
-                log.msg("trying process.signalProcess('{0}')".format(
-                        interruptSignal))
+                self.log_msg("trying process.signalProcess('{0}')".format(interruptSignal))
                 self.process.signalProcess(interruptSignal)
-                log.msg(" signal {0} sent successfully".format(interruptSignal))
+                self.log_msg(" signal {0} sent successfully".format(interruptSignal))
                 hit = 1
             except OSError:
                 log.err("from process.signalProcess:")
                 # could be no-such-process, because they finished very recently
             except error.ProcessExitedAlready:
-                log.msg("Process exited already - can't kill")
+                self.log_msg("Process exited already - can't kill")
                 # the process has already exited, and likely finished() has
                 # been called already or will be called shortly
 
@@ -806,25 +805,25 @@ class RunProcess(object):
             else:
                 cmd = "TASKKILL /PID {0} /T".format(pid)
 
-            log.msg("using {0} to kill pid {1}".format(cmd, pid))
+            self.log_msg("using {0} to kill pid {1}".format(cmd, pid))
             subprocess.check_call(cmd)
-            log.msg("taskkill'd pid {0}".format(pid))
+            self.log_msg("taskkill'd pid {0}".format(pid))
 
         except subprocess.CalledProcessError as e:
             # taskkill may return 128 or 255 as exit code when the child has already exited.
             # We can't handle this race condition in any other way than just interpreting the kill
             # action as successful
             if e.returncode in (128, 255):
-                log.msg("taskkill didn't find pid {0} to kill".format(pid))
+                self.log_msg("taskkill didn't find pid {0} to kill".format(pid))
             else:
-                log.msg("taskkill failed to kill process {0}: {1}".format(pid, e))
+                self.log_msg("taskkill failed to kill process {0}: {1}".format(pid, e))
 
     def kill(self, msg):
         # This may be called by the timeout, or when the user has decided to
         # abort this build.
         self._cancelTimers()
         msg += ", attempting to kill"
-        log.msg(msg)
+        self.log_msg(msg)
         self.send_update([('header', "\n" + msg + "\n")])
 
         # let the PP know that we are killing it, so that it can ensure that
@@ -841,8 +840,7 @@ class RunProcess(object):
             self.cleanUp(hit)
 
     def doBackupTimeout(self):
-        log.msg("we tried to kill the process, and it wouldn't die.."
-                " finish anyway")
+        self.log_msg("we tried to kill the process, and it wouldn't die.. finish anyway")
         self.killTimer = None
         signalName = "SIG" + self.interruptSignal
         self.send_update([('header', signalName + " failed to kill process\n")])

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -105,7 +105,7 @@ class FakeRunProcess(object):
                                   ).format(len(cls._expectations)))
         del cls._expectations
 
-    def __init__(self, command, workdir, unicode_encoding, send_update, **kwargs):
+    def __init__(self, command_id, command, workdir, unicode_encoding, send_update, **kwargs):
         kwargs['command'] = command
         kwargs['workdir'] = workdir
 

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -342,7 +342,8 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
                                        "13", "invalid command", {})
 
         unknownCommand = yield self.assertFailure(do_start(), base.UnknownCommand)
-        self.assertEqual(str(unknownCommand), "unrecognized WorkerCommand 'invalid command'")
+        self.assertEqual(str(unknownCommand),
+                         "(command 13): unrecognized WorkerCommand 'invalid command'")
 
 
 class TestBotFactory(unittest.TestCase):

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -99,24 +99,24 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         self.tearDownBasedir()
 
     def testCommandEncoding(self):
-        s = runprocess.RunProcess(u'abcd', self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, u'abcd', self.basedir, 'utf-8', self.send_update)
         self.assertIsInstance(s.command, bytes)
         self.assertIsInstance(s.fake_command, bytes)
 
     def testCommandEncodingList(self):
-        s = runprocess.RunProcess([u'abcd', b'efg'], self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, [u'abcd', b'efg'], self.basedir, 'utf-8', self.send_update)
         self.assertIsInstance(s.command[0], bytes)
         self.assertIsInstance(s.fake_command[0], bytes)
 
     def testCommandEncodingObfuscated(self):
-        s = runprocess.RunProcess([bsutil.Obfuscated(u'abcd', u'ABCD')], self.basedir, 'utf-8',
+        s = runprocess.RunProcess(0, [bsutil.Obfuscated(u'abcd', u'ABCD')], self.basedir, 'utf-8',
                                   self.send_update)
         self.assertIsInstance(s.command[0], bytes)
         self.assertIsInstance(s.fake_command[0], bytes)
 
     @defer.inlineCallbacks
     def testStart(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
 
         yield s.start()
 
@@ -125,8 +125,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testNoStdout(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  sendStdout=False)
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, sendStdout=False)
 
         yield s.start()
 
@@ -135,8 +135,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testKeepStdout(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  keepStdout=True)
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, keepStdout=True)
 
         yield s.start()
 
@@ -146,7 +146,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testStderr(self):
-        s = runprocess.RunProcess(stderrCommand("hello"), self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, stderrCommand("hello"), self.basedir, 'utf-8',
+                                  self.send_update)
 
         yield s.start()
 
@@ -155,8 +156,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testNoStderr(self):
-        s = runprocess.RunProcess(stderrCommand("hello"), self.basedir, 'utf-8', self.send_update,
-                                  sendStderr=False)
+        s = runprocess.RunProcess(0, stderrCommand("hello"), self.basedir, 'utf-8',
+                                  self.send_update, sendStderr=False)
 
         yield s.start()
 
@@ -165,8 +166,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_incrementalDecoder(self):
-        s = runprocess.RunProcess(stderrCommand("hello"), self.basedir, 'utf-8', self.send_update,
-                                  sendStderr=True)
+        s = runprocess.RunProcess(0, stderrCommand("hello"), self.basedir, 'utf-8',
+                                  self.send_update, sendStderr=True)
         pp = runprocess.RunProcessPP(s)
         # u"\N{SNOWMAN} when encoded to utf-8 bytes is b"\xe2\x98\x83"
         pp.outReceived(b"\xe2")
@@ -181,8 +182,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testInvalidUTF8(self):
-        s = runprocess.RunProcess(stderrCommand("hello"), self.basedir, 'utf-8', self.send_update,
-                                  sendStderr=True)
+        s = runprocess.RunProcess(0, stderrCommand("hello"), self.basedir, 'utf-8',
+                                  self.send_update, sendStderr=True)
         pp = runprocess.RunProcessPP(s)
         INVALID_UTF8 = b"\xff"
         with self.assertRaises(UnicodeDecodeError):
@@ -196,8 +197,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testKeepStderr(self):
-        s = runprocess.RunProcess(stderrCommand("hello"), self.basedir, 'utf-8', self.send_update,
-                                  keepStderr=True)
+        s = runprocess.RunProcess(0, stderrCommand("hello"), self.basedir, 'utf-8',
+                                  self.send_update, keepStderr=True)
 
         yield s.start()
 
@@ -208,7 +209,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def testStringCommand(self):
         # careful!  This command must execute the same on windows and UNIX
-        s = runprocess.RunProcess('echo hello', self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, 'echo hello', self.basedir, 'utf-8', self.send_update)
 
         yield s.start()
 
@@ -216,7 +217,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         self.assertTrue(('rc', 0) in self.updates, self.show())
 
     def testObfuscatedCommand(self):
-        s = runprocess.RunProcess([('obfuscated', 'abcd', 'ABCD')], self.basedir, 'utf-8',
+        s = runprocess.RunProcess(0, [('obfuscated', 'abcd', 'ABCD')], self.basedir, 'utf-8',
                                   self.send_update)
         self.assertEqual(s.command, [b'abcd'])
         self.assertEqual(s.fake_command, [b'ABCD'])
@@ -224,7 +225,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def testMultiWordStringCommand(self):
         # careful!  This command must execute the same on windows and UNIX
-        s = runprocess.RunProcess('echo Happy Days and Jubilation', self.basedir, 'utf-8',
+        s = runprocess.RunProcess(0, 'echo Happy Days and Jubilation', self.basedir, 'utf-8',
                                   self.send_update)
 
         # no quoting occurs
@@ -236,7 +237,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testInitialStdinUnicode(self):
-        s = runprocess.RunProcess(catCommand(), self.basedir, 'utf-8', self.send_update,
+        s = runprocess.RunProcess(0, catCommand(), self.basedir, 'utf-8', self.send_update,
                                   initialStdin=u'hello')
 
         yield s.start()
@@ -247,7 +248,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def testMultiWordStringCommandQuotes(self):
         # careful!  This command must execute the same on windows and UNIX
-        s = runprocess.RunProcess('echo "Happy Days and Jubilation"', self.basedir, 'utf-8',
+        s = runprocess.RunProcess(0, 'echo "Happy Days and Jubilation"', self.basedir, 'utf-8',
                                   self.send_update)
 
         if runtime.platformType == "win32":
@@ -273,7 +274,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
             # variable name.
         ]
 
-        s = runprocess.RunProcess(printArgsCommand() + args, self.basedir, 'utf-8',
+        s = runprocess.RunProcess(0, printArgsCommand() + args, self.basedir, 'utf-8',
                                   self.send_update)
         yield s.start()
 
@@ -286,7 +287,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         # this is highly contrived, but it proves the point.
         cmd = sys.executable + \
             ' -c "import sys; sys.stdout.write(\'b\\na\\n\')" | sort'
-        s = runprocess.RunProcess(cmd, self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, cmd, self.basedir, 'utf-8', self.send_update)
 
         yield s.start()
 
@@ -295,7 +296,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testCommandTimeout(self):
-        s = runprocess.RunProcess(sleepCommand(10), self.basedir, 'utf-8', self.send_update,
+        s = runprocess.RunProcess(0, sleepCommand(10), self.basedir, 'utf-8', self.send_update,
                                   timeout=5)
         clock = task.Clock()
         s._reactor = clock
@@ -310,7 +311,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testCommandMaxTime(self):
-        s = runprocess.RunProcess(sleepCommand(10), self.basedir, 'utf-8', self.send_update,
+        s = runprocess.RunProcess(0, sleepCommand(10), self.basedir, 'utf-8', self.send_update,
                                   maxTime=5)
         clock = task.Clock()
         s._reactor = clock
@@ -326,7 +327,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
     @compat.skipUnlessPlatformIs("posix")
     @defer.inlineCallbacks
     def test_stdin_closed(self):
-        s = runprocess.RunProcess(scriptCommand('assert_stdin_closed'),
+        s = runprocess.RunProcess(0, scriptCommand('assert_stdin_closed'),
                                   self.basedir, 'utf-8', self.send_update,
                                   # if usePTY=True, stdin is never closed
                                   usePTY=False,
@@ -337,7 +338,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_startCommand_exception(self):
-        s = runprocess.RunProcess(['whatever'], self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, ['whatever'], self.basedir, 'utf-8', self.send_update)
 
         # set up to cause an exception in _startCommand
         def _startCommand(*args, **kwargs):
@@ -362,8 +363,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testLogEnviron(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ={"FOO": "BAR"})
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ={"FOO": "BAR"})
 
         yield s.start()
 
@@ -372,8 +373,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testNoLogEnviron(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ={"FOO": "BAR"}, logEnviron=False)
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ={"FOO": "BAR"}, logEnviron=False)
 
         yield s.start()
 
@@ -386,8 +387,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         environ = {"EXPND": "-${PATH}-",
                    "DOESNT_EXPAND": "-${---}-",
                    "DOESNT_FIND": "-${DOESNT_EXISTS}-"}
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ=environ)
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ=environ)
 
         yield s.start()
 
@@ -399,8 +400,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testUnsetEnvironVar(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ={"PATH": None})
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ={"PATH": None})
 
         yield s.start()
 
@@ -411,8 +412,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testEnvironPythonPath(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ={"PYTHONPATH": 'a'})
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ={"PYTHONPATH": 'a'})
 
         yield s.start()
 
@@ -423,8 +424,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testEnvironArray(self):
-        s = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ={"FOO": ['a', 'b']})
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ={"FOO": ['a', 'b']})
 
         yield s.start()
 
@@ -435,8 +436,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     def testEnvironInt(self):
         with self.assertRaises(RuntimeError):
-            runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update,
-                                  environ={"BUILD_NUMBER": 13})
+            runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update, environ={"BUILD_NUMBER": 13})
 
     def _test_spawnAsBatch(self, cmd, comspec):
 
@@ -450,7 +451,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         if 'COMSPEC' not in tempEnviron:
             tempEnviron['COMSPEC'] = comspec
         self.patch(os, "environ", tempEnviron)
-        s = runprocess.RunProcess(cmd, self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, cmd, self.basedir, 'utf-8', self.send_update)
         s.pp = runprocess.RunProcessPP(s)
         s.deferred = defer.Deferred()
         d = s._spawnAsBatch(s.pp, s.command, "args",
@@ -577,8 +578,8 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         pidfile = self.newPidfile()
         self.pid = None
 
-        s = runprocess.RunProcess(scriptCommand('write_pidfile_and_sleep', pidfile), self.basedir,
-                                  'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, scriptCommand('write_pidfile_and_sleep', pidfile),
+                                  self.basedir, 'utf-8', self.send_update)
         if interruptSignal is not None:
             s.interruptSignal = interruptSignal
         runproc_d = s.start()
@@ -604,8 +605,8 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         # is not None
         pidfile = self.newPidfile()
         self.pid = None
-        s = runprocess.RunProcess(scriptCommand('write_pidfile_and_sleep', pidfile), self.basedir,
-                                  'utf-8', self.send_update, sigtermTime=1)
+        s = runprocess.RunProcess(0, scriptCommand('write_pidfile_and_sleep', pidfile),
+                                  self.basedir, 'utf-8', self.send_update, sigtermTime=1)
         runproc_d = s.start()
         pidfile_d = self.waitForPidfile(pidfile)
         self.receivedSIGTERM = False
@@ -658,7 +659,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         child_pidfile = self.newPidfile()
         self.child_pid = None
 
-        s = runprocess.RunProcess(scriptCommand('spawn_child', parent_pidfile, child_pidfile),
+        s = runprocess.RunProcess(0, scriptCommand('spawn_child', parent_pidfile, child_pidfile),
                                   self.basedir, 'utf-8', self.send_update, usePTY=usePTY,
                                   useProcGroup=useProcGroup)
         runproc_d = s.start()
@@ -708,7 +709,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         child_pidfile = self.newPidfile()
         self.child_pid = None
 
-        s = runprocess.RunProcess(scriptCommand('double_fork', parent_pidfile, child_pidfile),
+        s = runprocess.RunProcess(0, scriptCommand('double_fork', parent_pidfile, child_pidfile),
                                   self.basedir, 'utf-8', self.send_update, usePTY=usePTY,
                                   useProcGroup=useProcGroup)
         runproc_d = s.start()
@@ -833,8 +834,8 @@ class TestWindowsKilling(BasedirMixin, unittest.TestCase):
         # test a simple process that just sleeps waiting to die
         pidfile = self.new_pid_file()
 
-        s = runprocess.RunProcess(scriptCommand('write_pidfile_and_sleep', pidfile), self.basedir,
-                                  'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, scriptCommand('write_pidfile_and_sleep', pidfile),
+                                  self.basedir, 'utf-8', self.send_update)
         if interrupt_signal is not None:
             s.interruptSignal = interrupt_signal
         runproc_d = s.start()
@@ -854,8 +855,8 @@ class TestWindowsKilling(BasedirMixin, unittest.TestCase):
         # Tests that the process will receive SIGTERM if sigtermTimeout is not None
         pidfile = self.new_pid_file()
 
-        s = runprocess.RunProcess(scriptCommand('write_pidfile_and_sleep', pidfile), self.basedir,
-                                  'utf-8', self.send_update, sigtermTime=1)
+        s = runprocess.RunProcess(0, scriptCommand('write_pidfile_and_sleep', pidfile),
+                                  self.basedir, 'utf-8', self.send_update, sigtermTime=1)
 
         taskkill_calls = []
         orig_taskkill = s._taskkill
@@ -882,7 +883,7 @@ class TestWindowsKilling(BasedirMixin, unittest.TestCase):
         parent_pidfile = self.new_pid_file()
         child_pidfile = self.new_pid_file()
 
-        s = runprocess.RunProcess(scriptCommand('spawn_child', parent_pidfile, child_pidfile),
+        s = runprocess.RunProcess(0, scriptCommand('spawn_child', parent_pidfile, child_pidfile),
                                   self.basedir, 'utf-8', self.send_update)
         runproc_d = s.start()
 
@@ -905,7 +906,7 @@ class TestWindowsKilling(BasedirMixin, unittest.TestCase):
         parent_pidfile = self.new_pid_file()
         child_pidfile = self.new_pid_file()
 
-        s = runprocess.RunProcess(scriptCommand('double_fork', parent_pidfile, child_pidfile),
+        s = runprocess.RunProcess(0, scriptCommand('double_fork', parent_pidfile, child_pidfile),
                                   self.basedir, 'utf-8', self.send_update)
         runproc_d = s.start()
 
@@ -939,7 +940,8 @@ class TestLogFileWatcher(BasedirMixin, unittest.TestCase):
         self.tearDownBasedir()
 
     def makeRP(self):
-        rp = runprocess.RunProcess(stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
+        rp = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                   self.send_update)
         return rp
 
     def test_statFile_missing(self):

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -116,7 +116,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testStart(self):
-        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8', self.send_update)
+        s = runprocess.RunProcess(0, stdoutCommand('hello'), self.basedir, 'utf-8',
+                                  self.send_update)
 
         yield s.start()
 

--- a/worker/buildbot_worker/test/util/sourcecommand.py
+++ b/worker/buildbot_worker/test/util/sourcecommand.py
@@ -32,8 +32,8 @@ class SourceCommandTestMixin(command.CommandTestMixin):
 
         * writeSourcedata - writes to self.sourcedata (self is the TestCase)
         * readSourcedata - reads from self.sourcedata
-        * doClobber - invokes RunProcess(['clobber', DIRECTORY])
-        * doCopy - invokes RunProcess(['copy', cmd.srcdir, cmd.workdir])
+        * doClobber - invokes RunProcess(0, ['clobber', DIRECTORY])
+        * doCopy - invokes RunProcess(0, ['copy', cmd.srcdir, cmd.workdir])
         """
 
         cmd = command.CommandTestMixin.make_command(self, cmdclass, args, makedirs)


### PR DESCRIPTION
This allows to understand what's happening in case there are multiple commands being run in parallel.