### PR TITLE
Revert "e2e: Increase test timeout"

### DIFF
--- a/smokes-react/playwright.config.ts
+++ b/smokes-react/playwright.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
     testIdAttribute: 'data-bb-test-id'
   },
 
-  timeout: 90000,
   expect: {
     timeout: 15000
   },


### PR DESCRIPTION
Reverts buildbot/buildbot#7286. The log output was referring to the run time of a test file, not a test case.