### PR TITLE
www/react: Fix plugins development proxy

### DIFF
--- a/www/react-base/vite.config.ts
+++ b/www/react-base/vite.config.ts
@@ -31,9 +31,9 @@ const buildPluginsPathsMap = () => {
     }
   }
 
-  addPlugin('grid_view', path.join(root, `react-grid_view/buildbot_react_grid_view/static/`))
-  addPlugin('console_view', path.join(root, `react-console_view/buildbot_react_console_view/static/`))
-  addPlugin('waterfall_view',
+  addPlugin('react_grid_view', path.join(root, `react-grid_view/buildbot_react_grid_view/static/`))
+  addPlugin('react_console_view', path.join(root, `react-console_view/buildbot_react_console_view/static/`))
+  addPlugin('react_waterfall_view',
     path.join(root, `react-waterfall_view/buildbot_react_waterfall_view/static/`))
 
   return aliases;


### PR DESCRIPTION
This fixes the usage of `yarn run start` for plugin development