### PR TITLE
Gerrit change source improvements

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -408,7 +408,7 @@ class GerritSshStreamEventsConnector:
 
     def start_stream_process(self):
         if self.debug:
-            log.msg(f"{self.connector.name}: starting 'gerrit stream-events'")
+            log.msg(f"{self.change_source.name}: starting 'gerrit stream-events'")
 
         cmd = self._build_gerrit_command("stream-events")
         self._last_stream_process_start = self.reactor.seconds()
@@ -431,12 +431,12 @@ class GerritSshStreamEventsConnector:
             ])
 
             log.msg(
-                f"{self.connector.name}: stream-events failed; restarting after "
+                f"{self.change_source.name}: stream-events failed; restarting after "
                 f"{round(self._stream_process_timeout)}s.\n"
                 f"{len(self._last_lines_for_debug)} log lines follow:\n{log_lines}"
             )
 
-            self.master.reactor.callLater(self._stream_process_timeout, self.start_stream_process)
+            self.reactor.callLater(self._stream_process_timeout, self.start_stream_process)
             self._stream_process_timeout *= self.STREAM_BACKOFF_EXPONENT
             if self._stream_process_timeout > self.STREAM_BACKOFF_MAX:
                 self._stream_process_timeout = self.STREAM_BACKOFF_MAX
@@ -446,7 +446,7 @@ class GerritSshStreamEventsConnector:
 
             # make sure we log the reconnection, so that it might be detected
             # and network connectivity fixed
-            log.msg(f"{self.connector.name}: stream-events lost connection. Reconnecting...")
+            log.msg(f"{self.change_source.name}: stream-events lost connection. Reconnecting...")
             self.start_stream_process()
             self._stream_process_timeout = self.STREAM_BACKOFF_MIN
 
@@ -458,7 +458,7 @@ class GerritSshStreamEventsConnector:
 
         if self.debug:
             log.msg(
-                f"{self.connector.name}: querying for changed files in change {change}/{patchset}: {cmd}"
+                f"{self.change_source.name}: querying for changed files in change {change}/{patchset}: {cmd}"
             )
 
         rc, out = yield runprocess.run_process(self.reactor, cmd, env=None, collect_stderr=False)

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -408,18 +408,6 @@ class TestGerritChangeSource(
         self.assertEqual(len(self.master.data.updates.changesAdded), 0)
 
     @defer.inlineCallbacks
-    def test_duplicate_events_ignored(self):
-        s = yield self.create_gerrit_synchronized('somehost', 'someuser')
-        yield s._line_received_stream(json.dumps(self.patchset_created_event))
-        self.assertEqual(len(self.master.data.updates.changesAdded), 1)
-
-        patchset_created_event = copy.deepcopy(self.patchset_created_event)
-        patchset_created_event['change']['project'] = {'name': 'test'}
-
-        yield s._line_received_stream(json.dumps(patchset_created_event))
-        self.assertEqual(len(self.master.data.updates.changesAdded), 1)
-
-    @defer.inlineCallbacks
     def test_duplicate_non_source_events_not_ignored(self):
         s = yield self.create_gerrit_synchronized(
             'somehost',

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -693,12 +693,14 @@ class TestGerritChangeSource(
         yield d
 
         self.master.db.state.assertState(s._oid, last_event_ts=start_time + 42)
+        self.master.db.state.assertState(
+            s._oid, last_event_hashes=['f075e0927cab81dabee661a5aa3c65d502103a71']
+        )
 
         self.assert_events_received([
             {'eventCreatedOn': start_time + 1, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 3, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 5, 'type': 'patchset-created'},
-            {'eventCreatedOn': start_time + 41, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 41, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 42, 'type': 'patchset-created'},
         ])
@@ -816,11 +818,12 @@ class TestGerritChangeSource(
         yield d
 
         self.master.db.state.assertState(s._oid, last_event_ts=start_time + 42)
+        self.master.db.state.assertState(
+            s._oid, last_event_hashes=["f075e0927cab81dabee661a5aa3c65d502103a71"]
+        )
         self.assert_events_received([
             {'eventCreatedOn': start_time + 1, 'type': 'patchset-created'},
-            {'eventCreatedOn': start_time + 1, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 2, 'type': 'patchset-created'},
-            {'eventCreatedOn': start_time + 41, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 41, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 42, 'type': 'patchset-created'},
         ])
@@ -929,7 +932,6 @@ class TestGerritChangeSource(
 
         self.master.db.state.assertState(s._oid, last_event_ts=start_time + 257)
         self.assert_events_received([
-            {'eventCreatedOn': start_time + 1, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 1, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 2, 'type': 'patchset-created'},
             {'eventCreatedOn': start_time + 125, 'type': 'patchset-created'},

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -169,7 +169,7 @@ Git
 
 Repo/Gerrit
 
-* :bb:chsrc:`GerritChangeSource` connects to Gerrit via SSH to get a live stream of changes
+* :bb:chsrc:`GerritChangeSource` connects to Gerrit via SSH and optionally HTTP to get a live stream of changes
 * :bb:chsrc:`GerritEventLogPoller` connects to Gerrit via HTTP with the help of the plugin events-log_
 
 Monotone
@@ -1256,11 +1256,17 @@ GerritChangeSource
 
 The :bb:chsrc:`GerritChangeSource` class connects to a Gerrit server by its SSH interface and uses its event source mechanism, `gerrit stream-events <https://gerrit-documentation.storage.googleapis.com/Documentation/2.2.1/cmd-stream-events.html>`_.
 
-Note that the Gerrit event stream is stateless and any events that occur while buildbot is not connected to Gerrit will be lost.
-See :bb:chsrc:`GerritEventLogPoller` for a stateful change source.
+Optionally it may use the `events-log plugin <https://gerrit.googlesource.com/plugins/events-log/+/refs/heads/master/src/main/resources/Documentation/rest-api-events.md>`_
+to retrieve any events that occur while Buildbot is not connected. If events-log mechanism is not
+used any events that occur while buildbot is not connected to Gerrit will be lost.
 
 The ``patchset-created`` and ``ref-updated`` events will be deduplicated, that is, if multiple events related to the same revision are received, only the first will be acted upon.
 This allows ``GerritChangeSource`` to be used together with :bb:chsrc:`GerritEventLogPoller`.
+
+.. note::
+
+    The :bb:chsrc:`GerritChangeSource` requires either the ``txrequest`` or the ``treq`` package for
+    using the HTTP API.
 
 The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
 
@@ -1297,6 +1303,24 @@ The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
     If the server does not respond at least ``ssh_server_alive_count_max`` times, a reconnection is forced.
     This helps to avoid stuck connections in case network link is severed without notification in the TCP layer.
     Specifying ``None`` will omit the option from the ssh client command line.
+
+``http_url``
+    (optional) HTTP URL to use when fetching events from the Gerrit internal database. This is used
+    to fill in events that have occurred when Buildbot was not connected to the SSH API.
+    If the URL of the events-log endpoint for your server is
+    ``https://example.com/a/plugins/events-log/events/`` then the ``http_url`` is
+    ``https://example.com``.
+
+``http_auth``
+    (optional) authentication credentials for events-log plugin.
+    If Gerrit is configured with ``BasicAuth``, then it shall be ``('login', 'password')``.
+    If Gerrit is configured with ``DigestAuth``, then it shall be
+    ``requests.auth.HTTPDigestAuth('login', 'password')`` from the requests module.
+    However, note that usage of ``requests.auth.HTTPDigestAuth`` is incompatible with ``treq``.
+
+``http_poll_interval``
+    (optional) frequency to poll the HTTP API when events are not being received through the SSH
+    connection. The default is 30 seconds.
 
 ``debug``
     Print Gerrit event in the log (default `False`).
@@ -1443,14 +1467,8 @@ GerritEventLogPoller
 
 .. py:class:: buildbot.changes.gerritchangesource.GerritEventLogPoller
 
-The :bb:chsrc:`GerritEventLogPoller` class is similar to :bb:chsrc:`GerritChangeSource` but connects to the Gerrit server by its HTTP interface and uses the events-log_ plugin.
-
-Note that the decision of whether to use :bb:chsrc:`GerritEventLogPoller` and :bb:chsrc:`GerritChangeSource` will depend on your needs. The trade off is:
-
-1. :bb:chsrc:`GerritChangeSource` is low-overhead and reacts instantaneously to events, but a broken connection to Gerrit will lead to missed changes
-2. :bb:chsrc:`GerritEventLogPoller` is subject to polling overhead and reacts only at it's polling rate, but is robust to a broken connection to Gerrit and missed changes will be discovered when a connection is restored.
-
-You can use both at the same time to get the advantages of each. They will coordinate through the database to avoid duplicate changes generated for buildbot.
+The :bb:chsrc:`GerritEventLogPoller` class is similar to :bb:chsrc:`GerritChangeSource` and
+connects to the Gerrit server only by its HTTP interface and uses the events-log_ plugin.
 
 .. note::
 

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1260,9 +1260,6 @@ Optionally it may use the `events-log plugin <https://gerrit.googlesource.com/pl
 to retrieve any events that occur while Buildbot is not connected. If events-log mechanism is not
 used any events that occur while buildbot is not connected to Gerrit will be lost.
 
-The ``patchset-created`` and ``ref-updated`` events will be deduplicated, that is, if multiple events related to the same revision are received, only the first will be acted upon.
-This allows ``GerritChangeSource`` to be used together with :bb:chsrc:`GerritEventLogPoller`.
-
 .. note::
 
     The :bb:chsrc:`GerritChangeSource` requires either the ``txrequest`` or the ``treq`` package for

--- a/master/docs/manual/upgrading/4.0-upgrade.rst
+++ b/master/docs/manual/upgrading/4.0-upgrade.rst
@@ -65,6 +65,14 @@ More specifically, the recommended approach is as follows:
 
  - Upgrade to Buildbot 4.x series
 
+GerritChangeSource and GerritEventLogPoller
+-------------------------------------------
+
+Events between ``GerritChangeSource`` and ``GerritEventLogPoller`` are no longer deduplicated.
+The equivalent is setting ``GerritChangeSource`` with both SSH and HTTP APIs. The ``http_url``
+should be set to ``baseURL`` of argument ``GerritEventLogPoller`` without the ``/a`` suffix included.
+``http_auth`` should be set to ``auth`` argument of ``GerritEventLogPoller``.
+
 Build status generators
 -----------------------
 

--- a/newsfragments/gerrit-change-source-no-duplication.change
+++ b/newsfragments/gerrit-change-source-no-duplication.change
@@ -1,0 +1,2 @@
+Events between ``GerritChangeSource`` and ``GerritEventLogPoller`` are no longer deduplicated.
+Use ``GerritChangeSource`` with both SSH and HTTP API configured as a replacement.

--- a/newsfragments/gerrit-change-source-polling.feature
+++ b/newsfragments/gerrit-change-source-polling.feature
@@ -1,5 +1,7 @@
-Added ability to poll HTTP event API of gerrit server to ``GerritChangeSource``. This is used
-under following circumstances:
- - Any missed events are retrieved after Buildbot restart just like in ``GerritPollingChangeSource``.
- - Polling is used to detect any silent hang of underlying SSH connection when there are
-   prolonged periods of inactivity (these may happen even when ServerAliveInterval is used)
+Added ability to poll HTTP event API of Gerrit server to ``GerritChangeSource``. This has the
+following advantages compared to simply pointing ``GerritChangeSource`` and
+``GerritEventLogPoller`` at the same Gerrit server:
+
+ - All events are properly deduplicated
+ - SSH connection is restarted in case of silent hangs of underlying SSH connection (this may
+   happen even when ServerAliveInterval is used)

--- a/newsfragments/gerrit-change-source-polling.feature
+++ b/newsfragments/gerrit-change-source-polling.feature
@@ -1,0 +1,5 @@
+Added ability to poll HTTP event API of gerrit server to ``GerritChangeSource``. This is used
+under following circumstances:
+ - Any missed events are retrieved after Buildbot restart just like in ``GerritPollingChangeSource``.
+ - Polling is used to detect any silent hang of underlying SSH connection when there are
+   prolonged periods of inactivity (these may happen even when ServerAliveInterval is used)


### PR DESCRIPTION
This PR adds ability to poll HTTP event API of gerrit server to `GerritChangeSource`. This has the following advantages compared to simply pointing `GerritChangeSource` and `GerritEventLogPoller` at the same gerrit server:
 - All events are properly deduplicated
 - SSH connection is restarted in case of silent hangs of underlying SSH connection (this may
   happen even when ServerAliveInterval is used)

Additionally, events between `GerritChangeSource` and `GerritEventLogPoller` are no longer deduplicated.  `GerritChangeSource` should be used with both SSH and HTTP API configured as a replacement.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
