### PR TITLE
3.10 backport: Improve security of tarfile extraction addressed by PEP 706

### DIFF
--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -126,7 +126,10 @@ class DirectoryWriter(FileWriter):
 
         # Unpack archive and clean up after self
         with tarfile.open(name=self.tarname, mode=mode) as archive:
-            archive.extractall(path=self.destroot)
+            if hasattr(tarfile, 'data_filter'):
+                archive.extractall(path=self.destroot, filter='data')
+            else:
+                archive.extractall(path=self.destroot)
         os.remove(self.tarname)
 
 

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -77,7 +77,10 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
             with tarfile.open(tarball) as tf:
                 prefixes = set()
                 for inf in tf:
-                    tf.extract(inf)
+                    if hasattr(tarfile, 'data_filter'):
+                        tf.extract(inf, filter='data')
+                    else:
+                        tf.extract(inf)
                     prefixes.add(inf.name.split('/', 1)[0])
 
             # (note that tf.extractall isn't available in py2.4)

--- a/newsfragments/tarfile-pep706.bugfix
+++ b/newsfragments/tarfile-pep706.bugfix
@@ -1,0 +1,1 @@
+Improved security of tarfile extraction to help avoid CVE-2007-4559. See more details in https://peps.python.org/pep-0706/. Buildbot uses filter='data' now. (:issue:`7294`)


### PR DESCRIPTION
This PR backports #7295 to 3.10.x