### PR TITLE
Conditionalize use of importlib_resources to 3.9 or older.

### DIFF
--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -14,6 +14,11 @@
 # Copyright Buildbot Team Members
 
 
+try:
+    import importlib.resources as importlib_resources
+except ImportError:
+    import importlib_resources
+
 import importlib_resources
 
 from twisted.web import static

--- a/master/setup.py
+++ b/master/setup.py
@@ -478,7 +478,7 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     'msgpack >= 0.6.0',
     "croniter >= 1.3.0",
-    'importlib-resources >= 5',
+    "importlib-resources >= 5;python_version<'3.9'",
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
     'sqlalchemy >= 1.3.0, < 1.5',

--- a/newsfragments/importlib_resources.misc
+++ b/newsfragments/importlib_resources.misc
@@ -1,0 +1,1 @@
+Conditionalize importlib_resources for Python <3.9 only, for interoperability with more modern Pythons and without that module.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -56,7 +56,7 @@ hyperlink==21.0.0
 idna==2.10  # pyup: ignore (conflicts with moto on master)
 imagesize==1.4.1
 importlib-metadata==6.8.0
-importlib-resources==6.1.1
+importlib-resources==6.1.1; python_version < "3.9"
 incremental==22.10.0
 ipaddress==1.0.23
 isort==4.3.21   # pyup: ignore (until https://github.com/PyCQA/pylint/pull/3725 is merged)


### PR DESCRIPTION
Fedora and other distributions no longer carry Pythons older than 3.9, and also no longer ship the third-party importlib_resources module.


## Contributor Checklist:

* [N/A] I have updated the unit tests
* [Y] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation
