### PR TITLE
3.11 backports: gitpoller: ensure ssh private key has trailing new line

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -27,6 +27,7 @@ from buildbot.util import bytes2unicode
 from buildbot.util import private_tempdir
 from buildbot.util import runprocess
 from buildbot.util.git import GitMixin
+from buildbot.util.git import ensureSshKeyNewline
 from buildbot.util.git import getSshKnownHostsContents
 from buildbot.util.misc import writeLocalFile
 from buildbot.util.state import StateMixin
@@ -423,7 +424,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         # We change the permissions of the key file to be user-readable only so
         # that ssh does not complain. This is not used for security because the
         # parent directory will have proper permissions.
-        writeLocalFile(keyPath, self.sshPrivateKey, mode=stat.S_IRUSR)
+        writeLocalFile(keyPath, ensureSshKeyNewline(self.sshPrivateKey), mode=stat.S_IRUSR)
 
     def _downloadSshKnownHosts(self, path):
         if self.sshKnownHosts is not None:

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -1567,7 +1567,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
-        write_local_file_mock.assert_called_with(key_path, 'ssh-key',
+        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n',
                                                  mode=0o400)
 
     @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
@@ -1611,7 +1611,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
-        write_local_file_mock.assert_called_with(key_path, 'ssh-key',
+        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n',
                                                  mode=0o400)
 
     @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
@@ -1647,7 +1647,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.assertEqual(temp_dir_mock.dirs,
                          [(temp_dir_path, 0o700),
                           (temp_dir_path, 0o700)])
-        write_local_file_mock.assert_called_with(key_path, 'ssh-key',
+        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n',
                                                  mode=0o400)
 
 
@@ -1706,9 +1706,9 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
                           (temp_dir_path, 0o700)])
 
         expected_file_writes = [
-            mock.call(key_path, 'ssh-key', mode=0o400),
+            mock.call(key_path, 'ssh-key\n', mode=0o400),
             mock.call(known_hosts_path, '* ssh-host-key'),
-            mock.call(key_path, 'ssh-key', mode=0o400),
+            mock.call(key_path, 'ssh-key\n', mode=0o400),
             mock.call(known_hosts_path, '* ssh-host-key'),
         ]
 
@@ -1717,9 +1717,8 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
 
 
 class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
-
     def createPoller(self):
-        return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key',
+        return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key\n',
                                    sshKnownHosts='ssh-known-hosts')
 
     @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
@@ -1771,9 +1770,9 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                           (temp_dir_path, 0o700)])
 
         expected_file_writes = [
-            mock.call(key_path, 'ssh-key', mode=0o400),
+            mock.call(key_path, 'ssh-key\n', mode=0o400),
             mock.call(known_hosts_path, 'ssh-known-hosts'),
-            mock.call(key_path, 'ssh-key', mode=0o400),
+            mock.call(key_path, 'ssh-key\n', mode=0o400),
             mock.call(known_hosts_path, 'ssh-known-hosts'),
         ]
 

--- a/newsfragments/gitpoller-ssh-private-newline.bugfix
+++ b/newsfragments/gitpoller-ssh-private-newline.bugfix
@@ -1,0 +1,1 @@
+``GitPoller`` now ensure the SSH Private Key it uses has a trailing newline.


### PR DESCRIPTION
This PR backports #7424 to 3.11.x.