### PR TITLE
Old build canceller improvements

### DIFF
--- a/master/docs/manual/configuration/services/old_build_canceller.rst
+++ b/master/docs/manual/configuration/services/old_build_canceller.rst
@@ -5,7 +5,8 @@ OldBuildCanceller
 
 .. py:class:: buildbot.plugins.util.OldBuildCanceller
 
-The purpose of this service is to cancel builds on branches as soon as a new commit is detected on the branch.
+The purpose of this service is to cancel builds on branches as soon as a superseding build request
+is created from a new commit on the branch.
 
 This allows to reduce resource usage in projects that use Buildbot to run tests on pull request branches.
 For example, if a developer pushes new commits to the branch, notices and fixes a problem quickly and then pushes again, the builds that have been started on the older commit will be cancelled immediately instead of waiting for builds to finish.

--- a/newsfragments/old-build-canceller-only-created-buildrequests.bugfix
+++ b/newsfragments/old-build-canceller-only-created-buildrequests.bugfix
@@ -1,0 +1,3 @@
+``OldBuildCanceller`` will now cancel builds only if a superseding buildrequest is actually
+created. Previously it was enough to observe a superseding change even if it did not result in
+actually running builds.


### PR DESCRIPTION
It is possible that incoming change does not result in any builds at all. This may happen in cases when scheduler that handles the change has custom filters. In such cases existing builds should not be cancelled.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
