### PR TITLE
Fix typo in Dockerfile.master

### DIFF
--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -6,7 +6,7 @@
 # Use a multi-stage build:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-# Provides a base Debian (11) image with latest buildbot mater installed
+# Provides a base Debian (11) image with latest buildbot master installed
 # the master image is not optimized for size, but rather uses Debian for wider package availability
 
 # Provide an intermediate Docker image named "buildbot-build".


### PR DESCRIPTION
fix typo

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
