### PR TITLE
Delete deprecated Endpoint.isRaw and Endpoint.isCollection

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -23,7 +23,6 @@ from twisted.internet import defer
 
 from buildbot.data import exceptions
 from buildbot.util.twisted import async_to_deferred
-from buildbot.warnings import warn_deprecated
 
 
 class EndpointKind(enum.Enum):
@@ -117,24 +116,6 @@ class Endpoint:
     def __init__(self, rtype, master):
         self.rtype = rtype
         self.master = master
-        if hasattr(self, "isRaw"):
-            warn_deprecated(
-                "3.10.0",
-                "Endpoint.isRaw has been deprecated, "
-                "please set \"kind\" attribute instead. "
-                "isRaw = True is equivalent to kind = EndpointKind.RAW",
-            )
-            if self.isRaw:
-                self.kind = EndpointKind.RAW
-        if hasattr(self, "isCollection"):
-            warn_deprecated(
-                "3.10.0",
-                "Endpoint.isCollection has been deprecated, "
-                "please set \"kind\" attribute instead. "
-                "isCollection = True is equivalent to kind = EndpointKind.COLLECTION",
-            )
-            if self.isCollection:
-                self.kind = EndpointKind.COLLECTION
 
     def get(self, resultSpec, kwargs):
         raise NotImplementedError

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -20,16 +20,13 @@ from unittest import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot.data.base import Endpoint
 from buildbot.data.base import EndpointKind
 from buildbot.data.exceptions import InvalidQueryParameter
 from buildbot.test.fake import endpoint
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
-from buildbot.warnings import DeprecatedApiWarning
 from buildbot.www import authz
 from buildbot.www import graphql
 from buildbot.www import rest
@@ -1041,25 +1038,3 @@ class ContentTypeParser(unittest.TestCase):
         self.assertEqual(
             rest.ContentTypeParser(b"text/plain; Charset=UTF-8").gettype(), "text/plain"
         )
-
-
-class EndpointKindMigrationTest(unittest.TestCase):
-    def test_is_raw(self):
-        class TestEndpoint(Endpoint):
-            isRaw = True
-
-        with assertProducesWarning(
-            DeprecatedApiWarning, message_pattern=r"Endpoint.isRaw has been deprecated"
-        ):
-            ep = TestEndpoint(mock.Mock(), mock.Mock())
-        self.assertEqual(ep.kind, EndpointKind.RAW)
-
-    def test_is_collection(self):
-        class TestEndpoint(Endpoint):
-            isCollection = True
-
-        with assertProducesWarning(
-            DeprecatedApiWarning, message_pattern=r"Endpoint.isCollection has been deprecated"
-        ):
-            ep = TestEndpoint(mock.Mock(), mock.Mock())
-        self.assertEqual(ep.kind, EndpointKind.COLLECTION)

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -370,22 +370,6 @@ See that module's description for details.
                     "mime-type": "<mime-type>"
                 }
 
-    .. py:attribute:: isCollection
-
-        :type: boolean
-
-        If true, then this endpoint returns collections of resources.
-
-        This attribute is deprecated, use ``kind`` attribute instead.
-
-    .. py:attribute:: isRaw
-
-        :type: boolean
-
-        If true, then this endpoint returns a raw resource.
-
-        This attribute is deprecated, use ``kind`` attribute instead.
-
     .. py:method:: get(options, resultSpec, kwargs)
 
         :param dict options: model-specific options


### PR DESCRIPTION
This PR removes usages of deprecated Endpoint.isRaw and Endpoint.isCollection. PR is a partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
