### PR TITLE
3.11 backports: Add API to retrieve buildset sourcestamps

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -209,6 +209,7 @@ buildroot
 build's
 buildset
 buildsetcomplete
+buildsetid
 buildset's
 buildsets
 buildsetsubmitted

--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -63,13 +63,20 @@ class SourceStampsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /sourcestamps
+        /buildsets/:buildsetid/sourcestamps
     """
     rootLinkName = 'sourcestamps'
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
-        return [_db2data(ssdict) for ssdict in
-            (yield self.master.db.sourcestamps.getSourceStamps())]
+        buildsetid = kwargs.get("buildsetid")
+        if buildsetid is not None:
+            sourcestamps = \
+                yield self.master.db.sourcestamps.get_sourcestamps_for_buildset(buildsetid)
+        else:
+            sourcestamps = yield self.master.db.sourcestamps.getSourceStamps()
+
+        return [_db2data(ssdict) for ssdict in sourcestamps]
 
 
 class SourceStamp(base.ResourceType):

--- a/master/buildbot/test/fakedb/sourcestamps.py
+++ b/master/buildbot/test/fakedb/sourcestamps.py
@@ -158,6 +158,15 @@ class FakeSourceStampsComponent(FakeDBComponent):
             return None
 
     @defer.inlineCallbacks
+    def get_sourcestamps_for_buildset(self, buildsetid):
+        bset = yield self.db.buildsets.getBuildset(buildsetid)
+
+        results = []
+        for ssid in bset["sourcestamps"]:
+            results.append((yield self.getSourceStamp(ssid)))
+        return results
+
+    @defer.inlineCallbacks
     def getSourceStampsForBuild(self, buildid):
         build = yield self.db.builds.getBuild(buildid)
         breq = yield self.db.buildrequests.getBuildRequest(build['buildrequestid'])

--- a/master/buildbot/test/fakedb/sourcestamps.py
+++ b/master/buildbot/test/fakedb/sourcestamps.py
@@ -160,6 +160,8 @@ class FakeSourceStampsComponent(FakeDBComponent):
     @defer.inlineCallbacks
     def get_sourcestamps_for_buildset(self, buildsetid):
         bset = yield self.db.buildsets.getBuildset(buildsetid)
+        if bset is None:
+            return []
 
         results = []
         for ssid in bset["sourcestamps"]:

--- a/master/buildbot/test/unit/data/test_sourcestamps.py
+++ b/master/buildbot/test/unit/data/test_sourcestamps.py
@@ -76,10 +76,16 @@ class SourceStampsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpEndpoint()
-        self.db.insert_test_data([
-            fakedb.SourceStamp(id=13),
-            fakedb.SourceStamp(id=14),
-        ])
+        self.db.insert_test_data(
+            [
+                fakedb.Buildset(id=30, reason="foo", submitted_at=1300305712, results=-1),
+                fakedb.SourceStamp(id=13),
+                fakedb.SourceStamp(id=14),
+                fakedb.SourceStamp(id=15),
+                fakedb.BuildsetSourceStamp(sourcestampid=13, buildsetid=30),
+                fakedb.BuildsetSourceStamp(sourcestampid=14, buildsetid=30),
+            ]
+        )
 
     def tearDown(self):
         self.tearDownEndpoint()
@@ -91,8 +97,21 @@ class SourceStampsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         for m in sourcestamps:
             self.validateData(m)
 
-        self.assertEqual(sorted([m['ssid'] for m in sourcestamps]),
-                         [13, 14])
+        self.assertEqual(sorted([m['ssid'] for m in sourcestamps]), [13, 14, 15])
+
+    @defer.inlineCallbacks
+    def test_get_by_buildsetid_no_buildset(self):
+        sourcestamps = yield self.callGet(("buildsets", 101, "sourcestamps"))
+        self.assertEqual(sourcestamps, [])
+
+    @defer.inlineCallbacks
+    def test_get_by_buildsetid(self):
+        sourcestamps = yield self.callGet(("buildsets", 30, "sourcestamps"))
+
+        for m in sourcestamps:
+            self.validateData(m)
+
+        self.assertEqual(sorted([m['ssid'] for m in sourcestamps]), [13, 14])
 
 
 class SourceStamp(unittest.TestCase):

--- a/master/docs/developer/database/sourcestamps.rst
+++ b/master/docs/developer/database/sourcestamps.rst
@@ -88,6 +88,13 @@ Source stamps connector
         You probably don't want to do this!
         This method will be extended to allow appropriate filtering.
 
+    .. py:method:: get_sourcestamps_for_buildset(buildsetid)
+
+        :param buildsetid: buildset ID
+        :returns: list of ssdict, via Deferred
+
+        Get sourcestamps related to a buildset.
+
     .. py:method:: getSourceStampsForBuild(buildid)
 
         :param buildid: build ID

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -110,6 +110,7 @@ buildrequestid
 buildrequests
 buildset
 Buildset
+buildsetid
 buildsetids
 buildsets
 Buildsets

--- a/newsfragments/db-get-source-stamps-for-buildset.feature
+++ b/newsfragments/db-get-source-stamps-for-buildset.feature
@@ -1,2 +1,3 @@
 Low level database API now has ``get_sourcestamps_for_buildset`` to get source stamps for a
-buildset.
+buildset. "/buildsets/:buildsetid/sourcestamps" endpoint has been added to access this from the
+Data API.

--- a/newsfragments/db-get-source-stamps-for-buildset.feature
+++ b/newsfragments/db-get-source-stamps-for-buildset.feature
@@ -1,0 +1,2 @@
+Low level database API now has ``get_sourcestamps_for_buildset`` to get source stamps for a
+buildset.


### PR DESCRIPTION
This PR is a backport of #7354 to 3.11.x.