### PR TITLE
changes: remove HgPoller._stopOnFailure unused arg

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -431,9 +431,8 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
             # but at once to avoid impact from later errors
             yield self._setCurrentRev(new_rev, branch)
 
-    def _stopOnFailure(self, f):
+    def _stopOnFailure(self):
         "utility method to stop the service when a failure occurs"
         if self.running:
             d = defer.maybeDeferred(self.stopService)
             d.addErrback(log.err, 'while stopping broken HgPoller service')
-        return f


### PR DESCRIPTION
No longer used sinced _stopOnFailure is no longer called by deferred.addErrback since #6046

Fixes #7488