### PR TITLE
remove duplicate project description component

### DIFF
--- a/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
+++ b/www/react-base/src/components/ProjectWidgets/ProjectDescriptionWidget.tsx
@@ -39,13 +39,13 @@ export const ProjectDescriptionWidget = observer(({projectid}: ProjectDescriptio
   const renderDescription = (project: Project) => {
     if (project.description_format !== null && project.description_html !== null) {
       return (
-          <div><TableHeading>Description:</TableHeading>
+          <div>
             <div dangerouslySetInnerHTML={{__html: project.description_html}}/>
           </div>
       )
     } else {
       return (
-          <div><TableHeading>Description:</TableHeading>{project.description}</div>
+          <div>{project.description}</div>
       );
     }
   };


### PR DESCRIPTION
Previously the project field was being rendered twice when viewing a project.

Now it is only rendered once and `renderDescription` no longer returns the extra `<TableHeading>Description:</TableHeading>` component since it is already rendered in the card body

Before:
<img width="475" alt="image" src="https://github.com/buildbot/buildbot/assets/11269928/d1c34727-aebd-4936-bd1f-08bdae2507eb">


After:
<img width="470" alt="image" src="https://github.com/buildbot/buildbot/assets/11269928/e9b51594-92ff-4506-896e-888294c81881">
