### PR TITLE
Delete all usages of deprecated PollingChangeSource

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1063,7 +1063,6 @@ pollatlaunch
 pollatreconfigure
 poller
 pollers
-pollingchangesource
 pollinterval
 popnextbuild
 portstr

--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -22,7 +22,6 @@ from buildbot import config
 from buildbot.interfaces import IChangeSource
 from buildbot.util import service
 from buildbot.util.poll import method as poll_method
-from buildbot.warnings import warn_deprecated
 
 
 @implementer(IChangeSource)
@@ -128,42 +127,3 @@ class ReconfigurablePollingChangeSource(ChangeSource):
 
     def deactivate(self):
         return self.doPoll.stop()
-
-
-class PollingChangeSource(ReconfigurablePollingChangeSource):
-    # Legacy code will be very painful to port to BuildbotService life cycle
-    # because the unit tests keep doing shortcuts for the Service life cycle (i.e by no calling
-    # startService) instead of porting everything at once, we make a class to support legacy
-
-    def checkConfig(
-        self,
-        name=None,
-        pollInterval=60 * 10,
-        pollAtLaunch=False,
-        pollRandomDelayMin=0,
-        pollRandomDelayMax=0,
-        **kwargs,
-    ):
-        super().checkConfig(
-            name=name,
-            pollInterval=60 * 10,
-            pollAtLaunch=False,
-            pollRandomDelayMin=0,
-            pollRandomDelayMax=0,
-        )
-
-        warn_deprecated(
-            '3.3.0',
-            'PollingChangeSource has been deprecated: '
-            + 'please use ReconfigurablePollingChangeSource',
-        )
-
-        self.pollInterval = pollInterval
-        self.pollAtLaunch = pollAtLaunch
-        self.pollRandomDelayMin = pollRandomDelayMin
-        self.pollRandomDelayMax = pollRandomDelayMax
-
-    def reconfigService(self, *args, **kwargs):
-        # BuildbotServiceManager will detect such exception and swap old service with new service,
-        # instead of just reconfiguring
-        raise NotImplementedError()

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -65,7 +65,6 @@ class TestSetupPyEntryPoints(unittest.TestCase):
         known_not_exported = {
             'buildbot.changes.gerritchangesource.GerritChangeSourceBase',
             'buildbot.changes.base.ReconfigurablePollingChangeSource',
-            'buildbot.changes.base.PollingChangeSource',
             'buildbot.changes.base.ChangeSource',
         }
         self.verify_plugins_registered(

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -23,8 +23,6 @@ from buildbot.changes import base
 from buildbot.changes import manager
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util.warnings import assertProducesWarnings
-from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestChangeManager(unittest.TestCase, TestReactorMixin):
@@ -83,26 +81,3 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
         self.assertTrue(src1.running)
         self.assertFalse(src2.running)
         self.assertEqual(src1.pollInterval, 2)
-
-    @defer.inlineCallbacks
-    def test_reconfigService_change_legacy(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning, message_pattern="use ReconfigurablePollingChangeSource"
-        ):
-            (src1,) = self.make_sources(1, base.PollingChangeSource, pollInterval=1)
-        yield src1.setServiceParent(self.cm)
-
-        with assertProducesWarnings(
-            DeprecatedApiWarning, message_pattern="use ReconfigurablePollingChangeSource"
-        ):
-            (src2,) = self.make_sources(1, base.PollingChangeSource, pollInterval=2)
-
-        self.new_config.change_sources = [src2]
-
-        self.assertTrue(src1.running)
-        self.assertEqual(src1.pollInterval, 1)
-        yield self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
-
-        self.assertFalse(src1.running)
-        self.assertTrue(src2.running)
-        self.assertEqual(src2.pollInterval, 2)

--- a/master/docs/developer/cls-changesources.rst
+++ b/master/docs/developer/cls-changesources.rst
@@ -25,11 +25,3 @@ ReconfigurablePollingChangeSource
     Subclasses should override the ``poll`` method.
     This method may return a Deferred.
     Calls to ``poll`` will not overlap.
-
-PollingChangeSource
--------------------
-
-.. py:class:: PollingChangeSource
-
-    This is a legacy class for polling change sources not yet ported to the :py:class:`BuildbotService` component lifecycle.
-    Do not use for new code.


### PR DESCRIPTION
This PR removes all usages of deprecated PollingChangeSource. PR is a partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
