### PR TITLE
react-base: Fix `FieldChoiceString` component should map the `list` type

### DIFF
--- a/newsfragments/react-base-fix-issue-7491.bugfix
+++ b/newsfragments/react-base-fix-issue-7491.bugfix
@@ -1,0 +1,1 @@
+Fix ``ChoiceStringParameter`` fields were not present in ForceBuild Form.

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldAny.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldAny.tsx
@@ -56,7 +56,7 @@ export const FieldAny = observer(({field, fieldsState}: FieldAnyProps) => {
   if (field.type === 'username') {
     return <FieldUserName field={field as ForceSchedulerFieldUserName} fieldsState={fieldsState}/>
   }
-  if (field.type === 'choices') {
+  if (field.type === 'list') {
     return <FieldChoiceString field={field as ForceSchedulerFieldChoiceString}
                               fieldsState={fieldsState}/>
   }

--- a/www/react-data-module/src/data/classes/Forcescheduler.ts
+++ b/www/react-data-module/src/data/classes/Forcescheduler.ts
@@ -55,7 +55,7 @@ export type ForceSchedulerFieldUserName = ForceSchedulerFieldString & {
 }
 
 export type ForceSchedulerFieldChoiceString = ForceSchedulerFieldBase & {
-  // type: 'choices'
+  // type: 'list'
   choices: string[];
   strict: boolean;
 }


### PR DESCRIPTION
Fixes #7491

## Contributor Checklist:

* [N/A] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation
