### PR TITLE
process: remove AbstractWorkerForBuilder.setBuilder

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -273,8 +273,7 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
                 # just ignore it.
                 return self
 
-        wfb = workerforbuilder.WorkerForBuilder()
-        wfb.setBuilder(self)
+        wfb = workerforbuilder.WorkerForBuilder(self)
         self.attaching_workers.append(wfb)
 
         try:

--- a/master/buildbot/test/unit/process/test_workerforbuilder.py
+++ b/master/buildbot/test/unit/process/test_workerforbuilder.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from buildbot.process.builder import Builder
 from twisted.trial.unittest import TestCase
 
 from buildbot.process.workerforbuilder import AbstractWorkerForBuilder
@@ -37,8 +38,9 @@ class TestAbstractWorkerForBuilder(TestCase):
             def buildStarted(self, workerforbuilder):
                 self._buildStartedCalls.append(workerforbuilder)
 
+        fake_builder = Builder("fake_builder")
         worker = ConcreteWorker("worker", "pass")
-        workerforbuilder = AbstractWorkerForBuilder()
+        workerforbuilder = AbstractWorkerForBuilder(fake_builder)
         # FIXME: This should call attached, instead of setting the attribute
         # directly
         workerforbuilder.worker = worker
@@ -56,8 +58,9 @@ class TestAbstractWorkerForBuilder(TestCase):
         class ConcreteWorker(AbstractWorker):
             pass
 
+        fake_builder = Builder("fake_builder")
         worker = ConcreteWorker("worker", "pass")
-        workerforbuilder = AbstractWorkerForBuilder()
+        workerforbuilder = AbstractWorkerForBuilder(fake_builder)
         # FIXME: This should call attached, instead of setting the attribute
         # directly
         workerforbuilder.worker = worker


### PR DESCRIPTION
From looking at the code, it doesn't really make sense for a `WorkerForBuilder` to be instantiated without being linked to a `Builder`.
This improve typing a bit as `WorkerForBuilder.builder` can't be `None` now.

Feel free to close if the change is unwanted.

Didn't create a newsfragment as it looks to be an internal change only, but I can add one if necessary.

## Contributor Checklist:

* [x] I have updated the unit tests
* [N/A] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation
