### PR TITLE
steps: Disable unnecessary "wrong-spelling-in-comment" warning

### DIFF
--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -400,6 +400,7 @@ class P4(Source):
         yield self.runCommand(cmd)
 
         stdout = cmd.stdout.splitlines(keepends=False)
+        # pylint: disable=wrong-spelling-in-comment
         # Example output from p4 -ztag changes -m1
         # ... change 212798
         # ... time 1694770219


### PR DESCRIPTION
The comment below is an example output, it may contain all kinds of misspelled words.
