### PR TITLE
Delete deprecated BuildStatusGenerator `subject` parameter

### DIFF
--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -20,7 +20,6 @@ from buildbot import interfaces
 from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterRenderable
-from buildbot.warnings import warn_deprecated
 
 from .utils import BuildStatusGeneratorMixin
 
@@ -40,21 +39,12 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
         builders=None,
         schedulers=None,
         branches=None,
-        subject=None,
         add_logs=False,
         add_patch=False,
         report_new=False,
         message_formatter=None,
     ):
-        if subject is not None:
-            warn_deprecated(
-                '3.5.0',
-                'BuildStatusGenerator subject parameter has been '
-                + 'deprecated: please configure subject in the message formatter',
-            )
-        else:
-            subject = "Buildbot %(result)s in %(title)s on %(builder)s"
-
+        subject = "Buildbot %(result)s in %(title)s on %(builder)s"
         super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch)
         self.formatter = message_formatter
         if self.formatter is None:

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -20,7 +20,6 @@ from buildbot import interfaces
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatter
-from buildbot.warnings import warn_deprecated
 
 from .utils import BuildStatusGeneratorMixin
 
@@ -45,15 +44,7 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
         add_patch=False,
         message_formatter=None,
     ):
-        if subject is not None:
-            warn_deprecated(
-                '3.5.0',
-                'BuildSetStatusGenerator subject parameter has been '
-                + 'deprecated: please configure subject in the message formatter',
-            )
-        else:
-            subject = "Buildbot %(result)s in %(title)s on %(builder)s"
-
+        subject = "Buildbot %(result)s in %(title)s on %(builder)s"
         super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch)
         self.formatter = message_formatter
         if self.formatter is None:

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -28,8 +28,6 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.reporter import ReporterTestMixin
-from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
@@ -131,11 +129,6 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase,
                 'logs': [],
             },
         )
-
-    @defer.inlineCallbacks
-    def test_build_subject_deprecated(self):
-        with assertProducesWarning(DeprecatedApiWarning, "subject parameter"):
-            yield self.setup_generator(subject='subject')
 
     @defer.inlineCallbacks
     def test_build_message_no_result_formatter_no_subject(self):

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -27,8 +27,6 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.reporter import ReporterTestMixin
-from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestBuildSetGeneratorBase(
@@ -150,11 +148,6 @@ class TestBuildSetGenerator(TestBuildSetGeneratorBase):
                 'logs': [],
             },
         )
-
-    @defer.inlineCallbacks
-    def test_buildset_subject_deprecated(self):
-        with assertProducesWarning(DeprecatedApiWarning, "subject parameter"):
-            yield self.setup_generator(subject='subject')
 
     @defer.inlineCallbacks
     def test_buildset_message_no_result_formatter_no_subject(self):


### PR DESCRIPTION
This PR removes usages of deprecated BuildStatusGenerator `subject` parameter.
PR is partially addressing https://github.com/buildbot/buildbot/issues/7567.


* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
