### PR TITLE
makefile: Enable more strict mode for shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Enable more strict mode for shell
+.SHELLFLAGS := -eu -c
+
 # developer utilities
 DOCKERBUILD := docker build --build-arg http_proxy=$$http_proxy --build-arg https_proxy=$$https_proxy
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))


### PR DESCRIPTION
- The -e option makes the shell exit immediately if any command it runs exits with a non-zero status, effectively causing the Makefile to fail if any command fails.
- The -u option treats unset variables as an error. If any variable used in a command is not set, the shell will exit with an error.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
