### PR TITLE
process: Fix race condition in buildrequest cancelling path

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -340,6 +340,14 @@ class Build(properties.PropertiesMixin):
             self.controlStopBuild, ("control", "builds", str(self.buildid), "stop")
         )
 
+        # Check if buildrequest has been cancelled in the mean time. Must be done after subscription
+        # to stop control endpoint is established to avoid race condition.
+        for r in self.requests:
+            reason = self.master.botmaster.remove_in_progress_buildrequest(r.id)
+            if isinstance(reason, str):
+                yield self.stopBuild(reason=reason)
+                return
+
         # the preparation step counts the time needed for preparing the worker and getting the
         # locks.
         # we cannot use a real step as we don't have a worker yet.

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -27,6 +27,7 @@ class FakeBotMaster(service.AsyncMultiService, botmaster.LockRetrieverMixin):
         self.builders = {}  # dictionary mapping worker names to builders
         self.buildsStartedForWorkers = []
         self.delayShutdown = False
+        self._starting_brid_to_cancel = {}
 
     def getBuildersForWorker(self, workername):
         return self.builders.get(workername, [])
@@ -46,3 +47,13 @@ class FakeBotMaster(service.AsyncMultiService, botmaster.LockRetrieverMixin):
             self.shutdownDeferred = defer.Deferred()
             return self.shutdownDeferred
         return None
+
+    def add_in_progress_buildrequest(self, brid):
+        self._starting_brid_to_cancel[brid] = False
+
+    def remove_in_progress_buildrequest(self, brid):
+        return self._starting_brid_to_cancel.pop(brid, None)
+
+    def maybe_cancel_in_progress_buildrequest(self, brid, reason):
+        if brid in self._starting_brid_to_cancel:
+            self._starting_brid_to_cancel[brid] = reason

--- a/newsfragments/buildrequest-cancel-race-condition.bugfix
+++ b/newsfragments/buildrequest-cancel-race-condition.bugfix
@@ -1,0 +1,1 @@
+Fixed buildrequest cancel requests being ignored under certain infrequent conditions.


### PR DESCRIPTION
Previously there was a race condition in buildrequest cancel path. This has lead to complicated workarounds elsewhere.