### PR TITLE
Delete deprecated MessageFormatterBase props

### DIFF
--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -182,7 +182,6 @@ class MessageFormatterBase(util.ComparableMixin):
         self,
         ctx=None,
         want_properties=True,
-        wantProperties=None,
         want_steps=False,
         wantSteps=None,
         wantLogs=None,
@@ -192,15 +191,7 @@ class MessageFormatterBase(util.ComparableMixin):
         if ctx is None:
             ctx = {}
         self.context = ctx
-        if wantProperties is not None:
-            warn_deprecated(
-                '3.4.0',
-                f'{self.__class__.__name__}: wantProperties has been '
-                'deprecated, use want_properties',
-            )
-            self.want_properties = wantProperties
-        else:
-            self.want_properties = want_properties
+        self.want_properties = want_properties
         if wantSteps is not None:
             warn_deprecated(
                 '3.4.0',

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -183,7 +183,6 @@ class MessageFormatterBase(util.ComparableMixin):
         ctx=None,
         want_properties=True,
         want_steps=False,
-        wantSteps=None,
         wantLogs=None,
         want_logs=False,
         want_logs_content=False,
@@ -192,14 +191,7 @@ class MessageFormatterBase(util.ComparableMixin):
             ctx = {}
         self.context = ctx
         self.want_properties = want_properties
-        if wantSteps is not None:
-            warn_deprecated(
-                '3.4.0',
-                f'{self.__class__.__name__}: wantSteps has been deprecated, ' + 'use want_steps',
-            )
-            self.want_steps = wantSteps
-        else:
-            self.want_steps = want_steps
+        self.want_steps = want_steps
         if wantLogs is not None:
             warn_deprecated(
                 '3.4.0',

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -30,7 +30,6 @@ from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
-from buildbot.warnings import warn_deprecated
 
 
 def get_detected_status_text(mode, results, previous_results):
@@ -183,7 +182,6 @@ class MessageFormatterBase(util.ComparableMixin):
         ctx=None,
         want_properties=True,
         want_steps=False,
-        wantLogs=None,
         want_logs=False,
         want_logs_content=False,
     ):
@@ -192,17 +190,8 @@ class MessageFormatterBase(util.ComparableMixin):
         self.context = ctx
         self.want_properties = want_properties
         self.want_steps = want_steps
-        if wantLogs is not None:
-            warn_deprecated(
-                '3.4.0',
-                f'{self.__class__.__name__}: wantLogs has been deprecated, '
-                + 'use want_logs and want_logs_content',
-            )
-        else:
-            wantLogs = False
-
-        self.want_logs = want_logs or wantLogs
-        self.want_logs_content = want_logs_content or wantLogs
+        self.want_logs = want_logs
+        self.want_logs_content = want_logs_content
 
     def buildAdditionalContext(self, master, ctx):
         pass

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -284,11 +284,6 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
 
 
 class TestMessageFormatter(MessageFormatterTestBase):
-    def test_want_properties_deprecated(self):
-        with assertProducesWarning(DeprecatedApiWarning, "wantProperties has been deprecated"):
-            formatter = message.MessageFormatter(wantProperties=True)
-        self.assertEqual(formatter.want_properties, True)
-
     def test_want_steps_deprecated(self):
         with assertProducesWarning(DeprecatedApiWarning, "wantSteps has been deprecated"):
             formatter = message.MessageFormatter(wantSteps=True)

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -34,8 +34,6 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.misc import BuildDictLookAlike
-from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestMessageFormatting(unittest.TestCase):
@@ -284,13 +282,6 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
 
 
 class TestMessageFormatter(MessageFormatterTestBase):
-
-    def test_want_logs_deprecated(self):
-        with assertProducesWarning(DeprecatedApiWarning, "wantLogs has been deprecated"):
-            formatter = message.MessageFormatter(wantLogs=True)
-        self.assertEqual(formatter.want_logs, True)
-        self.assertEqual(formatter.want_logs_content, True)
-
     def test_unknown_template_type_for_default_message(self):
         with self.assertRaises(config.ConfigErrors):
             message.MessageFormatter(template_type='unknown')

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -284,10 +284,6 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
 
 
 class TestMessageFormatter(MessageFormatterTestBase):
-    def test_want_steps_deprecated(self):
-        with assertProducesWarning(DeprecatedApiWarning, "wantSteps has been deprecated"):
-            formatter = message.MessageFormatter(wantSteps=True)
-        self.assertEqual(formatter.want_steps, True)
 
     def test_want_logs_deprecated(self):
         with assertProducesWarning(DeprecatedApiWarning, "wantLogs has been deprecated"):

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -43,9 +43,6 @@ The constructor of the class takes the following arguments:
 ``want_properties``
     This parameter (defaults to True) will extend the content of the given ``build`` object with the Properties from the build.
 
-``wantProperties``
-    Deprecated, use ``want_properties`` set to the same value.
-
 ``want_steps``
     This parameter (defaults to False) will extend the content of the given ``build`` object with information about the steps of the build.
     Use it only when necessary as this increases the overhead in terms of CPU and memory on the master.

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -47,9 +47,6 @@ The constructor of the class takes the following arguments:
     This parameter (defaults to False) will extend the content of the given ``build`` object with information about the steps of the build.
     Use it only when necessary as this increases the overhead in terms of CPU and memory on the master.
 
-``wantSteps``
-    Deprecated, use ``want_steps`` set to the same value.
-
 ``wantLogs``
     Deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
 

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -47,9 +47,6 @@ The constructor of the class takes the following arguments:
     This parameter (defaults to False) will extend the content of the given ``build`` object with information about the steps of the build.
     Use it only when necessary as this increases the overhead in terms of CPU and memory on the master.
 
-``wantLogs``
-    Deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
-
 ``want_logs``
     This parameter (defaults to False) will extend the content of the steps of the given ``build`` object with the log metadata of each steps from the build.
     This implies ``wantSteps`` to be `True`.

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -10,7 +10,7 @@ This formatter can be used to generate arbitrary messages bodies according to ar
 As opposed to :ref:`MessageFormatterRenderable`, more information is made available to this reporter.
 As opposed to :ref:`MessageFormatterFunctionRaw`, only the message body can be customized.
 
-.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, want_steps=False, wantLogs=None, want_logs=False, want_logs_content=False)
+.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, want_steps=False, want_logs=False, want_logs_content=False)
 
     :param callable function: A callable that will be called with a dictionary.
 

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -10,7 +10,7 @@ This formatter can be used to generate arbitrary messages bodies according to ar
 As opposed to :ref:`MessageFormatterRenderable`, more information is made available to this reporter.
 As opposed to :ref:`MessageFormatterFunctionRaw`, only the message body can be customized.
 
-.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, want_steps=False, wantSteps=None, wantLogs=None, want_logs=False, want_logs_content=False)
+.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, want_steps=False, wantLogs=None, want_logs=False, want_logs_content=False)
 
     :param callable function: A callable that will be called with a dictionary.
 
@@ -27,7 +27,6 @@ As opposed to :ref:`MessageFormatterFunctionRaw`, only the message body can be c
         JSON output must not be encoded.
     :param boolean want_properties: include 'properties' in the build dictionary
     :param boolean want_steps: include 'steps' in the build dictionary
-    :param boolean wantSteps: deprecated, use ``want_steps`` instead
     :param boolean wantLogs: deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.
     :param boolean want_logs: include 'logs' in the steps dictionaries.
         This implies `wantSteps=True`.

--- a/master/docs/manual/configuration/report_generators/formatter_function.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_function.rst
@@ -10,7 +10,7 @@ This formatter can be used to generate arbitrary messages bodies according to ar
 As opposed to :ref:`MessageFormatterRenderable`, more information is made available to this reporter.
 As opposed to :ref:`MessageFormatterFunctionRaw`, only the message body can be customized.
 
-.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, wantProperties=None, want_steps=False, wantSteps=None, wantLogs=None, want_logs=False, want_logs_content=False)
+.. py:class:: MessageFormatterFunction(function, template_type, want_properties=True, want_steps=False, wantSteps=None, wantLogs=None, want_logs=False, want_logs_content=False)
 
     :param callable function: A callable that will be called with a dictionary.
 
@@ -26,7 +26,6 @@ As opposed to :ref:`MessageFormatterFunctionRaw`, only the message body can be c
     :param string template_type: either ``plain``, ``html`` or ``json`` depending on the output of the formatter.
         JSON output must not be encoded.
     :param boolean want_properties: include 'properties' in the build dictionary
-    :param boolean wantProperties: deprecated, use ``want_properties`` instead
     :param boolean want_steps: include 'steps' in the build dictionary
     :param boolean wantSteps: deprecated, use ``want_steps`` instead
     :param boolean wantLogs: deprecated, use ``want_logs`` and ``want_logs_content`` set to the same value.

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -9,7 +9,7 @@ This formatter is used to format messages in :ref:`Reportgen-WorkerMissingGenera
 
 It formats a message using the Jinja2_ templating language and picks the template either from a string or from a file.
 
-The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``wantProperties``, ``want_properties``, ``wantSteps``, ``want_steps``.
+The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``want_properties``, ``wantSteps``, ``want_steps``.
 
 ``template``
     The content of the template used to generate the body of the mail as string.

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -9,7 +9,7 @@ This formatter is used to format messages in :ref:`Reportgen-WorkerMissingGenera
 
 It formats a message using the Jinja2_ templating language and picks the template either from a string or from a file.
 
-The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``want_properties``, ``want_steps``.
+The constructor to that class takes the same arguments as MessageFormatter, minus ``want_logs``, ``want_logs_content``, ``want_properties``, ``want_steps``.
 
 ``template``
     The content of the template used to generate the body of the mail as string.

--- a/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_missing_worker.rst
@@ -9,7 +9,7 @@ This formatter is used to format messages in :ref:`Reportgen-WorkerMissingGenera
 
 It formats a message using the Jinja2_ templating language and picks the template either from a string or from a file.
 
-The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``want_properties``, ``wantSteps``, ``want_steps``.
+The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``want_logs``, ``want_logs_content``, ``want_properties``, ``want_steps``.
 
 ``template``
     The content of the template used to generate the body of the mail as string.


### PR DESCRIPTION
This PR removes usages of deprecated MessageFormatterBase props (wantProperties, wantSteps, wantLogs).
PR is partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
