### PR TITLE
e2e: Enable several flaky tests

### DIFF
--- a/smokes-react/tests/buildsnavigation.spec.ts
+++ b/smokes-react/tests/buildsnavigation.spec.ts
@@ -51,9 +51,7 @@ test.describe('previousnextlink', function() {
 
 test.describe('forceandstop', function() {
   test('should create a build with a dedicated reason and stop it during execution',
-      async ({page, browserName}) => {
-    test.skip(browserName === 'webkit', 'https://github.com/buildbot/buildbot/issues/7307');
-
+      async ({page}) => {
     await BuilderPage.gotoForce(page, "slowruntests", "force");
     await ForcePage.clickStartButtonAndWaitRedirectToBuild(page);
     await BuilderPage.clickStopButton(page);

--- a/smokes-react/tests/reason_force.spec.ts
+++ b/smokes-react/tests/reason_force.spec.ts
@@ -43,8 +43,7 @@ test.describe('force and cancel', function() {
   });
 
   test('should create a build with a dedicated reason and Start it',
-      async ({page, browserName}) => {
-    test.skip(browserName === 'webkit', 'https://github.com/buildbot/buildbot/issues/7355');
+      async ({page}) => {
     await BuilderPage.gotoBuildersList(page);
     await BuilderPage.goto(page, "runtests");
     await BuilderPage.gotoForce(page, "runtests", "force");

--- a/smokes-react/tests/rebuilds.spec.ts
+++ b/smokes-react/tests/rebuilds.spec.ts
@@ -26,8 +26,7 @@ test.describe('rebuilds', function() {
   });
 
   test('should navigate to a dedicated build and to use the rebuild button',
-      async ({page, browserName}) => {
-    test.skip(browserName === 'webkit', 'https://github.com/buildbot/buildbot/issues/7308');
+      async ({page}) => {
     await BuilderPage.gotoBuildersList(page);
     await BuilderPage.goto(page, "runtests");
     const lastbuild = await BuilderPage.getLastFinishedBuildNumber(page);


### PR DESCRIPTION
This PR enables several flaky tests, as the issue was fixed in #7434.

## Contributor Checklist:

* [ not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
