### PR TITLE
www: Show last builds that were built on the same builddir in debug tab

### DIFF
--- a/newsfragments/www-build-debug-prev-build-on-builddir.feature
+++ b/newsfragments/www-build-debug-prev-build-on-builddir.feature
@@ -1,0 +1,2 @@
+The debug tab in build page now shows previous build that has been built on the same worker
+for the same builder. This helps debugging any build directory cleanup problems.

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -316,7 +316,7 @@ const BuildView = observer(() => {
       <nav>
         {renderPager(build)}
       </nav>
-      <Tabs>
+      <Tabs mountOnEnter={true}>
         <Tab eventKey="build-steps" title="Build steps">
           { build !== null
             ? <BuildSummary build={build} condensed={false} parentBuild={parentBuild}

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -48,7 +48,6 @@ import {
   BadgeRound,
   ChangeUserAvatar,
   TopbarAction,
-  TopbarItem,
   dateFormat,
   durationFromNowFormat,
   useCurrentTime,
@@ -56,13 +55,12 @@ import {
   useTopbarItems,
   useTopbarActions,
 } from "buildbot-ui";
-import {RawData} from "../../components/RawData/RawData";
 import {PropertiesTable} from "../../components/PropertiesTable/PropertiesTable";
 import {ChangesTable} from "../../components/ChangesTable/ChangesTable";
 import {BuildSummary} from "../../components/BuildSummary/BuildSummary";
 import {Tab, Table, Tabs} from "react-bootstrap";
-import {TableHeading} from "../../components/TableHeading/TableHeading";
 import {buildTopbarItemsForBuilder} from "../../util/TopbarUtils";
+import {BuildViewDebugTab} from "./BuildViewDebugTab";
 
 const buildTopbarActions = (build: Build | null, isRebuilding: boolean, isStopping: boolean,
                             doRebuild: () => void, doStop: () => void) => {
@@ -312,23 +310,6 @@ const BuildView = observer(() => {
     ));
   };
 
-  const renderDebugInfo = () => {
-    if (buildrequest === null || buildset === null) {
-      return <TableHeading>Buildrequest:</TableHeading>;
-    }
-
-    return (
-      <>
-        <TableHeading>
-          <Link to={`/buildrequests/${buildrequest.id}`}>Buildrequest:</Link>
-        </TableHeading>
-        <RawData data={buildrequest.toObject()}/>
-        <TableHeading>Buildset:</TableHeading>
-        <RawData data={buildset.toObject()}/>
-      </>
-    );
-  }
-
   return (
     <div className="container bb-build-view">
       <AlertNotification text={errorMsg}/>
@@ -369,7 +350,7 @@ const BuildView = observer(() => {
           }
         </Tab>
         <Tab eventKey="debug" title="Debug">
-          {renderDebugInfo()}
+          <BuildViewDebugTab buildrequest={buildrequest} buildset={buildset}/>
         </Tab>
       </Tabs>
     </div>

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -350,7 +350,7 @@ const BuildView = observer(() => {
           }
         </Tab>
         <Tab eventKey="debug" title="Debug">
-          <BuildViewDebugTab buildrequest={buildrequest} buildset={buildset}/>
+          <BuildViewDebugTab build={build} buildrequest={buildrequest} buildset={buildset}/>
         </Tab>
       </Tabs>
     </div>

--- a/www/react-base/src/views/BuildView/BuildViewDebugTab.tsx
+++ b/www/react-base/src/views/BuildView/BuildViewDebugTab.tsx
@@ -1,0 +1,44 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {observer} from "mobx-react";
+import {Link} from "react-router-dom";
+import {Buildrequest, Buildset} from "buildbot-data-js";
+import {RawData} from "../../components/RawData/RawData";
+import {TableHeading} from "../../components/TableHeading/TableHeading";
+
+export type BuildViewDebugTabProps = {
+  buildset: Buildset | null;
+  buildrequest : Buildrequest | null;
+};
+
+export const BuildViewDebugTab = observer(({buildset, buildrequest}: BuildViewDebugTabProps) => {
+  if (buildrequest === null || buildset === null) {
+    return <TableHeading>Buildrequest:</TableHeading>;
+  }
+
+  return (
+    <>
+      <TableHeading>
+        <Link to={`/buildrequests/${buildrequest.id}`}>Buildrequest:</Link>
+      </TableHeading>
+      <RawData data={buildrequest.toObject()}/>
+      <TableHeading>Buildset:</TableHeading>
+      <RawData data={buildset.toObject()}/>
+    </>
+  );
+});


### PR DESCRIPTION
The debug tab in build page now shows previous build that has been built on the same worker for the same builder. This helps debugging any build directory cleanup problems.