### PR TITLE
test: Actually wait for text to match the builder name

### DIFF
--- a/smokes-react/tests/pendingbuildrequests.spec.ts
+++ b/smokes-react/tests/pendingbuildrequests.spec.ts
@@ -44,7 +44,11 @@ test.describe('pending build requests', function() {
     }).toBeGreaterThan(0);
 
     const br = await PendingBuildrequestsPage.getAllBuildrequestRows(page).first();
-    expect(await br.locator('td').nth(1).locator('a').textContent()).toMatch('slowruntests');
+    await expect.poll(async () => {
+      return (await br.locator('td').nth(1).locator('a').textContent());
+    }, {
+      message: "found at least one buildrequest with correct name"
+    }).toMatch('slowruntests');
 
     // kill remaining builds
     let gotAlert = false;


### PR DESCRIPTION
This PR fixes issues https://github.com/buildbot/buildbot/issues/7410 and https://github.com/buildbot/buildbot/issues/7407.
"pending build requests › shows" e2e test sometimes fails, due to waiting for the first text that showed up and trying to match it with a builder name.
This commit fixes the problem by actually waiting for updated text to match the builder name

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
