### PR TITLE
Add more metadata to data returned by raw endpoints

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -234,6 +234,13 @@ class NestedBuildDataRetriever:
             )
             return self.step_dict
 
+        # fallback when there's only indirect information
+        if 'logid' in self.args:
+            log_dict = await self.get_log_dict()
+            if log_dict is not None:
+                self.step_dict = await self.master.db.steps.getStep(stepid=log_dict['stepid'])
+                return self.step_dict
+
         self.step_dict = None
         return self.step_dict
 
@@ -256,6 +263,12 @@ class NestedBuildDataRetriever:
             self.build_dict = await self.master.db.builds.getBuildByNumber(
                 builderid=builder_dict['id'], number=self.args['build_number']
             )
+            return self.build_dict
+
+        # fallback when there's only indirect information
+        step_dict = await self.get_step_dict()
+        if step_dict is not None:
+            self.build_dict = await self.master.db.builds.getBuild(step_dict['buildid'])
             return self.build_dict
 
         self.build_dict = None
@@ -288,6 +301,12 @@ class NestedBuildDataRetriever:
             if builder_id is not None:
                 builder_dict = await self.master.db.builders.getBuilder(builder_id)
             self.builder_dict = builder_dict
+            return self.builder_dict
+
+        # fallback when there's only indirect information
+        build_dict = await self.get_build_dict()
+        if build_dict is not None:
+            self.builder_dict = await self.master.db.builders.getBuilder(build_dict['builderid'])
             return self.builder_dict
 
         self.builder_dict = None

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -200,6 +200,7 @@ class NestedBuildDataRetriever:
         'build_dict',
         'builder_dict',
         'log_dict',
+        'worker_dict',
     )
 
     def __init__(self, master, args):
@@ -211,6 +212,7 @@ class NestedBuildDataRetriever:
         self.build_dict = False
         self.builder_dict = False
         self.log_dict = False
+        self.worker_dict = False
 
     @async_to_deferred
     async def get_step_dict(self):
@@ -349,6 +351,21 @@ class NestedBuildDataRetriever:
         if log_dict is None:
             return None
         return log_dict['id']
+
+    @async_to_deferred
+    async def get_worker_dict(self):
+        if self.worker_dict is not False:
+            return self.worker_dict
+
+        build_dict = await self.get_build_dict()
+        if build_dict is not None:
+            workerid = build_dict.get('workerid', None)
+            if workerid is not None:
+                self.worker_dict = await self.master.db.workers.getWorker(workerid=workerid)
+                return self.worker_dict
+
+        self.worker_dict = None
+        return None
 
 
 class BuildNestingMixin:

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -22,6 +22,7 @@ from collections import UserList
 from twisted.internet import defer
 
 from buildbot.data import exceptions
+from buildbot.util.twisted import async_to_deferred
 from buildbot.warnings import warn_deprecated
 
 
@@ -177,6 +178,128 @@ class Endpoint:
         return "endpoint for " + ",".join(self.pathPatterns.split())
 
 
+class NestedBuildDataRetriever:
+    """
+    Efficiently retrieves data about various entities without repeating same queries over and over.
+    The following arg keys are supported:
+        - stepid
+        - step_name
+        - step_number
+        - buildid
+        - build_number
+        - builderid
+        - buildername
+    """
+
+    __slots__ = (
+        'master',
+        'args',
+        'step_dict',
+        'build_dict',
+        'builder_dict',
+    )
+
+    def __init__(self, master, args):
+        self.master = master
+        self.args = args
+        # False is used as special value as "not set". None is used as "not exists". This solves
+        # the problem of multiple database queries in case entity does not exist.
+        self.step_dict = False
+        self.build_dict = False
+        self.builder_dict = False
+
+    @async_to_deferred
+    async def get_step_dict(self):
+        if self.step_dict is not False:
+            return self.step_dict
+
+        if 'stepid' in self.args:
+            self.step_dict = await self.master.db.steps.getStep(stepid=self.args['stepid'])
+            return self.step_dict
+
+        if 'step_name' in self.args or 'step_number' in self.args:
+            build_dict = await self.get_build_dict()
+            if build_dict is None:
+                self.step_dict = None
+                return None
+
+            self.step_dict = await self.master.db.steps.getStep(
+                buildid=build_dict['id'],
+                number=self.args.get('step_number'),
+                name=self.args.get('step_name'),
+            )
+            return self.step_dict
+
+        self.step_dict = None
+        return self.step_dict
+
+    @async_to_deferred
+    async def get_build_dict(self):
+        if self.build_dict is not False:
+            return self.build_dict
+
+        if 'buildid' in self.args:
+            self.build_dict = await self.master.db.builds.getBuild(self.args['buildid'])
+            return self.build_dict
+
+        if 'build_number' in self.args:
+            builder_dict = await self.get_builder_dict()
+
+            if builder_dict is None:
+                self.build_dict = None
+                return None
+
+            self.build_dict = await self.master.db.builds.getBuildByNumber(
+                builderid=builder_dict['id'], number=self.args['build_number']
+            )
+            return self.build_dict
+
+        self.build_dict = None
+        return None
+
+    @async_to_deferred
+    async def get_build_id(self):
+        if 'buildid' in self.args:
+            return self.args['buildid']
+
+        build_dict = await self.get_build_dict()
+        if build_dict is None:
+            return None
+        return build_dict['id']
+
+    @async_to_deferred
+    async def get_builder_dict(self):
+        if self.builder_dict is not False:
+            return self.builder_dict
+
+        if 'builderid' in self.args:
+            self.builder_dict = await self.master.db.builders.getBuilder(self.args['builderid'])
+            return self.builder_dict
+
+        if 'buildername' in self.args:
+            builder_id = await self.master.db.builders.findBuilderId(
+                self.args['buildername'], autoCreate=False
+            )
+            builder_dict = None
+            if builder_id is not None:
+                builder_dict = await self.master.db.builders.getBuilder(builder_id)
+            self.builder_dict = builder_dict
+            return self.builder_dict
+
+        self.builder_dict = None
+        return None
+
+    @async_to_deferred
+    async def get_builder_id(self):
+        if 'builderid' in self.args:
+            return self.args['builderid']
+
+        builder_dict = await self.get_builder_dict()
+        if builder_dict is None:
+            return None
+        return builder_dict['id']
+
+
 class BuildNestingMixin:
     """
     A mixin for methods to decipher the many ways a various entities can be specified.
@@ -184,41 +307,13 @@ class BuildNestingMixin:
 
     @defer.inlineCallbacks
     def getBuildid(self, kwargs):
-        # need to look in the context of a step, specified by build or
-        # builder or whatever
-        if 'buildid' in kwargs:
-            return kwargs['buildid']
-        else:
-            builderid = yield self.getBuilderId(kwargs)
-            if builderid is None:
-                return None
-            build = yield self.master.db.builds.getBuildByNumber(
-                builderid=builderid, number=kwargs['build_number']
-            )
-            if not build:
-                return None
-            return build['id']
+        retriever = NestedBuildDataRetriever(self.master, kwargs)
+        return (yield retriever.get_build_id())
 
     @defer.inlineCallbacks
-    def getStepid(self, kwargs):
-        if 'stepid' in kwargs:
-            return kwargs['stepid']
-        else:
-            buildid = yield self.getBuildid(kwargs)
-            if buildid is None:
-                return None
-
-            dbdict = yield self.master.db.steps.getStep(
-                buildid=buildid, number=kwargs.get('step_number'), name=kwargs.get('step_name')
-            )
-            if not dbdict:
-                return None
-            return dbdict['id']
-
     def getBuilderId(self, kwargs):
-        if 'buildername' in kwargs:
-            return self.master.db.builders.findBuilderId(kwargs['buildername'], autoCreate=False)
-        return defer.succeed(kwargs['builderid'])
+        retriever = NestedBuildDataRetriever(self.master, kwargs)
+        return (yield retriever.get_builder_id())
 
     # returns Deferred that yields a number
     def get_project_id(self, kwargs):

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -79,8 +79,8 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builds/n:buildid
-        /builders/n:builderid/builds/n:number
-        /builders/i:buildername/builds/n:number
+        /builders/n:builderid/builds/n:build_number
+        /builders/i:buildername/builds/n:build_number
     """
 
     @defer.inlineCallbacks
@@ -91,7 +91,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
             bldr = yield self.getBuilderId(kwargs)
             if bldr is None:
                 return None
-            num = kwargs['number']
+            num = kwargs['build_number']
             dbdict = yield self.master.db.builds.getBuildByNumber(bldr, num)
 
         data = yield self.db2data(dbdict) if dbdict else None
@@ -114,7 +114,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         buildid = kwargs.get('buildid')
         if buildid is None:
             bldr = kwargs['builderid']
-            num = kwargs['number']
+            num = kwargs['build_number']
             dbdict = yield self.master.db.builds.getBuildByNumber(bldr, num)
             buildid = dbdict['id']
         self.master.mq.produce(

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -28,10 +28,11 @@ class LogChunkEndpointBase(base.BuildNestingMixin, base.Endpoint):
             logid = kwargs['logid']
             dbdict = None
         else:
-            stepid = yield self.getStepid(kwargs)
-            if stepid is None:
+            retriever = base.NestedBuildDataRetriever(self.master, kwargs)
+            step_dict = yield retriever.get_step_dict()
+            if step_dict is None:
                 return (None, None)
-            dbdict = yield self.master.db.logs.getLogBySlug(stepid, kwargs.get('log_slug'))
+            dbdict = yield self.master.db.logs.getLogBySlug(step_dict['id'], kwargs.get('log_slug'))
             if not dbdict:
                 return (None, None)
             logid = dbdict['id']

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -54,11 +54,12 @@ class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
             dbdict = yield self.master.db.logs.getLog(kwargs['logid'])
             return (yield self.db2data(dbdict)) if dbdict else None
 
-        stepid = yield self.getStepid(kwargs)
-        if stepid is None:
+        retriever = base.NestedBuildDataRetriever(self.master, kwargs)
+        step_dict = yield retriever.get_step_dict()
+        if step_dict is None:
             return None
 
-        dbdict = yield self.master.db.logs.getLogBySlug(stepid, kwargs.get('log_slug'))
+        dbdict = yield self.master.db.logs.getLogBySlug(step_dict['id'], kwargs.get('log_slug'))
         return (yield self.db2data(dbdict)) if dbdict else None
 
 
@@ -76,10 +77,11 @@ class LogsEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
-        stepid = yield self.getStepid(kwargs)
-        if not stepid:
+        retriever = base.NestedBuildDataRetriever(self.master, kwargs)
+        step_dict = yield retriever.get_step_dict()
+        if step_dict is None:
             return []
-        logs = yield self.master.db.logs.getLogs(stepid=stepid)
+        logs = yield self.master.db.logs.getLogs(stepid=step_dict['id'])
         results = []
         for dbdict in logs:
             results.append((yield self.db2data(dbdict)))

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -776,7 +776,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             fulllog = yield self.master.data.get(("logs", str(_log['logid']), "raw"))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
-        for i in ["err_text", "err_html"]:
+        for i in [
+            'testy_build_1_step_worker_preparation_log_err_text',
+            "testy_build_1_step_worker_preparation_log_err_html",
+        ]:
             self.assertIn("can't create dir", logs_by_name[i])
             # make sure stacktrace is present in html
             self.assertIn(
@@ -825,7 +828,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             fulllog = yield self.master.data.get(("logs", str(_log['logid']), "raw"))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
-        for i in ["err_text", "err_html"]:
+        for i in [
+            'testy_build_1_step_worker_preparation_log_err_text',
+            "testy_build_1_step_worker_preparation_log_err_html",
+        ]:
             self.assertIn("can't ping", logs_by_name[i])
             # make sure stacktrace is present in html
             self.assertIn(

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -93,7 +93,8 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
                 project='world-domination',
                 sourcestampid=144,
             ),
-            fakedb.Build(buildrequestid=1, masterid=1, workerid=1, builderid=1),
+            fakedb.Builder(id=1, name='builder'),
+            fakedb.Build(buildrequestid=1, masterid=1, workerid=1, builderid=1, number=1),
         ])
 
     def tearDown(self):
@@ -130,14 +131,7 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         )
         self.patch(self.db.changes, 'getChangesForBuild', mockGetChangeById)
 
-        fake_build = yield {'id': 1}
-        mockGetBuildByNumber = mock.Mock(
-            spec=self.db.builds.getBuildByNumber, return_value=fake_build
-        )
-        self.patch(self.db.builds, 'getBuildByNumber', mockGetBuildByNumber)
-
         changes = yield self.callGet(('builders', '1', 'builds', '1', 'changes'))
-
         self.validateData(changes[0])
         self.assertEqual(changes[0]['changeid'], 14)
 

--- a/master/buildbot/test/unit/data/test_logchunks.py
+++ b/master/buildbot/test/unit/data/test_logchunks.py
@@ -222,7 +222,8 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
         logchunk = yield self.callGet(path)
         self.validateData(logchunk)
         if logid == 60:
-            expContent = '\n'.join([line[1:] for line in expLines])
+            expContent = 'Builder: some:builder\nBuild number: 3\nWorker name: wrk\n'
+            expContent += '\n'.join([line[1:] for line in expLines])
             expFilename = "some:builder_build_3_step_make_log_stdio"
         else:
             expContent = '\n'.join(expLines) + '\n'

--- a/master/buildbot/test/unit/data/test_logchunks.py
+++ b/master/buildbot/test/unit/data/test_logchunks.py
@@ -223,10 +223,10 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
         self.validateData(logchunk)
         if logid == 60:
             expContent = '\n'.join([line[1:] for line in expLines])
-            expFilename = "stdio"
+            expFilename = "some:builder_build_3_step_make_log_stdio"
         else:
             expContent = '\n'.join(expLines) + '\n'
-            expFilename = "errors"
+            expFilename = "some:builder_build_3_step_make_log_errors"
 
         self.assertEqual(
             logchunk, {'filename': expFilename, 'mime-type': "text/plain", 'raw': expContent}

--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from functools import wraps
+
+from twisted.internet import defer
+
+
+def async_to_deferred(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return defer.ensureDeferred(fn(*args, **kwargs))
+        except Exception as e:
+            return defer.fail(e)
+
+    return wrapper

--- a/newsfragments/raw-log-filename.feature
+++ b/newsfragments/raw-log-filename.feature
@@ -1,0 +1,1 @@
+Raw logs downloaded from the web UI now include full identifying information in the filename.

--- a/newsfragments/raw-log-metadata.feature
+++ b/newsfragments/raw-log-metadata.feature
@@ -1,0 +1,1 @@
+Raw text logs downloaded from the web UI now include a small header with identifying information.


### PR DESCRIPTION
Currently the filename sent from raw endpoint to the browser contains only the log name. This becomes confusing very fast once many logs of the same type are downloaded, usually to a single directory. This is fixed by adding full build information to the name of the log, thus downloaded files have unique names most of the time.

Additionally, the same metadata has been added to the beginning of the raw log itself. This is useful when raw_inline endpoint is linked from a browser, as it's not clear from text what build the log is for.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)

