### PR TITLE
Draft: DockerLatentWorker: Explicitly disconnect when stopping instance

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -379,3 +379,6 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
             except docker.errors.APIError as e:
                 log.msg('Error while removing the image: %s', e)
         docker_client.close()
+        conn = self.conn
+        self.conn = None
+        self._disconnect(conn)


### PR DESCRIPTION
Seems to fix #4678

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
