### PR TITLE
locks: Compare lock owners by id() instead of by instance

### DIFF
--- a/newsfragments/fix-lock-handling.bugfix
+++ b/newsfragments/fix-lock-handling.bugfix
@@ -1,0 +1,2 @@
+Fixed an issue in lock handling which caused step locks to be acquired in excess of their
+configured capacity under certain conditions (:issue:`5655`, :issue:`5987`).


### PR DESCRIPTION
Storing lock owners in a list and then using "in" operator to check existence effectively uses "==" operator for comparisons. This is incorrect because the code must check not whether two instances are equal, but whether they are the same object.

To address this and to make code less brittle lock owners are now tracked by their id.

Fixes #5655. 
Fixes #5987.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
