### PR TITLE
process: Fix exception when buildstep is interrupted while already finishing

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -647,12 +647,8 @@ class BuildStep(results.ResultComputingConfigMixin,
                 lock.stopWaitingUntilAvailable(self, access, d)
             self._acquiringLocks = []
 
-        if self._waitingForLocks:
-            yield self.addCompleteLog(
-                'cancelled while waiting for locks', str(reason))
-        else:
-            yield self.addCompleteLog('cancelled', str(reason))
-
+        log_name = "cancelled while waiting for locks" if self._waitingForLocks else "cancelled"
+        yield self.addCompleteLog(log_name, str(reason))
         yield self._maybe_interrupt_cmd(reason)
 
     def releaseLocks(self):

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -410,12 +410,13 @@ class TestBuildStep(TestBuildStepMixin, config.ConfigErrorsMixin,
 
         @defer.inlineCallbacks
         def on_command(cmd):
-            cmd.conn.set_expect_interrupt()
-            cmd.conn.set_block_on_interrupt()
+            conn = cmd.conn
+            conn.set_expect_interrupt()
+            conn.set_block_on_interrupt()
             d1 = step.interrupt('interrupt reason')
             d2 = step.interrupt(failure.Failure(error.ConnectionLost()))
 
-            cmd.conn.unblock_waiters()
+            conn.unblock_waiters()
             yield d1
             yield d2
 

--- a/newsfragments/build-cancel-exceptions.bugfix
+++ b/newsfragments/build-cancel-exceptions.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition resulting in ``EXCEPTION`` build results when build steps that are about to end are cancelled.


### PR DESCRIPTION
Currently an exception may be thrown when buildstep is interrupted while it is already finishing:

The race condition happens like this:

1. buildstep is about to finish. run() is still proceeding
2. build is canceled. BuildStep.interrupt() is invoked. The latter calls addCompleteLog() which blocks in PlainLog.addContent()
3. run() finishes and proceeds to BuildStep._cleanup_logs(), which finishes the log that is being written to in (2).
4. PlainLog.addContent() completes and addCompleteLog() calls PlainLog.finish()
5. PlainLog.finish() upcalls to Log.finish(), which notices that the log has already been finished in (3) and raises AssertionError.

BuildStep.interrupt() is the only function that may be called outside the usual lifecycle of a step. BuildStep._cleanup_logs() should wait for it to complete.

