### PR TITLE
db: Cleanup lz4 import

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -23,21 +23,15 @@ from twisted.python import log
 from buildbot.db import base
 
 try:
-    # lz4 > 0.9.0
     from lz4.block import compress as dumps_lz4
     from lz4.block import decompress as read_lz4
 except ImportError:
-    try:
-        # lz4 < 0.9.0
-        from lz4 import dumps as dumps_lz4
-        from lz4 import loads as read_lz4
-    except ImportError:  # pragma: no cover
-        # config.py actually forbid this code path
-        def dumps_lz4(data):
-            return data
+    # config.py actually forbid this code path
+    def dumps_lz4(data):
+        return data
 
-        def read_lz4(data):
-            return data
+    def read_lz4(data):
+        return data
 
 
 def dumps_gzip(data):


### PR DESCRIPTION
lz4 0.9 has been released in 2017. It's unlikely that anyone uses older version.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
