### PR TITLE
3.10 backport: www: Fix React error message when its frontend is not installed

### DIFF
--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -306,8 +306,10 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
         self.reconfigurableResources = []
 
-        # we're going to need at least the base plugin (buildbot-www)
+        # we're going to need at least the base plugin (buildbot-www or buildbot-www-react)
         if self.base_plugin_name not in self.apps:
+            if self.base_plugin_name == 'base_react':
+                raise RuntimeError("could not find buildbot-www-react; is it installed?")
             raise RuntimeError("could not find buildbot-www; is it installed?")
 
         root = self.apps.get(self.base_plugin_name).resource


### PR DESCRIPTION
This PR backports #7314 to 3.10.x.