### PR TITLE
test: Actually wait for text to match the builder name

### DIFF
--- a/newsfragments/test-wait-for-builder-name-to-match.bugfix
+++ b/newsfragments/test-wait-for-builder-name-to-match.bugfix
@@ -1,0 +1,1 @@
+Fix test to actually wait for updated text to match a builder name (:isue:`7410`).

--- a/smokes-react/tests/pendingbuildrequests.spec.ts
+++ b/smokes-react/tests/pendingbuildrequests.spec.ts
@@ -44,7 +44,11 @@ test.describe('pending build requests', function() {
     }).toBeGreaterThan(0);
 
     const br = await PendingBuildrequestsPage.getAllBuildrequestRows(page).first();
-    expect(await br.locator('td').nth(1).locator('a').textContent()).toMatch('slowruntests');
+    await expect.poll(async () => {
+      return (await br.locator('td').nth(1).locator('a').textContent());
+    }, {
+      message: "found at least one buildrequest with correct name"
+    }).toMatch('slowruntests');
 
     // kill remaining builds
     let gotAlert = false;


### PR DESCRIPTION
This PR fixes issue https://github.com/buildbot/buildbot/issues/7410 and https://github.com/buildbot/buildbot/issues/7407.
A test randomly breaks, due to waiting for the first text that showed up and trying to match it with a builder name.
This commit fixes the problem by actually waiting for updated text to match the builder name

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
