### PR TITLE
process/buildrequestdistributor: sort unclaimed br cache by requestid

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -200,6 +200,7 @@ buildreq
 buildrequest
 buildrequestcompletions
 buildrequestdistributor
+buildrequestid
 buildrequestresults
 buildrequests
 buildrequestsconnectorcomponent

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -87,8 +87,8 @@ class BuildChooserBase:
                                                  [resultspec.Filter('claimed',
                                                                     'eq',
                                                                     [False])])
-            # sort by submitted_at, so the first is the oldest
-            brdicts.sort(key=lambda brd: brd['submitted_at'])
+            # sort by buildrequestid, so the first is the oldest
+            brdicts.sort(key=lambda brd: brd['buildrequestid'])
             self.unclaimedBrdicts = brdicts
         return self.unclaimedBrdicts
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -106,6 +106,7 @@ Buildmaster
 buildmasters
 buildnumber
 buildrequest
+buildrequestid
 buildrequests
 buildset
 Buildset

--- a/newsfragments/buildrequest-sort.bugfix
+++ b/newsfragments/buildrequest-sort.bugfix
@@ -1,0 +1,1 @@
+Buildrequests are now selected by priority and then by buildrequestid (previously, we used the age as the secondary sort parameter). This preserves the property of choosing the oldest buildrequest, but makes it predictable which buildrequest will be selected, as there might be multiple buildrequests with the same age.


### PR DESCRIPTION
When choosing the next buildrequest to build, we first look at their priority, then break ties by choosing the oldest ("submitted_at" field).

However, if multiple buildrequests were created at the same time, they will all have the same "submitted_at". This makes it unpredictable which will be selected.

To make it predictable, we can break ties using the buildrequestid instead. This preserves the property of choosing the oldest (as a br with a lower id will have a submitted_at <= then a br with a higher id).

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
