### PR TITLE
worker: Improve error logging on Kubernetes worker

### DIFF
--- a/master/buildbot/test/fake/kube.py
+++ b/master/buildbot/test/fake/kube.py
@@ -17,7 +17,7 @@ import copy
 import time
 
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
-from buildbot.util.kubeclientservice import KubeError
+from buildbot.util.kubeclientservice import KubeJsonError
 
 
 class KubeClientService(fakehttpclientservice.HTTPClientService):
@@ -31,7 +31,7 @@ class KubeClientService(fakehttpclientservice.HTTPClientService):
 
     def createPod(self, namespace, spec):
         if 'metadata' not in spec:
-            raise KubeError({
+            raise KubeJsonError(400, {
                 'message':
                     'Pod "" is invalid: metadata.name: '
                     'Required value: name or generateName is required'
@@ -47,9 +47,7 @@ class KubeClientService(fakehttpclientservice.HTTPClientService):
 
     def deletePod(self, namespace, name, graceperiod=0):
         if namespace + '/' + name not in self.pods:
-            raise KubeError({
-                'message': 'Pod not found',
-                'reason': 'NotFound'})
+            raise KubeJsonError(400, {"message": "Pod not found", "reason": "NotFound"})
 
         spec = self.pods[namespace + '/' + name]
 

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -122,6 +122,8 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.util.kubeclientservice.KubeClientService',
             'buildbot.util.kubeclientservice.KubeConfigLoaderBase',
             'buildbot.util.kubeclientservice.KubeError',
+            'buildbot.util.kubeclientservice.KubeJsonError',
+            'buildbot.util.kubeclientservice.KubeTextError',
             'buildbot.util.latent.CompatibleLatentWorkerMixin',
             'buildbot.util.lineboundaries.LineBoundaryFinder',
             'buildbot.util.lru.AsyncLRUCache',

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -30,7 +30,7 @@ from twisted.trial import unittest
 
 from buildbot.process.properties import Interpolate
 from buildbot.test.fake import fakemaster
-from buildbot.test.fake import httpclientservice as fakehttp
+from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake import kube as fakekube
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import config
@@ -114,47 +114,85 @@ sys.exit(1)
 """
 
 
-class KubeClientServiceTestKubeHardcodedConfig(config.ConfigErrorsMixin,
-                                              unittest.TestCase):
+class KubeClientServiceTestKubeHardcodedConfig(
+    TestReactorMixin,
+    config.ConfigErrorsMixin,
+    unittest.TestCase
+):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setup_test_reactor()
+        self.master = fakemaster.make_master(self)
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
+            self.master,
+            self,
+            "http://localhost:8001"
+        )
+
     def test_basic(self):
-        self.config = config = kubeclientservice.KubeHardcodedConfig(
+        self.config = kubeclientservice.KubeHardcodedConfig(
             master_url="http://localhost:8001",
             namespace="default"
         )
-        self.assertEqual(config.getConfig(), {
+        self.assertEqual(self.config.getConfig(), {
             'master_url': 'http://localhost:8001',
             'namespace': 'default',
             'headers': {}
         })
 
     @defer.inlineCallbacks
-    def test_verify_is_forwarded_to_keywords(self):
-        self.config = config = kubeclientservice.KubeHardcodedConfig(
+    def test_verify_is_forwarded(self):
+        self.config = kubeclientservice.KubeHardcodedConfig(
             master_url="http://localhost:8001",
             namespace="default",
             verify="/path/to/pem"
         )
-        service = kubeclientservice.KubeClientService(config)
-        _, kwargs = yield service._prepareRequest("/test", {})
-        self.assertEqual('/path/to/pem', kwargs['verify'])
+        self._http.expect(
+            "delete",
+            "/api/v1/namespaces/ns/pods/pod_name",
+            params={"graceperiod": 0},
+            verify="/path/to/pem",
+            code=200,
+            content_json={}
+        )
+        service = kubeclientservice.KubeClientService()
+        yield service.setServiceParent(self.master)
+        yield service.reconfigService(self.config)
+        yield service.deletePod("ns", "pod_name")
 
     @defer.inlineCallbacks
-    def test_verify_headers_are_passed_to_the_query(self):
-        self.config = config = kubeclientservice.KubeHardcodedConfig(
+    def test_verify_headers_are_forwarded(self):
+        self.config = kubeclientservice.KubeHardcodedConfig(
             master_url="http://localhost:8001",
             namespace="default",
             verify="/path/to/pem",
             headers={'Test': '10'}
         )
-        service = kubeclientservice.KubeClientService(config)
-        _, kwargs = yield service._prepareRequest("/test", {})
-        self.assertEqual({'Test': '10'}, kwargs['headers'])
 
+        self._http.expect(
+            "delete",
+            "/api/v1/namespaces/ns/pods/pod_name",
+            params={"graceperiod": 0},
+            headers={'Test': '10'},
+            verify="/path/to/pem",
+            code=200,
+            content_json={}
+        )
+        service = kubeclientservice.KubeClientService()
+        yield service.setServiceParent(self.master)
+        yield service.reconfigService(self.config)
+        yield service.deletePod("ns", "pod_name")
+
+    @defer.inlineCallbacks
     def test_the_configuration_parent_is_set_to_the_service(self):
         # This is needed to allow secret expansion
-        self.config = config = kubeclientservice.KubeHardcodedConfig(
-            master_url="http://localhost:8001")
-        service = kubeclientservice.KubeClientService(config)
+        self.config = kubeclientservice.KubeHardcodedConfig(
+            master_url="http://localhost:8001"
+        )
+        service = kubeclientservice.KubeClientService()
+        yield service.setServiceParent(self.master)
+        yield service.reconfigService(self.config)
         self.assertEqual(service, self.config.parent)
 
     def test_cannot_pass_both_bearer_and_basic_auth(self):
@@ -167,28 +205,49 @@ class KubeClientServiceTestKubeHardcodedConfig(config.ConfigErrorsMixin,
                 bearerToken="Bla")
 
     @defer.inlineCallbacks
-    def test_verify_bearerToken_is_expanded(self):
-        self.config = config = kubeclientservice.KubeHardcodedConfig(
+    def test_verify_bearer_token_is_rendered(self):
+        self.config = kubeclientservice.KubeHardcodedConfig(
             master_url="http://localhost:8001",
             namespace="default",
             verify="/path/to/pem",
-            bearerToken=Interpolate("%(kw:test)s", test=10))
-        service = kubeclientservice.KubeClientService(config)
-        _, kwargs = yield service._prepareRequest("/test", {})
-        self.assertEqual("Bearer 10", kwargs['headers']['Authorization'])
+            bearerToken=Interpolate("%(kw:test)s", test=10)
+        )
+
+        self._http.expect(
+            "delete",
+            "/api/v1/namespaces/ns/pods/pod_name",
+            params={"graceperiod": 0},
+            headers={"Authorization": "Bearer 10"},
+            verify="/path/to/pem",
+            code=200,
+            content_json={}
+        )
+        service = kubeclientservice.KubeClientService()
+        yield service.setServiceParent(self.master)
+        yield service.reconfigService(self.config)
+        yield service.deletePod("ns", "pod_name")
 
     @defer.inlineCallbacks
     def test_verify_basicAuth_is_expanded(self):
-        self.config = config = kubeclientservice.KubeHardcodedConfig(
+        self.config = kubeclientservice.KubeHardcodedConfig(
             master_url="http://localhost:8001",
             namespace="default",
             verify="/path/to/pem",
             basicAuth={'user': 'name', 'password': Interpolate("%(kw:test)s", test=10)})
-        service = kubeclientservice.KubeClientService(config)
-        _, kwargs = yield service._prepareRequest("/test", {})
 
-        expected = f'Basic {base64.b64encode("name:10".encode("utf-8"))}'
-        self.assertEqual(expected, kwargs['headers']['Authorization'])
+        self._http.expect(
+            "delete",
+            "/api/v1/namespaces/ns/pods/pod_name",
+            params={"graceperiod": 0},
+            headers={"Authorization": "Basic " + str(base64.b64encode("name:10".encode("utf-8")))},
+            verify="/path/to/pem",
+            code=200,
+            content_json={}
+        )
+        service = kubeclientservice.KubeClientService()
+        yield service.setServiceParent(self.master)
+        yield service.reconfigService(self.config)
+        yield service.deletePod("ns", "pod_name")
 
 
 class KubeClientServiceTestKubeCtlProxyConfig(config.ConfigErrorsMixin,
@@ -270,7 +329,7 @@ class RealKubeClientServiceTest(TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()
         self.master = fakemaster.make_master(self)
-        self.createKube()
+        yield self.createKube()
         yield self.kube.setServiceParent(self.master)
         yield self.master.startService()
 
@@ -416,14 +475,15 @@ class FakeKubeClientServiceTest(RealKubeClientServiceTest):
 
 
 class PatchedKubeClientServiceTest(RealKubeClientServiceTest):
+    @defer.inlineCallbacks
     def createKube(self):
+        self.http = yield fakehttpclientservice.HTTPClientService.getService(
+            self.master,
+            self,
+            "http://m"
+        )
         self.kube = kubeclientservice.KubeClientService(
             kubeclientservice.KubeHardcodedConfig(master_url='http://m'))
-        self.http = fakehttp.HTTPClientService('http://m')
-        self.kube.get = self.http.get
-        self.kube.post = self.http.post
-        self.kube.put = self.http.put
-        self.kube.delete = self.http.delete
 
     def expect(self, *args, **kwargs):
         return self.http.expect(*args, **kwargs)

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -434,7 +434,7 @@ class RealKubeClientServiceTest(TestReactorMixin, unittest.TestCase):
             },
             code=400,
             content_json=content)
-        with self.assertRaises(kubeclientservice.KubeError):
+        with self.assertRaises(kubeclientservice.KubeJsonError):
             yield self.kube.createPod(self.kube.namespace, spec)
 
     @defer.inlineCallbacks
@@ -452,7 +452,7 @@ class RealKubeClientServiceTest(TestReactorMixin, unittest.TestCase):
             json=None,
             code=404,
             content_json=content)
-        with self.assertRaises(kubeclientservice.KubeError):
+        with self.assertRaises(kubeclientservice.KubeJsonError):
             yield self.kube.deletePod(self.kube.namespace, 'pod-example')
 
     @defer.inlineCallbacks

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -216,8 +216,8 @@ class HTTPClientService(service.SharedService):
     def _doTReq(self, method, ep, **kwargs):
         url, kwargs = yield self._prepareRequest(ep, kwargs)
         # treq requires header values to be an array
-        kwargs['headers'] = {k: [v]
-                             for k, v in kwargs['headers'].items()}
+        if "headers" in kwargs:
+            kwargs['headers'] = {k: [v] for k, v in kwargs["headers"].items()}
         kwargs['agent'] = self._agent
 
         res = yield getattr(treq, method)(url, **kwargs)

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -116,9 +116,9 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
 
     @defer.inlineCallbacks
     def start_instance(self, build):
-        yield self.stop_instance(reportFailure=False)
-        pod_spec = yield self.renderWorkerPropsOnStart(build)
         try:
+            yield self.stop_instance(reportFailure=False)
+            pod_spec = yield self.renderWorkerPropsOnStart(build)
             yield self._kube.createPod(self.namespace, pod_spec)
         except kubeclientservice.KubeError as e:
             raise LatentWorkerFailedToSubstantiate(str(e)) from e
@@ -130,7 +130,7 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
         self.resetWorkerPropsOnStop()
         try:
             yield self._kube.deletePod(self.namespace, self.getContainerName())
-        except kubeclientservice.KubeError as e:
+        except kubeclientservice.KubeJsonError as e:
             if reportFailure and e.reason != 'NotFound':
                 raise
         if fast:


### PR DESCRIPTION
Sometimes Kubernetes API returns non-json response, but it's impossible to debug because the response itself is omitted. This PR improves logging of such erroneous responses.

Additionally, Kubernetes worker has been refactored to be more testable by making KubeClientService not derive HttpClientService.