### PR TITLE
util: Simplify DeferWaiter by removing unused cancel()

### DIFF
--- a/master/buildbot/test/unit/util/test_deferwaiter.py
+++ b/master/buildbot/test/unit/util/test_deferwaiter.py
@@ -74,44 +74,6 @@ class WaiterTests(unittest.TestCase):
         d = w.wait()
         self.assertTrue(d.called)
 
-    @defer.inlineCallbacks
-    def test_cancel_not_called(self):
-        w = DeferWaiter()
-
-        d1 = defer.Deferred()
-        w.add(d1)
-        self.assertTrue(w.has_waited())
-
-        w.cancel()
-        self.assertFalse(w.has_waited())
-
-        d = w.wait()
-        self.assertTrue(d.called)
-        with self.assertRaises(defer.CancelledError):
-            yield d1
-
-        self.flushLoggedErrors(defer.CancelledError)
-
-    @defer.inlineCallbacks
-    def test_cancel_called(self):
-        w = DeferWaiter()
-
-        d1_waited = defer.Deferred()
-        d1 = defer.succeed(None)
-        d1.addCallback(lambda _: d1_waited)
-        w.add(d1)
-
-        w.cancel()
-
-        d = w.wait()
-        self.assertTrue(d.called)
-        self.assertTrue(d1.called)
-        self.assertTrue(d1_waited.called)
-        with self.assertRaises(defer.CancelledError):
-            yield d1
-
-        self.flushLoggedErrors(defer.CancelledError)
-
 
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
 


### PR DESCRIPTION
The implementation of DeferWaiter is slower because it supports unused flexibility. Removing it simplifies code and makes it faster.

