### PR TITLE
www/react: Mark filtered tags on Builders page in bb-builders-view-container table header row as clickable

### DIFF
--- a/www/react-ui/src/util/TagFilterManager.tsx
+++ b/www/react-ui/src/util/TagFilterManager.tsx
@@ -191,7 +191,7 @@ export class TagFilterManager {
         enabledTagsElements.push((
           <>
             <Badge variant="success"
-                   onClick={() => this.toggleTag(tag)}>{tag}</Badge>
+                   onClick={() => this.toggleTag(tag)} className="clickable">{tag}</Badge>
             &nbsp;
           </>
         ));


### PR DESCRIPTION
Since the Badge implements onClick, hand mouse cursor highlights that it is clickable. I find this feature useful in case I need to filter a builder with multiple tags on a Buildbot instance with a huge amount of builders.

![image](https://github.com/buildbot/buildbot/assets/14224662/99df5a72-7c51-49ef-9ddc-f7a4614e48fe)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
