### PR TITLE
www-react: Fix crash on build ending

### DIFF
--- a/www/react-base/src/components/RawData/RawData.test.tsx
+++ b/www/react-base/src/components/RawData/RawData.test.tsx
@@ -50,6 +50,7 @@ describe('RawData component', function() {
       boolean: true,
       array: [321, "string", true],
       null: null,
+      undefined: undefined,
     }
 
     assertRenderSnapshot(obj);
@@ -63,6 +64,7 @@ describe('RawData component', function() {
       boolean: true,
       array: observable([321, "string", true]),
       null: null,
+      undefined: undefined,
     });
 
     assertRenderSnapshot(obj);
@@ -76,6 +78,7 @@ describe('RawData component', function() {
         {float: 123.4},
         {boolean: true},
         {null: null},
+        {undefined: undefined},
       ],
     };
 
@@ -90,6 +93,7 @@ describe('RawData component', function() {
         {float: 123.4},
         {boolean: true},
         {null: null},
+        {undefined: undefined},
       ],
     };
 
@@ -104,6 +108,7 @@ describe('RawData component', function() {
         observable({float: 123.4}),
         observable({boolean: true}),
         observable({null: null}),
+        observable({undefined: undefined}),
       ],
     });
 

--- a/www/react-base/src/components/RawData/RawData.test.tsx
+++ b/www/react-base/src/components/RawData/RawData.test.tsx
@@ -49,6 +49,7 @@ describe('RawData component', function() {
       float: 123.4,
       boolean: true,
       array: [321, "string", true],
+      null: null,
     }
 
     assertRenderSnapshot(obj);
@@ -61,6 +62,7 @@ describe('RawData component', function() {
       float: 123.4,
       boolean: true,
       array: observable([321, "string", true]),
+      null: null,
     });
 
     assertRenderSnapshot(obj);
@@ -73,6 +75,7 @@ describe('RawData component', function() {
         {int: 123},
         {float: 123.4},
         {boolean: true},
+        {null: null},
       ],
     };
 
@@ -86,6 +89,7 @@ describe('RawData component', function() {
         {int: 123},
         {float: 123.4},
         {boolean: true},
+        {null: null},
       ],
     };
 
@@ -99,6 +103,7 @@ describe('RawData component', function() {
         observable({int: 123}),
         observable({float: 123.4}),
         observable({boolean: true}),
+        observable({null: null}),
       ],
     });
 

--- a/www/react-base/src/components/RawData/RawData.tsx
+++ b/www/react-base/src/components/RawData/RawData.tsx
@@ -55,6 +55,9 @@ export const RawData = ({data}: RawDataProps) => {
     if (value === null) {
       return <dd>{"null"}&nbsp;</dd>;
     }
+    if (value === undefined) {
+      return <dd>{"undefined"}&nbsp;</dd>;
+    }
     if (isArrayOfObjectsRaw(value)) {
       return (
         <dd>

--- a/www/react-base/src/components/RawData/RawData.tsx
+++ b/www/react-base/src/components/RawData/RawData.tsx
@@ -52,8 +52,8 @@ export const RawData = ({data}: RawDataProps) => {
   }
 
   const renderDataElement = (value: any) => {
-    if (!isObjectRaw(value) && !isArrayOfObjectsRaw(value)) {
-      return <dd>{value === null ? "null" : value.toString()}&nbsp;</dd>;
+    if (value === null) {
+      return <dd>{"null"}&nbsp;</dd>;
     }
     if (isArrayOfObjectsRaw(value)) {
       return (
@@ -71,6 +71,8 @@ export const RawData = ({data}: RawDataProps) => {
         </dd>
       )
     }
+
+    return <dd>{value.toString()}&nbsp;</dd>;
   }
 
   const renderElements = () => {

--- a/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
+++ b/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`RawData component object with array of objects 1`] = `
         />
       </svg>
       <span>
-        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true}]
+        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true},{"null":null}]
       </span>
     </dd>
   </div>
@@ -139,6 +139,23 @@ exports[`RawData component object with array of objects expanded 1`] = `
             </div>
           </dl>
         </li>
+        <li>
+          <dl
+            className="dl-horizontal"
+          >
+            <div
+              className="bb-raw-data-key-value"
+            >
+              <dt>
+                null
+              </dt>
+              <dd>
+                null
+                 
+              </dd>
+            </div>
+          </dl>
+        </li>
       </ul>
     </dd>
   </div>
@@ -204,6 +221,17 @@ exports[`RawData component observable object 1`] = `
        
     </dd>
   </div>
+  <div
+    className="bb-raw-data-key-value"
+  >
+    <dt>
+      null
+    </dt>
+    <dd>
+      null
+       
+    </dd>
+  </div>
 </dl>
 `;
 
@@ -239,7 +267,7 @@ exports[`RawData component observable object with array of objects 1`] = `
         />
       </svg>
       <span>
-        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true}]
+        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true},{"null":null}]
       </span>
     </dd>
   </div>
@@ -302,6 +330,17 @@ exports[`RawData component simple object 1`] = `
     </dt>
     <dd>
       321,string,true
+       
+    </dd>
+  </div>
+  <div
+    className="bb-raw-data-key-value"
+  >
+    <dt>
+      null
+    </dt>
+    <dd>
+      null
        
     </dd>
   </div>

--- a/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
+++ b/www/react-base/src/components/RawData/__snapshots__/RawData.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`RawData component object with array of objects 1`] = `
         />
       </svg>
       <span>
-        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true},{"null":null}]
+        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true},{"null":null},{}]
       </span>
     </dd>
   </div>
@@ -156,6 +156,23 @@ exports[`RawData component object with array of objects expanded 1`] = `
             </div>
           </dl>
         </li>
+        <li>
+          <dl
+            className="dl-horizontal"
+          >
+            <div
+              className="bb-raw-data-key-value"
+            >
+              <dt>
+                undefined
+              </dt>
+              <dd>
+                undefined
+                 
+              </dd>
+            </div>
+          </dl>
+        </li>
       </ul>
     </dd>
   </div>
@@ -232,6 +249,17 @@ exports[`RawData component observable object 1`] = `
        
     </dd>
   </div>
+  <div
+    className="bb-raw-data-key-value"
+  >
+    <dt>
+      undefined
+    </dt>
+    <dd>
+      undefined
+       
+    </dd>
+  </div>
 </dl>
 `;
 
@@ -267,7 +295,7 @@ exports[`RawData component observable object with array of objects 1`] = `
         />
       </svg>
       <span>
-        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true},{"null":null}]
+        [{"str":"string"},{"int":123},{"float":123.4},{"boolean":true},{"null":null},{}]
       </span>
     </dd>
   </div>
@@ -341,6 +369,17 @@ exports[`RawData component simple object 1`] = `
     </dt>
     <dd>
       null
+       
+    </dd>
+  </div>
+  <div
+    className="bb-raw-data-key-value"
+  >
+    <dt>
+      undefined
+    </dt>
+    <dd>
+      undefined
        
     </dd>
   </div>


### PR DESCRIPTION
`RawData.renderDataElement` would receive an `undefined` value and try to call `.toString()` on it, resulting on a blank page.

I took the liberty to make some changes to the function as well as I felt it more legible. Let me know if you'd rather I revert it back to it's previous form.