### PR TITLE
3.11 backport: BuildView: Recalculate build value after buildsQuery.array update

### DIFF
--- a/newsfragments/use_updated_build_value.bugfix
+++ b/newsfragments/use_updated_build_value.bugfix
@@ -1,0 +1,1 @@
+Fix sporadic navigation to builders page when new build is started (:issue:`7307`).

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -181,6 +181,8 @@ const BuildView = observer(() => {
   const project = projectsQuery.getNthOrNull(0);
 
   useEffect(() => {
+    // note that in case buildsQuery.array was updated, we have to recalculate build value
+    const build = findOrNull(buildsQuery.array, b => b.number === buildnumber);
     if (buildsQuery.resolved && build === null) {
       navigate(`/builders/${builderid}`);
     }


### PR DESCRIPTION
This PR backports #7434 to 3.11.x.