### PR TITLE
Update towncrier to 23.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,13 @@ docs:
 	@echo "You can now open master/docs/_build/html/index.html"
 
 docs-towncrier:
+	# Check that master/docs/relnotes/index.rst is not already generated (so it's in the the staging area).
+	# If docs-release and docs-release-spelling are called one after the other, then towncrier will report duplicate release notes.
+	if ! git diff --name-only --cached | grep -q "master/docs/relnotes/index.rst"; then \
 	if command -v towncrier >/dev/null 2>&1 ;\
 	then \
 	towncrier --draft | grep  'No significant changes.' || yes n | towncrier ;\
+	fi \
 	fi
 
 docs-spelling:

--- a/master/docs/relnotes.rst.jinja
+++ b/master/docs/relnotes.rst.jinja
@@ -15,6 +15,7 @@
 {% for text, values in sections[section][category]|dictsort(by='value') %}
 - {{ text }}
 {% endfor %}
+
 {% else %}
 - {{ sections[section][category]['']|sort|join(', ') }}
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -32,7 +32,6 @@ certifi==2023.11.17
 cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2
-click-default-group==1.2.4
 click==8.1.7
 configparser==6.0.0
 constantly==23.10.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -114,7 +114,7 @@ testtools==2.7.1
 toml==0.10.2
 tomli==2.0.1
 tomlkit==0.12.3
-towncrier==21.9.0
+towncrier==23.11.0
 treq==23.11.0;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore
 Twisted==23.10.0

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -18,4 +18,4 @@ sphinxcontrib-spelling==8.0.0
 sphinxcontrib-websupport==1.2.4;  python_version < "3.9" # pyup: ignore
 sphinxcontrib-websupport==1.2.6;  python_version >= "3.9"
 Pygments==2.17.2
-towncrier==21.9.0
+towncrier==23.11.0


### PR DESCRIPTION
A master uses latest twisted we can update all twisted related packages now.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
