### PR TITLE
Revert "Fix build summary requests UI when a line break occurs in the step's build summary."

### DIFF
--- a/www/react-base/src/components/BuildSummary/BuildSummary.scss
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.scss
@@ -38,10 +38,6 @@
 .bb-build-summary-step-line {
   position:relative;
 
-  .bb-build-summary-step-label {
-    display: inline-block;
-  }
-
   &.list-group-item.bb-anchor-target {
     border: 2px solid #ffff00;
   }

--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -196,7 +196,7 @@ const BuildSummaryStepLine = observer(({build, step, logs, parentFullDisplay}: B
 
   return (
     <li key={step.id} className="bb-build-summary-step-line list-group-item" id={`bb-step-${step.number}`}>
-      <div className="bb-build-summary-step-label" onClick={() => setFullDisplay(!fullDisplay)}>
+      <div onClick={() => setFullDisplay(!fullDisplay)}>
         <AnchorLink className="bb-build-summary-step-anchor-link"
                     anchor={`bb-step-${step.number}`}>
           #


### PR DESCRIPTION
Reverts buildbot/buildbot#7389.

Fixes https://github.com/buildbot/buildbot/issues/7405.