### PR TITLE
process: Acquire step locks just before running a step

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -434,17 +434,7 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         yield self.addStep()
 
-        yield self._setup_locks()
-
         try:
-            # set up locks
-            yield self.acquireLocks()
-
-            if self.stopped:
-                raise BuildStepCancelled
-
-            yield self.master.data.updates.set_step_locks_acquired_at(self.stepid)
-
             yield self._render_renderables()
             # we describe ourselves only when renderables are interpolated
             self.updateSummary()
@@ -455,8 +445,17 @@ class BuildStep(results.ResultComputingConfigMixin,
             else:
                 doStep = yield self.doStepIf(self)
 
-            # run -- or skip -- the step
             if doStep:
+                yield self._setup_locks()
+
+                # set up locks
+                yield self.acquireLocks()
+
+                if self.stopped:
+                    raise BuildStepCancelled
+
+                yield self.master.data.updates.set_step_locks_acquired_at(self.stepid)
+
                 yield self.addTestResultSets()
                 try:
                     self._running = True

--- a/newsfragments/buildstep-dont-acquire-locks-if-skipped.change
+++ b/newsfragments/buildstep-dont-acquire-locks-if-skipped.change
@@ -1,0 +1,2 @@
+Buildbot will render step properties and check if step should be skipped before acquiring locks.
+This allows to skip waiting for locks in case step is skipped.


### PR DESCRIPTION
Step locks arguably should only prevent step from executing its run() function concurrently with another step. Currently various other functionality is protected by step locks including the check for whether step should run at all. This leads to unfortunate situation when step waits a long time for lock to become free and then decides that the step shouldn't run after all.

This PR moves such checks to before acquiring step lock. The largest change of behavior is that step properties may now be rendered a long time before the actual step is run. However, this should affect step runtime only in edge cases such as when step properties are rendered using external information such as time. Moving such code to the step itself would ensure that the properties are calculated when the step is running.