### PR TITLE
Delete deprecated isNewStyle()

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -740,10 +740,6 @@ class BuildStep(
     def run(self):
         raise NotImplementedError("A custom build step must implement run()")
 
-    def isNewStyle(self):
-        warn_deprecated('3.0.0', 'BuildStep.isNewStyle() always returns True')
-        return True
-
     @defer.inlineCallbacks
     def _maybe_interrupt_cmd(self, reason):
         if not self.cmd:


### PR DESCRIPTION
This PR removes deprecated isNewStyle(). This function is not used anywhere.
PR is partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
