### PR TITLE
.github: Set the maximum execution time for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,4 @@ jobs:
 
       - name: "Run tests for ${{ matrix.python-version }}"
         run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
+        timeout-minutes: 30

--- a/newsfragments/github-limit-test-run.misc
+++ b/newsfragments/github-limit-test-run.misc
@@ -1,0 +1,1 @@
+Github action of Buildbot CI limits the execution of the tests to 30 minutes to avoid wasting resources (:issue `7277`).


### PR DESCRIPTION
Fixes #7277

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
