### PR TITLE
Fix support for Twisted 23.10

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -36,6 +36,7 @@ matrix:
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
     - env: PYTHON=3.9 TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.10 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial

--- a/master/buildbot/asyncio.py
+++ b/master/buildbot/asyncio.py
@@ -26,7 +26,12 @@ def deferred_await(self):
     # if a deferred is awaited from a asyncio loop context, we must return
     # the future wrapper, but if it is awaited from normal twisted loop
     # we must return self.
-    if isinstance(asyncio.get_event_loop(), AsyncIOLoopWithTwisted):
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return self
+
+    if isinstance(loop, AsyncIOLoopWithTwisted):
         return self.asFuture(asyncio.get_event_loop())
     return self
 

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -139,3 +139,6 @@ warnings.filterwarnings('ignore', ".*Boto3 will no longer support Python .*",
 # autobahn is not updated for Twisted 22.04 and newer
 warnings.filterwarnings("ignore", "twisted.web.resource.NoResource was deprecated in",
                         category=DeprecationWarning)
+
+# Buildbot shows this warning after upgrading to Twisted 23.10
+warnings.filterwarnings('ignore', ".*unclosed event loop.*", category=Warning)

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -135,3 +135,7 @@ warnings.filterwarnings('ignore', "SelectableGroups dict interface is deprecated
 # boto3 shows this warning when on old Python
 warnings.filterwarnings('ignore', ".*Boto3 will no longer support Python .*",
                         category=Warning)
+
+# autobahn is not updated for Twisted 22.04 and newer
+warnings.filterwarnings("ignore", "twisted.web.resource.NoResource was deprecated in",
+                        category=DeprecationWarning)

--- a/master/setup.py
+++ b/master/setup.py
@@ -467,7 +467,7 @@ py_38 = sys.version_info[0] > 3 or (
 if not py_38:
     raise RuntimeError("Buildbot master requires at least Python-3.8")
 
-twisted_ver = ">= 18.7.0, <=22.10.0"
+twisted_ver = ">= 18.7.0, <=23.10.0"
 
 bundle_version = version.split("-")[0]
 

--- a/newsfragments/allow-twisted-dep-23-10.bugfix
+++ b/newsfragments/allow-twisted-dep-23-10.bugfix
@@ -1,0 +1,1 @@
+Fix support for Twisted 23.10

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -117,7 +117,7 @@ tomli==2.0.1
 tomlkit==0.12.3
 towncrier==21.9.0
 treq==22.2.0
-Twisted==22.4.0
+Twisted==23.10.0
 txaio==23.1.1
 txrequests==0.9.6
 types-PyYAML==6.0.12.12

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -24,7 +24,7 @@ PyHamcrest==1.9.0  # pyup: ignore
 psutil==5.9.6
 pycparser==2.21;  python_version >= "3.6"
 six==1.16.0
-Twisted==22.4.0;  python_version >= "3.6"
+Twisted==23.10.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
 txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.8.0;  python_version >= "3.7"


### PR DESCRIPTION
Previously tests were failing due to change in behavior somewhere deep within Twisted test framework which caused a bug within Buildbot to kill whole Twisted test session (but only when running in parallel mode). This PR fixes the problem.