### PR TITLE
p4: can now specify the client Type

### DIFF
--- a/master/docs/manual/configuration/steps/source_p4.rst
+++ b/master/docs/manual/configuration/steps/source_p4.rst
@@ -104,6 +104,12 @@ If you specify ``p4viewspec`` and any of ``p4base``, ``p4branch``, and/or ``p4ex
     This is added directly to the client spec's ``LineEnd`` property.
     The default is ``local``.
 
+``p4client_type``
+    (optional): The type of client to create.
+    A client type can be set to create a client better suited to CI use.
+    Learn more about client type in the `P4 documentation <https://www.perforce.com/manuals/p4sag/Content/P4SAG/performance.readonly.html>`_
+    The default is ``None``.
+
 ``p4extra_args``
     (optional): Extra arguments to be added to the P4 command-line for the ``sync`` command.
     So for instance if you want to sync only to populate a Perforce proxy (without actually syncing files to disk), you can do:

--- a/newsfragments/p4-client-type.feature
+++ b/newsfragments/p4-client-type.feature
@@ -1,0 +1,1 @@
+``buildbot.steps.source.p4.P4`` can now take a ``p4client_type`` argument to set the client type (More information on client type [here](https://www.perforce.com/manuals/p4sag/Content/P4SAG/performance.readonly.html))


### PR DESCRIPTION
Clients used by CI will cause a high fragmentation to the p4 server db.have.
Such clients can be set a type of `readonly` or `partitioned` depending on usage which will allow the p4 server to store their db.have per-client to avoid the fragmentation.
They however have limitations, so can't simply be set as the default (at least not in a simple patch release).

More about p4 client type can be found here: https://www.perforce.com/manuals/p4sag/Content/P4SAG/performance.readonly.html