### PR TITLE
allow secrets to be group-readable

### DIFF
--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -32,7 +32,7 @@ class SecretInAFile(SecretProviderBase):
     def checkFileIsReadOnly(self, dirname, secretfile):
         filepath = os.path.join(dirname, secretfile)
         obs_stat = stat.S_IMODE(os.stat(filepath).st_mode)
-        if (obs_stat & 0o77) != 0 and os.name == "posix":
+        if (obs_stat & 0o7) != 0 and os.name == "posix":
             config.error(f"Permissions {oct(obs_stat)} on file {secretfile} are too open."
                          " It is required that your secret files are NOT"
                          " accessible by others!")

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -57,7 +57,7 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         if os.name != "posix":
             self.skipTest("Permission checks only works on posix systems")
         filepath = self.createFileTemp(self.tmp_dir, "tempfile2.txt",
-                                       chmodRights=stat.S_IRGRP)
+                                       chmodRights=stat.S_IROTH)
         expctd_msg_error = " on file tempfile2.txt are too " \
                            "open. It is required that your secret files are" \
                            " NOT accessible by others!"

--- a/newsfragments/group-readable-secrets.bugfix
+++ b/newsfragments/group-readable-secrets.bugfix
@@ -1,0 +1,5 @@
+Enhanced the accessibility of secret files by enabling group-readability.
+Previously, secret files were exclusively accessible to the owner. Now,
+accessibility has been expanded to allow group members access as well. This
+enhancement is particularly beneficial when utilizing Systemd's LoadCredential
+feature, which configures secrets with group-readable (0o440) permissions.


### PR DESCRIPTION
Systemd's LoadCredential feature makes secrets group-readable (0o440) permissions. Services cannot modify secrets or their permission as they are mounted read-only.
By relaxing the check we allow buildbot to use secrets provided by systemd. In pratice group-readable secrets are a common pattern to share secrets between different process of the same group and buildbot shouldn't restrict this.

## Remove this paragraph

If you don't remove this paragraph from the pull request description, this means you didn't read our contributor documentation, and your patch will need more back and forth before it can be accepted!

Please have a look at our developer documentation before submitting your Pull Request.

http://docs.buildbot.net/latest/developer/quickstart.html

And especially:
http://docs.buildbot.net/latest/developer/pull-request.html


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
