### PR TITLE
Implement select_next_worker global configuration key 

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -144,6 +144,7 @@ class MasterConfig(util.ComparableMixin):
         self.collapseRequests = None
         self.codebaseGenerator = None
         self.prioritizeBuilders = None
+        self.select_next_worker = None
         self.multiMaster = False
         self.manhole = None
         self.protocols = {}
@@ -212,6 +213,7 @@ class MasterConfig(util.ComparableMixin):
         "revlink",
         "schedulers",
         "secretsProviders",
+        "select_next_worker",
         "services",
         "title",
         "titleURL",
@@ -396,6 +398,12 @@ class MasterConfig(util.ComparableMixin):
             error("prioritizeBuilders must be a callable")
         else:
             self.prioritizeBuilders = prioritizeBuilders
+
+        select_next_worker = config_dict.get("select_next_worker")
+        if select_next_worker is not None and not callable(select_next_worker):
+            error("select_next_worker must be a callable")
+        else:
+            self.select_next_worker = select_next_worker
 
         protocols = config_dict.get('protocols', {})
         if isinstance(protocols, dict):

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -159,6 +159,8 @@ class BasicBuildChooser(BuildChooserBase):
 
         self.nextWorker = self.bldr.config.nextWorker
         if not self.nextWorker:
+            self.nextWorker = self.master.config.select_next_worker
+        if not self.nextWorker:
             self.nextWorker = lambda _, workers, __: random.choice(
                 workers) if workers else None
 

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -58,6 +58,7 @@ global_defaults = {
     "properties": properties.Properties(),
     "collapseRequests": None,
     "prioritizeBuilders": None,
+    "select_next_worker": None,
     "protocols": {},
     "multiMaster": False,
     "manhole": None,
@@ -527,6 +528,16 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     def test_load_global_prioritizeBuilders_invalid(self):
         with capture_config_errors() as errors:
             self.cfg.load_global(self.filename, {'prioritizeBuilders': 'yes'})
+
+        self.assertConfigError(errors, "must be a callable")
+
+    def test_load_global_select_next_worker_callable(self):
+        callable = lambda: None
+        self.do_test_load_global({"select_next_worker": callable}, select_next_worker=callable)
+
+    def test_load_global_select_next_worker_invalid(self):
+        with capture_config_errors() as errors:
+            self.cfg.load_global(self.filename, {"select_next_worker": "yes"})
 
         self.assertConfigError(errors, "must be a callable")
 

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -27,10 +27,8 @@ from buildbot.process import factory
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import epoch2datetime
 from buildbot.util.eventual import fireEventually
-from buildbot.warnings import DeprecatedApiWarning
 
 
 def nth_worker(n):
@@ -740,19 +738,13 @@ class TestMaybeStartBuilds(TestBRDBase):
     # nextWorker
     @defer.inlineCallbacks
     def do_test_nextWorker(self, nextWorker, exp_choice=None, exp_warning=False):
-
-        def makeBuilderConfig():
-            return config.BuilderConfig(name='bldrconf',
-                                        workernames=['wk1', 'wk2'],
-                                        builddir='bdir',
-                                        factory=factory.BuildFactory(),
-                                        nextWorker=nextWorker)
-        if exp_warning:
-            with assertProducesWarning(DeprecatedApiWarning,
-                                       message_pattern=r"nextWorker now takes a 3rd argument"):
-                builder_config = makeBuilderConfig()
-        else:
-            builder_config = makeBuilderConfig()
+        builder_config = config.BuilderConfig(
+            name='bldrconf',
+            workernames=['wk1', 'wk2'],
+            builddir='bdir',
+            factory=factory.BuildFactory(),
+            nextWorker=nextWorker
+        )
 
         self.bldr = yield self.createBuilder('B', builderid=78,
                                              builder_config=builder_config)

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -16,6 +16,8 @@
 import random
 from unittest import mock
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.trial import unittest
@@ -737,14 +739,23 @@ class TestMaybeStartBuilds(TestBRDBase):
 
     # nextWorker
     @defer.inlineCallbacks
-    def do_test_nextWorker(self, nextWorker, exp_choice=None, exp_warning=False):
-        builder_config = config.BuilderConfig(
-            name='bldrconf',
-            workernames=['wk1', 'wk2'],
-            builddir='bdir',
-            factory=factory.BuildFactory(),
-            nextWorker=nextWorker
-        )
+    def do_test_nextWorker(self, nextWorker, global_select_next_worker, exp_choice=None):
+        if global_select_next_worker:
+            self.master.config.select_next_worker = nextWorker
+            builder_config = config.BuilderConfig(
+                name='bldrconf',
+                workernames=['wk1', 'wk2'],
+                builddir='bdir',
+                factory=factory.BuildFactory()
+            )
+        else:
+            builder_config = config.BuilderConfig(
+                name='bldrconf',
+                workernames=['wk1', 'wk2'],
+                builddir='bdir',
+                factory=factory.BuildFactory(),
+                nextWorker=nextWorker
+            )
 
         self.bldr = yield self.createBuilder('B', builderid=78,
                                              builder_config=builder_config)
@@ -769,39 +780,66 @@ class TestMaybeStartBuilds(TestBRDBase):
         yield self.do_test_maybeStartBuildsOnBuilder(rows=rows,
                                                      exp_claims=exp_claims, exp_builds=exp_builds)
 
-    def test_nextWorker_gets_buildrequest(self):
+    @parameterized.expand([True, False])
+    def test_nextWorker_gets_buildrequest(self, global_select_next_worker):
         def nextWorker(bldr, lst, br=None):
             self.assertNotEqual(br, None)
-        return self.do_test_nextWorker(nextWorker)
+        return self.do_test_nextWorker(
+            nextWorker,
+            global_select_next_worker=global_select_next_worker
+        )
 
-    def test_nextWorker_default(self):
+    @parameterized.expand([True, False])
+    def test_nextWorker_default(self, global_select_next_worker):
         self.patch(random, 'choice', nth_worker(2))
-        return self.do_test_nextWorker(None, exp_choice=2)
+        return self.do_test_nextWorker(
+            None,
+            exp_choice=2,
+            global_select_next_worker=global_select_next_worker
+        )
 
-    def test_nextWorker_simple(self):
+    @parameterized.expand([True, False])
+    def test_nextWorker_simple(self, global_select_next_worker):
         def nextWorker(bldr, lst, br=None):
             self.assertIdentical(bldr, self.bldr)
             return lst[1]
-        return self.do_test_nextWorker(nextWorker, exp_choice=1)
+        return self.do_test_nextWorker(
+            nextWorker,
+            global_select_next_worker=global_select_next_worker,
+            exp_choice=1
+        )
 
-    def test_nextWorker_deferred(self):
+    @parameterized.expand([True, False])
+    def test_nextWorker_deferred(self, global_select_next_worker):
         def nextWorker(bldr, lst, br=None):
             self.assertIdentical(bldr, self.bldr)
             return defer.succeed(lst[1])
-        return self.do_test_nextWorker(nextWorker, exp_choice=1)
+        return self.do_test_nextWorker(
+            nextWorker,
+            global_select_next_worker=global_select_next_worker,
+            exp_choice=1
+        )
 
+    @parameterized.expand([True, False])
     @defer.inlineCallbacks
-    def test_nextWorker_exception(self):
+    def test_nextWorker_exception(self, global_select_next_worker):
         def nextWorker(bldr, lst, br=None):
             raise RuntimeError("")
-        yield self.do_test_nextWorker(nextWorker)
+        yield self.do_test_nextWorker(
+            nextWorker,
+            global_select_next_worker=global_select_next_worker
+        )
         self.assertEqual(1, len(self.flushLoggedErrors(RuntimeError)))
 
+    @parameterized.expand([True, False])
     @defer.inlineCallbacks
-    def test_nextWorker_failure(self):
+    def test_nextWorker_failure(self, global_select_next_worker):
         def nextWorker(bldr, lst, br=None):
             return defer.fail(failure.Failure(RuntimeError()))
-        yield self.do_test_nextWorker(nextWorker)
+        yield self.do_test_nextWorker(
+            nextWorker,
+            global_select_next_worker=global_select_next_worker
+        )
         self.assertEqual(1, len(self.flushLoggedErrors(RuntimeError)))
 
     # _nextBuild

--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -79,6 +79,8 @@ Other optional keys may be set on each ``BuilderConfig``:
      As an example, for each ``worker`` in the list, ``worker.worker`` will be a :class:`Worker` object, and ``worker.worker.workername`` is the worker's name.
      The function can optionally return a Deferred, which should fire with the same results.
 
+    To control worker selection globally for all builders, use :bb:cfg:`select_next_worker`.
+
 ``nextBuild``
     (function, optional).
 

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -413,6 +413,28 @@ This parameter controls the order that the buildmaster can start builds, and is 
 It does not affect the order in which a builder processes the build requests in its queue.
 For that purpose, see :ref:`Prioritizing-Builds`.
 
+.. bb:cfg:: select_next_worker
+
+Prioritizing Workers
+~~~~~~~~~~~~~~~~~~~~
+
+By default Buildbot will select worker for a build randomly from available workers. This can be
+adjusted by ``select_next_worker`` function in global master configuration and additionally by
+``nextWorker`` per-builder configuration parameter. These two functions work exactly the same:
+
+The function is passed three arguments, the :class:`Builder` object which is assigning a new job,
+a list of :class:`WorkerForBuilder` objects and the :class:`BuildRequest`.
+
+The function should return one of the :class:`WorkerForBuilder` objects, or ``None`` if none of the
+available workers should be used. The function can optionally return a Deferred, which should fire
+with the same results.
+
+.. code-block:: python
+
+   def select_next_worker(builder, workers, buildrequest):
+       ...
+   c["select_next_worker"] = select_next_worker
+
 .. bb:cfg:: protocols
 
 .. _Setting-the-PB-Port-for-Workers:

--- a/newsfragments/global_select_next_worker.feature
+++ b/newsfragments/global_select_next_worker.feature
@@ -1,0 +1,2 @@
+Added `select_next_worker` global configuration key which sets default `nextWorker` customization
+hook on all builders.


### PR DESCRIPTION
This will allow to set default nextWorker globally without touching each builder configuration.