### PR TITLE
Declare Python3.12 compatibility in generated packages of master and worker

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -154,6 +154,7 @@ setup_args = {
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     'packages': [

--- a/newsfragments/setup-python312-compat.bugfix
+++ b/newsfragments/setup-python312-compat.bugfix
@@ -1,0 +1,1 @@
+setup: Declare Python3.12 compatibility in generated packages of master and worker

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -103,6 +103,7 @@ setup_args = {
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     'packages': [


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
