### PR TITLE
util: Use master.reactor as time source in ClusteredBuildbotService

### DIFF
--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -82,11 +82,11 @@ class TestPBChangeSource(
         self.setChangeSourceToMaster(None)
 
         # not quite enough time to cause it to activate
-        self.changesource.clock.advance(self.changesource.POLL_INTERVAL_SEC * 4 / 5)
+        self.reactor.advance(self.changesource.POLL_INTERVAL_SEC * 4 / 5)
         self.assertNotRegistered()
 
         # there we go!
-        self.changesource.clock.advance(self.changesource.POLL_INTERVAL_SEC * 2 / 5)
+        self.reactor.advance(self.changesource.POLL_INTERVAL_SEC * 2 / 5)
         self.assertRegistered(*self.EXP_DEFAULT_REGISTRATION)
 
     @defer.inlineCallbacks

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -361,9 +361,7 @@ class ClusteredBuildbotService(BuildbotService):
 
     def _startActivityPolling(self):
         self._activityPollCall = task.LoopingCall(self._activityPoll)
-        # plug in a clock if we have one, for tests
-        if hasattr(self, 'clock'):
-            self._activityPollCall.clock = self.clock
+        self._activityPollCall.clock = self.master.reactor
 
         d = self._activityPollCall.start(self.POLL_INTERVAL_SEC, now=True)
         self._activityPollDeferred = d


### PR DESCRIPTION
This reduces the number of test-related special cases in service code. Within Buildbot time is currently almost uniformly mocked via TestReactor.

