### PR TITLE
docs: Fix documentation for collapseRequests on BuilderConfig

### DIFF
--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -192,7 +192,7 @@ Possible values for both ``collapseRequests`` configurations are:
 ``False``
     Requests will never be collapsed.
 
-``callable(builder, req1, req2)``
+``callable(master, builder, req1, req2)``
     Requests will be collapsed if the callable returns true.
     See :ref:`Collapse-Request-Functions` for detailed example.
 


### PR DESCRIPTION
It seems that this one place in documentation was missed when collapseRequests grew a "master" argument.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
