### PR TITLE
www: Focus log search box on Ctrl+F hotkey

### DIFF
--- a/www/react-base/package.json
+++ b/www/react-base/package.json
@@ -52,6 +52,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dev-utils": "^11.0.3",
     "react-dom": "^18.2.0",
+    "react-hotkeys-hook": "^4.4.0",
     "react-icons": "^4.8.0",
     "react-refresh": "^0.8.3",
     "react-router-dom": "^6.3.0",

--- a/www/react-base/src/components/LogSearchField/LogSearchField.tsx
+++ b/www/react-base/src/components/LogSearchField/LogSearchField.tsx
@@ -16,7 +16,7 @@
 */
 
 import './LogSearchField.scss'
-import {useState} from "react";
+import {Ref, useState} from "react";
 import {FaChevronDown, FaChevronUp, FaSearch} from "react-icons/fa";
 
 export type LogSearchButtonProps = {
@@ -25,10 +25,12 @@ export type LogSearchButtonProps = {
   onTextChanged: (text: string) => void;
   onPrevClicked: () => void;
   onNextClicked: () => void;
+  inputRef: Ref<HTMLInputElement>;
 };
 
 export const LogSearchField = ({currentResult, totalResults,
-                                onTextChanged, onPrevClicked, onNextClicked}: LogSearchButtonProps) => {
+                                onTextChanged, onPrevClicked, onNextClicked,
+                                inputRef}: LogSearchButtonProps) => {
   const [searchText, setSearchText] = useState<string>('');
   const [hasFocus, setHasFocus] = useState<boolean>(false);
 
@@ -60,6 +62,7 @@ export const LogSearchField = ({currentResult, totalResults,
     <form role="search" className="bb-log-search-field">
       <FaSearch className="bb-log-search-field-icon"/>
       <input className="bb-log-search-field-text" type="text" value={searchText}
+             ref={inputRef}
              onFocus={() => setHasFocus(true)} onBlur={() => setHasFocus(false)}
              onChange={e => onSearchTextChanged(e.target.value)}
              onKeyDown={e => onKeyDown(e)}

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -17,6 +17,7 @@
 
 import './LogViewerText.scss'
 import {forwardRef, useCallback, useMemo, useRef, useState} from 'react';
+import {useHotkeys} from "react-hotkeys-hook";
 import {generateStyleElement} from "../../util/AnsiEscapeCodes";
 import {observer} from "mobx-react";
 import {Log, useDataAccessor} from "buildbot-data-js";
@@ -114,6 +115,9 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
     });
   }
 
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  useHotkeys('Ctrl+F', () => { searchInputRef.current?.focus(); }, {preventDefault: true});
+
   const outerElementType = useMemo(() => forwardRef<HTMLDivElement>((props, ref) => (
     <div ref={ref} onMouseDown={checkSelection} onMouseUp={checkSelection} {...props}/>
   )), []);
@@ -126,7 +130,8 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
                           totalResults={Math.max(manager.totalSearchResultCount, 0)}
                           onTextChanged={onSearchTextChanged}
                           onPrevClicked={() => manager.setPrevSearchResult()}
-                          onNextClicked={() => manager.setNextSearchResult()}/>
+                          onNextClicked={() => manager.setNextSearchResult()}
+                          inputRef={searchInputRef}/>
           <LogDownloadButton log={log}/>
         </div>
       </div>

--- a/www/react-base/yarn.lock
+++ b/www/react-base/yarn.lock
@@ -6647,6 +6647,11 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-hotkeys-hook@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.4.1.tgz#1f7a7a1c9c21d4fa3280bf340fcca8fd77d81994"
+  integrity sha512-sClBMBioFEgFGYLTWWRKvhxcCx1DRznd+wkFHwQZspnRBkHTgruKIHptlK/U/2DPX8BhHoRGzpMVWUXMmdZlmw==
+
 react-icons@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"


### PR DESCRIPTION
This PR adds a hotkey that focus in log viewer search box on ctrl+f instead of launching browser find functionality that does not actually see the full logs.