### PR TITLE
react-base: Minor fix and improvement to ForceBuildModal fields

### DIFF
--- a/newsfragments/react-base-fix-forcefield-choicestring-multiple.bugfix
+++ b/newsfragments/react-base-fix-forcefield-choicestring-multiple.bugfix
@@ -1,0 +1,1 @@
+Fix ``ChoiceStringParameter`` fields with ``multiple`` would not store the selected values

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.test.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.test.tsx
@@ -20,7 +20,7 @@ import { FieldBoolean } from "./FieldBoolean";
 import { ForceSchedulerFieldBoolean } from 'buildbot-data-js';
 import { ForceBuildModalFieldsState } from '../ForceBuildModalFieldsState';
 
-function assertRenderToSnapshot(defaultValue: 'true' | 'false', stateValue?: 'true' | 'false', updateValue: boolean = false) {
+function assertRenderToSnapshot(defaultValue: boolean, stateValue?: boolean, updateValue: boolean = false) {
   const field: ForceSchedulerFieldBoolean = {
     name: 'dummy',
     fullName: 'fullDummy',
@@ -47,12 +47,12 @@ function assertRenderToSnapshot(defaultValue: 'true' | 'false', stateValue?: 'tr
 
   if (updateValue) {
     const previousState = state.getValue(field.fullName);
-    const expectedState = previousState === "true" ? "false" : "true";
+    const expectedState = !previousState;
     renderer.act(() => {
       const elements = component.root.findAllByProps({'data-bb-test-id': `force-field-${field.fullName}`}, {deep: true});
       expect(elements.length).toBe(1);
       const checkbox = elements[0];
-      checkbox.props.onChange({target: {checked: expectedState === "true"}});
+      checkbox.props.onChange({target: {checked: expectedState}});
     });
     expect(state.getValue(field.fullName)).toBe(expectedState);
   }
@@ -60,22 +60,22 @@ function assertRenderToSnapshot(defaultValue: 'true' | 'false', stateValue?: 'tr
 
 describe('ForceFieldBoolean component', function () {
   it('render default value False', () => {
-    assertRenderToSnapshot('false');
+    assertRenderToSnapshot(false);
   });
 
   it('render default value True', () => {
-    assertRenderToSnapshot('true');
+    assertRenderToSnapshot(true);
   });
 
   it('render non-default value False', () => {
-    assertRenderToSnapshot('true', 'false');
+    assertRenderToSnapshot(true, false);
   });
 
   it('render non-default value True', () => {
-    assertRenderToSnapshot('false', 'true');
+    assertRenderToSnapshot(false, true);
   });
 
   it('change state on click', () => {
-    assertRenderToSnapshot('true', 'true', true);
+    assertRenderToSnapshot(true, true, true);
   });
 });

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.test.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.test.tsx
@@ -1,0 +1,81 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import renderer from 'react-test-renderer';
+import { FieldBoolean } from "./FieldBoolean";
+import { ForceSchedulerFieldBoolean } from 'buildbot-data-js';
+import { ForceBuildModalFieldsState } from '../ForceBuildModalFieldsState';
+
+function assertRenderToSnapshot(defaultValue: 'true' | 'false', stateValue?: 'true' | 'false', updateValue: boolean = false) {
+  const field: ForceSchedulerFieldBoolean = {
+    name: 'dummy',
+    fullName: 'fullDummy',
+    label: 'dummyLabel',
+    tablabel: 'dummyTabLabel',
+    type: 'bool',
+    default: defaultValue,
+    multiple: false,
+    regex: null,
+    hide: false,
+    maxsize: null,
+    autopopulate: null,
+  }
+  const state = new ForceBuildModalFieldsState();
+  state.createNewField(field.fullName, field.default);
+  if (stateValue !== undefined) {
+    state.setValue(field.fullName, stateValue);
+  }
+
+  const component = renderer.create(
+    <FieldBoolean field={field} fieldsState={state} />
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+
+  if (updateValue) {
+    const previousState = state.getValue(field.fullName);
+    const expectedState = previousState === "true" ? "false" : "true";
+    renderer.act(() => {
+      const elements = component.root.findAllByProps({'data-bb-test-id': `force-field-${field.fullName}`}, {deep: true});
+      expect(elements.length).toBe(1);
+      const checkbox = elements[0];
+      checkbox.props.onChange({target: {checked: expectedState === "true"}});
+    });
+    expect(state.getValue(field.fullName)).toBe(expectedState);
+  }
+}
+
+describe('ForceFieldBoolean component', function () {
+  it('render default value False', () => {
+    assertRenderToSnapshot('false');
+  });
+
+  it('render default value True', () => {
+    assertRenderToSnapshot('true');
+  });
+
+  it('render non-default value False', () => {
+    assertRenderToSnapshot('true', 'false');
+  });
+
+  it('render non-default value True', () => {
+    assertRenderToSnapshot('false', 'true');
+  });
+
+  it('change state on click', () => {
+    assertRenderToSnapshot('true', 'true', true);
+  });
+});

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.tsx
@@ -32,9 +32,11 @@ export const FieldBoolean = observer(({field, fieldsState}: FieldBooleanProps) =
       <div className="col-sm-10 col-sm-offset-2">
         <div className="checkbox">
           <label>
-            <input type="checkbox" checked={state.value === 'true'}
-                   onChange={event => fieldsState.setValue(field.fullName,
-                     event.target.checked ? 'true' : 'false')}/> {field.label}
+            <input
+              data-bb-test-id={`force-field-${field.fullName}`}
+              type="checkbox" checked={state.value === 'true'}
+              onChange={event => fieldsState.setValue(field.fullName,
+                event.target.checked ? 'true' : 'false')} /> {field.label}
           </label>
         </div>
       </div>

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldBoolean.tsx
@@ -34,9 +34,9 @@ export const FieldBoolean = observer(({field, fieldsState}: FieldBooleanProps) =
           <label>
             <input
               data-bb-test-id={`force-field-${field.fullName}`}
-              type="checkbox" checked={state.value === 'true'}
+              type="checkbox" checked={state.value}
               onChange={event => fieldsState.setValue(field.fullName,
-                event.target.checked ? 'true' : 'false')} /> {field.label}
+                event.target.checked)} /> {field.label}
           </label>
         </div>
       </div>

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldChoiceString.test.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldChoiceString.test.tsx
@@ -1,0 +1,130 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import renderer from 'react-test-renderer';
+import { FieldChoiceString } from "./FieldChoiceString";
+import { ForceSchedulerFieldChoiceString } from 'buildbot-data-js';
+import { ForceBuildModalFieldsState } from '../ForceBuildModalFieldsState';
+
+type FieldChoiceStringTestOptions = {
+  defaultValue: string | string[];
+  stateValue?: string | string[];
+  updateValueTo?: string[];
+  multiple?: boolean;
+  strict?: boolean;
+}
+
+function assertRenderToSnapshot(options: FieldChoiceStringTestOptions) {
+  const field: ForceSchedulerFieldChoiceString = {
+    name: 'dummy',
+    fullName: 'fullDummy',
+    label: 'dummyLabel',
+    tablabel: 'dummyTabLabel',
+    type: 'list',
+    default: options.defaultValue,
+    multiple: options.multiple ?? false,
+    regex: null,
+    hide: false,
+    maxsize: null,
+    autopopulate: null,
+    choices: ['A', 'B', 'C'],
+    strict: options.strict ?? true,
+  }
+  const state = new ForceBuildModalFieldsState();
+  state.createNewField(field.fullName, field.default);
+  if (options.stateValue !== undefined) {
+    state.setValue(field.fullName, options.stateValue);
+  }
+
+  const component = renderer.create(
+    <FieldChoiceString field={field} fieldsState={state} />
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+
+  if (options.updateValueTo !== undefined) {
+    if (!field.multiple) {
+      expect(options.updateValueTo.length).toBe(1);
+    }
+
+    const expectedState = options.updateValueTo;
+
+    const toClick: string[] = [];
+    if (!field.multiple) {
+      expect(expectedState.length).toBe(1);
+      toClick.push(expectedState[0]);
+    }
+    else {
+      const currentValue: string[] = state.getValue(field.fullName);
+      // click elements not in expected to unselect them
+      toClick.push(...currentValue.filter(e => !(expectedState.includes(e))));
+      // then click elements not currently selected
+      toClick.push(...expectedState.filter(e => !(currentValue.includes(e))));
+    }
+
+    renderer.act(() => {
+      const elements = component.root.findAll(
+        (node) => {
+          return node.props['data-bb-test-id'] === `force-field-${field.fullName}` && node.type !== 'select';
+        },
+        { deep: true }
+      );
+      expect(elements.length).toBe(1);
+      const select = elements[0];
+      for (const element of toClick) {
+        select.props.onChange({ target: { value: element } });
+      }
+    });
+
+    if (field.multiple) {
+      const stateValue: string[] = state.getValue(field.fullName);
+      stateValue.sort();
+      expectedState.sort();
+      expect(stateValue).toStrictEqual(expectedState);
+    }
+    else {
+      expect(state.getValue(field.fullName)).toBe(expectedState[0]);
+    }
+  }
+}
+
+describe('ForceFieldChoiceString component', function () {
+  it('render default value', () => {
+    assertRenderToSnapshot({ defaultValue: 'A' });
+    assertRenderToSnapshot({ defaultValue: 'B' });
+  });
+
+  it('render multiple default value', () => {
+    assertRenderToSnapshot({ defaultValue: ['A'], multiple: true });
+    assertRenderToSnapshot({ defaultValue: ['A', 'B'], multiple: true });
+  });
+
+  it('render non-default value', () => {
+    assertRenderToSnapshot({ defaultValue: 'A', stateValue: 'B' });
+  });
+
+  it('render multiple non-default value', () => {
+    assertRenderToSnapshot({ defaultValue: ['A'], stateValue: ['B', 'C'], multiple: true });
+  });
+
+  it('change state on click', () => {
+    assertRenderToSnapshot({ defaultValue: 'A', stateValue: 'B', updateValueTo: ['C'] });
+  });
+
+  it('change multiple state on click', () => {
+    assertRenderToSnapshot({ defaultValue: ['A'], stateValue: ['B', 'C'], updateValueTo: ['A', 'C'], multiple: true });
+  });
+});

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldChoiceString.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldChoiceString.tsx
@@ -29,18 +29,35 @@ type FieldChoiceStringProps = {
 export const FieldChoiceString = observer(({field, fieldsState}: FieldChoiceStringProps) => {
   const state = fieldsState.fields.get(field.fullName)!;
 
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!field.multiple) {
+      fieldsState.setValue(field.fullName, event.target.value);
+    }
+    else {
+      const currentValue = new Set(state.value);
+      if (currentValue.has(event.target.value)) {
+        currentValue.delete(event.target.value);
+      }
+      else {
+        currentValue.add(event.target.value);
+      }
+      fieldsState.setValue(field.fullName, [...currentValue]);
+    }
+  };
+
   return (
     <FieldBase field={field} fieldsState={fieldsState}>
       <Form.Label className="col-sm-10">{field.label}</Form.Label>
       <div className="col-sm-10">
-        <Form.Control as="select" multiple={field.multiple} value={state.value}
-                      onChange={event => fieldsState.setValue(field.fullName, event.target.value)}>
-          {field.choices.map(choice => (<option>{choice}</option>))}
+        <Form.Control data-bb-test-id={`force-field-${field.fullName}`}
+                      as="select" multiple={field.multiple} value={state.value}
+                      onChange={onChange}>
+          {field.choices.map(choice => (<option key={`force-field-${field.fullName}-option-${choice}`}>{choice}</option>))}
         </Form.Control>
         { !field.strict && !field.multiple
-          ? <input data-bb-test-id={`force-field-${field.fullName}`}
+          ? <input data-bb-test-id={`force-field-non-strict-${field.fullName}`}
                    className="select-editable form-control" type="text" value={state.value}
-                   onChange={event => fieldsState.setValue(field.fullName, event.target.value)}/>
+                   onChange={onChange}/>
           : <></>
         }
       </div>

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.test.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.test.tsx
@@ -27,7 +27,7 @@ function assertRenderToSnapshot(defaultValue: number, stateValue?: number, updat
     label: 'dummyLabel',
     tablabel: 'dummyTabLabel',
     type: 'int',
-    default: defaultValue.toString(),
+    default: defaultValue,
     multiple: false,
     regex: null,
     hide: false,
@@ -38,7 +38,7 @@ function assertRenderToSnapshot(defaultValue: number, stateValue?: number, updat
   const state = new ForceBuildModalFieldsState();
   state.createNewField(field.fullName, field.default);
   if (stateValue !== undefined) {
-    state.setValue(field.fullName, stateValue.toString());
+    state.setValue(field.fullName, stateValue);
   }
 
   const component = renderer.create(
@@ -47,7 +47,7 @@ function assertRenderToSnapshot(defaultValue: number, stateValue?: number, updat
   expect(component.toJSON()).toMatchSnapshot();
 
   if (updateValue !== undefined) {
-    const expectedState = updateValue.toString();
+    const expectedState = updateValue;
     renderer.act(() => {
       const elements = component.root.findAllByProps({'data-bb-test-id': `force-field-${field.fullName}`}, {deep: true});
       expect(elements.length).toBe(1);

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.test.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.test.tsx
@@ -1,0 +1,78 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import renderer from 'react-test-renderer';
+import { FieldInt } from "./FieldInt";
+import { ForceSchedulerFieldInt } from 'buildbot-data-js';
+import { ForceBuildModalFieldsState } from '../ForceBuildModalFieldsState';
+
+function assertRenderToSnapshot(defaultValue: number, stateValue?: number, updateValue?: number) {
+  const field: ForceSchedulerFieldInt = {
+    name: 'dummy',
+    fullName: 'fullDummy',
+    label: 'dummyLabel',
+    tablabel: 'dummyTabLabel',
+    type: 'int',
+    default: defaultValue.toString(),
+    multiple: false,
+    regex: null,
+    hide: false,
+    maxsize: null,
+    autopopulate: null,
+    size: 0,
+  }
+  const state = new ForceBuildModalFieldsState();
+  state.createNewField(field.fullName, field.default);
+  if (stateValue !== undefined) {
+    state.setValue(field.fullName, stateValue.toString());
+  }
+
+  const component = renderer.create(
+    <FieldInt field={field} fieldsState={state} />
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+
+  if (updateValue !== undefined) {
+    const expectedState = updateValue.toString();
+    renderer.act(() => {
+      const elements = component.root.findAllByProps({'data-bb-test-id': `force-field-${field.fullName}`}, {deep: true});
+      expect(elements.length).toBe(1);
+      const input = elements[0];
+      input.props.onChange({target: {value: expectedState}});
+    });
+    expect(state.getValue(field.fullName)).toBe(expectedState);
+  }
+}
+
+describe('ForceFieldInt component', function () {
+  it('render default value', () => {
+    assertRenderToSnapshot(0);
+    assertRenderToSnapshot(-0);
+    assertRenderToSnapshot(150);
+    assertRenderToSnapshot(-150);
+  });
+
+  it('render non-default value', () => {
+    assertRenderToSnapshot(0, -0);
+    assertRenderToSnapshot(0, 150);
+    assertRenderToSnapshot(0, -150);
+  });
+
+  it('change state on click', () => {
+    assertRenderToSnapshot(0, -150, 350);
+  });
+});

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.tsx
@@ -34,7 +34,7 @@ export const FieldInt = observer(({field, fieldsState}: FieldIntProps) => {
       <div className="col-sm-10">
         <input data-bb-test-id={`force-field-${field.fullName}`}
                type="text" className="form-control" value={state.value}
-               onChange={event => fieldsState.setValue(field.fullName, event.target.value)}/>
+               onChange={event => fieldsState.setValue(field.fullName, Number.parseInt(event.target.value))}/>
       </div>
     </FieldBase>
   );

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldInt.tsx
@@ -33,7 +33,7 @@ export const FieldInt = observer(({field, fieldsState}: FieldIntProps) => {
       <label htmlFor={field.fullName} className="control-label col-sm-10">{field.label}</label>
       <div className="col-sm-10">
         <input data-bb-test-id={`force-field-${field.fullName}`}
-               type="text" className="form-control" value={state.value}
+               type="number" className="form-control" value={state.value}
                onChange={event => fieldsState.setValue(field.fullName, Number.parseInt(event.target.value))}/>
       </div>
     </FieldBase>

--- a/www/react-base/src/components/ForceBuildModal/Fields/FieldString.test.tsx
+++ b/www/react-base/src/components/ForceBuildModal/Fields/FieldString.test.tsx
@@ -1,0 +1,74 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import renderer from 'react-test-renderer';
+import { FieldString } from "./FieldString";
+import { ForceSchedulerFieldString } from 'buildbot-data-js';
+import { ForceBuildModalFieldsState } from '../ForceBuildModalFieldsState';
+
+function assertRenderToSnapshot(defaultValue: string, stateValue?: string, updateValue?: string) {
+  const field: ForceSchedulerFieldString = {
+    name: 'dummy',
+    fullName: 'fullDummy',
+    label: 'dummyLabel',
+    tablabel: 'dummyTabLabel',
+    type: 'text',
+    default: defaultValue,
+    multiple: false,
+    regex: null,
+    hide: false,
+    maxsize: null,
+    autopopulate: null,
+    size: 0,
+  }
+  const state = new ForceBuildModalFieldsState();
+  state.createNewField(field.fullName, field.default);
+  if (stateValue !== undefined) {
+    state.setValue(field.fullName, stateValue.toString());
+  }
+
+  const component = renderer.create(
+    <FieldString field={field} fieldsState={state} />
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+
+  if (updateValue !== undefined) {
+    const expectedState = updateValue;
+    renderer.act(() => {
+      const elements = component.root.findAllByProps({'data-bb-test-id': `force-field-${field.fullName}`}, {deep: true});
+      expect(elements.length).toBe(1);
+      const input = elements[0];
+      input.props.onChange({target: {value: expectedState}});
+    });
+    expect(state.getValue(field.fullName)).toBe(expectedState);
+  }
+}
+
+describe('ForceFieldString component', function () {
+  it('render default value', () => {
+    assertRenderToSnapshot("");
+    assertRenderToSnapshot("default");
+  });
+
+  it('render non-default value', () => {
+    assertRenderToSnapshot("default", "stateValue");
+  });
+
+  it('change state on click', () => {
+    assertRenderToSnapshot("default", "stateValue", "updateValue");
+  });
+});

--- a/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldBoolean.test.tsx.snap
+++ b/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldBoolean.test.tsx.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForceFieldBoolean component change state on click 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="col-sm-10 col-sm-offset-2"
+  >
+    <div
+      className="checkbox"
+    >
+      <label>
+        <input
+          checked={true}
+          data-bb-test-id="force-field-fullDummy"
+          onChange={[Function]}
+          type="checkbox"
+        />
+         
+        dummyLabel
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldBoolean component render default value False 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="col-sm-10 col-sm-offset-2"
+  >
+    <div
+      className="checkbox"
+    >
+      <label>
+        <input
+          checked={false}
+          data-bb-test-id="force-field-fullDummy"
+          onChange={[Function]}
+          type="checkbox"
+        />
+         
+        dummyLabel
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldBoolean component render default value True 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="col-sm-10 col-sm-offset-2"
+  >
+    <div
+      className="checkbox"
+    >
+      <label>
+        <input
+          checked={true}
+          data-bb-test-id="force-field-fullDummy"
+          onChange={[Function]}
+          type="checkbox"
+        />
+         
+        dummyLabel
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldBoolean component render non-default value False 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="col-sm-10 col-sm-offset-2"
+  >
+    <div
+      className="checkbox"
+    >
+      <label>
+        <input
+          checked={false}
+          data-bb-test-id="force-field-fullDummy"
+          onChange={[Function]}
+          type="checkbox"
+        />
+         
+        dummyLabel
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldBoolean component render non-default value True 1`] = `
+<div
+  className="form-group"
+>
+  <div
+    className="col-sm-10 col-sm-offset-2"
+  >
+    <div
+      className="checkbox"
+    >
+      <label>
+        <input
+          checked={true}
+          data-bb-test-id="force-field-fullDummy"
+          onChange={[Function]}
+          type="checkbox"
+        />
+         
+        dummyLabel
+      </label>
+    </div>
+  </div>
+</div>
+`;

--- a/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldChoiceString.test.tsx.snap
+++ b/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldChoiceString.test.tsx.snap
@@ -1,0 +1,348 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForceFieldChoiceString component change multiple state on click 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={true}
+        onChange={[Function]}
+        value={
+          Array [
+            "B",
+            "C",
+          ]
+        }
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component change state on click 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={false}
+        onChange={[Function]}
+        value="B"
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component render default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={false}
+        onChange={[Function]}
+        value="A"
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component render default value 2`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={false}
+        onChange={[Function]}
+        value="B"
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component render multiple default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={true}
+        onChange={[Function]}
+        value={
+          Array [
+            "A",
+          ]
+        }
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component render multiple default value 2`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={true}
+        onChange={[Function]}
+        value={
+          Array [
+            "A",
+            "B",
+          ]
+        }
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component render multiple non-default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={true}
+        onChange={[Function]}
+        value={
+          Array [
+            "B",
+            "C",
+          ]
+        }
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldChoiceString component render non-default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="col-sm-10 form-label"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <select
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        multiple={false}
+        onChange={[Function]}
+        value="B"
+      >
+        <option>
+          A
+        </option>
+        <option>
+          B
+        </option>
+        <option>
+          C
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+`;

--- a/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldInt.test.tsx.snap
+++ b/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldInt.test.tsx.snap
@@ -1,0 +1,257 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForceFieldInt component change state on click 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="-150"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="0"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render default value 2`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="0"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render default value 3`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="150"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render default value 4`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="-150"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render non-default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="0"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render non-default value 2`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="150"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldInt component render non-default value 3`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="-150"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldInt.test.tsx.snap
+++ b/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldInt.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ForceFieldInt component change state on click 1`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={-150}
       />
     </div>
@@ -56,7 +56,7 @@ exports[`ForceFieldInt component render default value 1`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={0}
       />
     </div>
@@ -88,7 +88,7 @@ exports[`ForceFieldInt component render default value 2`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={-0}
       />
     </div>
@@ -120,7 +120,7 @@ exports[`ForceFieldInt component render default value 3`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={150}
       />
     </div>
@@ -152,7 +152,7 @@ exports[`ForceFieldInt component render default value 4`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={-150}
       />
     </div>
@@ -184,7 +184,7 @@ exports[`ForceFieldInt component render non-default value 1`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={-0}
       />
     </div>
@@ -216,7 +216,7 @@ exports[`ForceFieldInt component render non-default value 2`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={150}
       />
     </div>
@@ -248,7 +248,7 @@ exports[`ForceFieldInt component render non-default value 3`] = `
         className="form-control"
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
-        type="text"
+        type="number"
         value={-150}
       />
     </div>

--- a/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldInt.test.tsx.snap
+++ b/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldInt.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`ForceFieldInt component change state on click 1`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="-150"
+        value={-150}
       />
     </div>
   </div>
@@ -57,7 +57,7 @@ exports[`ForceFieldInt component render default value 1`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="0"
+        value={0}
       />
     </div>
   </div>
@@ -89,7 +89,7 @@ exports[`ForceFieldInt component render default value 2`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="0"
+        value={-0}
       />
     </div>
   </div>
@@ -121,7 +121,7 @@ exports[`ForceFieldInt component render default value 3`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="150"
+        value={150}
       />
     </div>
   </div>
@@ -153,7 +153,7 @@ exports[`ForceFieldInt component render default value 4`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="-150"
+        value={-150}
       />
     </div>
   </div>
@@ -185,7 +185,7 @@ exports[`ForceFieldInt component render non-default value 1`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="0"
+        value={-0}
       />
     </div>
   </div>
@@ -217,7 +217,7 @@ exports[`ForceFieldInt component render non-default value 2`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="150"
+        value={150}
       />
     </div>
   </div>
@@ -249,7 +249,7 @@ exports[`ForceFieldInt component render non-default value 3`] = `
         data-bb-test-id="force-field-fullDummy"
         onChange={[Function]}
         type="text"
-        value="-150"
+        value={-150}
       />
     </div>
   </div>

--- a/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldString.test.tsx.snap
+++ b/www/react-base/src/components/ForceBuildModal/Fields/__snapshots__/FieldString.test.tsx.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForceFieldString component change state on click 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        autoComplete="on"
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        id="fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="stateValue"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldString component render default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        autoComplete="on"
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        id="fullDummy"
+        onChange={[Function]}
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldString component render default value 2`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        autoComplete="on"
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        id="fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="default"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ForceFieldString component render non-default value 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <div
+      popover-is-open="field.haserrors"
+      popover-title="{{field.label}}"
+      popover-trigger="none"
+      uib-popover="{{field.errors}}"
+    />
+    <label
+      className="control-label col-sm-10"
+      htmlFor="fullDummy"
+    >
+      dummyLabel
+    </label>
+    <div
+      className="col-sm-10"
+    >
+      <input
+        autoComplete="on"
+        className="form-control"
+        data-bb-test-id="force-field-fullDummy"
+        id="fullDummy"
+        onChange={[Function]}
+        type="text"
+        value="stateValue"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/www/react-base/src/components/ForceBuildModal/ForceBuildModal.tsx
+++ b/www/react-base/src/components/ForceBuildModal/ForceBuildModal.tsx
@@ -102,13 +102,7 @@ export const ForceBuildModal = observer(({scheduler, builderid, onClose}: ForceB
     for (const field of fields) {
       const value = fieldsState.getValue(field.fullName);
       if (value !== null) {
-        if (field.type === "int") {
-          params[field.fullName] = Number.parseInt(value);
-        } else if (field.type === "bool") {
-          params[field.fullName] = value === "true";
-        } else {
-          params[field.fullName] = value;
-        }
+        params[field.fullName] = value;
       }
     }
 

--- a/www/react-base/src/components/ForceBuildModal/ForceBuildModalFieldsState.tsx
+++ b/www/react-base/src/components/ForceBuildModal/ForceBuildModalFieldsState.tsx
@@ -18,15 +18,15 @@
 import {action, makeObservable, observable} from "mobx";
 
 export class ForceBuildfieldsState {
-  @observable value: string = '';
+  @observable value: any = undefined;
   @observable errors: string[] = [];
 
-  constructor(value: string) {
+  constructor(value: any) {
     makeObservable(this);
     this.setValue(value);
   }
 
-  @action setValue(value: string) {
+  @action setValue(value: any) {
     this.value = value;
   }
 
@@ -42,17 +42,17 @@ export class ForceBuildfieldsState {
 export class ForceBuildModalFieldsState {
   fields = observable.map<string, ForceBuildfieldsState>();
 
-  setupField(name: string, defaultValue: string) {
+  setupField(name: string, defaultValue: any) {
     if (!this.fields.has(name)) {
       this.createNewField(name, defaultValue);
     }
   }
 
-  @action createNewField(name: string, defaultValue: string) {
+  @action createNewField(name: string, defaultValue: any) {
     this.fields.set(name, new ForceBuildfieldsState(defaultValue));
   }
 
-  @action setValue(name: string, value: string) {
+  @action setValue(name: string, value: any) {
     const field = this.fields.get(name);
     if (field === undefined) {
       throw Error(`Field with name ${name} does not exist`)
@@ -60,7 +60,7 @@ export class ForceBuildModalFieldsState {
     field.setValue(value);
   }
 
-  getValue(name: string): string | null {
+  getValue(name: string): any | null {
     const field = this.fields.get(name);
     if (field === undefined) {
       return null;


### PR DESCRIPTION
Mainly fix `FieldChoiceString` with `multiple`.

Biggest change was to untype the value stored by `ForceBuildfieldsState` as storing everything as string would be awkward in some places and I don't think it brought much to type it.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
