### PR TITLE
Combined buildset status generator

### DIFF
--- a/master/buildbot/reporters/generators/buildrequest.py
+++ b/master/buildbot/reporters/generators/buildrequest.py
@@ -88,6 +88,7 @@ class BuildRequestGenerator(BuildStatusGeneratorMixin):
             'type': buildmsg['type'],
             'results': build['results'],
             'builds': [build],
+            "buildset": build["buildset"],
             'users': list(users),
             'patches': patches,
             'logs': []

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -68,12 +68,11 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
         if not builds:
             return None
 
-        report = yield self.buildset_message(self.formatter, master, reporter, builds,
-                                             buildset['results'])
+        report = yield self.buildset_message(self.formatter, master, reporter, builds, buildset)
         return report
 
     @defer.inlineCallbacks
-    def buildset_message(self, formatter, master, reporter, builds, results):
+    def buildset_message(self, formatter, master, reporter, builds, buildset):
         # The given builds must refer to builds from a single buildset
         patches = []
         logs = []
@@ -81,6 +80,7 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
         subject = None
         msgtype = None
         users = set()
+        results = buildset["results"]
         for build in builds:
             patches.extend(self._get_patches_for_build(build))
 
@@ -115,6 +115,7 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
             'type': msgtype,
             'results': results,
             'builds': builds,
+            "buildset": buildset,
             'users': list(users),
             'patches': patches,
             'logs': logs

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -197,6 +197,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
             'type': buildmsg['type'],
             'results': results,
             'builds': [build],
+            "buildset": build["buildset"],
             'users': list(users),
             'patches': patches,
             'logs': logs

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -91,7 +91,6 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
         return False
 
     def is_message_needed_by_props(self, build):
-        # here is where we actually do something.
         builder = build['builder']
         scheduler = build['properties'].get('scheduler', [None])[0]
         branch = build['properties'].get('branch', [None])[0]

--- a/master/buildbot/reporters/generators/worker.py
+++ b/master/buildbot/reporters/generators/worker.py
@@ -62,6 +62,7 @@ class WorkerMissingGenerator(util.ComparableMixin):
             'type': msg['type'],
             'results': None,
             'builds': None,
+            "buildset": None,
             'users': worker['notify'],
             'patches': None,
             'logs': None,

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -290,6 +290,9 @@ class MessageFormatterRenderable(MessageFormatterBase):
 
     @defer.inlineCallbacks
     def render_message_subject(self, context):
+        if self.subject is None:
+            return None
+
         props = Properties.fromDict(context['build']['properties'])
         props.master = context['master']
 

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -145,6 +145,26 @@ def create_context_for_build(mode, build, is_buildset, master, blamelist):
     }
 
 
+def create_context_for_buildset(mode, buildset, builds, master, blamelist):
+    ss_list = buildset['sourcestamps']
+    results = buildset["results"]
+
+    return {
+        "results": results,
+        "result_names": Results,
+        "mode": mode,
+        "buildset": buildset,
+        "builds": builds,
+        "is_buildset": True,
+        "projects": get_projects_text(ss_list, master),
+        "status_detected": get_detected_status_text(mode, results, None),
+        "buildbot_title": master.config.title,
+        "buildbot_url": master.config.buildbotURL,
+        "blamelist": blamelist,
+        "sourcestamps": get_message_source_stamp_text(ss_list)
+    }
+
+
 def create_context_for_worker(master, worker):
     return {
         'buildbot_title': master.config.title,
@@ -237,6 +257,10 @@ class MessageFormatterBase(util.ComparableMixin):
         # Known kwargs keys: mode, users, is_buildset
         raise NotImplementedError
 
+    def format_message_for_buildset(self, master, buildset, builds, **kwargs):
+        # Known kwargs keys: mode, users, is_buildset
+        raise NotImplementedError
+
 
 class MessageFormatterEmpty(MessageFormatterBase):
     def format_message_for_build(self, master, build, **kwargs):
@@ -244,6 +268,13 @@ class MessageFormatterEmpty(MessageFormatterBase):
             'body': None,
             'type': 'plain',
             'subject': None
+        }
+
+    def format_message_for_buildset(self, master, buildset, builds, **kwargs):
+        return {
+            "body": None,
+            "type": "plain",
+            "subject": None
         }
 
 
@@ -257,6 +288,11 @@ class MessageFormatterFunction(MessageFormatterBase):
     @defer.inlineCallbacks
     def format_message_for_build(self, master, build, **kwargs):
         msgdict = yield self.render_message_dict(master, {'build': build})
+        return msgdict
+
+    @defer.inlineCallbacks
+    def format_message_for_buildset(self, master, buildset, builds, **kwargs):
+        msgdict = yield self.render_message_dict(master, {"buildset": buildset, "builds": builds})
         return msgdict
 
     def render_message_body(self, context):
@@ -279,6 +315,9 @@ class MessageFormatterRenderable(MessageFormatterBase):
     def format_message_for_build(self, master, build, **kwargs):
         msgdict = yield self.render_message_dict(master, {'build': build, 'master': master})
         return msgdict
+
+    def format_message_for_buildset(self, master, buildset, builds, **kwargs):
+        raise NotImplementedError
 
     @defer.inlineCallbacks
     def render_message_body(self, context):
@@ -413,6 +452,12 @@ class MessageFormatter(MessageFormatterBaseJinja):
     @defer.inlineCallbacks
     def format_message_for_build(self, master, build, is_buildset=False, users=None, mode=None):
         ctx = create_context_for_build(mode, build, is_buildset, master, users)
+        msgdict = yield self.render_message_dict(master, ctx)
+        return msgdict
+
+    @defer.inlineCallbacks
+    def format_message_for_buildset(self, master, buildset, builds, users=None, mode=None):
+        ctx = create_context_for_buildset(mode, buildset, builds, master, users)
         msgdict = yield self.render_message_dict(master, ctx)
         return msgdict
 

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -222,6 +222,20 @@ def getResponsibleUsersForBuild(master, buildid):
     return blamelist
 
 
+# perhaps we need data api for users with buildsets/:id/users
+@defer.inlineCallbacks
+def get_responsible_users_for_buildset(master, buildsetid):
+    props = yield master.data.get(("buildsets", buildsetid, "properties"))
+
+    # TODO: This currently does not track what changes were in the buildset. getChangesForBuild()
+    # would walk the change graph until it finds last successful build and uses the authors of
+    # the changes as blame list. Probably this needs to be done here too
+    owner = props.get("owner", None)
+    if owner:
+        return [owner[0]]
+    return []
+
+
 def getURLForBuild(master, builderid, build_number):
     prefix = master.config.buildbotURL
     return prefix + f"#/builders/{builderid}/builds/{build_number}"

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -582,7 +582,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
     def test_reporter_with_buildset(self):
         yield self.setupReporter(generator_class=BuildSetStatusGenerator)
         yield self.setupBuildResults(SUCCESS)
-        buildset = yield self.master.data.get(('buildsets', 98))
+        buildset = yield self.get_inserted_buildset()
         self._http.expect(
             "post",
             EXPECTED_API,

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -80,6 +80,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
     def test_build_message_start_no_result(self):
         g = yield self.setup_generator()
         buildrequest = yield self.insert_buildrequest_new()
+        buildset = yield self.get_inserted_buildset()
         build = yield g.partial_build_dict(self.master, buildrequest)
         report = yield g.buildrequest_message(self.master, build)
 
@@ -94,6 +95,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
             'type': 'plain',
             'results': None,
             'builds': [build],
+            "buildset": buildset,
             'users': [],
             'patches': [],
             'logs': []
@@ -128,6 +130,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
     def test_generate_new(self):
         g = yield self.setup_generator(add_patch=True)
         buildrequest = yield self.insert_buildrequest_new(insert_patch=False)
+        buildset = yield self.get_inserted_buildset()
         build = yield g.partial_build_dict(self.master, buildrequest)
         report = yield g.generate(self.master, None, ('buildrequests', 11, 'new'), buildrequest)
 
@@ -137,6 +140,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
             'type': 'plain',
             'results': None,
             'builds': [build],
+            "buildset": buildset,
             'users': [],
             'patches': [],
             'logs': []
@@ -147,6 +151,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
         self.maxDiff = None
         g = yield self.setup_generator(add_patch=True)
         buildrequest = yield self.insert_buildrequest_new(insert_patch=False)
+        buildset = yield self.get_inserted_buildset()
         build = yield g.partial_build_dict(self.master, buildrequest)
         report = yield g.generate(self.master, None, ('buildrequests', 11, 'cancel'), buildrequest)
 
@@ -159,6 +164,7 @@ class TestBuildRequestGenerator(ConfigErrorsMixin, TestReactorMixin,
             'type': 'plain',
             'results': CANCELLED,
             'builds': [build],
+            "buildset": buildset,
             'users': [],
             'patches': [],
             'logs': []

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -445,6 +445,29 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
         self.assertEqual(sorted(res), sorted(["me@foo", "him", "her"]))
 
     @defer.inlineCallbacks
+    def test_get_responsible_users_for_buildset_with_owner(self):
+        self.setupDb()
+
+        self.db.insert_test_data(
+            [
+                fakedb.BuildsetProperty(
+                    buildsetid=98,
+                    property_name="owner",
+                    property_value='["buildset_owner", "fakedb"]'
+                ),
+            ]
+        )
+
+        res = yield utils.get_responsible_users_for_buildset(self.master, 98)
+        self.assertEqual(sorted(res), sorted(["buildset_owner"]))
+
+    @defer.inlineCallbacks
+    def test_get_responsible_users_for_buildset_no_owner(self):
+        self.setupDb()
+        res = yield utils.get_responsible_users_for_buildset(self.master, 99)
+        self.assertEqual(sorted(res), sorted([]))
+
+    @defer.inlineCallbacks
     def test_getPreviousBuild(self):
         self.setupDb()
         build = yield self.master.data.get(("builds", 21))

--- a/master/buildbot/test/util/reporter.py
+++ b/master/buildbot/test/util/reporter.py
@@ -48,6 +48,20 @@ class ReporterTestMixin:
         return build
 
     @defer.inlineCallbacks
+    def insert_buildset_no_builds(
+        self,
+        results,
+        insert_ss=True,
+        parent_plan=False,
+        insert_patch=False
+    ):
+        self.insert_test_data(
+            [], results, insertSS=insert_ss, parentPlan=parent_plan, insert_patch=insert_patch
+        )
+        buildset = yield self.master.data.get(("buildsets", 98))
+        return buildset
+
+    @defer.inlineCallbacks
     def insert_build_finished(self, results=SUCCESS, **kwargs):
         return (yield self.insert_build(results=results, **kwargs))
 

--- a/master/buildbot/test/util/reporter.py
+++ b/master/buildbot/test/util/reporter.py
@@ -162,6 +162,9 @@ class ReporterTestMixin:
 
         self.setup_fake_get_changes_for_build()
 
+    def get_inserted_buildset(self):
+        return self.master.data.get(("buildsets", 98))
+
     def setup_fake_get_changes_for_build(self, has_change=True):
         @defer.inlineCallbacks
         def getChangesForBuild(buildid):

--- a/master/docs/manual/configuration/report_generators/buildset.rst
+++ b/master/docs/manual/configuration/report_generators/buildset.rst
@@ -8,7 +8,10 @@ BuildSetStatusGenerator
 .. py:class:: buildbot.reporters.BuildSetStatusGenerator
 
 This report generator sends a message about builds in a buildset.
-It is very similar to :bb:reportgen:`BuildStatusGenerator` but sends single message about all builds in a buildset, not individual builds.
+
+Message formatters are invoked for each matching build in the buildset. The collected messages are
+then joined and sent as a single message. :bb:reportgen:`BuildStatusGenerator` report generator
+uses the same message generation logic, but a single, not multiple builds.
 
 The following parameters are supported:
 

--- a/master/docs/manual/configuration/report_generators/buildset_combined.rst
+++ b/master/docs/manual/configuration/report_generators/buildset_combined.rst
@@ -1,0 +1,27 @@
+.. bb:reportgen:: BuildSetCombinedStatusGenerator
+
+.. _Reportgen-BuildSetCombinedStatusGenerator:
+
+BuildSetCombinedStatusGenerator
++++++++++++++++++++++++++++++++
+
+.. py:class:: buildbot.reporters.BuildSetCombinedStatusGenerator
+
+This report generator sends a message about a buildset.
+
+Message formatter is invoked only once for all builds in the buildset.
+
+It is very similar to :bb:reportgen:`BuildSetCombinedStatusGenerator` but invokes message formatters for each
+matching build in the buildset. The collected messages are then joined and sent as a single message.
+
+
+A buildset without any builds is useful as a means to report to code review system that a
+particular code version does not need to be tested.  For example in cases when a pull request is
+updated with the only difference being commit message being changed.
+
+The following parameters are supported:
+
+``message_formatter``
+    (instance of ``reporters.MessageFormatter``)
+    This is an instance of the ``reporters.MessageFormatter`` class that will be used to generate
+    message for the buildset.

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -66,10 +66,11 @@ The constructor of the class takes the following arguments:
     This implies ``want_logs`` and ``wantSteps`` to be `True`.
     Use it only when mandatory, as this greatly increases the overhead in terms of CPU and memory on the master.
 
-Context
-~~~~~~~
+Context (build)
+~~~~~~~~~~~~~~~
 
-The context that is given to the template consists of the following data:
+In the case the message formatter is used to create message for a build the context that is given
+to the template consists of the following data:
 
 ``results``
     The results of the build as an integer.
@@ -162,6 +163,54 @@ The context that is given to the template consists of the following data:
 
 ``sourcestamps``
     A string identifying the source stamps for which the build was made.
+
+Context (buildset)
+~~~~~~~~~~~~~~~~~~
+
+In the case the message formatter is used to create message for an buildset itself (see
+``BuildSetCombinedStatusGenerator``), the context that is given to the template consists of the
+following data:
+
+``results``
+    The results of the buildset as an integer.
+    Equivalent to ``build['results']``.
+
+``result_names``
+    A collection that allows accessing a textual identifier of build result.
+    The intended usage is ``result_names[results]``.
+
+    The following are possible values: ``success``, ``warnings``, ``failure``, ``skipped``, ``exception``, ``retry``, ``cancelled``.
+
+``mode``
+    The mode argument that has been passed to the report generator.
+
+``buildset``
+    The :bb:rtype:`buildset` dictionary from data API.
+
+``builds``
+    A list of  :bb:rtype:`build` dictionaries from data API. The builds are part of the buildset
+    that is being formatted.
+
+``is_buildset``
+    Always ``True``.
+
+``projects``
+    A string identifying the projects that the buildset was built for.
+
+``status_detected``
+    String that describes the build in terms of current buildset results, previous build results and ``mode``.
+
+``buildbot_title``
+    The title of the Buildbot instance as per ``c['title']`` from the ``master.cfg``
+
+``buildbot_url``
+    The URL of the Buildbot instance as per ``c['buildbotURL']`` from the ``master.cfg``
+
+``blamelist``
+    The list of users responsible for the buildset.
+
+``sourcestamps``
+    A string identifying the source stamps for which the buildset was made.
 
 Examples
 ~~~~~~~~

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -10,7 +10,17 @@ As opposed to :ref:`MessageFormatterRenderable`, more information is made availa
 
 .. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, wantProperties=None, want_steps=False, wantSteps=None, wantLogs=None, want_logs=False, want_logs_content=False)
 
-    :param callable function: A callable that will be called with a dictionary that contains ``build`` key with the value that contains the build dictionary as received from the data API.
+    :param callable function: A callable that will be called with a dictionary.
+
+        If the message formatter is used to format a build, the dictionary contains ``build`` key
+        with the build dictionary as received from the data API.
+
+        If the message formatter is used to format a buildset (e.g. when used from
+        :bb:reportgen:`BuildSetCombinedStatusGenerator`), the dictionary contains the following:
+
+         - ``buildset`` key with the buildset dictionary as received from the data API.
+         - ``builds`` key with the builds dictionaries as received from the data API.
+
     :param string template_type: either ``plain``, ``html`` or ``json`` depending on the output of the formatter.
         JSON output must not be encoded.
     :param boolean want_properties: include 'properties' in the build dictionary

--- a/master/docs/manual/configuration/report_generators/formatter_renderable.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_renderable.rst
@@ -9,6 +9,9 @@ This formatter is used to format messages in :ref:`Reportgen-BuildStatusGenerato
 
 It renders any renderable using the properties of the build that was passed by the status generator.
 
+This message formatter does not support formatting complete buildsets (
+:bb:reportgen:`BuildSetCombinedStatusGenerator`).
+
 The constructor of the class takes the following arguments:
 
 ``template``

--- a/master/docs/manual/configuration/report_generators/index.rst
+++ b/master/docs/manual/configuration/report_generators/index.rst
@@ -10,6 +10,7 @@ Report Generators
     build
     build_start_end
     buildset
+    buildset_combined
     worker
     formatter
     formatter_function
@@ -43,12 +44,14 @@ The following report generators are available:
  * :ref:`Reportgen-BuildStatusGenerator`
  * :ref:`Reportgen-BuildStartEndStatusGenerator`
  * :ref:`Reportgen-BuildSetStatusGenerator`
+ * :ref:`Reportgen-BuildSetCombinedStatusGenerator`
  * :ref:`Reportgen-WorkerMissingGenerator`
 
 The report generators may customize the reports using message formatters.
 The following message formatter classes are provided:
 
- * :ref:`MessageFormatter` (used in ``BuildStatusGenerator``, ``BuildStartEndStatusGenerator`` and ``BuildSetStatusGenerator``)
+ * :ref:`MessageFormatter` (used in ``BuildStatusGenerator``, ``BuildStartEndStatusGenerator``,
+   ``BuildSetCombinedStatusGenerator`` and ``BuildSetStatusGenerator``)
  * :ref:`MessageFormatterRenderable` (used in ``BuildStatusGenerator`` and ``BuildStartEndStatusGenerator``)
  * :ref:`MessageFormatterFunction` (used in ``BuildStatusGenerator`` and ``BuildStartEndStatusGenerator``)
  * :ref:`MessageFormatterMissingWorkers` (used in ``WorkerMissingGenerator``)

--- a/master/docs/manual/configuration/reporters/reporter_base.rst
+++ b/master/docs/manual/configuration/reporters/reporter_base.rst
@@ -52,6 +52,9 @@ This documents frequently used keys within the dictionaries that are passed to t
  - ``builds`` (a list of build dictionaries as reported by the data API)
     A list of builds that the report describes.
 
+ - ``buildset`` (a buildset dictionary as reported by the data API)
+    The buildset that is being described.
+
  - ``users`` (a list of strings)
     A list of users to send the report to.
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -334,7 +334,12 @@ setup_args = {
             ('buildbot.reporters.generators.buildrequest', [
                 'BuildRequestGenerator'
             ]),
-            ('buildbot.reporters.generators.buildset', ['BuildSetStatusGenerator']),
+            ("buildbot.reporters.generators.buildset",
+                [
+                    "BuildSetCombinedStatusGenerator",
+                    "BuildSetStatusGenerator",
+                ]
+             ),
             ('buildbot.reporters.generators.worker', ['WorkerMissingGenerator']),
             ('buildbot.reporters.mail', ['MailNotifier']),
             ('buildbot.reporters.pushjet', ['PushjetNotifier']),

--- a/newsfragments/combined-buildsets-status-generator.feature
+++ b/newsfragments/combined-buildsets-status-generator.feature
@@ -1,0 +1,2 @@
+Implemented a report generator (``BuildSetCombinedStatusGenerator``) that can access complete
+information about a buildset.

--- a/newsfragments/report-generator-reports-buildset.feature
+++ b/newsfragments/report-generator-reports-buildset.feature
@@ -1,0 +1,1 @@
+Added buildset information to dictionaries returned by report generators.


### PR DESCRIPTION
This allows much better control over what message is emitted upon buildset completion.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
