### PR TITLE
process: Implement a check for step attempting to acquire its build lock

### DIFF
--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -50,6 +50,7 @@ class FakeBuild(properties.PropertiesMixin):
         self.number = 13
         self.workdir = 'build'
         self.locks = []
+        self._locks_to_acquire = []
 
         self.sources = {}
         if props is None:

--- a/newsfragments/step-build-locks-not-same-check.feature
+++ b/newsfragments/step-build-locks-not-same-check.feature
@@ -1,0 +1,1 @@
+Implemented a check for step attempting to acquire the same lock as its build.


### PR DESCRIPTION
This is a fix for an existing feature, but it was broken for at least a decade because build.locks stored (lock, access) tuples whereas duplication check was being done using only bare lock.

This commit also fixes a step crash introduced in
75282ab325249a78e12cfac2d973f2510560919b

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
