### PR TITLE
www: Fix time rerendering

### DIFF
--- a/www/react-ui/src/stores/TimeStore.ts
+++ b/www/react-ui/src/stores/TimeStore.ts
@@ -19,11 +19,10 @@ import {action, makeObservable, observable} from "mobx";
 import moment from "moment";
 
 export class TimeStore {
-  @observable now: number;
+  @observable now: number = 0;
 
   constructor() {
     makeObservable(this);
-    this.now = 0;
   }
 
   @action setTime(now: number) {


### PR DESCRIPTION
Previously this.now assignment in constructor was making the property not observable. This caused pages not to be refreshed on timer ticks.
