### PR TITLE
www: Show only projects with builders

### DIFF
--- a/master/buildbot/db/projects.py
+++ b/master/buildbot/db/projects.py
@@ -59,6 +59,22 @@ class ProjectsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns a value
+    def get_active_projects(self):
+        def thd(conn):
+            projects_tbl = self.db.model.projects
+            builders_tbl = self.db.model.builders
+            bm_tbl = self.db.model.builder_masters
+
+            q = projects_tbl.select() \
+                .join(builders_tbl) \
+                .join(bm_tbl) \
+                .order_by(projects_tbl.c.name)
+            res = conn.execute(q)
+            return [self._project_dict_from_row(row) for row in res.fetchall()]
+
+        return self.db.pool.do(thd)
+
+    # returns a Deferred that returns a value
     def update_project_info(
         self,
         projectid,

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -361,6 +361,11 @@ types:
 /projects:
     description: This path selects all projects
     get:
+        queryParameters:
+            active:
+                type: boolean
+                description: Whether to return only active projects (with active builders) or all
+                required: false
         is:
         - bbget: {bbtype: project}
 

--- a/master/buildbot/test/fakedb/projects.py
+++ b/master/buildbot/test/fakedb/projects.py
@@ -95,6 +95,24 @@ class FakeProjectsComponent(FakeDBComponent):
             rv.append(self._row2dict(project))
         return rv
 
+    def get_active_projects(self):
+        rv = []
+
+        active_builderids = {
+            builderid for builderid, _ in self.db.builders.builder_masters.values()
+        }
+
+        active_projectids = {
+            builder["projectid"] for id, builder in self.db.builders.builders.items()
+            if id in active_builderids
+        }
+
+        for id, project in self.projects.items():
+            if id not in active_projectids:
+                continue
+            rv.append(self._row2dict(project))
+        return rv
+
     def update_project_info(
         self,
         projectid,

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -15,10 +15,13 @@
 
 from unittest import mock
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.data import projects
+from buildbot.data import resultspec
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
@@ -80,19 +83,34 @@ class ProjectsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         yield self.db.insert_test_data([
             fakedb.Project(id=1, name='project1'),
             fakedb.Project(id=2, name='project2'),
+            fakedb.Project(id=3, name='project3'),
+            fakedb.Master(id=100),
+            fakedb.Builder(id=200, projectid=2),
+            fakedb.Builder(id=201, projectid=3),
+            fakedb.BuilderMaster(id=300, builderid=200, masterid=100),
         ])
 
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @parameterized.expand([
+        ('no_filter', None, [1, 2, 3]),
+        ('active', True, [2]),
+        ('inactive', False, [1, 3]),
+    ])
     @defer.inlineCallbacks
-    def test_get(self):
-        projects = yield self.callGet(('projects',))
+    def test_get(self, name, active_filter, expected_projectids):
+        result_spec = None
+        if active_filter is not None:
+            result_spec = resultspec.OptimisedResultSpec(
+                filters=[resultspec.Filter('active', 'eq', [active_filter])])
+
+        projects = yield self.callGet(('projects',), resultSpec=result_spec)
 
         for b in projects:
             self.validateData(b)
 
-        self.assertEqual(sorted([b['projectid'] for b in projects]), [1, 2])
+        self.assertEqual(sorted([b['projectid'] for b in projects]), expected_projectids)
 
 
 class Project(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):

--- a/newsfragments/projects_active_api.feature
+++ b/newsfragments/projects_active_api.feature
@@ -1,0 +1,1 @@
+Added data and REST APIs to retrieve only projects with active builders.

--- a/www/react-base/src/views/ProjectsView/ProjectsView.tsx
+++ b/www/react-base/src/views/ProjectsView/ProjectsView.tsx
@@ -37,7 +37,8 @@ export const ProjectsView = observer(() => {
     {caption: "Projects", route: "/projects"}
   ]);
 
-  const projects = useDataApiQuery(() => Project.getAll(accessor));
+  const projects = useDataApiQuery(
+    () => Project.getAll(accessor, {query: {active: true}}));
 
   const filteredProjects = projects.array.filter(project => {
     return project.name.indexOf(projectNameFilter) >= 0;


### PR DESCRIPTION
This PR adjusts the projects view so that only projects with builders are shown. To support this new APIs in the DB layer have been added.
