### PR TITLE
reporters: BitbucketServerCoreAPIStatusPush: Support epoch time format

### DIFF
--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import datetime
 import re
 from urllib.parse import urlparse
 
@@ -30,6 +31,7 @@ from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.reporters.generators.buildrequest import BuildRequestGenerator
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.util import bytes2unicode
+from buildbot.util import datetime2epoch
 from buildbot.util import httpclientservice
 from buildbot.util import unicode2bytes
 
@@ -324,8 +326,13 @@ class BitbucketServerCoreAPIStatusPush(ReporterBase):
             if self.duration:
                 duration = yield props.render(self.duration)
             elif "complete_at" in build:
-                td = build['complete_at'] - build['started_at']
-                duration = int(td.seconds * 1000)
+                complete_at = build['complete_at']
+                started_at = build['started_at']
+                if isinstance(complete_at, datetime.datetime):
+                    complete_at = datetime2epoch(complete_at)
+                if isinstance(started_at, datetime.datetime):
+                    started_at = datetime2epoch(started_at)
+                duration = int(complete_at - started_at) * 1000
             if self.test_results:
                 test_results = yield props.render(self.test_results)
         else:

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -258,7 +258,7 @@ class TestBitbucketServerCoreAPIStatusPush(
             yield self.master.stopService()
 
     @defer.inlineCallbacks
-    def _check_start_and_finish_build(self, build, parentPlan=False):
+    def _check_start_and_finish_build(self, build, parentPlan=False, epoch=False):
         # we make sure proper calls to txrequests have been made
 
         _name = "Builder_parent #1 \u00bb Builder0 #0" if parentPlan else "Builder0 #0"
@@ -315,10 +315,16 @@ class TestBitbucketServerCoreAPIStatusPush(
             },
             code=HTTP_PROCESSED,
         )
-        build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
+        if epoch:
+            build['started_at'] = 1554161913
+        else:
+            build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
         build['complete'] = False
         yield self.sp._got_event(('builds', 20, 'new'), build)
-        build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        if epoch:
+            build["complete_at"] = 1554161923
+        else:
+            build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         build['complete'] = True
         yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
@@ -384,6 +390,12 @@ class TestBitbucketServerCoreAPIStatusPush(
         yield self.setupReporter()
         build = yield self.insert_build_finished(SUCCESS)
         yield self._check_start_and_finish_build(build)
+
+    @defer.inlineCallbacks
+    def test_basic_epoch(self):
+        yield self.setupReporter()
+        build = yield self.insert_build_finished(SUCCESS)
+        yield self._check_start_and_finish_build(build, epoch=True)
 
     @defer.inlineCallbacks
     def test_with_parent(self):

--- a/newsfragments/BitbucketServerCoreAPIStatusPush-fix-for-epoch.bugfix
+++ b/newsfragments/BitbucketServerCoreAPIStatusPush-fix-for-epoch.bugfix
@@ -1,0 +1,1 @@
+``BitbucketServerCoreAPIStatusPush`` now handles epoch time format in events as well as `datetime.datetime`.


### PR DESCRIPTION
Events produced by WAMP message queue implementation use epoch instead of `datetime.datetime` format. Calculating duration is now compatible with both formats for values of `started_at` and `complete_at`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
