### PR TITLE
www: Rename confusing variables

### DIFF
--- a/www/react-data-module/src/data/BasicDataMultiCollection.ts
+++ b/www/react-data-module/src/data/BasicDataMultiCollection.ts
@@ -30,14 +30,14 @@ export class BasicDataMultiCollection<ParentDataType extends BaseClass,
 
   @observable byParentId = observable.map<string, Collection>();
   @observable sortedParentIds = observable.array<string>();
-  callback: (child: ParentDataType) => Collection;
+  callback: (parent: ParentDataType) => Collection;
   private disposer: IReactionDisposer;
 
   constructor(accessor: IDataAccessor,
               parentArray: IObservableArray<ParentDataType> | null,
               parentArrayMap: ObservableMap<string, DataCollection<ParentDataType>> | null,
               parentFilteredIds: IObservableArray<string> | null,
-              callback: (child: ParentDataType) => Collection) {
+              callback: (parent: ParentDataType) => Collection) {
     makeObservable(this);
 
     this.accessor = accessor;

--- a/www/react-data-module/src/data/DataCollection.ts
+++ b/www/react-data-module/src/data/DataCollection.ts
@@ -99,7 +99,7 @@ export class DataCollection<DataType extends BaseClass> implements IDataCollecti
   }
 
   getRelated<ChildDataType extends BaseClass>(
-      callback: (child: DataType) => DataCollection<ChildDataType>) {
+      callback: (parent: DataType) => DataCollection<ChildDataType>) {
     return new DataMultiCollection<DataType, ChildDataType>(this.accessor, this.array, null, null,
       callback);
   }

--- a/www/react-data-module/src/data/DataMultiCollection.ts
+++ b/www/react-data-module/src/data/DataMultiCollection.ts
@@ -20,16 +20,23 @@ export class DataMultiCollection<ParentDataType extends BaseClass,
 
   // Acquires nth element across all collections tracked by this multi collection. The iteration
   // order is in ascending order of parent IDs.
+  //
+  // Note that when there are many key-value pairs waiting for replies from the server side, nth
+  // element might appear in an unexpected position. First requests replies can take longer than
+  // replies to the following values, so they get their values first. In this case, nth element
+  // will actually be later than expected, because preceding values have not arrived yet.
+  // The nth element is always the same when there is only one key-value pair or when all the
+  // information has already been acquired from the server.
   getNthOrNull(index: number): DataType | null {
     for (const parentId of this.sortedParentIds) {
-      const parent = this.byParentId.get(parentId);
-      if (parent === undefined) {
+      const childCollection = this.byParentId.get(parentId);
+      if (childCollection === undefined) {
         continue;
       }
-      if (index < parent.array.length) {
-        return parent.array[index];
+      if (index < childCollection.array.length) {
+        return childCollection.array[index];
       }
-      index -= parent.array.length;
+      index -= childCollection.array.length;
     }
     return null;
   }
@@ -37,31 +44,31 @@ export class DataMultiCollection<ParentDataType extends BaseClass,
   getAll(): DataType[] {
     const all: DataType[] = [];
     for (const parentId of this.sortedParentIds) {
-      const parent = this.byParentId.get(parentId);
-      if (parent === undefined) {
+      const childCollection = this.byParentId.get(parentId);
+      if (childCollection === undefined) {
         continue;
       }
-      all.push(...parent.array);
+      all.push(...childCollection.array);
     }
     return all;
   }
 
   getNthOfParentOrNull(parentId: string, index: number): DataType | null {
-    const collection = this.byParentId.get(parentId);
-    if (collection === undefined) {
+    const childCollection = this.byParentId.get(parentId);
+    if (childCollection === undefined) {
       return null;
     }
-    if (index >= collection.array.length) {
+    if (index >= childCollection.array.length) {
       return null;
     }
-    return collection.array[index];
+    return childCollection.array[index];
   }
 
   getParentCollectionOrEmpty(parentId: string): DataCollection<DataType> {
-    const collection = this.byParentId.get(parentId);
-    if (collection === undefined) {
+    const childCollection = this.byParentId.get(parentId);
+    if (childCollection === undefined) {
       return new DataCollection<DataType>();
     }
-    return collection;
+    return childCollection;
   }
 }


### PR DESCRIPTION
This PR renames confusing variables: parent -> childCollection.
Comment is added to explain DataMultiCollection.getNthOrNull().


* [not_needed] I have updated the unit tests
* [ not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ not_needed] I have updated the appropriate documentation
