### PR TITLE
www: Fix navigate() before page load finishes

### DIFF
--- a/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
+++ b/www/react-base/src/views/BuildRequestView/BuildRequestView.tsx
@@ -17,7 +17,7 @@
 
 import {observer} from "mobx-react";
 import {FaSpinner, FaStop} from "react-icons/fa";
-import {Fragment, useState} from "react";
+import {Fragment, useEffect, useState} from "react";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
@@ -112,10 +112,12 @@ export const BuildRequestView = observer(() => {
     {caption: buildRequestId.toString(), route: `/buildrequests/${buildRequestId}`},
   ]));
 
-  if (buildsQuery.array.length > 0 && redirectToBuild) {
-    const build = buildsQuery.getNthOrNull(0);
-    navigate(`/builders/${build?.builderid}/builds/${build?.number}`);
-  }
+  useEffect(() => {
+    if (buildsQuery.array.length > 0 && redirectToBuild) {
+      const build = buildsQuery.getNthOrNull(0);
+      navigate(`/builders/${build?.builderid}/builds/${build?.number}`);
+    }
+  }, [buildsQuery.array.length > 0]);
 
   const cancelBuildRequest = () => {
     if (isCancelling) {

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -19,7 +19,7 @@ import './BuildView.scss';
 import {observer} from "mobx-react";
 import {FaSpinner} from "react-icons/fa";
 import {AlertNotification} from "../../components/AlertNotification/AlertNotification";
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
@@ -180,9 +180,11 @@ const BuildView = observer(() => {
   const worker = workersQuery.getNthOrNull(0);
   const project = projectsQuery.getNthOrNull(0);
 
-  if (buildsQuery.resolved && build === null) {
-    navigate(`/builders/${builderid}`);
-  }
+  useEffect(() => {
+    if (buildsQuery.resolved && build === null) {
+      navigate(`/builders/${builderid}`);
+    }
+  }, [buildsQuery.resolved, build === null]);
 
   const responsibleUsers = computed(() => getResponsibleUsers(propertiesQuery, changesQuery)).get();
   /*


### PR DESCRIPTION
Certain views redirect to another page without user intervention. This sometimes causes an exception in developer console:

Cannot update a component (`HashRouter`) while rendering a different component

navigate() should be called from within useEffect() in such case.
