### PR TITLE
worker: Fix another crash when using KubeCtlProxyConfigLoader

### DIFF
--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -139,9 +139,10 @@ class KubeCtlProxyConfigLoader(KubeConfigLoaderBase):
             self.terminated_deferred.callback(None)
 
     def checkConfig(self, proxy_port=8001, namespace="default"):
+        self.proxy_port = proxy_port
+        self.namespace = namespace
         self.pp = None
         self.process = None
-        self.proxy_port = proxy_port
 
     @defer.inlineCallbacks
     def ensureSubprocessKilled(self):


### PR DESCRIPTION
KubeCtlProxyConfigLoader requires self.namespace for its configuration dictionary, but it's not available before reconfigService() is called.