### PR TITLE
worker: Implement affinity customization for Kubernetes worker

### DIFF
--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -114,6 +114,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
             "name": "buildbot-worker-87de7e"
         }
         expected_spec = {
+            "affinity": {},
             "containers": [
                 {
                     "name": "buildbot-worker-87de7e",
@@ -241,6 +242,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
             "name": "buildbot-worker-87de7e"
         }
         expected_spec = {
+            "affinity": {},
             "containers": [
                 {
                     "name": "buildbot-worker-87de7e",

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -137,6 +137,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
                     "volumeMounts": []
                 }
             ],
+            "nodeSelector": {},
             "restartPolicy": "Never",
             "volumes": []
         }
@@ -265,6 +266,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
                     "volumeMounts": []
                 }
             ],
+            "nodeSelector": {},
             "restartPolicy": "Never",
             "volumes": []
         }

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -42,6 +42,7 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
                 "name": self.getContainerName()
             },
             "spec": {
+                "affinity": (yield self.get_affinity(build)),
                 "containers": [{
                     "name": self.getContainerName(),
                     "image": image,
@@ -63,6 +64,9 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
 
     def get_build_container_volume_mounts(self, build):
         return []
+
+    def get_affinity(self, build):
+        return {}
 
     def get_volumes(self, build):
         return []

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -53,6 +53,7 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
                     "resources": (yield self.getBuildContainerResources(build)),
                     "volumeMounts": (yield self.get_build_container_volume_mounts(build)),
                 }] + (yield self.getServicesContainers(build)),
+                "nodeSelector": (yield self.get_node_selector(build)),
                 "restartPolicy": "Never",
                 "volumes": (yield self.get_volumes(build)),
             }
@@ -66,6 +67,9 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
         return []
 
     def get_affinity(self, build):
+        return {}
+
+    def get_node_selector(self, build):
         return {}
 
     def get_volumes(self, build):

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -426,6 +426,33 @@ All those methods take props object which is a L{IProperties} allowing to get so
                     }
                 ]
 
+    .. py:method:: get_affinity(self, props)
+
+        This method computes the `affinity <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling>`_ part of the pod spec.
+
+        Example:
+
+        .. code-block:: python
+
+            def get_affinity(self, props):
+                return {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                "matchExpressions": [
+                                    {
+                                        "key": "topology.kubernetes.io/zone",
+                                        "operator": "In",
+                                        "values": [
+                                            "antarctica-east1"
+                                        ]
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                }
+
     .. py:method:: getServicesContainers(self, props)
 
         This method compute a list of containers spec to put alongside the worker container.

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -426,6 +426,19 @@ All those methods take props object which is a L{IProperties} allowing to get so
                     }
                 ]
 
+    .. py:method:: get_node_selector(self, props)
+
+        This method computes the `nodeSelector <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling>`_ part of the pod spec.
+
+        Example:
+
+        .. code-block:: python
+
+            def get_node_selector(self, props):
+                return {
+                    "my-label": "my-label-value"
+                }
+
     .. py:method:: get_affinity(self, props)
 
         This method computes the `affinity <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling>`_ part of the pod spec.

--- a/newsfragments/worker-k8s-affinity.feature
+++ b/newsfragments/worker-k8s-affinity.feature
@@ -1,1 +1,1 @@
-Implement support for customizing `affinity` field in Kubernetes pod spec for Kubernetes worker.
+Implement support for customizing `affinity` and `nodeSelector` fields in Kubernetes pod spec for Kubernetes worker.

--- a/newsfragments/worker-k8s-affinity.feature
+++ b/newsfragments/worker-k8s-affinity.feature
@@ -1,0 +1,1 @@
+Implement support for customizing `affinity` field in Kubernetes pod spec for Kubernetes worker.


### PR DESCRIPTION
This allows to limit where kubernetes pod can be scheduled.