### PR TITLE
3.11 backports: changes: remove HgPoller._stopOnFailure unused arg 

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -357,9 +357,8 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
             # but at once to avoid impact from later errors
             yield self._setCurrentRev(new_rev, branch)
 
-    def _stopOnFailure(self, f):
+    def _stopOnFailure(self):
         "utility method to stop the service when a failure occurs"
         if self.running:
             d = defer.maybeDeferred(self.stopService)
             d.addErrback(log.err, 'while stopping broken HgPoller service')
-        return f

--- a/newsfragments/mercurial-crash-init.bugfix
+++ b/newsfragments/mercurial-crash-init.bugfix
@@ -1,0 +1,1 @@
+Fixed an error in HgPoller when repository initialization fails (:issue:`7488`)


### PR DESCRIPTION
This PR backports #7553 to 3.11.x