### PR TITLE
schedulers: Fix old build canceller for sourcestamps with no branch

### DIFF
--- a/master/buildbot/schedulers/canceller.py
+++ b/master/buildbot/schedulers/canceller.py
@@ -323,6 +323,8 @@ class OldBuildCanceller(BuildbotService):
 
     def _default_branch_key(self, ss_or_change):
         branch = ss_or_change['branch']
+        if branch is None:
+            return None
 
         # On some VCS systems each iteration of a PR gets its own branch. We want to track all
         # iterations of the PR as a single unit.

--- a/newsfragments/old-build-canceller-ss-no-branch.bugfix
+++ b/newsfragments/old-build-canceller-ss-no-branch.bugfix
@@ -1,0 +1,1 @@
+Fixed ``OldBuildCanceller`` crashes when sourcestamp with no branch was ingested.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
