### PR TITLE
Migrate from deprecated distutils to setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ flake8:
 
 frontend_deps: $(VENV_NAME)
 	$(PIP) install -e pkg
-	$(PIP) install wheel buildbot
+	$(PIP) install build wheel buildbot
 	for i in $(WWW_DEP_PKGS); \
 		do (cd $$i; $(YARN) install --pure-lockfile; $(YARN) run build); done
 
@@ -84,7 +84,7 @@ frontend: frontend_deps
 # build frontend wheels for installation elsewhere
 frontend_wheels: frontend_deps
 	for i in pkg $(WWW_PKGS); \
-		do (cd $$i; $(PYTHON) setup.py bdist_wheel || exit 1) || exit 1; done
+		do (cd $$i; $(PYTHON) -m build --no-isolation --wheel || exit 1) || exit 1; done
 
 # do installation tests. Test front-end can build and install for all install methods
 frontend_install_tests: frontend_deps
@@ -114,7 +114,7 @@ docker-buildbot-master:
 
 $(VENV_NAME):
 	virtualenv -p $(VENV_PY_VERSION) $(VENV_NAME)
-	$(PIP) install -U pip setuptools wheel
+	$(PIP) install -U build pip setuptools wheel
 
 # helper for virtualenv creation
 virtualenv: $(VENV_NAME)   # usage: make virtualenv VENV_PY_VERSION=python3.4

--- a/common/maketarball.sh
+++ b/common/maketarball.sh
@@ -4,13 +4,13 @@ pkg=$1
 (
     cd ${pkg}
     rm -rf MANIFEST dist
-    if [ ${pkg} == "master" ] || [ ${pkg} == "worker" ]; then
-        python setup.py sdist
+    if [ ${pkg} == "master" ] || [ ${pkg} == "worker" ] || [ ${pkg} == "pkg" ]; then
+        python -m build --no-isolation --sdist
         # wheels must be build separately in order to properly omit tests
-        python setup.py bdist_wheel
+        python -m build --no-isolation --wheel
     else
         # retry once to workaround instabilities
-        python setup.py sdist bdist_wheel || (git clean -xdf; python setup.py sdist bdist_wheel)
+        python -m build --no-isolation || (git clean -xdf; python -m build --no-isolation)
     fi
 )
 cp ${pkg}/dist/* dist/

--- a/common/validate.sh
+++ b/common/validate.sh
@@ -145,11 +145,11 @@ git log "$REVRANGE" --pretty=oneline || exit 1
 if ! $quick && ! $no_js; then
     for module in www/react-base www/react-console_view www/react-grid_view www/react-waterfall_view www/badges;
     do
-        status "running 'setup.py develop' for $module"
-        if ! (cd $module; python setup.py develop >/dev/null ); then
-            warning "$module/setup.py failed; retrying with cleared build/ dist/"
+        status "running 'pip install -e' for $module"
+        if ! (cd $module; pip install -e . >/dev/null ); then
+            warning "pip install -e for $module failed; retrying with cleared build/ dist/"
             rm -rf "$module/build" "$module/dist"
-            (cd $module; python setup.py develop >/dev/null ) || not_ok "$module/setup.py failed"
+            (cd $module; pip install -e . >/dev/null ) || not_ok "$module/setup.py failed"
         fi
     done
 else

--- a/common/validate.sh
+++ b/common/validate.sh
@@ -143,12 +143,12 @@ echo "${MAGENTA}Validating the following commits:${NORM}"
 git log "$REVRANGE" --pretty=oneline || exit 1
 
 if ! $quick && ! $no_js; then
-    for module in www/base www/console_view www/grid_view www/waterfall_view www/codeparameter www/wsgi_dashboards;
+    for module in www/react-base www/react-console_view www/react-grid_view www/react-waterfall_view www/badges;
     do
         status "running 'setup.py develop' for $module"
         if ! (cd $module; python setup.py develop >/dev/null ); then
-            warning "$module/setup.py failed; retrying with cleared libs/"
-            rm -rf "$module/libs"
+            warning "$module/setup.py failed; retrying with cleared build/ dist/"
+            rm -rf "$module/build" "$module/dist"
             (cd $module; python setup.py develop >/dev/null ) || not_ok "$module/setup.py failed"
         fi
     done

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -41,7 +41,7 @@ def gitDescribeToPep440(version):
         if v.group('dev'):
             patch += 1
             dev = int(v.group('dev'))
-            return f"{major}.{minor}.{patch}-dev{dev}"
+            return f"{major}.{minor}.{patch}.dev{dev}"
         if v.group('post'):
             return f"{major}.{minor}.{patch}.post{v.group('post')}"
         return f"{major}.{minor}.{patch}"

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -162,6 +162,8 @@ class CPAN(BuildFactory):
         self.addStep(PerlModuleTest(command=["make", "test"]))
 
 
+# deprecated, use Distutils
+@deprecate.deprecated(versions.Version("buildbot", 4, 0, 0))
 class Distutils(BuildFactory):
     def __init__(self, source, python="python", test=None):
         super().__init__([source])

--- a/master/buildbot/test/unit/test_version.py
+++ b/master/buildbot/test/unit/test_version.py
@@ -29,7 +29,7 @@ class VersioningUtilsTests(unittest.SynchronousTestCase):
             raise unittest.SkipTest(self.module_under_test + " package is not installed") from e
 
     def test_gitDescribeToPep440devVersion(self):
-        self.assertEqual(self.m.gitDescribeToPep440("v0.9.8-20-gf0f45ca"), "0.9.9-dev20")
+        self.assertEqual(self.m.gitDescribeToPep440("v0.9.8-20-gf0f45ca"), "0.9.9.dev20")
 
     def test_gitDescribeToPep440tag(self):
         self.assertEqual(self.m.gitDescribeToPep440("v0.9.8"), "0.9.8")
@@ -38,7 +38,7 @@ class VersioningUtilsTests(unittest.SynchronousTestCase):
         self.assertEqual(self.m.gitDescribeToPep440("v0.9.9.post1"), "0.9.9.post1")
 
     def test_gitDescribeToPep440p1dev(self):
-        self.assertEqual(self.m.gitDescribeToPep440("v0.9.9.post1-20-gf0f45ca"), "0.9.10-dev20")
+        self.assertEqual(self.m.gitDescribeToPep440("v0.9.9.post1-20-gf0f45ca"), "0.9.10.dev20")
 
     def test_getVersionFromArchiveIdNoTag(self):
         version = self.m.getVersionFromArchiveId("1514651968  (git-archive-version)")

--- a/master/docs/manual/configuration/buildfactories.rst
+++ b/master/docs/manual/configuration/buildfactories.rst
@@ -323,6 +323,8 @@ Arguments:
 Distutils
 ~~~~~~~~~
 
+.. deprecated:: 4.0
+
 .. py:class:: buildbot.process.factory.Distutils
 
 Most Python modules use the ``distutils`` package to provide configuration and build services.

--- a/master/docs/manual/installation/installation.rst
+++ b/master/docs/manual/installation/installation.rst
@@ -39,15 +39,26 @@ If you plan to use TLS or SSL in master configuration (e.g. to fetch resources o
 Installation From Tarballs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Buildbot master and ``buildbot-worker`` are installed using the standard Python `distutils <http://docs.python.org/library/distutils.html>`_ process.
-For either component, after unpacking the tarball, the process is:
+Use pip to install ``buildbot`` master or ``buildbot-worker`` using tarball.
+
+.. note::
+
+    Support for installation using ``setup.py`` has been discontinued due to the deprecation of support in the ``distutils`` and ``setuptools`` packages.
+    For more details, see `Why you shouldn't invoke setup.py directly <https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html>`_.
+
+If you have a tarball file named buildbot.tar.gz in your current directory, you can install it using:
 
 .. code-block:: bash
 
-    python setup.py build
-    python setup.py install
+    pip install buildbot.tar.gz
 
-where the install step may need to be done as root.
+Alternatively, you can provide a URL if the tarball is hosted online. Make sure to replace the URL with the actual URL of tarball you want to install.
+
+.. code-block:: bash
+
+    pip install https://github.com/buildbot/buildbot/releases/download/v3.10.1/buildbot-3.10.1.tar.gz
+
+Installation may need to be done as root.
 This will put the bulk of the code in somewhere like :file:`/usr/lib/pythonx.y/site-packages/buildbot`.
 It will also install the :command:`buildbot` command-line tool in :file:`/usr/bin/buildbot`.
 

--- a/newsfragments/distutils-deprecation.change
+++ b/newsfragments/distutils-deprecation.change
@@ -1,0 +1,1 @@
+The ``buildbot.process.factory.Distutils`` factory has been deprecated.

--- a/newsfragments/distutils-to-setuptools.change
+++ b/newsfragments/distutils-to-setuptools.change
@@ -1,0 +1,2 @@
+Master and Worker packages have stopped using the deprecated distutils package and rely on setuptools.
+Worker installation now requires setuptools.

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -70,7 +70,7 @@ def gitDescribeToPep440(version):
         if v.group('dev'):
             patch += 1
             dev = int(v.group('dev'))
-            return "{}.{}.{}-dev{}".format(major, minor, patch, dev)
+            return "{}.{}.{}.dev{}".format(major, minor, patch, dev)
         if v.group('post'):
             return "{}.{}.{}.post{}".format(major, minor, patch, v.group('post'))
         return "{}.{}.{}".format(major, minor, patch)

--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -24,20 +24,31 @@ from twisted.trial import unittest
 
 
 class BuildbotWWWPkg(unittest.TestCase):
-    pkgName = "buildbot_www"
-    pkgPaths = ["www", "base"]
-    epName = "base"
+    pkgName = "buildbot_www_react"
+    pkgPaths = ["www", "react-base"]
+    epName = "base_react"
 
     loadTestScript = dedent(
         """
         from importlib.metadata import entry_points
         import re
         apps = {}
-        for ep in entry_points().get('buildbot.www', []):
+
+        eps = entry_points()
+        entry_point = "buildbot.www"
+        if hasattr(eps, "select"):
+            entry_point_group = eps.select(group=entry_point)
+        else:
+            entry_point_group = eps.get(entry_point, [])
+
+        for ep in entry_point_group:
             apps[ep.name] = ep.load()
 
         print(apps["%(epName)s"])
-        assert("scripts.js" in apps["%(epName)s"].resource.listNames())
+        expected_file = "scripts.js"
+        if "%(epName)s" == "base_react":
+            expected_file = "index.html"
+        assert(expected_file in apps["%(epName)s"].resource.listNames())
         assert(re.match(r'\d+\.\d+\.\d+', apps["%(epName)s"].version) is not None)
         assert(apps["%(epName)s"].description is not None)
         """
@@ -57,25 +68,17 @@ class BuildbotWWWPkg(unittest.TestCase):
         self.rmtree(os.path.join(self.path, "dist"))
         self.rmtree(os.path.join(self.path, "static"))
 
-    def run_setup(self, cmd):
-        check_call([sys.executable, 'setup.py', cmd], cwd=self.path)
+    def run_build(self, kind):
+        check_call([sys.executable, "-m", "build", "--no-isolation", f"--{kind}"], cwd=self.path)
 
     def check_correct_installation(self):
         # assert we can import buildbot_www
-        # and that it has an endpoint with resource containing file "script.js"
+        # and that it has an endpoint with resource containing file "script.js" or "index.html" (in case of buildbot_www_react)
         check_call([sys.executable, '-c', self.loadTestScript % dict(epName=self.epName)])
 
-    def test_install(self):
-        self.run_setup("install")
-        self.check_correct_installation()
-
     def test_wheel(self):
-        self.run_setup("bdist_wheel")
+        self.run_build("wheel")
         check_call("pip install dist/*.whl", shell=True, cwd=self.path)
-        self.check_correct_installation()
-
-    def test_develop(self):
-        self.run_setup("develop")
         self.check_correct_installation()
 
     def test_develop_via_pip(self):
@@ -83,24 +86,18 @@ class BuildbotWWWPkg(unittest.TestCase):
         self.check_correct_installation()
 
     def test_sdist(self):
-        self.run_setup("sdist")
+        self.run_build("sdist")
         check_call("pip install dist/*.tar.gz", shell=True, cwd=self.path)
         self.check_correct_installation()
 
 
 class BuildbotConsolePkg(BuildbotWWWPkg):
-    pkgName = "buildbot-console-view"
-    pkgPaths = ["www", "console_view"]
-    epName = "console_view"
+    pkgName = "buildbot-react-console-view"
+    pkgPaths = ["www", "react-console_view"]
+    epName = "react_console_view"
 
 
 class BuildbotWaterfallPkg(BuildbotWWWPkg):
-    pkgName = "buildbot-waterfall-view"
-    pkgPaths = ["www", "waterfall_view"]
-    epName = "waterfall_view"
-
-
-class BuildbotCodeparameterPkg(BuildbotWWWPkg):
-    pkgName = "buildbot-codeparameter"
-    pkgPaths = ["www", "codeparameter"]
-    epName = "codeparameter"
+    pkgName = "buildbot-react-waterfall-view"
+    pkgPaths = ["www", "react-waterfall_view"]
+    epName = "react_waterfall_view"

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -45,7 +45,7 @@ def gitDescribeToPep440(version):
         if v.group('dev'):
             patch += 1
             dev = int(v.group('dev'))
-            return "{0}.{1}.{2}-dev{3}".format(major, minor, patch, dev)
+            return "{0}.{1}.{2}.dev{3}".format(major, minor, patch, dev)
         if v.group('post'):
             return "{0}.{1}.{2}.post{3}".format(major, minor, patch, v.group('post'))
         return "{0}.{1}.{2}".format(major, minor, patch)

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -28,8 +28,7 @@ try:
     # If setuptools is installed, then we'll add setuptools-specific arguments
     # to the setup args.
     import setuptools
-    from distutils.command.install_data import install_data
-    from setuptools import setup
+    from setuptools import Command, setup
     from setuptools.command.sdist import sdist
 except ImportError:
     setuptools = None
@@ -39,21 +38,21 @@ except ImportError:
 BUILDING_WHEEL = bool("bdist_wheel" in sys.argv)
 
 
-class our_install_data(install_data):
+class our_install_data(Command):
+    def initialize_options(self):
+        self.install_dir = None
+
     def finalize_options(self):
         self.set_undefined_options(
             'install',
             ('install_lib', 'install_dir'),
         )
-        install_data.finalize_options(self)
 
     def run(self):
-        install_data.run(self)
         # ensure there's a buildbot_worker/VERSION file
         fn = os.path.join(self.install_dir, 'buildbot_worker', 'VERSION')
         with open(fn, 'w') as f:
             f.write(version)
-        self.outfiles.append(fn)
 
 
 class our_sdist(sdist):

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -22,18 +22,11 @@ Standard setup script.
 import os
 import sys
 
-from buildbot_worker import version
+from setuptools import Command
+from setuptools import setup
+from setuptools.command.sdist import sdist
 
-try:
-    # If setuptools is installed, then we'll add setuptools-specific arguments
-    # to the setup args.
-    import setuptools
-    from setuptools import Command, setup
-    from setuptools.command.sdist import sdist
-except ImportError:
-    setuptools = None
-    from distutils.command.sdist import sdist
-    from distutils.core import setup
+from buildbot_worker import version
 
 BUILDING_WHEEL = bool("bdist_wheel" in sys.argv)
 
@@ -144,60 +137,59 @@ if sys.platform == "win32":
 
 twisted_ver = ">= 18.7.0"
 
-if setuptools is not None:
-    setup_args['install_requires'] = [
-        'twisted ' + twisted_ver,
-        'future',
+setup_args['install_requires'] = [
+    'twisted ' + twisted_ver,
+    'future',
+]
+
+if sys.version_info >= (3, 6):
+    # Message pack is only supported on Python 3.6 and newer
+    setup_args['install_requires'] += [
+        'autobahn >= 0.16.0',
+        'msgpack >= 0.6.0',
+    ]
+else:
+    # Automat 20.2.0 is the last version that supports Python 2.7. Unfortunately the package
+    # did not update its metadata and thus newer versions advertise Python 2.7 support even
+    # though they are broken.
+    setup_args['install_requires'] += [
+        'Automat <= 20.2.0',
     ]
 
-    if sys.version_info >= (3, 6):
-        # Message pack is only supported on Python 3.6 and newer
-        setup_args['install_requires'] += [
-            'autobahn >= 0.16.0',
-            'msgpack >= 0.6.0',
-        ]
-    else:
-        # Automat 20.2.0 is the last version that supports Python 2.7. Unfortunately the package
-        # did not update its metadata and thus newer versions advertise Python 2.7 support even
-        # though they are broken.
-        setup_args['install_requires'] += [
-            'Automat <= 20.2.0',
-        ]
+# buildbot_worker_windows_service needs pywin32
+if sys.platform == "win32":
+    setup_args['install_requires'].append('pywin32')
 
-    # buildbot_worker_windows_service needs pywin32
-    if sys.platform == "win32":
-        setup_args['install_requires'].append('pywin32')
-
-    # Unit test hard dependencies.
-    test_deps = [
-        'psutil',
+# Unit test hard dependencies.
+test_deps = [
+    'psutil',
+]
+if sys.version_info < (3, 3):
+    # unittest.mock added in Python 3.3
+    test_deps += [
+        'mock',
     ]
-    if sys.version_info < (3, 3):
-        # unittest.mock added in Python 3.3
-        test_deps += [
-            'mock',
-        ]
 
-    setup_args['tests_require'] = test_deps
+setup_args['tests_require'] = test_deps
 
-    setup_args['extras_require'] = {
-        'test': [
-            'pep8',
-            # spellcheck introduced in version 1.4.0
-            'pylint>=1.4.0',
-            'pyenchant',
-            'flake8~=3.9.0',
-        ]
-        + test_deps,
-    }
+setup_args['extras_require'] = {
+    'test': [
+        'pep8',
+        # spellcheck introduced in version 1.4.0
+        'pylint>=1.4.0',
+        'pyenchant',
+        'flake8~=3.9.0',
+    ]
+    + test_deps,
+}
 
-    if '--help-commands' in sys.argv or 'trial' in sys.argv or 'test' in sys.argv:
-        setup_args['setup_requires'] = [
-            'setuptools_trial',
-        ]
+if '--help-commands' in sys.argv or 'trial' in sys.argv or 'test' in sys.argv:
+    setup_args['setup_requires'] = [
+        'setuptools_trial',
+    ]
 
-    if os.getenv('NO_INSTALL_REQS'):
-        setup_args['install_requires'] = None
-        setup_args['extras_require'] = None
+if os.getenv('NO_INSTALL_REQS'):
+    setup_args['install_requires'] = None
+    setup_args['extras_require'] = None
 
 setup(**setup_args)


### PR DESCRIPTION
Implements #7203
Related article can be found here:  https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

* [x] migrate scripts away from direct invocation of `setup.py`
    * [x] `setup.py sdist`/ `setup.py bdist_wheel` -> `python -m build`
    * [x] migrate `setup.py develop` -> `pip install -e`
* [x] migrate tests away from direct invocation of `setup.py`
    * [x] `setup.py sdist`/ `setup.py bdist_wheel` -> `python -m build`
    * [x] migrate `setup.py develop` -> `pip install -e`
* [ ] can we deprecate `buildbot.process.factory.Distutils` build factory ?

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
