### PR TITLE
smokes: Increase tests timeout to improve reliability

### DIFF
--- a/smokes-react/playwright.config.ts
+++ b/smokes-react/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  timeout: 90000,
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
Tests timeout is increased to improve reliability.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
