### PR TITLE
3.10 backport: requirements: Update SQLAlchemy from 1.4.40 to 1.4.50

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -19,6 +19,7 @@ import warnings
 from unittest import mock
 
 import setuptools  # force import setuptools before any other distutils imports
+from sqlalchemy.exc import RemovedIn20Warning
 
 from buildbot import monkeypatches
 from buildbot.test.util.warnings import assertProducesWarning  # noqa pylint: disable=wrong-import-position
@@ -142,3 +143,12 @@ warnings.filterwarnings("ignore", "twisted.web.resource.NoResource was deprecate
 
 # Buildbot shows this warning after upgrading to Twisted 23.10
 warnings.filterwarnings('ignore', ".*unclosed event loop.*", category=Warning)
+
+# Ignore sqlalchemy 1.5 warning
+# sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not
+# compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications,
+# ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable
+# SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable
+# SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0
+# at: https://sqlalche.me/e/b8d9) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+warnings.filterwarnings("ignore", category=RemovedIn20Warning)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -108,7 +108,7 @@ singledispatch==4.1.0
 six==1.16.0
 snowballstemmer==2.2.0
 # Buildbot supports only sqlalchemy >= 1.3.0, < 1.5
-SQLAlchemy==1.4.40  # pyup: ignore
+SQLAlchemy==1.4.50  # pyup: ignore
 sqlparse==0.4.4
 termcolor==2.3.0
 testtools==2.7.1


### PR DESCRIPTION
This PR backports #7313 to 3.10.x.