### PR TITLE
POC: Check if there is bug in towncrier==21.9.0 (DO NOT MERGE)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ docs-towncrier:
 	if command -v towncrier >/dev/null 2>&1 ;\
 	then \
 	towncrier --draft | grep  'No significant changes.' || yes n | towncrier ;\
+	echo "---- Diff start ----"; \
+	git --no-pager diff --cached; \
+	echo "---- Diff end ----"; \
 	fi
 
 docs-spelling:


### PR DESCRIPTION
Intent of this PR/commit is to check that there is unspotted bug in in towncrier==21.9.0 happens on buildbot infrastructure as I see it on my own machine

Details:
As docs-towncrier target is called twice
from docs-release
and from docs-release-spelling
it generates release notes for PR twice.
This was fixed in towncrier 22.8.0.rc1 (2022-08-28) and is reported as error

Release notes:
"The detection of duplicate release notes was fixed and recording changes of same version is no longer triggered"
https://towncrier.readthedocs.io/en/stable/release-notes.html#id81

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
