### PR TITLE
www: Make Builder related URLs take buildername

### DIFF
--- a/newsfragments/www-buildername-in-urls.feature
+++ b/newsfragments/www-buildername-in-urls.feature
@@ -1,0 +1,1 @@
+allow to pass `buildername` as `builderid` in `builders/:builderid`, `builders/:builderid/builds/:buildnumber`, and `builders/:builderid/builds/:buildnumber/steps/:stepnumber/logs/:logslug` website URLs.


### PR DESCRIPTION
This allow to share user-friendly URLs between users.

Note that using `buildername` in APIs can be problematic, see #7552.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation
