### PR TITLE
smokes: improve pendingbuildrequests test

### DIFF
--- a/smokes-react/master.cfg
+++ b/smokes-react/master.cfg
@@ -9,7 +9,10 @@ c = BuildmasterConfig = {}
 
 ####### WORKERS
 
-c['workers'] = [worker.Worker("example-worker", "pass")]
+c['workers'] = [
+  worker.Worker("example-worker", "pass"),
+  worker.Worker("shutdown-worker", "pass"),
+]
 c['protocols'] = {'pb': {'port': 9989}}
 
 
@@ -19,7 +22,7 @@ c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
         'https://github.com/buildbot/hello-world.git',  # the buildbot clone of pyflakes
         workdir='gitpoller-workdir', branch='master',
-        pollinterval=300))
+        pollInterval=300))
 
 ####### SCHEDULERS
 
@@ -60,6 +63,10 @@ c['schedulers'].append(schedulers.ForceScheduler(
             label="Name of the Build release.",
             default="")]))
 
+c['schedulers'].append(schedulers.ForceScheduler(
+                            name="force-neverruntests",
+                            builderNames=["neverruntests"]))
+
 ####### BUILDERS
 
 factory = util.BuildFactory()
@@ -87,6 +94,11 @@ c['builders'].append(
                        tags=['slow', 'runt'],
                        workernames=["example-worker"],
                        factory=slowfactory))
+c['builders'].append(
+    util.BuilderConfig(name="neverruntests",
+                       tags=['slow', 'runt', 'never'],
+                       workernames=["shutdown-worker"],
+                       factory=factory))
 
 for i in range(NUM_BUILDERS):
     c['builders'].append(

--- a/smokes-react/tests/pendingbuildrequests.spec.ts
+++ b/smokes-react/tests/pendingbuildrequests.spec.ts
@@ -27,14 +27,11 @@ test.describe('pending build requests', function() {
   });
 
   test('shows', async ({page}) => {
+    const testBuildername = "neverruntests";
     await BuilderPage.gotoBuildersList(page);
-    await BuilderPage.gotoForce(page, "slowruntests", "force");
-    await ForcePage.clickStartButtonAndWait(page);
-    await BuilderPage.gotoForce(page, "slowruntests", "force");
+    await BuilderPage.gotoForce(page, testBuildername, "force-neverruntests");
     await ForcePage.clickStartButtonAndWait(page);
 
-    // hopefully we'll see at least one buildrequest by the time we get to
-    // the pending build requests page
     await PendingBuildrequestsPage.goto(page);
 
     await expect.poll(async () => {
@@ -43,12 +40,12 @@ test.describe('pending build requests', function() {
       message: "found at least one buildrequest"
     }).toBeGreaterThan(0);
 
-    const br = await PendingBuildrequestsPage.getAllBuildrequestRows(page).first();
+    const br = PendingBuildrequestsPage.getAllBuildrequestRows(page).first();
     await expect.poll(async () => {
       return (await br.locator('td').nth(1).locator('a').textContent());
     }, {
       message: "found at least one buildrequest with correct name"
-    }).toMatch('slowruntests');
+    }).toMatch(testBuildername);
 
     // kill remaining builds
     let gotAlert = false;
@@ -57,7 +54,7 @@ test.describe('pending build requests', function() {
       await dialog.accept()
     });
 
-    await BuilderPage.goto(page, "slowruntests");
+    await BuilderPage.goto(page, testBuildername);
     await ForcePage.clickCancelWholeQueue(page);
     await expect.poll(() => gotAlert, {
       message: "found confirmation alert"


### PR DESCRIPTION
Add a new Builder neverruntests assigned to an offline worker to be sure we can see the build request before it's claimed.

Fixes #5125

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
