### PR TITLE
www/react: Implement case insensitive search in logs as an option

### DIFF
--- a/newsfragments/www-case-insensitive-search.feature
+++ b/newsfragments/www-case-insensitive-search.feature
@@ -1,0 +1,1 @@
+Add support for case insensitive search within the logs.

--- a/www/react-base/src/components/LogSearchField/LogSearchField.scss
+++ b/www/react-base/src/components/LogSearchField/LogSearchField.scss
@@ -3,9 +3,9 @@
 
 .bb-log-search-field {
   position: relative;
-  width: 270px;
+  width: 300px;
   display: inline-block;
-  margin-right: 1rem;
+  margin-right: 0.5rem;
 }
 
 .bb-log-search-field-icon {
@@ -28,6 +28,28 @@
   padding: 0.5rem;
 }
 
+.bb-log-search-field-options {
+  position: absolute;
+  top: 0.4rem;
+  color: $body-color;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.bb-log-search-field-options-toggled {
+  border: rgb(0, 0, 255);
+  background-color: rgba(0, 0, 255, 0.4);
+}
+.bb-log-search-field-options-untoggled {
+  border: none;
+  background-color: rgba(255, 255, 255, 0);
+}
+
+.bb-log-search-field-options-case {
+  margin-left: 1.75rem;
+}
+
 .bb-log-search-field-nav-button {
   border-radius: 0.25rem;
   border: 0px solid transparent;
@@ -44,7 +66,7 @@
 
 .bb-log-search-field-text {
   width: 100%;
-  padding: 0.375rem 0.75rem 0.375rem 2rem;
+  padding: 0.375rem 0.75rem 0.375rem 3rem;
   border-radius: 0.25rem;
   overflow: visible;
 }

--- a/www/react-base/src/components/LogSearchField/LogSearchField.tsx
+++ b/www/react-base/src/components/LogSearchField/LogSearchField.tsx
@@ -18,26 +18,51 @@
 import './LogSearchField.scss'
 import {Ref, useState} from "react";
 import {FaChevronDown, FaChevronUp, FaSearch} from "react-icons/fa";
+import {VscCaseSensitive} from "react-icons/vsc";
 
 export type LogSearchButtonProps = {
   currentResult: number;
   totalResults: number;
-  onTextChanged: (text: string) => void;
+  onSearchInputChanged: (text: string, caseSensitive: boolean) => void;
   onPrevClicked: () => void;
   onNextClicked: () => void;
   inputRef: Ref<HTMLInputElement>;
 };
 
 export const LogSearchField = ({currentResult, totalResults,
-                                onTextChanged, onPrevClicked, onNextClicked,
+                                onSearchInputChanged, onPrevClicked, onNextClicked,
                                 inputRef}: LogSearchButtonProps) => {
   const [searchText, setSearchText] = useState<string>('');
   const [hasFocus, setHasFocus] = useState<boolean>(false);
+  const [isCaseSensitive, setIsCaseSensitive] = useState<boolean>(true);
 
   const onSearchTextChanged = (text: string) => {
     setSearchText(text);
-    onTextChanged(text);
+    onSearchInputChanged(text, isCaseSensitive);
   };
+
+  const onCaseInsensitiveToggled = () => {
+    const newValue = !isCaseSensitive;
+    setIsCaseSensitive(newValue);
+    onSearchInputChanged(searchText, newValue);
+  }
+
+  const optionButtonClass = (optionName: string, isToggled: boolean) => {
+    return [
+      'bb-log-search-field-options',
+      `bb-log-search-field-options-${optionName}`,
+      `bb-log-search-field-options-${isToggled ? 'toggled' : 'untoggled'}`,
+    ].join(' ');
+  };
+  const renderOptions = () => (
+    <>
+      <button
+        className={optionButtonClass('case', isCaseSensitive)}
+        onClick={onCaseInsensitiveToggled}>
+        <VscCaseSensitive />
+      </button>
+    </>
+  );
 
   const renderSearchNav = () => (
     <div className="bb-log-search-field-nav">
@@ -58,16 +83,19 @@ export const LogSearchField = ({currentResult, totalResults,
     }
   }
 
+  const shouldRenderOptionals = (hasFocus || searchText !== '');
+
   return (
     <form role="search" className="bb-log-search-field">
       <FaSearch className="bb-log-search-field-icon"/>
+      {shouldRenderOptionals ? renderOptions() : <></>}
       <input className="bb-log-search-field-text" type="text" value={searchText}
              ref={inputRef}
              onFocus={() => setHasFocus(true)} onBlur={() => setHasFocus(false)}
              onChange={e => onSearchTextChanged(e.target.value)}
              onKeyDown={e => onKeyDown(e)}
              placeholder="Search log"/>
-      {(hasFocus || searchText !== '') ? renderSearchNav() : <></>}
+      {shouldRenderOptionals ? renderSearchNav() : <></>}
     </form>
   );
 }

--- a/www/react-base/src/components/LogViewer/LogTextManager.test.ts
+++ b/www/react-base/src/components/LogViewer/LogTextManager.test.ts
@@ -325,6 +325,14 @@ describe('LogTextManager', () => {
         {offset: 90, limit: 10},
       ]);
       expect(manager.totalSearchResultCount).toEqual(100);
+
+      manager.setSearchString("aaAAa");
+
+      expect(manager.totalSearchResultCount).toEqual(0);
+
+      manager.setSearchCaseSensitivity(false);
+
+      expect(manager.totalSearchResultCount).toEqual(100);
     });
   });
 });

--- a/www/react-base/src/components/LogViewer/LogViewerText.tsx
+++ b/www/react-base/src/components/LogViewer/LogViewerText.tsx
@@ -99,8 +99,9 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
     return [overscanStartIndex, overscanStopIndex, visibleStartIndex, visibleStopIndex];
   }
 
-  const onSearchTextChanged = (text: string) => {
+  const onSearchInputChanged = (text: string, caseSensitive: boolean) => {
     manager.setSearchString(text === '' ? null : text);
+    manager.setSearchCaseSensitivity(caseSensitive);
   }
 
   const listRef = useRef<FixedSizeList<any>>(null);
@@ -128,7 +129,7 @@ export const LogViewerText = observer(({log, downloadInitiateOverscanRowCount, d
         <div>
           <LogSearchField currentResult={manager.currentSearchResultIndex + 1}
                           totalResults={Math.max(manager.totalSearchResultCount, 0)}
-                          onTextChanged={onSearchTextChanged}
+                          onSearchInputChanged={onSearchInputChanged}
                           onPrevClicked={() => manager.setPrevSearchResult()}
                           onNextClicked={() => manager.setNextSearchResult()}
                           inputRef={searchInputRef}/>

--- a/www/react-base/src/util/LogChunkSearch.test.ts
+++ b/www/react-base/src/util/LogChunkSearch.test.ts
@@ -20,7 +20,8 @@ import {
   ChunkSearchResults, findNextSearchResult, findPrevSearchResult,
   findTextInChunkRaw,
   overlaySearchResultsOnLine,
-  resultsListToLineIndexMap
+  resultsListToLineIndexMap,
+  getMatcher,
 } from "./LogChunkSearch";
 
 describe('LogChunkSearch', () => {
@@ -115,7 +116,7 @@ describe('LogChunkSearch', () => {
 
   describe('findTextInChunkRaw', () => {
     it('no escapes', () => {
-      expect(findTextInChunkRaw(parseLogChunk(20, 'oaaa\nboaaabaaa\no\noaaab\n', 's'), 'aaa'))
+      expect(findTextInChunkRaw(parseLogChunk(20, 'oaaa\nboaaabaaa\no\noaaab\n', 's'), getMatcher('aaa')))
         .toEqual([
           {lineIndex: 20, lineStart: 0},
           {lineIndex: 21, lineStart: 1},
@@ -125,7 +126,7 @@ describe('LogChunkSearch', () => {
     });
     it('many escapes', () => {
       expect(findTextInChunkRaw(parseLogChunk(20,
-          'oaaa\nboa\x1b[36maabaa\x1b[36ma\no\no\x1b[36maaa\x1b[36mb\n', 's', true), 'aaa'))
+          'oaaa\nboa\x1b[36maabaa\x1b[36ma\no\no\x1b[36maaa\x1b[36mb\n', 's', true), getMatcher('aaa')))
         .toEqual([
           {lineIndex: 20, lineStart: 0},
           {lineIndex: 21, lineStart: 1},
@@ -136,7 +137,18 @@ describe('LogChunkSearch', () => {
     it('some escapes', () => {
       expect(findTextInChunkRaw(parseLogChunk(20,
           'o\no\no\no\no\no\noaaa\nboa\x1b[36maabaa\x1b[36ma\no\no\x1b[36maaa\x1b[36mb\n', 's'),
-          'aaa'))
+          getMatcher('aaa')))
+        .toEqual([
+          {lineIndex: 26, lineStart: 0},
+          {lineIndex: 27, lineStart: 1},
+          {lineIndex: 27, lineStart: 5},
+          {lineIndex: 29, lineStart: 0},
+        ]);
+    });
+    it('case insensitive', () => {
+      expect(findTextInChunkRaw(parseLogChunk(20,
+          'o\no\no\no\no\no\noaaa\nboa\x1b[36maabaa\x1b[36ma\no\no\x1b[36maaa\x1b[36mb\n', 's'),
+          getMatcher('aAa', {caseInsensitive: true})))
         .toEqual([
           {lineIndex: 26, lineStart: 0},
           {lineIndex: 27, lineStart: 1},

--- a/www/react-base/src/util/Regex.test.ts
+++ b/www/react-base/src/util/Regex.test.ts
@@ -1,0 +1,31 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {regexEscape} from "./Regex";
+
+describe('Regex', () => {
+  describe('escape', () => {
+
+    it('no change', () => {
+      expect(regexEscape("this is a simple test")).toStrictEqual("this is a simple test");
+    });
+    it('escapes symbols', () => {
+      expect(regexEscape("/ \\ [ ] ( ) - ^ $ . | ? + * { }"))
+        .toStrictEqual("\\/ \\\\ \\[ \\] \\( \\) \\- \\^ \\$ \\. \\| \\? \\+ \\* \\{ \\}");
+    });
+  });
+});

--- a/www/react-base/src/util/Regex.ts
+++ b/www/react-base/src/util/Regex.ts
@@ -1,0 +1,20 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+export function regexEscape(src: string) {
+  return src.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&')
+}


### PR DESCRIPTION
The default is still case-sensitive search.

Style/CSS is pretty janky, that's really not my skills there, so I'd welcome anyone that want to clean it up.


I may implement regex search if there is interest (on our users side, or here). Did not do it right here as there is issues with result highlighting due to assumption that highlighting should be from found index beginning + length of input (which is no longer the case with a regex). I guess there will also be issues with matches that span more than one line.

Also, I add to implement a `regexEscape` because there is none available directly in JS...
I didn't know if there was a guideline about third-party lib, but if not, it might be worth it to use one to delegate testing to it.