### PR TITLE
Buildstep param checks

### DIFF
--- a/master/buildbot/config/checks.py
+++ b/master/buildbot/config/checks.py
@@ -41,6 +41,10 @@ def check_param_type(value, default_value, class_inst, name, types, types_msg):
     return default_value
 
 
+def check_param_bool(value, class_inst, name):
+    return check_param_type(value, False, class_inst, name, (bool,), "bool")
+
+
 def check_param_str(value, class_inst, name):
     return check_param_type(value, "(unknown)", class_inst, name, (str,), "str")
 
@@ -55,6 +59,10 @@ def check_param_int(value, class_inst, name):
 
 def check_param_int_none(value, class_inst, name):
     return check_param_type(value, None, class_inst, name, (int, type(None)), "int or None")
+
+
+def check_param_number_none(value, class_inst, name):
+    return check_param_type(value, 0, class_inst, name, (int, float, None), "int or float or None")
 
 
 def check_markdown_support(class_inst):

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -189,7 +189,7 @@ class ShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
                 'decodeRC',
                 'stdioLogName',
                 'workdir',
-            ] + buildstep.BuildStep.parms
+            ] + buildstep.BuildStep._params_names
 
             invalid_args = []
             for arg in kwargs:

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1244,6 +1244,13 @@ class TestShellMixin(
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
 
+    def test_bad_arg_type(self):
+        mixin = SimpleShellCommand()
+        with self.assertRaisesConfigError(
+            "SimpleShellCommand argument usePTY must be an instance of bool"
+        ):
+            mixin.setupShellMixin({'usePTY': 13})
+
     @defer.inlineCallbacks
     def test_no_default_workdir(self):
         self.setup_step(SimpleShellCommand(command=['cmd', 'arg']), want_default_work_dir=False)

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -134,7 +134,7 @@ class TestBuildStep(
         When BuildStep is passed a name that isn't a string, it reports
         a config error.
         """
-        with self.assertRaisesConfigError("BuildStep name must be a string"):
+        with self.assertRaisesConfigError("BuildStep argument name must be an instance of str"):
             buildstep.BuildStep(name=5)
 
     def test_name_too_long(self):

--- a/newsfragments/shellmixin-error-on-bad-type.feature
+++ b/newsfragments/shellmixin-error-on-bad-type.feature
@@ -1,0 +1,2 @@
+Added check for correct argument types to `ShellCommand` build step and all steps deriving from `ShellMixin`.
+This will avoid wrong arguments causing confusing errors in unrelated parts of the codebase.

--- a/newsfragments/shellmixin-error-on-bad-type.feature
+++ b/newsfragments/shellmixin-error-on-bad-type.feature
@@ -1,2 +1,3 @@
-Added check for correct argument types to `ShellCommand` build step and all steps deriving from `ShellMixin`.
-This will avoid wrong arguments causing confusing errors in unrelated parts of the codebase.
+Added check for correct argument types to `BuildStep` and `ShellCommand` build steps and all steps
+deriving from `ShellMixin`. This will avoid wrong arguments causing confusing errors in unrelated
+parts of the codebase.


### PR DESCRIPTION
This PR adds check for correct argument types to `BuildStep` and `ShellCommand` build steps and all steps deriving
from `ShellMixin`. This will avoid wrong arguments causing confusing errors in unrelated parts of the codebase.