### PR TITLE
smokes: Increase expect.poll timeout in waitBuildFinished

### DIFF
--- a/smokes-react/tests/pages/builder.ts
+++ b/smokes-react/tests/pages/builder.ts
@@ -100,7 +100,7 @@ export class BuilderPage {
   }
 
   static async waitBuildFinished(page: Page, reference: number) {
-    await expect.poll(async () => {
+    await expect.configure({ timeout: 30000 }).poll(async () => {
       const currentBuildCount = await BuilderPage.getLastFinishedBuildNumber(page);
       return currentBuildCount === reference;
     }, {


### PR DESCRIPTION
This PR increases expect.poll timeout for better test reliability.
Fixes https://github.com/buildbot/buildbot/issues/7539.
