### PR TITLE
docs: add warning about libvirt latent workers

### DIFF
--- a/master/docs/manual/configuration/workers-libvirt.rst
+++ b/master/docs/manual/configuration/workers-libvirt.rst
@@ -69,6 +69,11 @@ Should set up a KVM compatible libvirt network for your buildbot VM's to run on.
 Configuring your Master
 -----------------------
 
+.. warning::
+   There is currently a buildbot bug that fails to use the ``base_image`` if provided.
+   This means that the worker always uses the ``hd_image`` and changes will persist between builds.
+   See the `GitHub issue <https://github.com/buildbot/buildbot/issues/7122>`_ for details.
+
 If you want to add a simple on demand VM to your setup, you only need the following.
 We set the username to ``minion1``, the password to ``sekrit``.
 The base image is called ``base_image`` and a copy of it will be made for the duration of the VM's life.

--- a/newsfragments/libvirt-latent-bug.doc
+++ b/newsfragments/libvirt-latent-bug.doc
@@ -1,0 +1,1 @@
+Describe an existing bug with Libvirt latent workers that does not use a copy of the image (:issue `7122`).


### PR DESCRIPTION
There is currently a bug that makes the libvirt latent workers not use copies of the hd_image (so they are not really latent). Add warning in the documentation with a link to the GitHub Issue
(https://github.com/buildbot/buildbot/issues/7122).

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
