### PR TITLE
worker: Work around bug in reactor.spawnProcess on Twisted 23.10

### DIFF
--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -165,7 +165,8 @@ class KubeCtlProxyConfigLoader(KubeConfigLoaderBase):
             self.pp,
             self.kube_ctl_proxy_cmd[0],
             self.kube_ctl_proxy_cmd + ["-p", str(self.proxy_port)],
-            env=None)
+            env=os.environ
+        )
         self.kube_proxy_output = yield self.pp.got_output_deferred
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Twisted 23.10 and some other versions implement spawnProcess using os.posix_spawnp(). If spawnProcess() is passed env=None, then for os.posix_spawnp() it is changed to empty environment. As a result, kubectl is started with empty environment and can't find its configuration.
