### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 51"

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -49,7 +49,7 @@ extras==1.0.0
 fixtures==4.1.0
 funcsigs==1.0.2
 graphql-core==3.2.3
-greenlet==3.0.1
+greenlet==3.0.2
 hvac==1.2.1
 hyperlink==21.0.0
 idna==2.10  # pyup: ignore (conflicts with moto on master)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -78,7 +78,7 @@ pathlib2==2.3.7.post1
 pbr==6.0.0
 pep8==1.7.1
 Pillow==10.1.0
-platformdirs==4.0.0
+platformdirs==4.1.0
 psutil==5.9.6
 pyaml==23.9.7
 pyasn1-modules==0.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -66,7 +66,7 @@ lazy-object-proxy==1.9.0  # pyup: ignore (required by astroid)
 ldap3==2.9.1
 lz4==4.3.2
 Mako==1.3.0
-markdown2==2.4.11
+markdown2==2.4.12
 MarkupSafe==2.1.3
 mccabe==0.7.0
 more-itertools==10.1.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ Automat==22.10.0
 Babel==2.14.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
-botocore==1.33.6
+botocore==1.34.2
 certifi==2023.11.17
 cffi==1.16.0
 chardet==5.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,7 +10,7 @@ boto3==1.34.2
 flake8==6.1.0;  python_version >= "3.8.1"
 msgpack==1.0.7
 Markdown==3.5.1
-pylint==3.0.2
+pylint==3.0.3
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests
 # are reproducible. The versions should be upgraded whenever we see new versions to catch problems

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -24,7 +24,7 @@ asn1crypto==1.5.1
 astroid==3.0.2
 attrs==23.1.0
 Automat==22.10.0
-Babel==2.13.1
+Babel==2.14.0
 backports.functools-lru-cache==1.6.6
 boto==2.49.0
 botocore==1.33.6

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,7 +21,7 @@ alabaster==0.7.13
 alembic==1.11.3
 appdirs==1.4.4
 asn1crypto==1.5.1
-astroid==3.0.1
+astroid==3.0.2
 attrs==23.1.0
 Automat==22.10.0
 Babel==2.13.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -37,7 +37,7 @@ click==8.1.7
 configparser==6.0.0
 constantly==15.1.0
 cookies==2.2.1
-coverage==7.3.2
+coverage==7.3.3
 croniter==2.0.1
 cryptography==41.0.7
 decorator==5.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -120,7 +120,7 @@ Twisted==23.10.0
 txaio==23.1.1
 txrequests==0.9.6
 types-PyYAML==6.0.12.12
-typing_extensions==4.8.0
+typing_extensions==4.9.0
 unidiff==0.7.5
 # botocore depends on urllib3<1.27
 urllib3==1.26.18  # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ astroid==3.0.2
 attrs==23.1.0
 Automat==22.10.0
 Babel==2.14.0
-backports.functools-lru-cache==1.6.6
+backports.functools-lru-cache==2.0.0
 boto==2.49.0
 botocore==1.33.6
 certifi==2023.11.17

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -79,7 +79,7 @@ pbr==6.0.0
 pep8==1.7.1
 Pillow==10.1.0
 platformdirs==4.1.0
-psutil==5.9.6
+psutil==5.9.7
 pyaml==23.9.7
 pyasn1-modules==0.3.0
 pyasn1==0.5.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ buildbot-www==3.10.0
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-boto3==1.33.6
+boto3==1.34.2
 flake8==6.1.0;  python_version >= "3.8.1"
 msgpack==1.0.7
 Markdown==3.5.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==3.9.2
+buildbot-www==3.10.0
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -43,7 +43,7 @@ cryptography==41.0.7
 decorator==5.1.1
 dicttoxml==1.7.16
 dill==0.3.7
-docker==6.1.3
+docker==7.0.0
 docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
 extras==1.0.0
 fixtures==4.1.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -70,7 +70,7 @@ markdown2==2.4.12
 MarkupSafe==2.1.3
 mccabe==0.7.0
 more-itertools==10.1.0
-moto==4.2.11
+moto==4.2.12
 olefile==0.47
 packaging==23.2
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -99,7 +99,7 @@ requests==2.31.0
 responses==0.24.1
 ruamel.yaml==0.18.5
 ruamel.yaml.clib==0.2.8
-s3transfer==0.8.2
+s3transfer==0.9.0
 scandir==1.10.0
 service-identity==23.1.0
 setuptools-trial==0.6.0

--- a/requirements-cidb.txt
+++ b/requirements-cidb.txt
@@ -1,3 +1,3 @@
 psycopg2-binary==2.9.9
-mysqlclient==2.2.0
+mysqlclient==2.2.1
 pg8000==1.30.3

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -28,7 +28,7 @@ Twisted==23.10.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
 txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.9.0;  python_version >= "3.7"
-typing-extensions==4.8.0;  python_version < "3.7" and python_version >= "3.5"
+typing-extensions==4.9.0;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
 zope.interface==6.1;  python_version >= "3.6"
 -e worker

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -21,7 +21,7 @@ parameterized==0.9.0;  python_version >= "3.6"
 pbr==6.0.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
-psutil==5.9.6
+psutil==5.9.7
 pycparser==2.21;  python_version >= "3.6"
 six==1.16.0
 Twisted==23.10.0;  python_version >= "3.6"

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -27,7 +27,7 @@ six==1.16.0
 Twisted==23.10.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
 txaio==23.1.1;  python_version >= "3.6"
-typing-extensions==4.8.0;  python_version >= "3.7"
+typing-extensions==4.9.0;  python_version >= "3.7"
 typing-extensions==4.8.0;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
 zope.interface==6.1;  python_version >= "3.6"


### PR DESCRIPTION
I did following changes to failing #7279:

- `drop 127931b42 Update alembic from 1.11.3 to 1.13.0`
- `drop d090bd8f0 Update hvac from 1.2.1 to 2.0.0` (multiple possible breaking changes https://github.com/hvac/hvac/blob/main/CHANGELOG.md#200)

Dropped Twisted project dependencies for now. Trying to fix in another PR.
- `drop 56453d14a Update constantly from 15.1.0 to 23.10.4`
- `drop c5673fc69 Update constantly from 15.1.0 to 23.10.4`
- `drop 95e38dfab Update towncrier from 21.9.0 to 23.11.0`
- `drop 5da9c95ac Update towncrier from 21.9.0 to 23.11.0`
- `drop 1737d1f99 Update treq from 22.2.0 to 23.11.0`


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
