### PR TITLE
pkg: Don't use announce() for logging

### DIFF
--- a/newsfragments/www-package-build-older-python.bugfix
+++ b/newsfragments/www-package-build-older-python.bugfix
@@ -1,0 +1,1 @@
+Fix web frontend package build on certain Python versions (e.g. 3.9).

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -227,8 +227,7 @@ class BuildJsCommand(Command):
             ]
 
             for command in commands:
-                self.announce('Running command: {}'.format(str(" ".join(command))),
-                              level=logging.INFO)
+                logging.info('Running command: {}'.format(str(" ".join(command))))
                 subprocess.check_call(command, shell=shell)
 
         self.copy_tree(os.path.join(package, 'static'), os.path.join(


### PR DESCRIPTION
setuptools.Command() does not document this function. It also crashes with an exception on Python 3.9 for example, as underlying distutils does not understand the level=logging.INFO argument.

Fixes 91b32a1a6e0024f3c7e0c22a4e536607c881d0f6.
