### PR TITLE
data: Expose build request cancellation to the data API

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -100,6 +100,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
             return (yield self.db2data(buildrequest))
         return None
 
+    @defer.inlineCallbacks
     def cancel_request(self, brid, args, kwargs):
         reason = args.get('reason', 'no reason')
         # first, try to claim the request; if this fails, then it's too late to
@@ -133,20 +134,20 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
         self.master.mq.produce(('buildrequests', str(brid), 'cancel'), brdict)
         return None
 
+    @defer.inlineCallbacks
     def set_request_priority(self, brid, args, kwargs):
         priority = args['priority']
         yield self.master.db.buildrequests.set_build_requests_priority(
             brids=[brid], priority=priority
         )
-        return None
 
     @defer.inlineCallbacks
     def control(self, action, args, kwargs):
         brid = kwargs['buildrequestid']
         if action == "cancel":
-            return self.cancel_request(brid, args, kwargs)
+            yield self.cancel_request(brid, args, kwargs)
         elif action == "set_priority":
-            return self.set_request_priority(brid, args, kwargs)
+            yield self.set_request_priority(brid, args, kwargs)
         else:
             raise ValueError(f"action: {action} is not supported")
 

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -19,7 +19,6 @@ from buildbot.data import base
 from buildbot.data import types
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.db.buildrequests import NotClaimedError
-from buildbot.process import results
 from buildbot.process.results import RETRY
 
 
@@ -101,40 +100,6 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
         return None
 
     @defer.inlineCallbacks
-    def cancel_request(self, brid, args, kwargs):
-        reason = args.get('reason', 'no reason')
-        # first, try to claim the request; if this fails, then it's too late to
-        # cancel the build anyway
-        try:
-            b = yield self.master.db.buildrequests.claimBuildRequests(brids=[brid])
-        except AlreadyClaimedError:
-            self.master.botmaster.maybe_cancel_in_progress_buildrequest(brid, reason)
-
-            # In case the build request has been claimed on this master, the call to
-            # maybe_cancel_in_progress_buildrequest above will ensure that they are either visible
-            # to the data API call below, or canceled.
-            builds = yield self.master.data.get(("buildrequests", brid, "builds"))
-
-            # Any other master will observe the buildrequest cancel messages and will try to
-            # cancel the buildrequest or builds internally.
-            #
-            # TODO: do not try to cancel builds that run on another master. Note that duplicate
-            # cancels do not have any downside.
-            for b in builds:
-                self.master.mq.produce(
-                    ("control", "builds", str(b['buildid']), "stop"), {'reason': reason}
-                )
-            return None
-
-        # then complete it with 'CANCELLED'; this is the closest we can get to
-        # cancelling a request without running into trouble with dangling
-        # references.
-        yield self.master.data.updates.completeBuildRequests([brid], results.CANCELLED)
-        brdict = yield self.master.db.buildrequests.getBuildRequest(brid)
-        self.master.mq.produce(('buildrequests', str(brid), 'cancel'), brdict)
-        return None
-
-    @defer.inlineCallbacks
     def set_request_priority(self, brid, args, kwargs):
         priority = args['priority']
         yield self.master.db.buildrequests.set_build_requests_priority(
@@ -145,7 +110,10 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
     def control(self, action, args, kwargs):
         brid = kwargs['buildrequestid']
         if action == "cancel":
-            yield self.cancel_request(brid, args, kwargs)
+            self.master.mq.produce(
+                ('control', 'buildrequests', str(brid), 'cancel'),
+                {'reason': args.get('reason', 'no reason')},
+            )
         elif action == "set_priority":
             yield self.set_request_priority(brid, args, kwargs)
         else:

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -95,7 +95,8 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
         self.shuttingDown = False
 
         # subscription to new build requests
-        self.buildrequest_consumer = None
+        self.buildrequest_consumer_new = None
+        self.buildrequest_consumer_unclaimed = None
 
         # a distributor for incoming build requests; see below
         self.brd = BuildRequestDistributor(self)

--- a/master/buildbot/test/fake/fakemq.py
+++ b/master/buildbot/test/fake/fakemq.py
@@ -102,6 +102,11 @@ class FakeMQConnector(service.AsyncMultiService, base.MQBase):
             self.testcase.assertEqual(sorted(self.productions), sorted(exp))
         self.productions = []
 
+    @defer.inlineCallbacks
+    def wait_consumed(self):
+        # waits until all messages have been consumed
+        yield self._deferwaiter.wait()
+
 
 class FakeQueueRef:
     def stopConsuming(self):

--- a/newsfragments/buildrequest-cancel-data-message.feature
+++ b/newsfragments/buildrequest-cancel-data-message.feature
@@ -1,0 +1,1 @@
+Build request cancellation has been exposed to the Data API.


### PR DESCRIPTION
This PR also fixes https://github.com/buildbot/buildbot/pull/7460 in multimaster mode as it assumed buildrequest cancellation happens via data API message.