### PR TITLE
www: Fix initialization of default setting values from config

### DIFF
--- a/newsfragments/www-fix-default-settings.bugfix
+++ b/newsfragments/www-fix-default-settings.bugfix
@@ -1,0 +1,1 @@
+Fix initialization of default setting values from config.

--- a/smokes-react/tests/pages/settings.ts
+++ b/smokes-react/tests/pages/settings.ts
@@ -33,6 +33,11 @@ export class SettingsPage {
     await SettingsPage.getItem(page, "Waterfall", "scaling_waterfall").fill(value);
   }
 
+  static async checkBuildersBuildFetchLimit(page: Page, value: number) {
+    expect(await SettingsPage.getItem(page, "Builders", "buildFetchLimit").getAttribute("value"))
+      .toEqual(value.toString());
+  }
+
   static async checkScallingFactor(page: Page, value: string) {
     expect(await SettingsPage.getItem(page, "Waterfall", "scaling_waterfall").getAttribute("value"))
       .toEqual(value);

--- a/smokes-react/tests/settings.spec.ts
+++ b/smokes-react/tests/settings.spec.ts
@@ -20,6 +20,14 @@ import {BuilderPage} from './pages/builder';
 import {SettingsPage} from './pages/settings';
 
 test.describe('manage settings', function() {
+  test.describe('base', () => {
+    test('Builders.buildFetchLimit uses default value from config', async ({page}) => {
+      await BuilderPage.gotoBuildersList(page);
+      await SettingsPage.goto(page);
+      await SettingsPage.checkBuildersBuildFetchLimit(page, 201);
+    })
+  });
+
   test.describe('waterfall', () => {
     test('change the "scalling factor" and check it', async ({page}) => {
       const scalingFactor = '10';

--- a/www/react-base/src/index.tsx
+++ b/www/react-base/src/index.tsx
@@ -46,8 +46,8 @@ const doRender = (buildbotFrontendConfig: Config) => {
 
   const sidebarStore = new SidebarStore();
   const topbarStore = new TopbarStore();
-  globalSettings.applyBuildbotConfig(buildbotFrontendConfig);
   initializeGlobalSetup(buildbotFrontendConfig);
+  globalSettings.applyBuildbotConfig(buildbotFrontendConfig);
   globalSettings.load();
 
   for (const pluginKey in buildbotFrontendConfig.plugins) {


### PR DESCRIPTION
Current approach sets the value, not defaultValue field when initializing default www config values from BuildbotConfig ui_default_config field. This makes it impossible to differentiate between values set by user and default values coming from Buildbot defaults or site-specific Buildbot config.

To avoid this the code has been updated to track whether setting value has been updated by the user or not.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
