### PR TITLE
pretty print argv

### DIFF
--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -16,6 +16,7 @@
 import os
 import pprint
 import re
+import shlex
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -91,7 +92,8 @@ class MasterShellCommand(BuildStep):
             yield self.stdio_log.addHeader(" ".join(command) + "\n\n")
         yield self.stdio_log.addHeader("** RUNNING ON BUILDMASTER **\n")
         yield self.stdio_log.addHeader(f" in dir {os.getcwd()}\n")
-        yield self.stdio_log.addHeader(f" argv: {argv}\n")
+        quoted_argv = shlex.join(map(lambda s: s.decode("utf-8") if isinstance(s, bytes) else s, argv))
+        yield self.stdio_log.addHeader(f" argv: {quoted_argv}\n")
 
         os_env = os.environ
         if self.env is None:

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -24,6 +24,7 @@ from future.utils import iteritems
 from future.utils import string_types
 from future.utils import text_type
 
+import shlex
 import os
 import pprint
 import re
@@ -331,7 +332,7 @@ class RunProcess(object):
             return cmd
 
         self.command = to_bytes(util.Obfuscated.get_real(command))
-        self.fake_command = to_bytes(util.Obfuscated.get_fake(command))
+        self.fake_command = util.Obfuscated.get_fake(command)
 
         self.sendStdout = sendStdout
         self.sendStderr = sendStderr
@@ -531,7 +532,7 @@ class RunProcess(object):
         self.send_update([('header', msg + u"\n")])
 
         # then the obfuscated command array for resolving unambiguity
-        msg = u" argv: {0}".format(self.fake_command)
+        msg = u" argv: {0}".format(shlex.join(self.fake_command))
         self.log_msg(u" " + msg)
         self.send_update([('header', msg + u"\n")])
 


### PR DESCRIPTION
Before:

argv: [b'some', b'args', b'with spaces']

After:

argv: some args 'with spaces'

This is nice because we can easily copy'n'paste commands like this into
a shell to locally reproduce them.


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
