### PR TITLE
www: Introduce internalId to specify instances of DataCollection

### DIFF
--- a/www/react-data-module/src/data/DataClient.ts
+++ b/www/react-data-module/src/data/DataClient.ts
@@ -19,6 +19,7 @@ export class DataClient {
   restClient: RestClient;
   webSocketClient: WebSocketClient;
   private jsonRpcId: number = 1;
+  nextDataCollectionInternalId: number = 0;
 
   constructor(restClient: RestClient, webSocketClient: WebSocketClient) {
     this.restClient = restClient;
@@ -30,7 +31,8 @@ export class DataClient {
                                   query: Query, subscribe: boolean) {
     return this.getAny(endpoint, accessor, descriptor, query, subscribe,
       () => {
-        const c = new DataCollection<DataType>();
+        const c = new DataCollection<DataType>(this.nextDataCollectionInternalId);
+        this.nextDataCollectionInternalId += 1;
         c.open(endpoint, query, accessor, descriptor, this.webSocketClient);
         return c;
       });

--- a/www/react-data-module/src/data/DataCollection.ts
+++ b/www/react-data-module/src/data/DataCollection.ts
@@ -38,13 +38,15 @@ export class DataCollection<DataType extends BaseClass> implements IDataCollecti
   descriptor!: IDataDescriptor<DataType>;
   webSocketClient!: WebSocketClient;
   isOpen: boolean = false;
+  internalId: number = 0;
 
   @observable resolved: boolean = false;
   @observable array: IObservableArray<DataType> = observable<DataType>([]);
   @observable byId: {[key: string]: DataType} = {};
 
-  constructor() {
+  constructor(internalId: number = 0) {
     makeObservable(this);
+    this.internalId = internalId;
   }
 
   listener(data: any) {


### PR DESCRIPTION
This PR introduces internalId member for DataCollection. It is useful for easier debugging when the instances of DataCollection must be distinguished.

## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
