### PR TITLE
Update alembic from 1.11.3 to 1.13.1 with fix for mysql

### DIFF
--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -122,7 +122,13 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
         def comp(engine):
             # use compare_model_to_db, which gets everything but indexes
             with engine.connect() as conn:
-                diff = compare_metadata(MigrationContext.configure(conn), self.db.model.metadata)
+                opts = None
+                if engine.dialect.name == 'mysql':
+                    # Disable type comparisons for mysql. Since 1.12.0 it is enabled by default.
+                    # https://alembic.sqlalchemy.org/en/latest/changelog.html#change-1.12.0
+                    # There is issue with comparison MEDIUMBLOB() vs LargeBinary(length=65536) in logchunks table.
+                    opts = {"compare_type": False}
+                diff = compare_metadata(MigrationContext.configure(conn, opts=opts), self.db.model.metadata)
 
             if engine.dialect.name == 'mysql':
                 # MySQL/MyISAM does not support foreign keys, which is expected.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -20,7 +20,7 @@ ruff==0.1.13
 
 alabaster==0.7.16; python_version >= "3.9"
 alabaster==0.7.13; python_version < "3.9" # pyup: ignore 0.7.14 dropped support for Python 3.8 and earlier
-alembic==1.11.3
+alembic==1.13.1
 appdirs==1.4.4
 asn1crypto==1.5.1
 astroid==3.0.2


### PR DESCRIPTION
Alembic 1.12.0 changed default for type comparison.
Since 1.12.0 this is on by default. See https://alembic.sqlalchemy.org/en/latest/changelog.html#change-1.12.0
In case of mysql, there is issue with comparison MEDIUMBLOB() vs LargeBinary(length=65536) in logchunks table.
Problem is reported by trial test `buildbot.test.integration.test_upgrade.UpgradeTestEmpty.test_emptydb_modelmatches`

```
[[('modify_type',
None,
'logchunks',
'content',
{'existing_comment': None,
'existing_nullable': True,
'existing_server_default': False},
MEDIUMBLOB(),
LargeBinary(length=65536))]]
```

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
