### PR TITLE
Implement worker pause reason

### DIFF
--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -31,6 +31,7 @@ class Db2DataMixin:
             'name': dbdict['name'],
             'workerinfo': dbdict['workerinfo'],
             'paused': dbdict['paused'],
+            "pause_reason": dbdict["pause_reason"],
             'graceful': dbdict['graceful'],
             'connected_to': [
                 {'masterid': id}
@@ -132,6 +133,7 @@ class Worker(base.ResourceType):
         configured_on = types.List(of=MasterBuilderEntityType("master_builder", 'MasterBuilder'))
         workerinfo = types.JsonObject()
         paused = types.Boolean()
+        pause_reason = types.NoneOk(types.String())
         graceful = types.Boolean()
     entityType = EntityType(name, 'Worker')
 
@@ -188,8 +190,12 @@ class Worker(base.ResourceType):
 
     @base.updateMethod
     @defer.inlineCallbacks
-    def set_worker_paused(self, workerid, paused):
-        yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
+    def set_worker_paused(self, workerid, paused, pause_reason=None):
+        yield self.master.db.workers.set_worker_paused(
+            workerid=workerid,
+            paused=paused,
+            pause_reason=pause_reason
+        )
         bs = yield self.master.data.get(('workers', workerid))
         self.produceEvent(bs, 'state_updated')
 

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -20,6 +20,7 @@ from buildbot.data import base
 from buildbot.data import exceptions
 from buildbot.data import types
 from buildbot.util import identifiers
+from buildbot.warnings import warn_deprecated
 
 
 class Db2DataMixin:
@@ -178,10 +179,24 @@ class Worker(base.ResourceType):
     @base.updateMethod
     @defer.inlineCallbacks
     def setWorkerState(self, workerid, paused, graceful):
-        yield self.master.db.workers.setWorkerState(
-            workerid=workerid,
-            paused=paused,
-            graceful=graceful)
+        warn_deprecated("3.10.0", "setWorkerState() has been deprecated, "
+                        "please use set_worker_paused() and/or set_worker_graceful()")
+        yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
+        yield self.master.db.workers.set_worker_graceful(workerid=workerid, graceful=graceful)
+        bs = yield self.master.data.get(('workers', workerid))
+        self.produceEvent(bs, 'state_updated')
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def set_worker_paused(self, workerid, paused):
+        yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
+        bs = yield self.master.data.get(('workers', workerid))
+        self.produceEvent(bs, 'state_updated')
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def set_worker_graceful(self, workerid, graceful):
+        yield self.master.db.workers.set_worker_graceful(workerid=workerid, graceful=graceful)
         bs = yield self.master.data.get(('workers', workerid))
         self.produceEvent(bs, 'state_updated')
 

--- a/master/buildbot/db/migrations/versions/064_2023-10-29_add_worker_pause_reason.py
+++ b/master/buildbot/db/migrations/versions/064_2023-10-29_add_worker_pause_reason.py
@@ -1,0 +1,37 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""add pause_reason column to workers table
+
+Revision ID: 064
+Revises: 063
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '064'
+down_revision = '063'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("workers", sa.Column("pause_reason", sa.Text, nullable=True))
+
+
+def downgrade():
+    op.drop_column("workers", "pause_reason")

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -331,6 +331,7 @@ class Model(base.DBConnectorComponent):
         sa.Column("name", sa.String(50), nullable=False),
         sa.Column("info", JsonObject, nullable=False),
         sa.Column("paused", sa.SmallInteger, nullable=False, server_default="0"),
+        sa.Column("pause_reason", sa.Text, nullable=True),
         sa.Column("graceful", sa.SmallInteger, nullable=False, server_default="0"),
     )
 

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -229,9 +229,17 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns None
-    def setWorkerState(self, workerid, paused, graceful):
+    def set_worker_paused(self, workerid, paused):
         def thd(conn):
             tbl = self.db.model.workers
             q = tbl.update(whereclause=tbl.c.id == workerid)
-            conn.execute(q, paused=int(paused), graceful=int(graceful))
+            conn.execute(q, paused=int(paused))
+        return self.db.pool.do(thd)
+
+    # returns a Deferred that returns None
+    def set_worker_graceful(self, workerid, graceful):
+        def thd(conn):
+            tbl = self.db.model.workers
+            q = tbl.update(whereclause=tbl.c.id == workerid)
+            conn.execute(q, graceful=int(graceful))
         return self.db.pool.do(thd)

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -30,7 +30,13 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
         return self.findSomethingId(
             tbl=tbl,
             whereclause=(tbl.c.name == name),
-            insert_values={"name": name, "info": {}, "paused": 0, "graceful": 0}
+            insert_values={
+                "name": name,
+                "info": {},
+                "paused": 0,
+                "pause_reason": None,
+                "graceful": 0
+            }
         )
 
     def _deleteFromConfiguredWorkers_thd(self, conn, buildermasterids, workerid=None):
@@ -135,7 +141,9 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
             j = j.outerjoin(bm_tbl)
             q = sa.select(
                 [workers_tbl.c.id, workers_tbl.c.name, workers_tbl.c.info,
-                 workers_tbl.c.paused, workers_tbl.c.graceful,
+                 workers_tbl.c.paused,
+                 workers_tbl.c.pause_reason,
+                 workers_tbl.c.graceful,
                  bm_tbl.c.builderid, bm_tbl.c.masterid],
                 from_obj=[j],
                 order_by=[workers_tbl.c.id])
@@ -168,6 +176,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                         'connected_to': [],
                         'workerinfo': row.info,
                         'paused': bool(row.paused),
+                        "pause_reason": row.pause_reason,
                         'graceful': bool(row.graceful)}
                     rv[lastId] = res
                 if row.builderid and row.masterid:
@@ -229,11 +238,11 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns None
-    def set_worker_paused(self, workerid, paused):
+    def set_worker_paused(self, workerid, paused, pause_reason=None):
         def thd(conn):
             tbl = self.db.model.workers
             q = tbl.update(whereclause=tbl.c.id == workerid)
-            conn.execute(q, paused=int(paused))
+            conn.execute(q, paused=int(paused), pause_reason=pause_reason)
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns None

--- a/master/buildbot/spec/types/worker.raml
+++ b/master/buildbot/spec/types/worker.raml
@@ -26,6 +26,9 @@ properties:
     paused:
         description: the worker is paused if it is connected but doesn't accept new builds
         type: bool
+    pause_reason?:
+        description: the reason for pausing the worker, if the worker is paused
+        type: string
     graceful:
         description: the worker is graceful if it doesn't accept new builds, and will shutdown when builds are finished
         type: bool

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -453,8 +453,8 @@ class FakeUpdates(service.AsyncService):
         yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
         yield self.master.db.workers.set_worker_graceful(workerid=workerid, graceful=graceful)
 
-    def set_worker_paused(self, workerid, paused):
-        return self.master.db.workers.set_worker_paused(workerid, paused)
+    def set_worker_paused(self, workerid, paused, pause_reason=None):
+        return self.master.db.workers.set_worker_paused(workerid, paused, pause_reason=pause_reason)
 
     def set_worker_graceful(self, workerid, graceful):
         return self.master.db.workers.set_worker_graceful(workerid, graceful)

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -448,11 +448,16 @@ class FakeUpdates(service.AsyncService):
     def schedulerEnable(self, schedulerid, v):
         return self.master.db.schedulers.enable(schedulerid, v)
 
+    @defer.inlineCallbacks
     def setWorkerState(self, workerid, paused, graceful):
-        return self.master.db.workers.setWorkerState(
-            workerid=workerid,
-            paused=paused,
-            graceful=graceful)
+        yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
+        yield self.master.db.workers.set_worker_graceful(workerid=workerid, graceful=graceful)
+
+    def set_worker_paused(self, workerid, paused):
+        return self.master.db.workers.set_worker_paused(workerid, paused)
+
+    def set_worker_graceful(self, workerid, graceful):
+        return self.master.db.workers.set_worker_graceful(workerid, graceful)
 
     # methods form BuildData resource
     @defer.inlineCallbacks

--- a/master/buildbot/test/fakedb/workers.py
+++ b/master/buildbot/test/fakedb/workers.py
@@ -202,10 +202,14 @@ class FakeWorkersComponent(FakeDBComponent):
                 break
         return defer.succeed(None)
 
-    def setWorkerState(self, workerid, paused, graceful):
+    def set_worker_paused(self, workerid, paused):
         worker = self.workers.get(workerid)
         if worker is not None:
             worker['paused'] = int(paused)
+
+    def set_worker_graceful(self, workerid, graceful):
+        worker = self.workers.get(workerid)
+        if worker is not None:
             worker['graceful'] = int(graceful)
 
     def _configuredOn(self, workerid, builderid=None, masterid=None):

--- a/master/buildbot/test/fakedb/workers.py
+++ b/master/buildbot/test/fakedb/workers.py
@@ -29,10 +29,25 @@ class Worker(Row):
     id_column = 'id'
     required_columns = ('name', )
 
-    def __init__(self, id=None, name='some:worker', info=None, paused=0, graceful=0):
+    def __init__(
+        self,
+        id=None,
+        name='some:worker',
+        info=None,
+        paused=0,
+        pause_reason=None,
+        graceful=0
+    ):
         if info is None:
             info = {"a": "b"}
-        super().__init__(id=id, name=name, info=info, paused=paused, graceful=graceful)
+        super().__init__(
+            id=id,
+            name=name,
+            info=info,
+            paused=paused,
+            pause_reason=pause_reason,
+            graceful=graceful
+        )
 
 
 class ConnectedWorker(Row):
@@ -69,6 +84,7 @@ class FakeWorkersComponent(FakeDBComponent):
                     "id": row.id,
                     "name": row.name,
                     "paused": row.paused,
+                    "pause_reason": row.pause_reason,
                     "graceful": row.graceful,
                     "info": row.info
                 }
@@ -94,7 +110,10 @@ class FakeWorkersComponent(FakeDBComponent):
         self.workers[id] = {
             "id": id,
             "name": name,
-            "info": {}
+            "info": {},
+            "paused": 0,
+            "pause_reason": None,
+            "graceful": 0
         }
         return defer.succeed(id)
 
@@ -202,10 +221,11 @@ class FakeWorkersComponent(FakeDBComponent):
                 break
         return defer.succeed(None)
 
-    def set_worker_paused(self, workerid, paused):
+    def set_worker_paused(self, workerid, paused, pause_reason=None):
         worker = self.workers.get(workerid)
         if worker is not None:
             worker['paused'] = int(paused)
+            worker['pause_reason'] = pause_reason
 
     def set_worker_graceful(self, workerid, graceful):
         worker = self.workers.get(workerid)
@@ -241,6 +261,7 @@ class FakeWorkersComponent(FakeDBComponent):
             'workerinfo': w['info'],
             'name': w['name'],
             'paused': bool(w.get('paused')),
+            'pause_reason': w.get("pause_reason"),
             'graceful': bool(w.get('graceful')),
             'configured_on': self._configuredOn(w['id'], builderid, masterid),
             'connected_to': self._connectedTo(w['id'], masterid),

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -77,6 +77,7 @@ def w1(builderid=None, masterid=None):
         'workerinfo': {},
         'paused': False,
         'graceful': False,
+        "pause_reason": None,
         'connected_to': [
             {'masterid': 13},
         ],
@@ -93,6 +94,7 @@ def w2(builderid=None, masterid=None):
         'name': 'windows',
         'workerinfo': {'a': 'b'},
         'paused': False,
+        "pause_reason": None,
         'graceful': False,
         'connected_to': [
             {'masterid': 14},
@@ -178,10 +180,11 @@ class WorkerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_set_worker_paused(self):
-        yield self.master.data.updates.set_worker_paused(2, True)
+        yield self.master.data.updates.set_worker_paused(2, True, "reason")
         worker = yield self.callGet(('workers', 2))
         self.validateData(worker)
         self.assertEqual(worker['paused'], True)
+        self.assertEqual(worker["pause_reason"], "reason")
 
     @defer.inlineCallbacks
     def test_set_worker_graceful(self):
@@ -260,7 +263,7 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_set_worker_paused_find_by_paused(self):
-        yield self.master.data.updates.set_worker_paused(2, True)
+        yield self.master.data.updates.set_worker_paused(2, True, None)
         resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('paused', 'eq', [True])])
 
@@ -299,7 +302,7 @@ class Worker(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def test_signature_set_worker_paused(self):
         @self.assertArgSpecMatches(self.master.data.updates.set_worker_paused)
-        def set_worker_paused(self, workerid, paused):
+        def set_worker_paused(self, workerid, paused, pause_reason=None):
             pass
 
     def test_signature_set_worker_graceful(self):

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -174,6 +174,21 @@ class WorkerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         worker = yield self.callGet(('workers', 2))
         self.validateData(worker)
         self.assertEqual(worker['paused'], True)
+        self.assertEqual(worker['graceful'], False)
+
+    @defer.inlineCallbacks
+    def test_set_worker_paused(self):
+        yield self.master.data.updates.set_worker_paused(2, True)
+        worker = yield self.callGet(('workers', 2))
+        self.validateData(worker)
+        self.assertEqual(worker['paused'], True)
+
+    @defer.inlineCallbacks
+    def test_set_worker_graceful(self):
+        yield self.master.data.updates.set_worker_graceful(2, True)
+        worker = yield self.callGet(('workers', 2))
+        self.validateData(worker)
+        self.assertEqual(worker['graceful'], True)
 
     @defer.inlineCallbacks
     def test_actions(self):
@@ -244,8 +259,8 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
                          sorted([w2(masterid=13, builderid=41)], key=configuredOnKey))
 
     @defer.inlineCallbacks
-    def test_setWorkerStateFindByPaused(self):
-        yield self.master.data.updates.setWorkerState(2, True, False)
+    def test_set_worker_paused_find_by_paused(self):
+        yield self.master.data.updates.set_worker_paused(2, True)
         resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('paused', 'eq', [True])])
 
@@ -280,6 +295,16 @@ class Worker(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
             self.master.data.updates.workerConfigured,  # fake
             self.rtype.workerConfigured)  # real
         def workerConfigured(self, workerid, masterid, builderids):
+            pass
+
+    def test_signature_set_worker_paused(self):
+        @self.assertArgSpecMatches(self.master.data.updates.set_worker_paused)
+        def set_worker_paused(self, workerid, paused):
+            pass
+
+    def test_signature_set_worker_graceful(self):
+        @self.assertArgSpecMatches(self.master.data.updates.set_worker_graceful)
+        def set_worker_graceful(self, workerid, graceful):
             pass
 
     def test_findWorkerId(self):

--- a/master/buildbot/test/unit/db/test_workers.py
+++ b/master/buildbot/test/unit/db/test_workers.py
@@ -121,7 +121,7 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_set_worker_paused(self):
         @self.assertArgSpecMatches(self.db.workers.set_worker_paused)
-        def set_worker_paused(self, workerid, paused):
+        def set_worker_paused(self, workerid, paused, pause_reason=None):
             pass
 
     def test_signature_set_worker_graceful(self):
@@ -164,6 +164,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "connected_to": [],
             "configured_on": []
@@ -184,6 +185,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'two',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "connected_to": [11],
             "configured_on": []
@@ -210,6 +212,7 @@ class Tests(interfaces.InterfaceTests):
                 "name": 'two',
                 "workerinfo": {'a': 'b'},
                 "paused": False,
+                "pause_reason": None,
                 "graceful": False,
                 "connected_to": [10, 11],
                 "configured_on": [
@@ -229,6 +232,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "connected_to": [],
             "configured_on": []
@@ -247,6 +251,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": [
                 {'masterid': 10, 'builderid': 20}
@@ -268,6 +273,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": [
                 {'masterid': 10, 'builderid': 20}
@@ -287,6 +293,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": sorted([
                 {'masterid': 10, 'builderid': 20},
@@ -308,6 +315,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": sorted([
                 {'masterid': 10, 'builderid': 20},
@@ -326,6 +334,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": [
                 {'masterid': 11, 'builderid': 20},
@@ -344,6 +353,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": [
                 {'masterid': 11, 'builderid': 20},
@@ -362,6 +372,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'zero',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": False,
             "configured_on": [
                 {'masterid': 11, 'builderid': 20},
@@ -386,6 +397,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'zero',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": [],
                         "connected_to": []
@@ -394,6 +406,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'one',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": [],
                         "connected_to": []
@@ -419,6 +432,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'zero',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                             {'masterid': 10, 'builderid': 20},
@@ -431,6 +445,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'one',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                             {'masterid': 11, 'builderid': 20},
@@ -469,6 +484,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'zero',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                             {'masterid': 10, 'builderid': 20},
@@ -480,6 +496,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'one',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                              {'masterid': 11, 'builderid': 20},
@@ -507,6 +524,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'zero',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                             {'masterid': 10, 'builderid': 20},
@@ -535,6 +553,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'zero',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                              {'masterid': 11, 'builderid': 20},
@@ -546,6 +565,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'one',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([
                             {'masterid': 11, 'builderid': 20},
@@ -575,6 +595,7 @@ class Tests(interfaces.InterfaceTests):
                         "name": 'one',
                         "workerinfo": {'a': 'b'},
                         "paused": False,
+                        "pause_reason": None,
                         "graceful": False,
                         "configured_on": sorted([{'masterid': 11, 'builderid': 22}, ],
                             key=configuredOnKey),
@@ -587,7 +608,7 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_getWorkers_with_paused(self):
         yield self.insert_test_data(self.baseRows + self.multipleMasters)
-        yield self.db.workers.set_worker_paused(31, paused=True)
+        yield self.db.workers.set_worker_paused(31, paused=True, pause_reason="reason")
         yield self.db.workers.set_worker_graceful(31, graceful=False)
         workerdicts = yield self.db.workers.getWorkers(
             paused=True)
@@ -600,6 +621,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'one',
             "workerinfo": {'a': 'b'},
             "paused": True,
+            "pause_reason": "reason",
             "graceful": False,
             "configured_on": [],
             "connected_to": [11]
@@ -620,6 +642,7 @@ class Tests(interfaces.InterfaceTests):
             "name": 'one',
             "workerinfo": {'a': 'b'},
             "paused": False,
+            "pause_reason": None,
             "graceful": True,
             "configured_on": [],
             "connected_to": [11]
@@ -640,6 +663,7 @@ class Tests(interfaces.InterfaceTests):
             'name': self.W1_NAME,
             'workerinfo': NEW_INFO,
             'paused': False,
+            "pause_reason": None,
             'graceful': False,
             'configured_on': [],
             'connected_to': [11]
@@ -684,7 +708,7 @@ class Tests(interfaces.InterfaceTests):
     def test_set_worker_paused_existing(self):
         yield self.insert_test_data(self.baseRows + self.worker1_rows)
 
-        yield self.db.workers.set_worker_paused(self.W1_ID, False)
+        yield self.db.workers.set_worker_paused(self.W1_ID, False, None)
 
         w = yield self.db.workers.getWorker(self.W1_ID)
         self.assertEqual(w, {
@@ -692,12 +716,13 @@ class Tests(interfaces.InterfaceTests):
             'name': self.W1_NAME,
             'workerinfo': self.W1_INFO,
             'paused': False,
+            "pause_reason": None,
             'graceful': False,
             'configured_on': [],
             'connected_to': []
         })
 
-        yield self.db.workers.set_worker_paused(self.W1_ID, True)
+        yield self.db.workers.set_worker_paused(self.W1_ID, True, "reason")
 
         w = yield self.db.workers.getWorker(self.W1_ID)
         self.assertEqual(w, {
@@ -705,6 +730,7 @@ class Tests(interfaces.InterfaceTests):
             'name': self.W1_NAME,
             'workerinfo': self.W1_INFO,
             'paused': True,
+            "pause_reason": "reason",
             'graceful': False,
             'configured_on': [],
             'connected_to': []
@@ -722,6 +748,7 @@ class Tests(interfaces.InterfaceTests):
             'name': self.W1_NAME,
             'workerinfo': self.W1_INFO,
             'paused': False,
+            "pause_reason": None,
             'graceful': False,
             'configured_on': [],
             'connected_to': []
@@ -735,6 +762,7 @@ class Tests(interfaces.InterfaceTests):
             'name': self.W1_NAME,
             'workerinfo': self.W1_INFO,
             'paused': False,
+            "pause_reason": None,
             'graceful': True,
             'configured_on': [],
             'connected_to': []

--- a/master/buildbot/test/unit/db/test_workers.py
+++ b/master/buildbot/test/unit/db/test_workers.py
@@ -119,9 +119,14 @@ class Tests(interfaces.InterfaceTests):
         def deconfigureAllWorkersForMaster(self, masterid):
             pass
 
-    def test_signature_setWorkerState(self):
-        @self.assertArgSpecMatches(self.db.workers.setWorkerState)
-        def setWorkerState(self, workerid, paused, graceful):
+    def test_signature_set_worker_paused(self):
+        @self.assertArgSpecMatches(self.db.workers.set_worker_paused)
+        def set_worker_paused(self, workerid, paused):
+            pass
+
+    def test_signature_set_worker_graceful(self):
+        @self.assertArgSpecMatches(self.db.workers.set_worker_graceful)
+        def set_worker_graceful(self, workerid, graceful):
             pass
 
     @defer.inlineCallbacks
@@ -582,7 +587,8 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_getWorkers_with_paused(self):
         yield self.insert_test_data(self.baseRows + self.multipleMasters)
-        yield self.db.workers.setWorkerState(31, paused=True, graceful=False)
+        yield self.db.workers.set_worker_paused(31, paused=True)
+        yield self.db.workers.set_worker_graceful(31, graceful=False)
         workerdicts = yield self.db.workers.getWorkers(
             paused=True)
         for workerdict in workerdicts:
@@ -602,7 +608,8 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_getWorkers_with_graceful(self):
         yield self.insert_test_data(self.baseRows + self.multipleMasters)
-        yield self.db.workers.setWorkerState(31, paused=False, graceful=True)
+        yield self.db.workers.set_worker_paused(31, paused=False)
+        yield self.db.workers.set_worker_graceful(31, graceful=True)
         workerdicts = yield self.db.workers.getWorkers(
             graceful=True)
         for workerdict in workerdicts:
@@ -674,11 +681,10 @@ class Tests(interfaces.InterfaceTests):
         self.assertEqual(w['connected_to'], [])
 
     @defer.inlineCallbacks
-    def test_setWorkerState_existing(self):
+    def test_set_worker_paused_existing(self):
         yield self.insert_test_data(self.baseRows + self.worker1_rows)
 
-        yield self.db.workers.setWorkerState(
-            workerid=self.W1_ID, paused=False, graceful=True)
+        yield self.db.workers.set_worker_paused(self.W1_ID, False)
 
         w = yield self.db.workers.getWorker(self.W1_ID)
         self.assertEqual(w, {
@@ -686,13 +692,12 @@ class Tests(interfaces.InterfaceTests):
             'name': self.W1_NAME,
             'workerinfo': self.W1_INFO,
             'paused': False,
-            'graceful': True,
+            'graceful': False,
             'configured_on': [],
             'connected_to': []
         })
 
-        yield self.db.workers.setWorkerState(
-            workerid=self.W1_ID, paused=True, graceful=False)
+        yield self.db.workers.set_worker_paused(self.W1_ID, True)
 
         w = yield self.db.workers.getWorker(self.W1_ID)
         self.assertEqual(w, {
@@ -701,6 +706,36 @@ class Tests(interfaces.InterfaceTests):
             'workerinfo': self.W1_INFO,
             'paused': True,
             'graceful': False,
+            'configured_on': [],
+            'connected_to': []
+        })
+
+    @defer.inlineCallbacks
+    def test_set_worker_graceful_existing(self):
+        yield self.insert_test_data(self.baseRows + self.worker1_rows)
+
+        yield self.db.workers.set_worker_graceful(self.W1_ID, False)
+
+        w = yield self.db.workers.getWorker(self.W1_ID)
+        self.assertEqual(w, {
+            'id': self.W1_ID,
+            'name': self.W1_NAME,
+            'workerinfo': self.W1_INFO,
+            'paused': False,
+            'graceful': False,
+            'configured_on': [],
+            'connected_to': []
+        })
+
+        yield self.db.workers.set_worker_graceful(self.W1_ID, True)
+
+        w = yield self.db.workers.getWorker(self.W1_ID)
+        self.assertEqual(w, {
+            'id': self.W1_ID,
+            'name': self.W1_NAME,
+            'workerinfo': self.W1_INFO,
+            'paused': False,
+            'graceful': True,
             'configured_on': [],
             'connected_to': []
         })

--- a/master/buildbot/test/unit/db_migrate/test_versions_064_add_worker_pause_reason.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_064_add_worker_pause_reason.py
@@ -1,0 +1,78 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.db.types.json import JsonObject
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        workers = sautils.Table(
+            "workers", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String(50), nullable=False),
+            sa.Column("info", JsonObject, nullable=False),
+            sa.Column("paused", sa.SmallInteger, nullable=False, server_default="0"),
+            sa.Column("graceful", sa.SmallInteger, nullable=False, server_default="0"),
+        )
+        workers.create()
+
+        conn.execute(workers.insert(), [{
+            "id": 4,
+            "name": "worker1",
+            "info": "{\"key\": \"value\"}",
+            "paused": 0,
+            "graceful": 0,
+        }])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            workers = sautils.Table('workers', metadata, autoload=True)
+            self.assertIsInstance(workers.c.pause_reason.type, sa.Text)
+
+            q = sa.select([
+                workers.c.name,
+                workers.c.pause_reason,
+            ])
+
+            num_rows = 0
+            for row in conn.execute(q):
+                self.assertEqual(row.name, "worker1")
+                self.assertIsNone(row.pause_reason)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+        return self.do_test_migration('063', '064', setup_thd, verify_thd)

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -414,6 +414,7 @@ dbdict['workerdict'] = DictValidator(
         )
     ),
     paused=BooleanValidator(),
+    pause_reason=NoneOk(StringValidator()),
     graceful=BooleanValidator(),
     connected_to=ListValidator(IntValidator()),
     workerinfo=JsonValidator(),

--- a/master/docs/developer/database/workers.rst
+++ b/master/docs/developer/database/workers.rst
@@ -100,3 +100,22 @@ Workers connector
         :returns: Deferred
 
         Change the state of a worker (see definition of states above in worker dict description).
+
+        This method is deprecated.
+
+    .. py:method:: set_worker_paused(workerid, paused)
+
+        :param integer workerid: the ID of the worker whose state is being changed
+        :param integer paused: the paused state
+        :returns: Deferred
+
+        Changes the ``paused`` state of the worker (see definition of states above in worker dict description).
+
+    .. py:method:: set_worker_graceful(workerid, graceful)
+
+        :param integer workerid: the ID of the worker whose state is being changed
+        :param integer graceful: the graceful state
+        :returns: Deferred
+
+        Changes the ``graceful`` state of the worker (see definition of states above in worker dict description).
+

--- a/master/docs/developer/database/workers.rst
+++ b/master/docs/developer/database/workers.rst
@@ -14,6 +14,7 @@ Workers connector
     * ``name`` - the name of the worker
     * ``workerinfo`` - worker information as dictionary
     * ``paused`` - boolean indicating worker is paused and shall not take new builds
+    * ``pause_reason`` - string indicating the reason for working being paused
     * ``graceful`` - boolean indicating worker will be shutdown as soon as build finished
     * ``connected_to`` - a list of masters, by ID, to which this worker is currently connected.
       This list will typically contain only one master, but in unusual circumstances the same worker may appear to be connected to multiple masters simultaneously
@@ -103,10 +104,11 @@ Workers connector
 
         This method is deprecated.
 
-    .. py:method:: set_worker_paused(workerid, paused)
+    .. py:method:: set_worker_paused(workerid, paused, pause_reason=None)
 
         :param integer workerid: the ID of the worker whose state is being changed
         :param integer paused: the paused state
+        :param string pause_reason: the reason for pausing the worker.
         :returns: Deferred
 
         Changes the ``paused`` state of the worker (see definition of states above in worker dict description).

--- a/newsfragments/data-updates-split-worker-state.removal
+++ b/newsfragments/data-updates-split-worker-state.removal
@@ -1,0 +1,2 @@
+``master.data.updates.setWorkerState()`` has been deprecated.
+Use ``master.data.updates.set_worker_paused()`` and ``master.data.updates.set_worker_graceful()`` as replacements.

--- a/www/react-base/src/views/WorkerView/WorkerView.tsx
+++ b/www/react-base/src/views/WorkerView/WorkerView.tsx
@@ -15,6 +15,7 @@
   Copyright Buildbot Team Members
 */
 
+import {useState} from "react";
 import {observer} from "mobx-react";
 import {
   Build,
@@ -28,6 +29,7 @@ import {useParams} from "react-router-dom";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
+import {WorkerActionsModal} from "../../components/WorkerActionsModal/WorkerActionsModal";
 
 export const WorkerView = observer(() => {
   const workerid = Number.parseInt(useParams<"workerid">().workerid ?? "");
@@ -45,11 +47,19 @@ export const WorkerView = observer(() => {
       }
     }));
 
+  const [workerForActions, setWorkerForActions] = useState<null|Worker>(null);
+
   return (
     <div className="container">
       <WorkersTable workers={workersQuery.array} buildersQuery={buildersQuery}
                     mastersQuery={mastersQuery}
-                    buildsForWorker={null} onWorkerIconClick={(w) => {}}/>
+                    buildsForWorker={null}
+                    onWorkerIconClick={(worker) => setWorkerForActions(worker)}/>
+      { workerForActions !== null
+        ? <WorkerActionsModal worker={workerForActions}
+                              onClose={() => setWorkerForActions(null)}/>
+        : <></>
+      }
       <BuildsTable builds={buildsQuery} builders={buildersQuery}/>
     </div>
   );

--- a/www/react-data-module/src/data/classes/Worker.ts
+++ b/www/react-data-module/src/data/classes/Worker.ts
@@ -26,6 +26,7 @@ export class Worker extends BaseClass {
   @observable connected_to!: ConnectedMaster[];
   @observable name!: string;
   @observable paused!: boolean;
+  @observable pause_reason!: string|null;
   @observable graceful!: boolean;
   @observable workerinfo!: {[key: string]: any};
 
@@ -41,6 +42,7 @@ export class Worker extends BaseClass {
     this.connected_to = object.connected_to;
     this.name = object.name;
     this.paused = object.paused;
+    this.pause_reason = object.pause_reason;
     this.graceful = object.graceful;
     this.workerinfo = object.workerinfo;
   }
@@ -52,6 +54,7 @@ export class Worker extends BaseClass {
       connected_to: this.connected_to,
       name: this.name,
       paused: this.paused,
+      pause_reason: this.pause_reason,
       graceful: this.graceful,
       workerinfo: this.workerinfo,
     };


### PR DESCRIPTION
This PR implements displaying worker pause reason. Previously the only part of the feature that was already completed was an edit box in the web UI (so effectively not implemented).