### PR TITLE
3.11 backport: www: Restore relative paths in React frontend

### DIFF
--- a/newsfragments/www-relative-path.bugfix
+++ b/newsfragments/www-relative-path.bugfix
@@ -1,0 +1,2 @@
+Fixed a regression in React UI that prevented hosting Buildbot at a custom URL prefix. This allows
+to support multiple Buildbot instances on a single server.

--- a/www/react-base/vite.config.ts
+++ b/www/react-base/vite.config.ts
@@ -89,6 +89,9 @@ export default defineConfig({
     serveBuildbotPlugins(),
     visualizer(),
   ],
+  // this makes all path references into relative paths, thus Buildbot can be hosted at a custom
+  // path prefix, like my-domain.com/custom-buildbot-path/
+  base: './',
   build: {
     target: ['es2015'],
     outDir: outDir,


### PR DESCRIPTION
This PR backports #7559 to 3.11.x