### PR TITLE
Git steps: implement auth by user/password

### DIFF
--- a/master/buildbot/test/unit/util/test_git.py
+++ b/master/buildbot/test/unit/util/test_git.py
@@ -113,6 +113,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
         self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
         self.assertFalse(self.supports_lsremote_symref)
+        self.assertFalse(self.supports_credential_store)
 
     def test_git_noversion(self):
         self.parseGitFeatures('git')
@@ -123,6 +124,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
         self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
         self.assertFalse(self.supports_lsremote_symref)
+        self.assertFalse(self.supports_credential_store)
 
     def test_git_zero_version(self):
         self.parseGitFeatures('git version 0.0.0')
@@ -133,6 +135,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
         self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
         self.assertFalse(self.supports_lsremote_symref)
+        self.assertFalse(self.supports_credential_store)
 
     def test_git_2_10_0(self):
         self.parseGitFeatures('git version 2.10.0')
@@ -143,6 +146,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertTrue(self.supportsSshPrivateKeyAsEnvOption)
         self.assertTrue(self.supportsSshPrivateKeyAsConfigOption)
         self.assertTrue(self.supports_lsremote_symref)
+        self.assertTrue(self.supports_credential_store)
 
 
 class TestAdjustCommandParamsForSshPrivateKey(GitMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/util/test_git_credential.py
+++ b/master/buildbot/test/unit/util/test_git_credential.py
@@ -1,0 +1,42 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.process.properties import Properties
+from buildbot.process.properties import Property
+from buildbot.test.fake.fakebuild import FakeBuild
+from buildbot.util.git_credential import GitCredentialInputRenderer
+
+
+class TestGitCredentialInputRenderer(unittest.TestCase):
+    def setUp(self):
+        self.props = Properties()
+        self.build = FakeBuild(props=self.props)
+
+    @defer.inlineCallbacks
+    def test_render(self):
+        self.props.setProperty("password", "property_password", "test")
+        renderer = GitCredentialInputRenderer(
+            username="user",
+            password=Property("password"),
+            url="https://example.com/repo.git",
+        )
+        rendered = yield self.build.render(renderer)
+        self.assertEqual(
+            rendered,
+            "url=https://example.com/repo.git\nusername=user\npassword=property_password\n",
+        )

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -89,6 +89,7 @@ class GitMixin:
         self.supportsSshPrivateKeyAsConfigOption = False
         self.supportsFilters = False
         self.supports_lsremote_symref = False
+        self.supports_credential_store = False
 
     def parseGitFeatures(self, version_stdout):
         match = re.match(r"^git version (\d+(\.\d+)*)", version_stdout)
@@ -106,6 +107,8 @@ class GitMixin:
             self.supportsSubmoduleForce = True
         if version >= parse_version("1.7.8"):
             self.supportsSubmoduleCheckout = True
+        if version >= parse_version("1.7.9"):
+            self.supports_credential_store = True
         if version >= parse_version("2.3.0"):
             self.supportsSshPrivateKeyAsEnvOption = True
         if version >= parse_version("2.8.0"):

--- a/master/buildbot/util/git_credential.py
+++ b/master/buildbot/util/git_credential.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-from twisted.internet import defer
 from zope.interface import implementer
 
 from buildbot.interfaces import IRenderable
 from buildbot.util import ComparableMixin
+from buildbot.util.twisted import async_to_deferred
 
 
 @implementer(IRenderable)
@@ -31,8 +31,8 @@ class GitCredentialInputRenderer(ComparableMixin):
     def __init__(self, **credential_attributes) -> None:
         self._credential_attributes: dict[str, IRenderable | str] = credential_attributes
 
-    @defer.inlineCallbacks
-    def getRenderingFor(self, build):
+    @async_to_deferred
+    async def getRenderingFor(self, build):
         props = build.getProperties()
 
         rendered_attributes = []
@@ -46,7 +46,7 @@ class GitCredentialInputRenderer(ComparableMixin):
             attributes.sort(key=lambda e: e[0] != "url")
 
         for key, value in attributes:
-            rendered_value = yield props.render(value)
+            rendered_value = await props.render(value)
             if rendered_value is not None:
                 rendered_attributes.append(f"{key}={rendered_value}\n")
 

--- a/master/buildbot/util/git_credential.py
+++ b/master/buildbot/util/git_credential.py
@@ -1,0 +1,91 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from twisted.internet import defer
+from zope.interface import implementer
+
+from buildbot.interfaces import IRenderable
+from buildbot.util import ComparableMixin
+
+
+@implementer(IRenderable)
+class GitCredentialInputRenderer(ComparableMixin):
+    compare_attrs = ('_credential_attributes',)
+
+    def __init__(self, **credential_attributes) -> None:
+        self._credential_attributes: dict[str, IRenderable | str] = credential_attributes
+
+    @defer.inlineCallbacks
+    def getRenderingFor(self, build):
+        props = build.getProperties()
+
+        rendered_attributes = []
+
+        attributes = list(self._credential_attributes.items())
+
+        # git-credential-approve parsing of the `url` attribute
+        # will reset all other fields
+        # So make sure it's the first attribute in the form
+        if 'url' in self._credential_attributes:
+            attributes.sort(key=lambda e: e[0] != "url")
+
+        for key, value in attributes:
+            rendered_value = yield props.render(value)
+            if rendered_value is not None:
+                rendered_attributes.append(f"{key}={rendered_value}\n")
+
+        return "".join(rendered_attributes)
+
+
+class GitCredentialOptions(NamedTuple):
+    # Each element of `credentials` should be a `str` which is a input format for git-credential
+    # ref: https://git-scm.com/docs/git-credential#IOFMT
+    credentials: list[IRenderable | str]
+    # value to set the git config `credential.useHttpPath` to.
+    # ref: https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-useHttpPath
+    use_http_path: bool | None = None
+
+
+def add_user_password_to_credentials(
+    auth_credentials: tuple[IRenderable | str, IRenderable | str],
+    url: IRenderable | str | None,
+    credential_options: GitCredentialOptions | None,
+) -> GitCredentialOptions:
+    if credential_options is None:
+        credential_options = GitCredentialOptions(credentials=[])
+    else:
+        # create a new instance to avoid side-effects
+        credential_options = GitCredentialOptions(
+            credentials=credential_options.credentials[:],
+            use_http_path=credential_options.use_http_path,
+        )
+
+    username, password = auth_credentials
+    credential_options.credentials.insert(
+        0,
+        IRenderable(  # placate typing
+            GitCredentialInputRenderer(
+                url=url,
+                username=username,
+                password=password,
+            )
+        ),
+    )
+
+    return credential_options

--- a/master/docs/manual/configuration/misc/git_credential_options.rst
+++ b/master/docs/manual/configuration/misc/git_credential_options.rst
@@ -1,0 +1,39 @@
+.. _GitCredentialOptions:
+
+GitCredentialOptions
+++++++++++++++++++++
+
+.. py:class:: buildbot.util.GitCredentialOptions
+
+The following parameters are supported by the :py:class:`GitCredentialOptions`:
+
+
+``credentials``
+    (optional, a list of strings)
+    Each element of the list must be in the `git-credential input format <https://git-scm.com/docs/git-credential#IOFMT>`_
+    and will be passed as input to ``git credential approve``.
+
+``use_http_path``
+    (optional, a boolean)
+    If provided, will set the `credential.useHttpPath <https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-useHttpPath>`_
+    configuration to it's value for commands that require credentials.
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from buildbot.plugins import util
+
+    factory.addStep(steps.Git(
+        repourl='https://example.com/hello-world.git', mode='incremental',
+        git_credentials=util.GitCredentialOptions(
+            credentials=[
+                (
+                    "url=https://example.com/hello-world.git\n"
+                    "username=username\n"
+                    "password=token\n"
+                ),
+            ],
+        ),
+    ))

--- a/master/docs/manual/configuration/misc/index.rst
+++ b/master/docs/manual/configuration/misc/index.rst
@@ -9,9 +9,11 @@ Miscellaneous Configuration
 
     source_stamp_filter
     change_filter
+    git_credential_options
 
 
 This section outlines miscellaneous functionality that is useful for configuration but does not fit any other section.
 
 * :ref:`SourceStampFilter`
 * :ref:`ChangeFilter`
+* :ref:`GitCredentialOptions`

--- a/master/docs/manual/configuration/steps/gitpush.rst
+++ b/master/docs/manual/configuration/steps/gitpush.rst
@@ -60,3 +60,13 @@ The GitPush step takes the following arguments:
    This may be either a :ref:`Secret` or just a string.
    `sshPrivateKey` must be specified in order to use this option.
    `sshHostKey` must not be specified in order to use this option.
+
+``auth_credentials``
+
+    (optional) An username/password tuple to use when running git for push operations.
+    The worker's git version needs to be at least 1.7.9.
+
+``git_credentials``
+
+    (optional) See :ref:`GitCredentialOptions`.
+    The worker's git version needs to be at least 1.7.9.

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -152,3 +152,13 @@ The Git step takes the following arguments:
    This may be either a :ref:`Secret` or just a string.
    `sshPrivateKey` must be specified in order to use this option.
    `sshHostKey` must not be specified in order to use this option.
+
+``auth_credentials``
+
+   (optional) An username/password tuple to use when running git for fetch operations.
+   The worker's git version needs to be at least 1.7.9.
+
+``git_credentials``
+
+   (optional) See :ref:`GitCredentialOptions`.
+   The worker's git version needs to be at least 1.7.9.

--- a/master/setup.py
+++ b/master/setup.py
@@ -565,6 +565,10 @@ setup_args = {
                     ),
                     ('buildbot.steps.shellsequence', ['ShellArg']),
                     (
+                        'buildbot.util.git_credential',
+                        ['GitCredentialInputRenderer', 'GitCredentialOptions'],
+                    ),
+                    (
                         'buildbot.util.kubeclientservice',
                         [
                             'KubeHardcodedConfig',

--- a/newsfragments/git-step-credential-auth.feature
+++ b/newsfragments/git-step-credential-auth.feature
@@ -1,0 +1,1 @@
+:bb:step:`Git` and :bb:step:`GitPush` now supports authentication with username/password. Credentials can be provided through the `auth_credentials` and/or `git_credentials` parameters.


### PR DESCRIPTION
This implement user/password authentication for the Git and GitPush steps (first part of #7384).

Authentication is handled with the builtin git credential flow using the [git-credential-store](https://git-scm.com/docs/git-credential-store) backend.

Credentials are stored using `git credential approve`.
An alternative implementation could directly write the credential file that git-credential-store would read, but it's not supposed to be user facing ([see doc](https://git-scm.com/docs/git-credential-store#_storage_format): "Do not view or edit the file with editors") so might be subject to change in the future.
Whereas the [git credential IOFormat](https://git-scm.com/docs/git-credential#IOFMT) is defined and should be stable.

Also, it allow to implement auth through another git-credential backend in the future if needed.

Credentials can be provided to the steps as a simple user/password tuple with `auth_credentials`, in which case, it will complete the auth form with the `repourl` the step is supposed to clone.
It's also possible to directly provide the `git credential` form through `git_credentials` (`GitCredentialOptions`). This might be needed for repositories that have submodule which are private and require a different set of credentials.

`GitCredentialOptions` also has a `use_http_path` member to override the config value of the same name. This is needed in case multiple credentials are needed for the same host (eg. GIthub repositories owner by different org/user). See [doc](https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-useHttpPath).

I'll implement the same mechanism in `GitPoller` in another PR once this one is accepted as it require some more code change to provide a way for `GitServiceAuth` to run commands.

PS: Thanks for the `async_to_deferred` helper!

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
