### PR TITLE
Warn gitPoller.pollinterval deprecated

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -33,6 +33,7 @@ from buildbot.util.git import GitServiceAuth
 from buildbot.util.git import check_ssh_config
 from buildbot.util.state import StateMixin
 from buildbot.util.twisted import async_to_deferred
+from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -100,6 +101,10 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated(
+                '3.11.2',
+                'pollinterval has been deprecated: please use pollInterval'
+            )
 
         if only_tags and (branch or branches):
             config.error("GitPoller: can't specify only_tags and branch/branches")

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -23,6 +23,7 @@ from buildbot.config.master import FileLoader
 from buildbot.scripts import runner
 from buildbot.test.util import dirs
 from buildbot.test.util.warnings import assertNotProducesWarnings
+from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.warnings import DeprecatedApiWarning
 
 
@@ -43,7 +44,7 @@ class RealConfigs(dirs.DirsMixin, unittest.TestCase):
     def test_0_9_0b5_api_renamed_config(self):
         with open(self.filename, "w", encoding='utf-8') as f:
             f.write(sample_0_9_0b5_api_renamed)
-        with assertNotProducesWarnings(DeprecatedApiWarning):
+        with assertProducesWarning(DeprecatedApiWarning):
             FileLoader(self.basedir, self.filename).loadConfig()
 
 

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -33,6 +33,8 @@ from buildbot.test.util import logging
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.util.twisted import async_to_deferred
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 # Test that environment variables get propagated to subprocesses (See #2116)
 os.environ['TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'] = 'TRUE'
@@ -2191,9 +2193,12 @@ class TestGitPollerConstructor(
             )
 
     @defer.inlineCallbacks
-    def test_oldPollInterval(self):
-        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", pollinterval=10))
-        self.assertEqual(poller.pollInterval, 10)
+    def test_deprecatedPollInterval(self):
+        with assertProducesWarning(DeprecatedApiWarning, 'pollinterval has been deprecated: '
+            + 'please use pollInterval'
+        ):
+            poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", pollinterval=10))
+            self.assertEqual(poller.pollInterval, 10)
 
     @defer.inlineCallbacks
     def test_branches_default(self):


### PR DESCRIPTION
This PR fixes https://github.com/buildbot/buildbot/issues/7568.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
