### PR TITLE
Gitpoller: track remote default branch

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1435,6 +1435,7 @@ svnversion
 sw
 swartz
 symlink
+symref
 syncallbranches
 syncmail
 syncQuietly

--- a/master/buildbot/test/unit/util/test_git.py
+++ b/master/buildbot/test/unit/util/test_git.py
@@ -112,6 +112,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertFalse(self.supportsSubmoduleCheckout)
         self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
         self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
+        self.assertFalse(self.supports_lsremote_symref)
 
     def test_git_noversion(self):
         self.parseGitFeatures('git')
@@ -121,6 +122,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertFalse(self.supportsSubmoduleCheckout)
         self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
         self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
+        self.assertFalse(self.supports_lsremote_symref)
 
     def test_git_zero_version(self):
         self.parseGitFeatures('git version 0.0.0')
@@ -130,6 +132,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertFalse(self.supportsSubmoduleCheckout)
         self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
         self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
+        self.assertFalse(self.supports_lsremote_symref)
 
     def test_git_2_10_0(self):
         self.parseGitFeatures('git version 2.10.0')
@@ -139,6 +142,7 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertTrue(self.supportsSubmoduleCheckout)
         self.assertTrue(self.supportsSshPrivateKeyAsEnvOption)
         self.assertTrue(self.supportsSshPrivateKeyAsConfigOption)
+        self.assertTrue(self.supports_lsremote_symref)
 
 
 class TestAdjustCommandParamsForSshPrivateKey(GitMixin, unittest.TestCase):

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -88,6 +88,7 @@ class GitMixin:
         self.supportsSshPrivateKeyAsEnvOption = False
         self.supportsSshPrivateKeyAsConfigOption = False
         self.supportsFilters = False
+        self.supports_lsremote_symref = False
 
     def parseGitFeatures(self, version_stdout):
         match = re.match(r"^git version (\d+(\.\d+)*)", version_stdout)
@@ -107,6 +108,9 @@ class GitMixin:
             self.supportsSubmoduleCheckout = True
         if version >= parse_version("2.3.0"):
             self.supportsSshPrivateKeyAsEnvOption = True
+        if version >= parse_version("2.8.0"):
+            # https://github.com/git/git/blob/v2.8.0/Documentation/RelNotes/2.8.0.txt#L72-L73
+            self.supports_lsremote_symref = True
         if version >= parse_version("2.10.0"):
             self.supportsSshPrivateKeyAsConfigOption = True
         if version >= parse_version("2.27.0"):

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -885,6 +885,8 @@ It accepts the following arguments:
     * a callable which takes a single argument.
       It should take a remote refspec (such as ``'refs/heads/master'``), and return a boolean indicating whether that branch should be fetched.
 
+    If not provided, :bb:chsrc:`GitPoller` will use ``HEAD`` to fetch the remote default branch.
+
 ``branch``
     Accepts a single branch name to fetch.
     Exists for backwards compatibility with old configurations.

--- a/newsfragments/gitpoller-default-branch.change
+++ b/newsfragments/gitpoller-default-branch.change
@@ -1,0 +1,1 @@
+``GitPoller`` no longer track the ``master`` branch when not provided ``branch`` nor ``branches``. It now track the remote's default branch.


### PR DESCRIPTION
`GitPoller` `branches` would default to `[master]` is not provided.

Now, `GitPoller` will use `HEAD` to track the branch set as default by the remote.

I believe this closes #2848

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
