### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 05"

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -23,7 +23,7 @@ alabaster==0.7.13; python_version < "3.9" # pyup: ignore 0.7.14 dropped support 
 alembic==1.13.1
 appdirs==1.4.4
 asn1crypto==1.5.1
-astroid==3.0.2
+astroid==3.0.3
 attrs==23.2.0
 Automat==22.10.0
 Babel==2.14.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -71,7 +71,7 @@ ldap3==2.9.1
 lz4==4.3.3
 Mako==1.3.2
 markdown2==2.4.12
-MarkupSafe==2.1.3
+MarkupSafe==2.1.5
 mccabe==0.7.0
 more-itertools==10.2.0
 moto==4.2.13

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -40,7 +40,7 @@ constantly==23.10.4
 cookies==2.2.1
 coverage==7.4.1
 croniter==2.0.1
-cryptography==41.0.7
+cryptography==42.0.2
 decorator==5.1.1
 dicttoxml==1.7.16
 dill==0.3.7

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -97,7 +97,7 @@ pyparsing==3.1.1
 pypugjs==5.9.12
 python-dateutil==2.8.2
 python-subunit==1.4.4
-pytz==2023.3.post1
+pytz==2024.1
 PyYAML==6.0.1
 requests==2.31.0
 responses==0.24.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -83,7 +83,7 @@ pbr==6.0.0
 pep8==1.7.1
 Pillow==10.2.0
 platformdirs==4.2.0
-psutil==5.9.7
+psutil==5.9.8
 pyaml==23.12.0
 pyasn1==0.5.1
 pyasn1-modules==0.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -82,7 +82,7 @@ pathlib2==2.3.7.post1
 pbr==6.0.0
 pep8==1.7.1
 Pillow==10.2.0
-platformdirs==4.1.0
+platformdirs==4.2.0
 psutil==5.9.7
 pyaml==23.12.0
 pyasn1==0.5.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -74,7 +74,7 @@ markdown2==2.4.12
 MarkupSafe==2.1.5
 mccabe==0.7.0
 more-itertools==10.2.0
-moto==4.2.13
+moto==5.0.1
 olefile==0.47
 packaging==23.2
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -69,7 +69,7 @@ jsonref==1.1.0
 lazy-object-proxy==1.9.0  # pyup: ignore (required by astroid)
 ldap3==2.9.1
 lz4==4.3.3
-Mako==1.3.0
+Mako==1.3.2
 markdown2==2.4.12
 MarkupSafe==2.1.3
 mccabe==0.7.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -43,7 +43,7 @@ croniter==2.0.1
 cryptography==42.0.2
 decorator==5.1.1
 dicttoxml==1.7.16
-dill==0.3.7
+dill==0.3.8
 docker==7.0.0
 docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
 extras==1.0.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -29,7 +29,7 @@ Automat==22.10.0
 Babel==2.14.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
-botocore==1.34.19
+botocore==1.34.34
 certifi==2023.11.17
 cffi==1.16.0
 chardet==5.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -92,7 +92,7 @@ pycparser==2.21
 pyenchant==3.2.2
 pyflakes==3.2.0
 PyJWT==2.8.0
-pyOpenSSL==23.3.0
+pyOpenSSL==24.0.0
 pyparsing==3.1.1
 pypugjs==5.9.12
 python-dateutil==2.8.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -30,7 +30,7 @@ Babel==2.14.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
 botocore==1.34.34
-certifi==2023.11.17
+certifi==2024.2.2
 cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==3.10.1
+buildbot-www==3.11.0
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -38,7 +38,7 @@ click==8.1.7
 configparser==6.0.0
 constantly==23.10.4
 cookies==2.2.1
-coverage==7.4.0
+coverage==7.4.1
 croniter==2.0.1
 cryptography==41.0.7
 decorator==5.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ buildbot-www==3.11.0
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-boto3==1.34.19
+boto3==1.34.34
 flake8==7.0.0;  python_version >= "3.8.1"
 msgpack==1.0.7
 Markdown==3.5.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,7 +11,7 @@ flake8==7.0.0;  python_version >= "3.8.1"
 msgpack==1.0.7
 Markdown==3.5.2
 pylint==3.0.3
-ruff==0.1.13
+ruff==0.2.0
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests
 # are reproducible. The versions should be upgraded whenever we see new versions to catch problems

--- a/requirements-cidb.txt
+++ b/requirements-cidb.txt
@@ -1,3 +1,3 @@
 psycopg2-binary==2.9.9
-mysqlclient==2.2.1
+mysqlclient==2.2.3
 pg8000==1.30.4

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -8,7 +8,7 @@ Automat==22.10.0;  python_version >= "3.6"
 cffi==1.16.0;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==41.0.7;  python_version >= "3.6"
+cryptography==42.0.2;  python_version >= "3.6"
 funcsigs==1.0.2
 future==0.18.3
 hyperlink==21.0.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -22,7 +22,7 @@ parameterized==0.9.0;  python_version >= "3.6"
 pbr==6.0.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
-psutil==5.9.7
+psutil==5.9.8
 pycparser==2.21;  python_version >= "3.6"
 six==1.16.0
 Twisted==23.10.0;  python_version >= "3.6"


### PR DESCRIPTION
Changes made to PR #7426
* dropped 493574608 Update alembic from 1.11.3 to 1.13.1 (failing [buildbot.test.integration.test_upgrade.UpgradeTestEmpty.test_emptydb_modelmatches](https://buildbot.buildbot.net/#/builders/89/builds/7847) on mysql)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
