### PR TITLE
docker: Upgrade minimum required docker-py version

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-__version__ = "1.10.6"
+__version__ = "4.0"
 
 
 class Client:

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -27,7 +27,6 @@ class Client:
         self.base_url = base_url
         self.call_args_create_container = []
         self.call_args_create_host_config = []
-        self.called_class_name = None
         self._images = [
             {'RepoTags': ['busybox:latest', 'worker:latest', 'tester:latest']}]
         self._pullable = ['alpine:latest', 'tester:latest']
@@ -91,7 +90,6 @@ class Client:
 
     def create_container(self, image, *args, **kwargs):
         self.call_args_create_container.append(kwargs)
-        self.called_class_name = self.__class__.__name__
         name = kwargs.get('name', None)
         if 'buggy' in image:
             raise RuntimeError('we could not create this container')

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -105,7 +105,7 @@ class Client:
             'image': image,
             'Id': ret['Id'],
             'name': name,  # docker does not return this
-            'Names': [name]  # this what docker returns
+            'Names': ["/" + name]  # this what docker returns
         }
         return ret
 

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -23,7 +23,6 @@ class Client:
     start_exception = None
 
     def __init__(self, base_url):
-        Client.latest = self
         self.base_url = base_url
         self.call_args_create_container = []
         self.call_args_create_host_config = []

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -103,7 +103,10 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         yield bs.start_instance(self.build)
         client = docker.Client.latest
-        self.assertEqual(client.called_class_name, "APIClient")
+        self.assertEqual(
+            [c["Names"] for c in client._containers.values()],
+            [["buildbot-bot-87de7e"]]
+        )
 
     @defer.inlineCallbacks
     def test_constructor_nopassword(self):

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -51,7 +51,6 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
             image='busybox:latest', builder='docker_worker', distro='wheezy')
         self.build2 = Properties(
             image='busybox:latest', builder='docker_worker2', distro='wheezy')
-        self.patch(dockerworker, 'client', docker)
         docker.Client.containerCreated = False
         docker.Client.start_exception = None
 

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -113,7 +113,7 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         yield bs.start_instance(self.build)
         self.assertEqual(
             [c["Names"] for c in self._client._containers.values()],
-            [["buildbot-bot-87de7e"]]
+            [["/buildbot-bot-87de7e"]]
         )
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -99,7 +99,6 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
 
     @defer.inlineCallbacks
     def test_contruction_minimal_docker(self):
-        self.patch(dockerworker, 'docker_py_version', parse_version("4.0"))
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         yield bs.start_instance(self.build)
         client = docker.Client.latest
@@ -156,9 +155,8 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
             'network_mode': 'fake',
             'dns': ['1.1.1.1', '1.2.3.4'],
             'binds': ['/tmp:/tmp:ro'],
+            "init": True,
         }
-        if dockerworker.docker_py_version >= parse_version("2.2"):
-            expected['init'] = True
         self.assertEqual(client.call_args_create_host_config, [expected])
 
     @defer.inlineCallbacks
@@ -213,9 +211,7 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         client = docker.Client.latest
         self.assertEqual(len(client.call_args_create_container), 1)
 
-        expected = {'prop': 'value-docker_worker', 'binds': []}
-        if dockerworker.docker_py_version >= parse_version("2.2"):
-            expected['init'] = True
+        expected = {'prop': 'value-docker_worker', 'binds': [], "init": True}
         self.assertEqual(client.call_args_create_host_config, [expected])
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+from packaging.version import parse as parse_version
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -96,7 +98,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_contruction_minimal_docker_py(self):
-        self.patch(dockerworker, 'docker_py_version', 1.10)
+        self.patch(dockerworker, 'docker_py_version', parse_version("1.10"))
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         yield bs.start_instance(self.build)
         client = docker.APIClient.latest
@@ -106,7 +108,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_contruction_minimal_docker(self):
-        self.patch(dockerworker, 'docker_py_version', 2.0)
+        self.patch(dockerworker, 'docker_py_version', parse_version("2.0"))
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         yield bs.start_instance(self.build)
         client = docker.Client.latest
@@ -163,7 +165,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
             'dns': ['1.1.1.1', '1.2.3.4'],
             'binds': ['/tmp:/tmp:ro'],
         }
-        if dockerworker.docker_py_version >= 2.2:
+        if dockerworker.docker_py_version >= parse_version("2.2"):
             expected['init'] = True
         self.assertEqual(client.call_args_create_host_config, [expected])
 
@@ -220,7 +222,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
         self.assertEqual(len(client.call_args_create_container), 1)
 
         expected = {'prop': 'value-docker_worker', 'binds': []}
-        if dockerworker.docker_py_version >= 2.2:
+        if dockerworker.docker_py_version >= parse_version("2.2"):
             expected['init'] = True
         self.assertEqual(client.call_args_create_host_config, [expected])
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -34,13 +34,11 @@ from buildbot.worker import AbstractLatentWorker
 
 try:
     import docker
-    from docker import client
     from docker.errors import NotFound
-    _hush_pyflakes = [docker, client]
+    _hush_pyflakes = [docker]
     docker_py_version = parse_version(docker.__version__)
 except ImportError:
     docker = None
-    client = None
     docker_py_version = parse_version("0.0")
 
 
@@ -212,7 +210,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         return volume_list, volumes
 
     def _getDockerClient(self, client_args):
-        return client.APIClient(**client_args)
+        return docker.APIClient(**client_args)
 
     def renderWorkerProps(self, build):
         return build.render((self.docker_host, self.image, self.dockerfile,

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -19,6 +19,8 @@ import json
 import socket
 from io import BytesIO
 
+from packaging.version import parse as parse_version
+
 from twisted.internet import defer
 from twisted.internet import threads
 from twisted.python import log
@@ -35,11 +37,11 @@ try:
     from docker import client
     from docker.errors import NotFound
     _hush_pyflakes = [docker, client]
-    docker_py_version = float(docker.__version__.rsplit(".", 1)[0])
+    docker_py_version = parse_version(docker.__version__)
 except ImportError:
     docker = None
     client = None
-    docker_py_version = 0.0
+    docker_py_version = parse_version("0.0")
 
 
 def _handle_stream_line(line):
@@ -210,7 +212,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         return volume_list, volumes
 
     def _getDockerClient(self, client_args):
-        if 1.0 <= docker_py_version < 2.0:
+        if parse_version("1.0") <= docker_py_version < parse_version("2.0"):
             docker_client = client.Client(**client_args)
         else:
             docker_client = client.APIClient(**client_args)
@@ -304,7 +306,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
 
         volumes, binds = self._thd_parse_volumes(volumes)
         host_config['binds'] = binds
-        if docker_py_version >= 2.2 and 'init' not in host_config:
+        if docker_py_version >= parse_version("2.2") and 'init' not in host_config:
             host_config['init'] = True
         host_config = docker_client.create_host_config(**host_config)
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -140,8 +140,8 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
 
         super().checkConfig(name, password, image, masterFQDN, **kwargs)
 
-        if not client:
-            config.error("The python module 'docker>=2.0' is needed to use a"
+        if docker_py_version < parse_version("4.0.0"):
+            config.error("The python module 'docker>=4.0' is needed to use a"
                          " DockerLatentWorker")
         if not image and not dockerfile:
             config.error("DockerLatentWorker: You need to specify at least"
@@ -212,11 +212,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         return volume_list, volumes
 
     def _getDockerClient(self, client_args):
-        if parse_version("1.0") <= docker_py_version < parse_version("2.0"):
-            docker_client = client.Client(**client_args)
-        else:
-            docker_client = client.APIClient(**client_args)
-        return docker_client
+        return client.APIClient(**client_args)
 
     def renderWorkerProps(self, build):
         return build.render((self.docker_host, self.image, self.dockerfile,
@@ -306,7 +302,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
 
         volumes, binds = self._thd_parse_volumes(volumes)
         host_config['binds'] = binds
-        if docker_py_version >= parse_version("2.2") and 'init' not in host_config:
+        if 'init' not in host_config:
             host_config['init'] = True
         host_config = docker_client.create_host_config(**host_config)
 

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -153,13 +153,13 @@ To do this, enter the following lines in a Python prompt where docker-py is inst
 
     >>> import docker
     >>> docker_socket = 'tcp://localhost:2375'
-    >>> client = docker.client.APIClient(base_url=docker_socket)
+    >>> client = docker.client.DockerClient(base_url=docker_socket)
     >>> worker_image = 'my_project_worker'
-    >>> container = client.create_container(worker_image)
-    >>> client.start(container['Id'])
+    >>> container = client.containers.create_container(worker_image)
+    >>> client.containers.start(container['Id'])
     >>> # Optionally examine the logs of the master
-    >>> client.stop(container['Id'])
-    >>> client.wait(container['Id'])
+    >>> client.containers.stop(container['Id'])
+    >>> client.containers.wait(container['Id'])
     0
 
 It is now time to add the new worker to the master configuration under :bb:cfg:`workers`.

--- a/newsfragments/docker-min-version.removal
+++ b/newsfragments/docker-min-version.removal
@@ -1,0 +1,1 @@
+Buildbot now requires ``docker`` of version v4.0.0 or newer for Docker support.


### PR DESCRIPTION
This PR upgrades minimum required docker-py version to >= v4.0 and cleans up the code to take into account that we can rely on the new version.