### PR TITLE
worker: Fix race condition in worker state handling

### DIFF
--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -28,7 +28,6 @@ from buildbot.interfaces import ILatentWorker
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
 from buildbot.util import Notifier
-from buildbot.util import deferwaiter
 from buildbot.worker.base import AbstractWorker
 
 
@@ -162,7 +161,6 @@ class AbstractLatentWorker(AbstractWorker):
         super().__init__(*args, **kwargs)
         self._substantiation_notifier = Notifier()
         self._start_stop_lock = defer.DeferredLock()
-        self._deferwaiter = deferwaiter.DeferWaiter()
         self._check_instance_timer = None
 
     def checkConfig(self, name, password,


### PR DESCRIPTION
Previously the Deferreds returned by worker state handling methods were not waited for. Under certain conditions this could lead actions being executed after master shutdown leading to erroneous behavior.

