### PR TITLE
maketarballs: removing silently failing command related to removing AngularJS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ flake8:
 frontend_deps: $(VENV_NAME)
 	$(PIP) install -e pkg
 	$(PIP) install wheel buildbot
-	cd www/build_common; $(YARN) install --pure-lockfile
 	for i in $(WWW_DEP_PKGS); \
 		do (cd $$i; $(YARN) install --pure-lockfile; $(YARN) run build); done
 


### PR DESCRIPTION

"/bin/sh: 1: cd: can't cd to www/build_common"

Looks like it was not removed as part in PR #7287

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
