### PR TITLE
adapt interfaces compliance test helpers to typing

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 from functools import reduce
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -40,6 +42,10 @@ from buildbot.reporters.utils import getURLForBuild
 from buildbot.util import Notifier
 from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
+
+if TYPE_CHECKING:
+    from buildbot.process.builder import Builder
+    from buildbot.process.workerforbuilder import AbstractWorkerForBuilder
 
 
 class Build(properties.PropertiesMixin):
@@ -118,7 +124,7 @@ class Build(properties.PropertiesMixin):
     def getProperties(self):
         return self.properties
 
-    def setBuilder(self, builder):
+    def setBuilder(self, builder: Builder) -> None:
         """
         Set the given builder as our builder.
 
@@ -271,7 +277,8 @@ class Build(properties.PropertiesMixin):
             )
             self.setProperty("builddir", builddir, "Worker")
 
-    def setupWorkerForBuilder(self, workerforbuilder):
+    def setupWorkerForBuilder(self, workerforbuilder: AbstractWorkerForBuilder):
+        assert workerforbuilder.worker is not None
         self.path_module = workerforbuilder.worker.path_module
         self.workername = workerforbuilder.worker.workername
         self.worker_info = workerforbuilder.worker.info

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -13,8 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import warnings
 import weakref
+from typing import TYPE_CHECKING
 
 from twisted.application import service
 from twisted.internet import defer
@@ -33,6 +36,10 @@ from buildbot.util import bytes2unicode
 from buildbot.util import epoch2datetime
 from buildbot.util import service as util_service
 from buildbot.util.render_description import render_description
+
+if TYPE_CHECKING:
+    from buildbot.config.builder import BuilderConfig
+    from buildbot.config.master import MasterConfig
 
 
 def enforceChosenWorker(bldr, workerforbuilder, breq):
@@ -79,7 +86,7 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
         # Tracks config version for locks
         self.config_version = None
 
-    def _find_builder_config_by_name(self, new_config):
+    def _find_builder_config_by_name(self, new_config: MasterConfig) -> BuilderConfig | None:
         for builder_config in new_config.builders:
             if builder_config.name == self.name:
                 return builder_config

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -13,8 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import inspect
 import sys
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -59,6 +62,10 @@ from buildbot.util import deferwaiter
 from buildbot.util import flatten
 from buildbot.util.test_result_submitter import TestResultSubmitter
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from buildbot.process.build import Build
+    from buildbot.worker.base import AbstractWorker
 
 
 class BuildStepFailed(Exception):
@@ -267,7 +274,7 @@ class BuildStep(
     _locks_to_acquire = []
     progressMetrics = ()  # 'time' is implicit
     useProgress = True  # set to False if step is really unpredictable
-    build = None
+    build: Build | None = None
     step_status = None
     progress = None
     logEncoding = None
@@ -366,11 +373,11 @@ class BuildStep(
 
     __repr__ = __str__
 
-    def setBuild(self, build):
+    def setBuild(self, build: Build) -> None:
         self.build = build
         self.master = self.build.master
 
-    def setWorker(self, worker):
+    def setWorker(self, worker: AbstractWorker):
         self.worker = worker
 
     @deprecate.deprecated(versions.Version("buildbot", 0, 9, 0))

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -14,10 +14,17 @@
 # Copyright Buildbot Team Members
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.python.constants import NamedConstant
 from twisted.python.constants import Names
+
+if TYPE_CHECKING:
+    from buildbot.worker.base import AbstractWorker
 
 
 class States(Names):
@@ -33,7 +40,7 @@ class AbstractWorkerForBuilder:
     def __init__(self):
         self.ping_watchers = []
         self.state = None  # set in subclass
-        self.worker = None
+        self.worker: AbstractWorker | None = None
         self.builder_name = None
         self.locks = None
 

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -36,7 +36,7 @@ class InterfaceTests:
             self.assertArgSpecMatches(obj.methodUnderTest, self.fakeMethod)
         """
 
-        def filter(signature):
+        def filter(signature: inspect.Signature):
             if len(signature.parameters) == 0:
                 return signature
 
@@ -53,7 +53,15 @@ class InterfaceTests:
             for name in delete_names:
                 parameters.pop(name)
 
-            signature = signature.replace(parameters=parameters.values())
+            # Remove all type annotations
+            # as they can be stored as str when quoted or when `__future__.annotations`
+            # is imported, we can't check whether the types are compatible.
+            # Type checking should be left to a static type checker
+            signature = signature.replace(return_annotation=inspect.Signature.empty)
+            for name, param in parameters.items():
+                parameters[name] = param.replace(annotation=inspect.Parameter.empty)
+
+            signature = signature.replace(parameters=list(parameters.values()))
             return signature
 
         def remove_decorators(func):


### PR DESCRIPTION
While doing some cleanup in the context of #7384 (yeah, I'm fully gone into a rabbit hole), I added some types and found out that the unit tests checking that interfaces are properly inherited failed due to these new annotations.

As mentioned in the comment, I believe typing should be left to a static checker and not done here.

Regarding the type hints additions, I had to import `TYPE_CHECKING` to avoid some cyclical-import (and it avoid importing stuff used only for type checking in other contexts so always a plus).
I choose to import `from __future__ import annotations` as, while I tested locally with Py3.11 and thus it might be needed for older versions, it allowed to not have to quote the types in function calls when the imports are conditioned by `TYPE_CHECKING`.

## Contributor Checklist:

* [X] I have updated the unit tests
* [N/A?] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A?] I have updated the appropriate documentation
