### PR TITLE
Delete deprecated LibVirtWorker `connection` argument

### DIFF
--- a/master/buildbot/test/unit/worker/test_libvirt.py
+++ b/master/buildbot/test/unit/worker/test_libvirt.py
@@ -26,8 +26,6 @@ from buildbot.test.fake import libvirt as libvirtfake
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
-from buildbot.test.util.warnings import assertProducesWarnings
-from buildbot.warnings import DeprecatedApiWarning
 from buildbot.worker import libvirt as libvirtworker
 
 
@@ -100,21 +98,6 @@ class TestLibVirtWorker(TestReactorMixin, MasterRunProcessMixin, unittest.TestCa
         self.patch(libvirtworker, "libvirt", None)
         with self.assertRaises(config.ConfigErrors):
             self.create_worker('bot', 'pass', None, 'path', 'path')
-
-    def test_deprecated_connection(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning, message_pattern='connection argument has been deprecated'
-        ):
-            self.create_worker('bot', 'pass', libvirtworker.Connection('test'), 'path', 'path')
-
-    def test_deprecated_connection_and_uri(self):
-        with self.assertRaises(config.ConfigErrors):
-            with assertProducesWarnings(
-                DeprecatedApiWarning, message_pattern='connection argument has been deprecated'
-            ):
-                self.create_worker(
-                    'bot', 'pass', libvirtworker.Connection('test'), 'path', 'path', uri='custom'
-                )
 
     @defer.inlineCallbacks
     def test_get_domain_id(self):

--- a/master/buildbot/worker/libvirt.py
+++ b/master/buildbot/worker/libvirt.py
@@ -24,7 +24,6 @@ from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.util import runprocess
 from buildbot.util.queue import ConnectableThreadQueue
-from buildbot.warnings import warn_deprecated
 from buildbot.worker import AbstractLatentWorker
 
 try:
@@ -128,7 +127,6 @@ class LibVirtWorker(AbstractLatentWorker):
         self,
         name,
         password,
-        connection=None,
         hd_image=None,
         base_image=None,
         uri="system:///",
@@ -139,15 +137,6 @@ class LibVirtWorker(AbstractLatentWorker):
         super().__init__(name, password, **kwargs)
         if not libvirt:
             config.error("The python module 'libvirt' is needed to use a LibVirtWorker")
-
-        if connection is not None:
-            warn_deprecated(
-                '3.2.0',
-                'LibVirtWorker connection argument has been deprecated: ' + 'please use uri',
-            )
-            if uri != "system:///":
-                config.error('connection and uri arguments cannot be used together')
-            uri = connection.uri
 
         self.uri = uri
         self.image = hd_image

--- a/master/docs/manual/configuration/workers-libvirt.rst
+++ b/master/docs/manual/configuration/workers-libvirt.rst
@@ -100,9 +100,6 @@ If you don't, buildbot won't be able to find a VM to start.
 ``password``
     A password for the buildbot to login to the master with.
 
-``connection``
-    :class:`Connection` instance wrapping connection to libvirt. (deprecated, use ``uri``).
-
 ``hd_image``
     The path to a libvirt disk image, normally in qcow2 format when using KVM.
 


### PR DESCRIPTION
This PR removes usages of deprecated LibVirtWorker `connection` argument.
PR is partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [ not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
