### PR TITLE
Remove workaround for fixing AngularJS build failures

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -127,21 +127,18 @@ script:
   - title: frontend build tests
     condition: TESTS == "js_build" and TRAVIS_PULL_REQUEST
     cmd: |
-      export NODE_OPTIONS=--openssl-legacy-provider
       export PATH=/tmp/bbvenv/bin/:$PATH
       make frontend
 
   - title: full frontend tests
     condition: TESTS == "js_build" and not TRAVIS_PULL_REQUEST
     cmd: |
-      export NODE_OPTIONS=--openssl-legacy-provider
       export PATH=/tmp/bbvenv/bin/:$PATH
       make frontend_install_tests
 
   - title: frontend unit tests
     condition: TESTS == "js_unit"
     cmd: |
-      export NODE_OPTIONS=--openssl-legacy-provider
       export PATH=/tmp/bbvenv/bin/:$PATH
       make frontend_tests
 
@@ -201,7 +198,6 @@ script:
   - title: maketarballs
     condition: TESTS in ("e2e_react_whl", "e2e_react_tgz")
     cmd:  |
-      export NODE_OPTIONS=--openssl-legacy-provider
       export PATH=/tmp/bbvenv/bin/:$PATH
       make tarballs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,10 @@ jobs:
           command: |
             . .venv/bin/activate
             make docs-release
-            NODE_OPTIONS=--openssl-legacy-provider make tarballs
+            make tarballs
             # Note that installing www/react-base depends on frontend_deps target being built, which is
             # a dependency of the tarballs target.
-            NODE_OPTIONS=--openssl-legacy-provider pip install -e www/react-base
+            pip install -e www/react-base
             pyinstaller pyinstaller/buildbot-worker.spec
             # we test the new generated binary with the global virtualenv
             SANDBOXED_WORKER_PATH=`pwd`/dist/buildbot-worker trial --reporter=text --rterrors buildbot.test.integration.interop


### PR DESCRIPTION
Now that Buildbot uses React framework, this workaround is unnecessary. It was needed earlier, when AngularJS frontend was used to fix specific build failures.

* [not_needed] I have updated the unit tests
* [ not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
