### PR TITLE
test: fix assertArgSpecMatches

### DIFF
--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -37,9 +37,6 @@ class InterfaceTests:
         """
 
         def filter(signature: inspect.Signature):
-            if len(signature.parameters) == 0:
-                return signature
-
             parameters = OrderedDict(signature.parameters)
             for name in parameters:
                 if name == 'self':


### PR DESCRIPTION
If a method did not have parameters but the return was typed, `filter` would early out and not remove the return type from the signature.