### PR TITLE
3.10 backport: Declare Python3.12 compatibility in generated packages of master and …

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -154,6 +154,7 @@ setup_args = {
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     'packages': [

--- a/newsfragments/setup-python312-compat.bugfix
+++ b/newsfragments/setup-python312-compat.bugfix
@@ -1,0 +1,1 @@
+setup: Declare Python3.12 compatibility in generated packages of master and worker

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -106,6 +106,7 @@ setup_args = {
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     'packages': [


### PR DESCRIPTION
This PR backports #7340 to 3.10.x.