### PR TITLE
util: correctly type hint async_to_deferred decorator

### DIFF
--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -24,14 +24,16 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Coroutine
+    from typing import ParamSpec
     from typing import TypeVar
 
     _T = TypeVar('_T')
+    _P = ParamSpec('_P')
 
 
-def async_to_deferred(fn: Callable[[Any, Any], Coroutine[Any, Any, _T]]):
+def async_to_deferred(fn: Callable[_P, Coroutine[Any, Any, _T]]):
     @wraps(fn)
-    def wrapper(*args, **kwargs) -> defer.Deferred[_T]:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> defer.Deferred[_T]:
         try:
             return defer.ensureDeferred(fn(*args, **kwargs))
         except Exception as e:


### PR DESCRIPTION
In #7546, I added typing to `async_to_deferred` allowing correct type of the return value.
With this change, parameters are correctly typed as well.

Ex:
Before, my IDE suggested `GitPoller._get_refs` would get `*args, **kwargs` as args.
Now, it correctly suggest it's true parameters.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
