### PR TITLE
www: Use __package__ as the first arg to buildbot.www.plugin.Application

### DIFF
--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -29,11 +29,11 @@ else:
 
 class Application:
 
-    def __init__(self, modulename, description, ui=True):
+    def __init__(self, package_name, description, ui=True):
         self.description = description
-        self.version = importlib_resources.files(modulename).joinpath("VERSION")
+        self.version = importlib_resources.files(package_name).joinpath("VERSION")
         self.version = bytes2unicode(self.version.read_bytes())
-        self.static_dir = importlib_resources.files(modulename) / "static"
+        self.static_dir = importlib_resources.files(package_name) / "static"
         self.resource = static.File(self.static_dir)
         self.ui = ui
 

--- a/newsfragments/plugins-application-package.change
+++ b/newsfragments/plugins-application-package.change
@@ -1,0 +1,3 @@
+``buildbot.www.plugin.Application`` no longer accepts module name as the first parameter.
+It requires the name of package. In most cases where ``__name__`` was being passed, ``__package__``
+is now required.

--- a/www/badges/buildbot_badges/__init__.py
+++ b/www/badges/buildbot_badges/__init__.py
@@ -143,5 +143,5 @@ class Api:
 
 
 # create the interface for the setuptools entry point
-ep = Application(__name__, "Buildbot badges", ui=False)
+ep = Application(__package__, "Buildbot badges", ui=False)
 ep.resource = Api(ep).app.resource()

--- a/www/nestedexample/buildbot_nestedexample/__init__.py
+++ b/www/nestedexample/buildbot_nestedexample/__init__.py
@@ -64,6 +64,6 @@ class NestedExample(NestedParameter):
 
 
 # create the interface for the setuptools entry point
-ep = Application(__name__, "Buildbot nested parameter example")
+ep = Application(__package__, "Buildbot nested parameter example")
 api = Api(ep)
 ep.resource.putChild("api", api.app.resource())

--- a/www/react-base/buildbot_www_react/__init__.py
+++ b/www/react-base/buildbot_www_react/__init__.py
@@ -16,4 +16,4 @@
 from buildbot.www.plugin import Application
 
 # create the interface for the setuptools entry point
-ep = Application(__name__, "Buildbot UI (React)")
+ep = Application(__package__, "Buildbot UI (React)")

--- a/www/react-console_view/buildbot_react_console_view/__init__.py
+++ b/www/react-console_view/buildbot_react_console_view/__init__.py
@@ -16,4 +16,4 @@
 from buildbot.www.plugin import Application
 
 # create the interface for the setuptools entry point
-ep = Application(__name__, "Buildbot Console View plugin")
+ep = Application(__package__, "Buildbot Console View plugin")

--- a/www/react-grid_view/buildbot_react_grid_view/__init__.py
+++ b/www/react-grid_view/buildbot_react_grid_view/__init__.py
@@ -16,4 +16,4 @@
 from buildbot.www.plugin import Application
 
 # create the interface for the setuptools entry point
-ep = Application(__name__, "Buildbot Grid View plugin")
+ep = Application(__package__, "Buildbot Grid View plugin")

--- a/www/react-waterfall_view/buildbot_react_waterfall_view/__init__.py
+++ b/www/react-waterfall_view/buildbot_react_waterfall_view/__init__.py
@@ -16,4 +16,4 @@
 from buildbot.www.plugin import Application
 
 # create the interface for the setuptools entry point
-ep = Application(__name__, "Buildbot Waterfall View plugin")
+ep = Application(__package__, "Buildbot Waterfall View plugin")


### PR DESCRIPTION
The previous usage was broken by migration from importlib_resources to importlib.resources in af41ac879f4be9e5e2edd37a6a51e816075363fa.
