### PR TITLE
www/react: Fix ChangeDetails for change with empty revlink

### DIFF
--- a/www/react-ui/src/components/ChangeDetails/ChangeDetails.tsx
+++ b/www/react-ui/src/components/ChangeDetails/ChangeDetails.tsx
@@ -119,7 +119,7 @@ export const ChangeDetails = ({change, compact, showDetails, setShowDetails}: Ch
         <OverlayTrigger placement="top"
                         overlay={popoverWithText("comments-" + change.id, change.comments)}>
           {
-            change.revlink !== null
+            change.revlink
             ? <a href={change.revlink}>{change.comments.split("\n")[0]}</a>
             : <span>{change.comments.split("\n")[0]}</span>
           }


### PR DESCRIPTION
Change can have a `revlink` which is an empty string.
In this case, `ChangeDetails` would display the change message as a link with a href to `""`.