### PR TITLE
BuildView: Recalculate build value after buildsQuery.array update

### DIFF
--- a/newsfragments/use_updated_build_value.bugfix
+++ b/newsfragments/use_updated_build_value.bugfix
@@ -1,0 +1,1 @@
+Fix sporadic navigation to builders page when new build is started (:issue:`7307`).

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -181,6 +181,8 @@ const BuildView = observer(() => {
   const project = projectsQuery.getNthOrNull(0);
 
   useEffect(() => {
+    // note that in case buildsQuery.array was updated, we have to recalculate build value
+    const build = findOrNull(buildsQuery.array, b => b.number === buildnumber);
     if (buildsQuery.resolved && build === null) {
       navigate(`/builders/${builderid}`);
     }


### PR DESCRIPTION
This PR fixes https://github.com/buildbot/buildbot/issues/7307.
useEffect() setup function uses old value of build when buildsQuerry.array is updated. Therefore, build value is calculated right in the setup function to make sure that the newest value from updated buildsQuerry.array is used.

* [not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
