### PR TITLE
Add a way to show inline raw logs in the browser

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -29,6 +29,7 @@ class EndpointKind(enum.Enum):
     SINGLE = 1
     COLLECTION = 2
     RAW = 3
+    RAW_INLINE = 4
 
 
 class ResourceType:

--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -35,7 +35,7 @@ class Db2DataMixin:
 
 class BuildDatasNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/data
         /builders/i:buildername/builds/n:build_number/data
@@ -56,7 +56,7 @@ class BuildDatasNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpo
 
 class BuildDataNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/data/i:name
         /builders/i:buildername/builds/n:build_number/data/i:name
@@ -75,8 +75,7 @@ class BuildDataNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoi
 
 class BuildDataEndpoint(base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
-    isRaw = True
+    kind = base.EndpointKind.RAW
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/data/i:name/value
         /builders/i:buildername/builds/n:build_number/data/i:name/value

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -22,7 +22,7 @@ from buildbot.data import types
 
 class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builders/n:builderid
         /builders/i:buildername
@@ -55,7 +55,7 @@ class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
 
 class BuildersEndpoint(base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     rootLinkName = 'builders'
     pathPatterns = """
         /builders

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -84,7 +84,7 @@ class Db2DataMixin:
 
 class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /buildrequests/n:buildrequestid
     """
@@ -152,7 +152,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
 
 class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /buildrequests
         /builders/n:builderid/buildrequests

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -73,7 +73,7 @@ class Db2DataMixin:
 
 class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builds/n:buildid
         /builders/n:builderid/builds/n:number
@@ -132,7 +132,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
 class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builds
         /builders/n:builderid/builds

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -71,7 +71,7 @@ class Db2DataMixin:
 
 class BuildsetEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /buildsets/n:bsid
     """
@@ -85,7 +85,7 @@ class BuildsetEndpoint(Db2DataMixin, base.Endpoint):
 
 class BuildsetsEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /buildsets
     """

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -66,7 +66,7 @@ class FixerMixin:
 
 class ChangeEndpoint(FixerMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /changes/n:changeid
     """
@@ -79,7 +79,7 @@ class ChangeEndpoint(FixerMixin, base.Endpoint):
 
 class ChangesEndpoint(FixerMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /changes
         /builders/n:builderid/builds/n:build_number/changes

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -57,7 +57,7 @@ class ChangeSourceEndpoint(Db2DataMixin, base.Endpoint):
 
 class ChangeSourcesEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /changesources
         /masters/n:masterid/changesources

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -37,7 +37,7 @@ def forceScheduler2Data(sched):
 
 class ForceSchedulerEndpoint(base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /forceschedulers/i:schedulername
     """
@@ -72,7 +72,7 @@ class ForceSchedulerEndpoint(base.Endpoint):
 
 class ForceSchedulersEndpoint(base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /forceschedulers
         /builders/:builderid/forceschedulers

--- a/master/buildbot/data/graphql.py
+++ b/master/buildbot/data/graphql.py
@@ -23,6 +23,7 @@ from buildbot.asyncio import AsyncIOLoopWithTwisted
 from buildbot.asyncio import as_deferred
 from buildbot.asyncio import as_future
 from buildbot.data import resultspec
+from buildbot.data.base import EndpointKind
 from buildbot.data.types import Entity
 from buildbot.util import service
 
@@ -256,7 +257,7 @@ class GraphQLConnector(service.AsyncService):
             rspec = None
             kwargs = ep.get_kwargs_from_graphql(parent, resolve_info, args)
 
-            if ep.isCollection or ep.isPseudoCollection:
+            if ep.kind == EndpointKind.COLLECTION or ep.isPseudoCollection:
                 args = {k: _enforce_list(v) for k, v in args.items()}
                 rspec = self.data.resultspec_from_jsonapi(args, ep.rtype.entityType, True)
 

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -45,7 +45,7 @@ class LogChunkEndpoint(LogChunkEndpointBase):
 
     # Note that this is a singular endpoint, even though it overrides the
     # offset/limit query params in ResultSpec
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     isPseudoCollection = True
     pathPatterns = """
         /logchunks
@@ -98,8 +98,7 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
 
     # Note that this is a singular endpoint, even though it overrides the
     # offset/limit query params in ResultSpec
-    isCollection = False
-    isRaw = True
+    kind = base.EndpointKind.RAW
     pathPatterns = """
         /logs/n:logid/raw
         /steps/n:stepid/logs/i:log_slug/raw

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -38,7 +38,7 @@ class EndpointMixin:
 
 class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /logs/n:logid
         /steps/n:stepid/logs/i:log_slug
@@ -67,7 +67,7 @@ class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
 
 class LogsEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /steps/n:stepid/logs
         /builds/n:buildid/steps/i:step_name/logs

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -39,7 +39,7 @@ def _db2data(master):
 
 class MasterEndpoint(base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /masters/n:masterid
         /builders/n:builderid/masters/n:masterid
@@ -60,7 +60,7 @@ class MasterEndpoint(base.Endpoint):
 
 class MastersEndpoint(base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /masters
         /builders/n:builderid/masters

--- a/master/buildbot/data/projects.py
+++ b/master/buildbot/data/projects.py
@@ -33,7 +33,7 @@ def project_db_to_data(dbdict):
 
 class ProjectEndpoint(base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /projects/n:projectid
         /projects/i:projectname
@@ -53,7 +53,7 @@ class ProjectEndpoint(base.BuildNestingMixin, base.Endpoint):
 
 class ProjectsEndpoint(base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     rootLinkName = 'projects'
     pathPatterns = """
         /projects

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -23,7 +23,7 @@ from buildbot.data import types
 
 class BuildsetPropertiesEndpoint(base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /buildsets/n:bsid/properties
     """
@@ -34,7 +34,7 @@ class BuildsetPropertiesEndpoint(base.Endpoint):
 
 class BuildPropertiesEndpoint(base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/properties
         /builds/n:buildid/properties
@@ -50,7 +50,7 @@ class BuildPropertiesEndpoint(base.Endpoint):
 
 class PropertiesListEndpoint(base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builds/n:buildid/property_list
         /buildsets/n:bsid/properties_list

--- a/master/buildbot/data/root.py
+++ b/master/buildbot/data/root.py
@@ -21,7 +21,7 @@ from buildbot.data import types
 
 
 class RootEndpoint(base.Endpoint):
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = "/"
 
     def get(self, resultSpec, kwargs):
@@ -39,7 +39,7 @@ class Root(base.ResourceType):
 
 
 class SpecEndpoint(base.Endpoint):
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = "/application.spec"
 
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -41,7 +41,7 @@ class Db2DataMixin:
 
 class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /schedulers/n:schedulerid
         /masters/n:masterid/schedulers/n:schedulerid
@@ -67,7 +67,7 @@ class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
 
 class SchedulersEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /schedulers
         /masters/n:masterid/schedulers

--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -46,7 +46,7 @@ def _db2data(ss):
 
 class SourceStampEndpoint(base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /sourcestamps/n:ssid
     """
@@ -60,7 +60,7 @@ class SourceStampEndpoint(base.Endpoint):
 
 class SourceStampsEndpoint(base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /sourcestamps
     """

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -42,7 +42,7 @@ class Db2DataMixin:
 
 class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /steps/n:stepid
         /builds/n:buildid/steps/i:step_name
@@ -70,7 +70,7 @@ class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
 class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builds/n:buildid/steps
         /builders/n:builderid/builds/n:build_number/steps

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -40,7 +40,7 @@ class Db2DataMixin:
 
 class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builders/n:builderid/test_result_sets
         /builders/i:buildername/test_result_sets
@@ -85,7 +85,7 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
 
 class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /test_result_sets/n:test_result_setid
     """

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -38,7 +38,7 @@ class Db2DataMixin:
 
 class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /test_result_sets/n:test_result_setid/results
         """

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -43,7 +43,7 @@ class Db2DataMixin:
 
 class WorkerEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /workers/n:workerid
         /workers/i:name
@@ -83,7 +83,7 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
 
 class WorkersEndpoint(Db2DataMixin, base.Endpoint):
 
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     rootLinkName = 'workers'
     pathPatterns = """
         /workers

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -38,7 +38,7 @@ stepData = {
 
 
 class TestsEndpoint(base.Endpoint):
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = """
     /tests
     /test
@@ -51,8 +51,7 @@ class TestsEndpoint(base.Endpoint):
 
 
 class RawTestsEndpoint(base.Endpoint):
-    isCollection = False
-    isRaw = True
+    kind = base.EndpointKind.RAW
     pathPatterns = "/rawtest"
 
     def get(self, resultSpec, kwargs):
@@ -64,7 +63,7 @@ class RawTestsEndpoint(base.Endpoint):
 
 
 class FailEndpoint(base.Endpoint):
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = "/test/fail"
 
     def get(self, resultSpec, kwargs):
@@ -72,7 +71,7 @@ class FailEndpoint(base.Endpoint):
 
 
 class TestEndpoint(base.Endpoint):
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = """
     /tests/n:testid
     /test/n:testid
@@ -90,7 +89,7 @@ class TestEndpoint(base.Endpoint):
 
 
 class StepsEndpoint(base.Endpoint):
-    isCollection = True
+    kind = base.EndpointKind.COLLECTION
     pathPatterns = "/tests/n:testid/steps"
 
     def get(self, resultSpec, kwargs):
@@ -100,7 +99,7 @@ class StepsEndpoint(base.Endpoint):
 
 
 class StepEndpoint(base.Endpoint):
-    isCollection = False
+    kind = base.EndpointKind.SINGLE
     pathPatterns = "/tests/n:testid/steps/n:stepid"
 
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -20,6 +20,7 @@ from unittest import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.data.base import EndpointKind
 from buildbot.data.exceptions import InvalidQueryParameter
 from buildbot.test.fake import endpoint
 from buildbot.test.reactor import TestReactorMixin
@@ -257,7 +258,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
 
         endpoint.TestEndpoint.rtype = mock.MagicMock()
         endpoint.TestsEndpoint.rtype = mock.MagicMock()
-        endpoint.Test.isCollection = True
+        endpoint.Test.kind = EndpointKind.COLLECTION
         endpoint.Test.rtype = endpoint.Test
 
     def assertRestCollection(self, typeName, items,

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -84,7 +84,7 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
         self.assertIdentical(endpoint, self.ep)
         rv = yield endpoint.get(resultSpec, kwargs)
 
-        if self.ep.isCollection:
+        if self.ep.kind == base.EndpointKind.COLLECTION:
             self.assertIsInstance(rv, (list, base.ListResult))
         else:
             self.assertIsInstance(rv, (dict, type(None)))

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -256,11 +256,12 @@ class V2RootResource(resource.Resource):
             endpoint.kind == EndpointKind.COLLECTION
         )
 
-    def encodeRaw(self, data, request):
+    def encodeRaw(self, data, request, is_inline):
         request.setHeader(b"content-type",
                           unicode2bytes(data['mime-type']) + b'; charset=utf-8')
-        request.setHeader(b"content-disposition",
-                          b'attachment; filename=' + unicode2bytes(data['filename']))
+        if not is_inline:
+            request.setHeader(b"content-disposition",
+                              b'attachment; filename=' + unicode2bytes(data['filename']))
         request.write(unicode2bytes(data['raw']))
         return
 
@@ -289,7 +290,11 @@ class V2RootResource(resource.Resource):
                 return
 
             if ep.kind == EndpointKind.RAW:
-                self.encodeRaw(data, request)
+                self.encodeRaw(data, request, False)
+                return
+
+            if ep.kind == EndpointKind.RAW_INLINE:
+                self.encodeRaw(data, request, True)
                 return
 
             # post-process any remaining parts of the resultspec

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -360,6 +360,16 @@ See that module's description for details.
                     "filename": "filename_to_be_used_in_content_disposition_attachement_header"
                 }
 
+        - ``EndpointKind.RAW_INLINE`` - returns a raw resource which is shown inline in HTTP client.
+
+            The difference between ``RAW`` resource is that content-disposition header is not set.
+            The get() method from endpoint should return following data structure::
+
+                {
+                    "raw": "raw data to be sent to the http client",
+                    "mime-type": "<mime-type>"
+                }
+
     .. py:attribute:: isCollection
 
         :type: boolean

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -340,11 +340,33 @@ See that module's description for details.
         If set, then the first path pattern for this endpoint will be included as a link in the root of the API.
         This should be set for any endpoints that begin an explorable tree.
 
+    .. py:attribute:: kind
+
+        :type: number
+
+        Defines type of the endpoint.
+        The following endpoint types are supported:
+
+        - ``EndpointKind.SINGLE`` - returns single resource
+        - ``EndpointKind.COLLECTION`` - returns a collection of resources
+        - ``EndpointKind.RAW`` - returns a raw resource.
+
+            Raw resources are used to get the data not encoded in JSON via the REST API.
+            The get() method from endpoint should return following data structure::
+
+                {
+                    "raw": "raw data to be sent to the http client",
+                    "mime-type": "<mime-type>",
+                    "filename": "filename_to_be_used_in_content_disposition_attachement_header"
+                }
+
     .. py:attribute:: isCollection
 
         :type: boolean
 
         If true, then this endpoint returns collections of resources.
+
+        This attribute is deprecated, use ``kind`` attribute instead.
 
     .. py:attribute:: isRaw
 
@@ -352,15 +374,7 @@ See that module's description for details.
 
         If true, then this endpoint returns a raw resource.
 
-        Raw resources are used to get the data not encoded in JSON via the REST API.
-        In the REST principles, this should be done via another endpoint, and not via a query parameter.
-        The get() method from endpoint should return following data structure::
-
-            {
-                "raw": "raw data to be sent to the http client",
-                "mime-type": "<mime-type>",
-                "filename": "filename_to_be_used_in_content_disposition_attachement_header"
-            }
+        This attribute is deprecated, use ``kind`` attribute instead.
 
     .. py:method:: get(options, resultSpec, kwargs)
 

--- a/master/docs/manual/upgrading/4.0-upgrade.rst
+++ b/master/docs/manual/upgrading/4.0-upgrade.rst
@@ -89,3 +89,10 @@ Migration to ``croniter`` involves ensuring that the input times are passed as t
 
 The original ``buildbot.util.croniter`` code always assumed the input time is in the current timezone.
 The ``croniter`` package assumes the input time is in UTC timezone.
+
+
+Endpoint attributes
+-------------------
+
+``buildbot.data.base.Endpoint`` no longer provides ``isRaw`` and ``isCollection`` attributes.
+The equivalent in Buildbot 4.x is setting the ``kind`` attribute to ``EndpointKind.RAW`` and ``EndpointKind.COLLECTION`` respectively.

--- a/newsfragments/data-api-israw-iscollection.change
+++ b/newsfragments/data-api-israw-iscollection.change
@@ -1,0 +1,3 @@
+The ``isRaw`` and ``isCollection`` attributes of the ``Endpoint`` type have been deprecated.
+``Endpoint`` is used to extend the Buildbot API.
+Us a replacement use the new ``kind`` attribute.

--- a/newsfragments/endpointkind-raw-inline.feature
+++ b/newsfragments/endpointkind-raw-inline.feature
@@ -1,0 +1,1 @@
+Added ``EndpointKind.RAW_INLINE`` data API endpoint type which will show the response data inline in the browser instead of downloading as a file.

--- a/www/react-base/src/components/LogDownloadButtons/LogDownloadButtons.scss
+++ b/www/react-base/src/components/LogDownloadButtons/LogDownloadButtons.scss
@@ -2,5 +2,6 @@
 .bb-log-download-button.btn {
   // This fixes wrong vertical alignment in relation to other elements if the download button is part of the text
   // line with other content.
+  display: inline;
   vertical-align: top;
 }

--- a/www/react-base/src/components/LogDownloadButtons/LogDownloadButtons.tsx
+++ b/www/react-base/src/components/LogDownloadButtons/LogDownloadButtons.tsx
@@ -15,24 +15,31 @@
   Copyright Buildbot Team Members
 */
 
-import './LogDownloadButton.scss';
+import './LogDownloadButtons.scss';
 import {useContext} from "react";
+import {Button, ButtonGroup} from "react-bootstrap";
 import {FaDownload} from "react-icons/fa";
 import {DataClientContext, Log} from "buildbot-data-js";
 
-export type LogDownloadButtonProps = {
+export type LogDownloadButtonsProps = {
   log: Log;
 }
 
-export const LogDownloadButton = ({log}: LogDownloadButtonProps) => {
+export const LogDownloadButtons = ({log}: LogDownloadButtonsProps) => {
   const dataClient = useContext(DataClientContext);
   const apiRootUrl = dataClient.restClient.rootUrl;
 
   return (
-    <a href={`${apiRootUrl}/logs/${log.id}/raw`} title="download log"
-       className="btn btn-default btn-xs bb-log-download-button">
-      <FaDownload/>&nbsp;
-      Download
-    </a>
+    <ButtonGroup>
+      <Button href={`${apiRootUrl}/logs/${log.id}/raw`} variant="default" title="download log"
+        className="bb-log-download-button btn-sm">
+        <FaDownload/>
+      </Button>
+      <Button href={`${apiRootUrl}/logs/${log.id}/raw_inline`} variant="default"
+              title="show log"
+              className="bb-log-download-button btn-sm">
+        Raw
+      </Button>
+    </ButtonGroup>
   );
 }

--- a/www/react-base/src/components/LogPreview/LogPreview.tsx
+++ b/www/react-base/src/components/LogPreview/LogPreview.tsx
@@ -25,7 +25,7 @@ import {observer, useLocalObservable} from "mobx-react";
 import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {ArrowExpander, useStateWithDefaultIfNotSet} from "buildbot-ui";
 import {CancellablePromise, Log, useDataAccessor} from "buildbot-data-js";
-import {LogDownloadButton} from "../LogDownloadButton/LogDownloadButton";
+import {LogDownloadButtons} from "../LogDownloadButtons/LogDownloadButtons";
 
 type RenderedLogLine = {
   content: JSX.Element[];
@@ -197,7 +197,7 @@ export const LogPreview = observer(({builderid, buildnumber, stepnumber, log,
               <Link to={`/builders/${builderid}/builds/${buildnumber}/steps/${stepnumber}/logs/${log.slug}`}>
                 view all {log.num_lines} line{log.num_lines > 1 ? 's' : ''}&nbsp;
               </Link>
-              <LogDownloadButton log={log}/>
+              <LogDownloadButtons log={log}/>
             </div>
           </div>
         </div>

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -24,7 +24,7 @@ import {Log, useDataAccessor} from "buildbot-data-js";
 import {FixedSizeList, ListOnItemsRenderedProps} from 'buildbot-ui';
 import AutoSizer, {Size} from "react-virtualized-auto-sizer";
 import {digitCount} from "../../util/Math";
-import {LogDownloadButton} from "../LogDownloadButton/LogDownloadButton";
+import {LogDownloadButtons} from "../LogDownloadButtons/LogDownloadButtons";
 import {LogSearchField} from "../LogSearchField/LogSearchField";
 import {LogTextManager} from "./LogTextManager";
 import {LogViewerTextLineRenderer} from "./LogViewerTextLineRenderer";
@@ -132,7 +132,7 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
                           onPrevClicked={() => manager.setPrevSearchResult()}
                           onNextClicked={() => manager.setNextSearchResult()}
                           inputRef={searchInputRef}/>
-          <LogDownloadButton log={log}/>
+          <LogDownloadButtons log={log}/>
         </div>
       </div>
       <FixedSizeList


### PR DESCRIPTION
This PR adds a button to show full log inline as a browser tab instead of downloading it as a file.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
