### PR TITLE
Improvements to the React GUI for builders and workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 VENV_NAME := .venv$(VENV_PY_VERSION)
 PIP ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/pip
-PYTHON ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/python
+VENV_PYTHON ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/python
 YARN := $(shell which yarnpkg || which yarn)
 
 
@@ -93,7 +93,7 @@ frontend: frontend_deps
 # build frontend wheels for installation elsewhere
 frontend_wheels: frontend_deps
 	for i in pkg $(WWW_PKGS); \
-		do (cd $$i; $(PYTHON) setup.py bdist_wheel || exit 1) || exit 1; done
+		do (cd $$i; $(VENV_PYTHON) setup.py bdist_wheel || exit 1) || exit 1; done
 
 # do installation tests. Test front-end can build and install for all install methods
 frontend_install_tests: frontend_deps
@@ -125,7 +125,7 @@ docker-buildbot-master:
 
 $(VENV_NAME):
 	$(VENV_CREATE) $(VENV_NAME)
-	$(PYTHON) -m pip install --upgrade pip 
+	$(VENV_PYTHON) -m pip install --upgrade pip 
 	$(PIP) install -U setuptools wheel
 
 # helper for virtualenv creation

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,21 @@ ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: docs pylint flake8 virtualenv
 
+ifeq ($(OS),Windows_NT)
+  VENV_BIN_DIR := Scripts
+  VENV_PY_VERSION ?= python
+  VENV_CREATE := python -m venv
+else
+  VENV_BIN_DIR := bin
+	VENV_PY_VERSION ?= python3
+  VENV_CREATE := virtualenv -p $(VENV_PY_VERSION)
+endif
 
 VENV_NAME := .venv$(VENV_PY_VERSION)
-PIP ?= $(ROOT_DIR)/$(VENV_NAME)/bin/pip
-PYTHON ?= $(ROOT_DIR)/$(VENV_NAME)/bin/python
-VENV_PY_VERSION ?= python3
+PIP ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/pip
+PYTHON ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/python
 YARN := $(shell which yarnpkg || which yarn)
+
 
 WWW_PKGS := www/base www/react-base www/console_view www/react-console_view www/grid_view www/react-grid_view www/waterfall_view www/react-waterfall_view www/wsgi_dashboards www/react-wsgi_dashboards www/badges
 WWW_EX_PKGS := www/nestedexample www/codeparameter
@@ -26,7 +35,7 @@ docs:
 	$(MAKE) -C master/docs dev
 	@echo "You can now open master/docs/_build/html/index.html"
 
-docs-towncrier:
+docs-towncrier:	
 	if command -v towncrier >/dev/null 2>&1 ;\
 	then \
 	towncrier --draft | grep  'No significant changes.' || yes n | towncrier ;\
@@ -115,8 +124,9 @@ docker-buildbot-master:
 	$(DOCKERBUILD) -t buildbot/buildbot-master:master master
 
 $(VENV_NAME):
-	virtualenv -p $(VENV_PY_VERSION) $(VENV_NAME)
-	$(PIP) install -U pip setuptools wheel
+	$(VENV_CREATE) $(VENV_NAME)
+	$(PYTHON) -m pip install --upgrade pip 
+	$(PIP) install -U setuptools wheel
 
 # helper for virtualenv creation
 virtualenv: $(VENV_NAME)   # usage: make virtualenv VENV_PY_VERSION=python3.4
@@ -125,13 +135,13 @@ virtualenv: $(VENV_NAME)   # usage: make virtualenv VENV_PY_VERSION=python3.4
 		-r requirements-cidocs.txt \
 		packaging towncrier
 	@echo now you can type following command  to activate your virtualenv
-	@echo . $(VENV_NAME)/bin/activate
+	@echo . $(VENV_NAME)/$(VENV_BIN_DIR)/activate
 
 TRIALOPTS?=buildbot
 
 .PHONY: trial
 trial: virtualenv
-	. $(VENV_NAME)/bin/activate && trial $(TRIALOPTS)
+	. $(VENV_NAME)/$(VENV_BIN_DIR)/activate && trial $(TRIALOPTS)
 
 release_notes: $(VENV_NAME)
 	test ! -z "$(VERSION)"  #  usage: make release_notes VERSION=0.9.2
@@ -139,7 +149,7 @@ release_notes: $(VENV_NAME)
 	git commit -m "Release notes for $(VERSION)"
 
 $(ALL_PKGS_TARGETS): cleanup_for_tarballs frontend_deps
-	. $(VENV_NAME)/bin/activate && ./common/maketarball.sh $(patsubst %_pkg,%,$@)
+	. $(VENV_NAME)/$(VENV_BIN_DIR)/activate && ./common/maketarball.sh $(patsubst %_pkg,%,$@)
 
 cleanup_for_tarballs:
 	find master pkg worker www -name VERSION -exec rm {} \;
@@ -171,4 +181,4 @@ finishrelease:
 
 pyinstaller: virtualenv
 	$(PIP) install pyinstaller
-	$(VENV_NAME)/bin/pyinstaller pyinstaller/buildbot-worker.spec
+	$(VENV_NAME)/$(VENV_BIN_DIR)/pyinstaller pyinstaller/buildbot-worker.spec

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -710,6 +710,7 @@ class MasterConfig(util.ComparableMixin):
             'project_widgets',
             'graphql',
             'theme',
+            'build_number_format',
             'max_recent_builds',
         }
         unknown = set(list(www_cfg)) - allowed

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -710,6 +710,7 @@ class MasterConfig(util.ComparableMixin):
             'project_widgets',
             'graphql',
             'theme',
+            'max_recent_builds',
         }
         unknown = set(list(www_cfg)) - allowed
 

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -224,6 +224,14 @@ This server is configured with the ``www`` configuration key, which specifies a 
 
     Configures of the number of builds displayed in the Home App; default number is 20.
 
+``build_number_format``
+
+    Allows replacing the build number part of the build list for a builder or worker with a concatenated list of properties
+    retrieved from the build, e.g. a build version number.
+    
+    The option is specified as an array of one or more strings, e.g. ["foo", "bar"], which uses the build properties
+    "foo" and "bar" to present the build number, if all are present in the build properties.     
+
 .. note::
 
     The :bb:cfg:`buildbotURL` configuration value gives the base URL that all masters will use to generate links.

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -220,6 +220,10 @@ This server is configured with the ``www`` configuration key, which specifies a 
             "bb-sidebar-stripe-current-color": "#8c5e10",
         }
 
+``max_recent_builds``
+
+    Configures of the number of builds displayed in the Home App; default number is 20.
+
 .. note::
 
     The :bb:cfg:`buildbotURL` configuration value gives the base URL that all masters will use to generate links.

--- a/newsfragments/build-time-info.bugfix
+++ b/newsfragments/build-time-info.bugfix
@@ -1,0 +1,1 @@
+Display Information about when build completed, instead of just when it started

--- a/newsfragments/display-properties-as-build-number.feature
+++ b/newsfragments/display-properties-as-build-number.feature
@@ -1,1 +1,1 @@
-Added retrieval of properties to be displayed as the build number in views. The list of propertynames is specified as a list in the "build_number_format" attribute of the "www" config.
+Added retrieval of properties to be displayed as the build number in views. The list of property names is specified as a list in the "build_number_format" attribute of the "www" config.

--- a/newsfragments/display-properties-as-build-number.feature
+++ b/newsfragments/display-properties-as-build-number.feature
@@ -1,0 +1,1 @@
+Added retrieval of properties to be displayed as the build number in views. The list of propertynames is specified as a list in the "build_number_format" attribute of the "www" config.

--- a/newsfragments/makefile-for-windows.bugfix
+++ b/newsfragments/makefile-for-windows.bugfix
@@ -1,1 +1,1 @@
-Update Makefile to handle Windows paths and Python. Also modified the webpack config file to handle Windows paths.
+Update `Makefile` to handle Windows paths and Python. Also modified the webpack config file to handle Windows paths.

--- a/newsfragments/makefile-for-windows.bugfix
+++ b/newsfragments/makefile-for-windows.bugfix
@@ -1,0 +1,1 @@
+Update Makefile to handle Windows paths and Python. Also modified the webpack config file to handle Windows paths.

--- a/newsfragments/project-configuration-of-number-of-build-to-display.bugfix
+++ b/newsfragments/project-configuration-of-number-of-build-to-display.bugfix
@@ -1,0 +1,1 @@
+Let the project configure max recent builds to display in Home app using the "max_recent_builds" attribute in the "www" config

--- a/newsfragments/reduce-tags-column-width-when-no-tags.bugfix
+++ b/newsfragments/reduce-tags-column-width-when-no-tags.bugfix
@@ -1,0 +1,1 @@
+Make Tags column in Builders page take less space when there are no tags

--- a/newsfragments/revision-column.bugfix
+++ b/newsfragments/revision-column.bugfix
@@ -1,0 +1,1 @@
+Display revision info column in BuildsTable.

--- a/www/base/webpack.config.js
+++ b/www/base/webpack.config.js
@@ -2,6 +2,7 @@
 
 const common = require('buildbot-build-common');
 const env = require('yargs').argv.env;
+const path = require("path");
 const pkg = require('./package.json');
 const WebpackShellPlugin = require('webpack-shell-plugin');
 const WebpackCopyPlugin = require('copy-webpack-plugin');
@@ -40,7 +41,7 @@ module.exports = function() {
         }],
         extraPlugins: [
             new WebpackShellPlugin({
-                onBuildEnd:['./node_modules/.bin/pug src/app/index.jade -o buildbot_www/static/']
+                onBuildEnd:[path.join('.', 'node_modules', '.bin', 'pug') + ' src/app/index.jade -o buildbot_www/static/']
             }),
             new WebpackCopyPlugin([
                 {   from: './node_modules/outdated-browser-rework/dist/outdated-browser-rework.min.js',

--- a/www/react-base/src/components/BuildersTable/BuildersTable.tsx
+++ b/www/react-base/src/components/BuildersTable/BuildersTable.tsx
@@ -31,6 +31,7 @@ import {
   BuildLinkWithSummaryTooltip,
   WorkerBadge,
   TagFilterManager,
+  GetBuildLinkExtraPropertiesList,  
 } from "buildbot-ui";
 import {computed} from "mobx";
 import {Table} from "react-bootstrap";
@@ -63,7 +64,7 @@ export const BuildersTable = observer(
             limit: buildFetchLimit,
             order: '-started_at',
             builderid__eq: builderIds,
-            property: 'branch',
+            property: ['branch', ...GetBuildLinkExtraPropertiesList()],
           }})
       });
 

--- a/www/react-base/src/components/BuildersTable/BuildersTable.tsx
+++ b/www/react-base/src/components/BuildersTable/BuildersTable.tsx
@@ -130,10 +130,10 @@ export const BuildersTable = observer(
           <td>
             {buildElements}
           </td>
-          <td style={{width: "20%"}}>
+          <td>
             {filterManager.getElementsForTags(builder.tags)}
           </td>
-          <td style={{width: "20%"}}>
+          <td>
             {workerElements}
           </td>
         </tr>
@@ -155,11 +155,11 @@ export const BuildersTable = observer(
       <tr>
         <th>Builder Name</th>
         <th>Builds</th>
-        <th>
+        <th style={{maxWidth: "20%", minWidth: "70px"}}>
           {filterManager.getFiltersHelpElement()}
           {filterManager.getEnabledFiltersElements()}
         </th>
-        <th style={{width: "20%px"}}>Workers</th>
+        <th style={{width: "20%"}}>Workers</th>
       </tr>
       {builderRowElements}
       </tbody>

--- a/www/react-base/src/components/BuildsTable/BuildsTable.tsx
+++ b/www/react-base/src/components/BuildsTable/BuildsTable.tsx
@@ -59,6 +59,18 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
       )
       : <></>;
 
+    const buildStartedCompletedElement = build.complete
+      ? (
+          <span title={dateFormat(build.complete_at!)}>
+            {durationFormat(build.complete_at! - build.started_at)}
+          </span>
+      )
+      : (
+          <span title={dateFormat(build.started_at)}>
+            {durationFromNowFormat(build.started_at, now)}
+          </span>
+      );
+
     return (
       <tr key={build.id}>
         {builderNameElement}
@@ -66,9 +78,7 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
           <BuildLinkWithSummaryTooltip build={build}/>
         </td>
         <td>
-          <span title={dateFormat(build.started_at)}>
-            {durationFromNowFormat(build.started_at, now)}
-          </span>
+          {buildStartedCompletedElement}
         </td>
         <td>
           {buildCompleteInfoElement}
@@ -98,7 +108,7 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
           <tr>
             { builders !== null ? <td width="200px">Builder</td> : <></> }
             <td width="100px">#</td>
-            <td width="150px">Started At</td>
+            <td width="150px">Completed At</td>
             <td width="150px">Duration</td>
             <td width="200px">Owners</td>
             <td width="150px">Worker</td>

--- a/www/react-base/src/components/BuildsTable/BuildsTable.tsx
+++ b/www/react-base/src/components/BuildsTable/BuildsTable.tsx
@@ -83,6 +83,9 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
         <td>
           {buildCompleteInfoElement}
         </td>
+        <td>
+          {getPropertyValueOrDefault(build.properties, "revision", "(unknown)")}
+        </td>
         <td>{getPropertyValueArrayOrEmpty(build.properties, 'owners').map((owner, index) => (
           <span key={index}>{owner}</span>
         ))}
@@ -110,6 +113,7 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
             <td width="100px">#</td>
             <td width="150px">Completed At</td>
             <td width="150px">Duration</td>
+            <td width='150px'>Revision</td>
             <td width="200px">Owners</td>
             <td width="150px">Worker</td>
             <td>Status</td>

--- a/www/react-base/src/components/BuildsTable/BuildsTable.tsx
+++ b/www/react-base/src/components/BuildsTable/BuildsTable.tsx
@@ -62,12 +62,12 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
     const buildStartedCompletedElement = build.complete
       ? (
           <span title={dateFormat(build.complete_at!)}>
-            {durationFormat(build.complete_at! - build.started_at)}
+            {dateFormat(build.complete_at!)}
           </span>
       )
       : (
           <span title={dateFormat(build.started_at)}>
-            {durationFromNowFormat(build.started_at, now)}
+            Started at {dateFormat(build.started_at)}
           </span>
       );
 

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -64,6 +64,10 @@ import {Tab, Table, Tabs} from "react-bootstrap";
 import {TableHeading} from "../../components/TableHeading/TableHeading";
 import {buildTopbarItemsForBuilder} from "../../util/TopbarUtils";
 
+import {
+  SetBuildLinkExtraProperties,  
+} from "buildbot-ui";
+
 const buildTopbarActions = (build: Build | null, isRebuilding: boolean, isStopping: boolean,
                             doRebuild: () => void, doStop: () => void) => {
   const actions: TopbarAction[] = [];
@@ -374,12 +378,17 @@ const BuildView = observer(() => {
   );
 });
 
-buildbotSetupPlugin((reg) => {
+buildbotSetupPlugin((reg, config) => {
+  const build_number_format = config.build_number_format;
+
+  SetBuildLinkExtraProperties(build_number_format);
+
   reg.registerRoute({
     route: "builders/:builderid/builds/:buildnumber",
     group: null,
     element: () => <BuildView/>,
   });
+
 
   reg.registerSettingGroup({
     name:'Build',

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -103,7 +103,7 @@ export const BuilderView = observer(() => {
   const buildsQuery = useDataApiQuery(() =>
     buildersQuery.getRelated(builder => Build.getAll(accessor, {query: {
         builderid: builder.builderid,
-        property: ["owners", "workername", "branch"],
+        property: ["owners", "workername", "branch", "revision"],
         limit: numBuilds,
         order: '-number'
       }

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -38,6 +38,9 @@ import {ForceBuildModal} from "../../components/ForceBuildModal/ForceBuildModal"
 import {TableHeading} from "../../components/TableHeading/TableHeading";
 import {FaStop, FaSpinner} from "react-icons/fa";
 import {buildTopbarItemsForBuilder} from "../../util/TopbarUtils";
+import {
+  GetBuildLinkExtraPropertiesList,  
+} from "buildbot-ui";
 
 const anyCancellableBuilds = (builds: DataCollection<Build>,
                               buildrequests: DataCollection<Buildrequest>) => {
@@ -103,7 +106,7 @@ export const BuilderView = observer(() => {
   const buildsQuery = useDataApiQuery(() =>
     buildersQuery.getRelated(builder => Build.getAll(accessor, {query: {
         builderid: builder.builderid,
-        property: ["owners", "workername", "branch", "revision"],
+        property: ["owners", "workername", "branch", "revision", ...GetBuildLinkExtraPropertiesList()],
         limit: numBuilds,
         order: '-number'
       }

--- a/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
+++ b/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
@@ -44,7 +44,7 @@ export const ChangeBuildsView = observer(() => {
 
   const buildsQuery = useDataApiSingleElementQuery(change,
     c => c.getBuilds({query: {
-        property: ["owners", "workername"],
+        property: ["owners", "workername", "branch", "revision"],
         limit: buildsFetchLimit
       }}));
 

--- a/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
+++ b/www/react-base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
@@ -31,6 +31,9 @@ import {useState} from "react";
 import {ChangeDetails} from "buildbot-ui";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {LoadingDiv} from "../../components/LoadingDiv/LoadingDiv";
+import {
+  GetBuildLinkExtraPropertiesList,  
+} from "buildbot-ui";
 
 
 export const ChangeBuildsView = observer(() => {
@@ -44,7 +47,7 @@ export const ChangeBuildsView = observer(() => {
 
   const buildsQuery = useDataApiSingleElementQuery(change,
     c => c.getBuilds({query: {
-        property: ["owners", "workername", "branch", "revision"],
+        property: ["owners", "workername", "branch", "revision", ...GetBuildLinkExtraPropertiesList()],
         limit: buildsFetchLimit
       }}));
 

--- a/www/react-base/src/views/HomeView/HomeView.tsx
+++ b/www/react-base/src/views/HomeView/HomeView.tsx
@@ -159,7 +159,9 @@ export const HomeView = observer(() => {
   )
 });
 
-buildbotSetupPlugin((reg) => {
+buildbotSetupPlugin((reg, config) => {
+  let max_recent_builds= config.max_recent_builds;
+
   reg.registerMenuGroup({
     name: 'home',
     caption: 'Home',
@@ -175,6 +177,8 @@ buildbotSetupPlugin((reg) => {
     element: () => <HomeView/>,
   });
 
+  if (max_recent_builds == null) max_recent_builds = 20
+
   reg.registerSettingGroup({
     name: 'Home',
     caption: 'Home page related settings',
@@ -182,6 +186,6 @@ buildbotSetupPlugin((reg) => {
       type: 'integer',
       name: 'max_recent_builds',
       caption: 'Max recent builds',
-      defaultValue: 20
+      defaultValue: max_recent_builds
     }]});
 });

--- a/www/react-base/src/views/WorkerView/WorkerView.tsx
+++ b/www/react-base/src/views/WorkerView/WorkerView.tsx
@@ -40,7 +40,7 @@ export const WorkerView = observer(() => {
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const buildsQuery = useDataApiQuery(() =>
     Build.getAll(accessor, {query: {
-        property: ["owners", "workername"],
+        property: ["owners", "workername", "branch", "revision"],
         workerid__eq: workerid,
         limit: 100,
         order: "-buildid",

--- a/www/react-base/src/views/WorkerView/WorkerView.tsx
+++ b/www/react-base/src/views/WorkerView/WorkerView.tsx
@@ -30,6 +30,9 @@ import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {WorkerActionsModal} from "../../components/WorkerActionsModal/WorkerActionsModal";
+import {
+  GetBuildLinkExtraPropertiesList,  
+} from "buildbot-ui";
 
 export const WorkerView = observer(() => {
   const workerid = Number.parseInt(useParams<"workerid">().workerid ?? "");
@@ -40,7 +43,7 @@ export const WorkerView = observer(() => {
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const buildsQuery = useDataApiQuery(() =>
     Build.getAll(accessor, {query: {
-        property: ["owners", "workername", "branch", "revision"],
+        property: ["owners", "workername", "branch", "revision", ...GetBuildLinkExtraPropertiesList()],
         workerid__eq: workerid,
         limit: 100,
         order: "-buildid",

--- a/www/react-base/src/views/WorkersView/WorkersView.tsx
+++ b/www/react-base/src/views/WorkersView/WorkersView.tsx
@@ -79,7 +79,7 @@ export const WorkersView = observer(() => {
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const buildsQuery = useDataApiQuery(() =>
     Build.getAll(accessor, {query: {
-        property: ["owners", "workername"],
+        property: ["owners", "workername", "branch"],
         limit: 200,
         order: '-buildid'
       }

--- a/www/react-base/src/views/WorkersView/WorkersView.tsx
+++ b/www/react-base/src/views/WorkersView/WorkersView.tsx
@@ -29,6 +29,9 @@ import {
 } from "buildbot-data-js";
 import {WorkerActionsModal} from "../../components/WorkerActionsModal/WorkerActionsModal";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
+import {
+  GetBuildLinkExtraPropertiesList,  
+} from "buildbot-ui";
 
 const isWorkerFiltered = (worker: Worker, showOldWorkers: boolean) => {
   if (showOldWorkers) {
@@ -79,7 +82,7 @@ export const WorkersView = observer(() => {
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const buildsQuery = useDataApiQuery(() =>
     Build.getAll(accessor, {query: {
-        property: ["owners", "workername", "branch"],
+        property: ["owners", "workername", "branch", ...GetBuildLinkExtraPropertiesList()],
         limit: 200,
         order: '-buildid'
       }

--- a/www/react-ui/src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx
+++ b/www/react-ui/src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx
@@ -29,6 +29,36 @@ type BuildLinkWithSummaryTooltipProps = {
   builder?: Builder | null;
 };
 
+let extra_properties : string[] | null  = null;
+
+export function SetBuildLinkExtraProperties(property_names: string[] | null) {
+  if (property_names == null || property_names.length == 0) {
+    extra_properties = null;
+    return;
+  }
+
+  extra_properties = property_names;
+}
+
+export function GetBuildLinkExtraPropertiesList() : string[] {
+  return extra_properties || [];
+}
+
+function ProduceBuildNumber(build: Build): string | number {
+  if (extra_properties == null) {
+    return build.number;
+  }
+
+  let build_number = "";
+  for (const property_name of extra_properties) {
+    if (!(property_name in build.properties)) {
+      return build.number;
+    }
+    build_number += build.properties[property_name][0];
+  }
+  return build_number;  
+}
+
 export const BuildLinkWithSummaryTooltip =
   observer(({build, builder}: BuildLinkWithSummaryTooltipProps) => {
 
@@ -42,11 +72,13 @@ export const BuildLinkWithSummaryTooltip =
       <BuildSummaryTooltip build={build}/>
     </Tooltip>
   );
+  
+  const build_number = ProduceBuildNumber(build);
 
   const buildText = ('branch' in build.properties) && (build.properties['branch'][0] !== null) &&
                     (build.properties['branch'][0] !== "")
-    ? `${build.properties['branch'][0]} (${build.number})`
-    : `${build.number}`;
+    ? `${build.properties['branch'][0]} (${build_number})`
+    : `${build_number}`;
 
   const linkText = builder !== undefined
     ? `${builder.name} / ${buildText}`


### PR DESCRIPTION
This set of patches have the following improvements that I would like to have included in a future 3.11+ release.

We have been using patches similar to these for several years in the Angular JS version.

The GUI patches are:

* Project configuration of number of recent builds to display in the Home App
* Show the revision property for a build in the builders and workers pages
* Improve display of build completion time 
* Let the project specify properties to use to display e.g. a build 1.2.3.4 version number instead of just build number 999 on that builder.
* Let the Tags column on the Builders page be less wide when there are no tags

Additionally:

* Fix the Makefile to work on Windows

## Contributor Checklist:

* I have updated the unit tests (no tests affected AFAICT)
* I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* I have updated the appropriate documentation
