### PR TITLE
bbtravis: Work around test failure on Python 3.12

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -40,6 +40,7 @@ matrix:
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.10 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.11 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.12 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
 
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=dev_virtualenv
 

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -76,6 +76,9 @@ install:
   - /tmp/bbvenv/bin/pip install -U pip wheel
   - condition: TESTS not in ("dev_virtualenv", "smokes", "e2e_react_whl", "e2e_react_tgz", "trial_worker")
     cmd: /tmp/bbvenv/bin/pip install -r requirements-ci.txt
+  # On python 3.12 workaround done in dcbc28d1431e1aae892f7fdc0e266253365bc11e is no longer enough.
+  - condition: TESTS not in ("dev_virtualenv", "smokes", "e2e_react_whl", "e2e_react_tgz", "trial_worker")
+    cmd: /tmp/bbvenv/bin/pip install -e master -e worker
   - condition: TESTS == "dev_virtualenv"
     cmd: /tmp/bbvenv/bin/pip install -r requirements-ci.txt -r requirements-ciworker.txt -r requirements-cidocs.txt
   - condition: TESTS == "trial_worker"


### PR DESCRIPTION
Buildbot already works around a potential bug in Twisted:
https://github.com/twisted/twisted/issues/11840.

Unfortunately, the workaround done in is no longer enough on Python 3.12
https://github.com/buildbot/buildbot/commit/dcbc28d1431e1aae892f7fdc0e266253365bc11e. Seems like reinstalling Buildbot master again fixes the issue.