### PR TITLE
Delete deprecated Worker.setWorkerState()

### DIFF
--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -20,7 +20,6 @@ from buildbot.data import base
 from buildbot.data import exceptions
 from buildbot.data import types
 from buildbot.util import identifiers
-from buildbot.warnings import warn_deprecated
 
 
 class Db2DataMixin:
@@ -170,19 +169,6 @@ class Worker(base.ResourceType):
         bs['last_connection'] = last_connection
         bs['notify'] = notify
         self.produceEvent(bs, 'missing')
-
-    @base.updateMethod
-    @defer.inlineCallbacks
-    def setWorkerState(self, workerid, paused, graceful):
-        warn_deprecated(
-            "3.10.0",
-            "setWorkerState() has been deprecated, "
-            "please use set_worker_paused() and/or set_worker_graceful()",
-        )
-        yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
-        yield self.master.db.workers.set_worker_graceful(workerid=workerid, graceful=graceful)
-        bs = yield self.master.data.get(('workers', workerid))
-        self.produceEvent(bs, 'state_updated')
 
     @base.updateMethod
     @defer.inlineCallbacks

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -470,11 +470,6 @@ class FakeUpdates(service.AsyncService):
     def schedulerEnable(self, schedulerid, v):
         return self.master.db.schedulers.enable(schedulerid, v)
 
-    @defer.inlineCallbacks
-    def setWorkerState(self, workerid, paused, graceful):
-        yield self.master.db.workers.set_worker_paused(workerid=workerid, paused=paused)
-        yield self.master.db.workers.set_worker_graceful(workerid=workerid, graceful=graceful)
-
     def set_worker_paused(self, workerid, paused, pause_reason=None):
         return self.master.db.workers.set_worker_paused(workerid, paused, pause_reason=pause_reason)
 

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -176,14 +176,6 @@ class WorkerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(worker, None)
 
     @defer.inlineCallbacks
-    def test_setWorkerState(self):
-        yield self.master.data.updates.setWorkerState(2, True, False)
-        worker = yield self.callGet(('workers', 2))
-        self.validateData(worker)
-        self.assertEqual(worker['paused'], True)
-        self.assertEqual(worker['graceful'], False)
-
-    @defer.inlineCallbacks
     def test_set_worker_paused(self):
         yield self.master.data.updates.set_worker_paused(2, True, "reason")
         worker = yield self.callGet(('workers', 2))

--- a/master/docs/developer/database/workers.rst
+++ b/master/docs/developer/database/workers.rst
@@ -93,16 +93,6 @@ Workers connector
         Unregister all the workers configured to a master for given builders.
         This shall happen when master is disabled or before reconfiguration.
 
-    .. py:method:: setWorkerState(workerid, paused, graceful)
-
-        :param integer workerid: the ID of the worker whose state is being changed
-        :param integer paused: the paused state
-        :param integer graceful: the graceful state
-        :returns: Deferred
-
-        Change the state of a worker (see definition of states above in worker dict description).
-
-        This method is deprecated.
 
     .. py:method:: set_worker_paused(workerid, paused, pause_reason=None)
 


### PR DESCRIPTION
This PR removes usages of deprecated Worker.setWorkerState(). PR is a partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
