### PR TITLE
3.10 backport: pkg: Don't use announce() for logging

### DIFF
--- a/newsfragments/www-package-build-older-python.bugfix
+++ b/newsfragments/www-package-build-older-python.bugfix
@@ -1,0 +1,1 @@
+Fix web frontend package build on certain Python versions (e.g. 3.9).

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -227,8 +227,7 @@ class BuildJsCommand(Command):
             ]
 
             for command in commands:
-                self.announce('Running command: {}'.format(str(" ".join(command))),
-                              level=logging.INFO)
+                logging.info('Running command: {}'.format(str(" ".join(command))))
                 subprocess.check_call(command, shell=shell)
 
         self.copy_tree(os.path.join(package, 'static'), os.path.join(


### PR DESCRIPTION
This PR backports #7269 to 3.10.x.