### PR TITLE
source/git: use finally block to delete ssh private key

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -143,11 +143,9 @@ class Git(Source, GitStepMixin):
                 yield self.patch(patch)
             yield self.parseGotRevision()
             res = yield self.parseCommitDescription()
-            yield self._removeSshPrivateKeyIfNeeded()
             return res
-        except Exception:
+        finally:
             yield self._removeSshPrivateKeyIfNeeded()
-            raise
 
     @defer.inlineCallbacks
     def mode_full(self):


### PR DESCRIPTION
Just a minor simplification


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
