### PR TITLE
Add missing warn_deprecated for *.pollinterval

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -167,6 +167,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         if name is None:
             name = repourl

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -25,6 +25,7 @@ from buildbot.util import bytes2unicode
 from buildbot.util import deferredLocked
 from buildbot.util import runprocess
 from buildbot.util.state import StateMixin
+from buildbot.warnings import warn_deprecated
 
 
 class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
@@ -82,6 +83,7 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         if branch and branches:
             config.error("HgPoller: can't specify both branch and branches")
@@ -126,6 +128,7 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         self.repourl = repourl
 

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -32,6 +32,7 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
+from buildbot.warnings import warn_deprecated
 
 debug_logging = False
 
@@ -159,6 +160,7 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         name = self.build_name(name, p4port, p4base)
 
@@ -209,6 +211,7 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         name = self.build_name(name, p4port, p4base)
 

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -27,6 +27,7 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
+from buildbot.warnings import warn_deprecated
 
 # these split_file_* functions are available for use as values to the
 # split_file= argument.
@@ -121,6 +122,7 @@ class SVNPoller(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         if name is None:
             name = repourl
@@ -157,6 +159,7 @@ class SVNPoller(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
+            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
 
         if name is None:
             name = repourl

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -30,7 +30,7 @@ from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import config
 from buildbot.test.util import logging
-from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.util.twisted import async_to_deferred
@@ -2193,9 +2193,11 @@ class TestGitPollerConstructor(
             )
 
     @defer.inlineCallbacks
-    def test_deprecatedPollInterval(self):
-        with assertProducesWarning(
-            DeprecatedApiWarning, 'pollinterval has been deprecated: ' + 'please use pollInterval'
+    def test_deprecated_pollinterval(self):
+        with assertProducesWarnings(
+            DeprecatedApiWarning,
+            2,
+            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
         ):
             poller = yield self.attachChangeSource(
                 gitpoller.GitPoller("/tmp/git.git", pollinterval=10)

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -23,6 +23,8 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 ENVIRON_2116_KEY = 'TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'
 LINESEP_BYTES = os.linesep.encode("ascii")
@@ -460,3 +462,40 @@ class HgPollerNoTimestamp(TestHgPoller):
     """Test HgPoller() without parsing revision commit timestamp"""
 
     usetimestamps = False
+
+
+class TestHgPollerPollIntervalDeprecated(
+    MasterRunProcessMixin, changesource.ChangeSourceMixin, TestReactorMixin, unittest.TestCase
+):
+    usetimestamps = True
+    branches = None
+    bookmarks = None
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setup_test_reactor()
+        self.setup_master_run_process()
+        yield self.setUpChangeSource()
+        self.remote_repo = 'ssh://example.com/foo/baz'
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+        yield self.tearDownChangeSource()
+
+    @defer.inlineCallbacks
+    def test_deprecatedPollInterval(self):
+        with assertProducesWarning(
+            DeprecatedApiWarning,
+            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
+        ):
+            self.poller = hgpoller.HgPoller(
+                self.remote_repo,
+                usetimestamps=self.usetimestamps,
+                workdir='/some/dir',
+                branches=self.branches,
+                bookmarks=self.bookmarks,
+                revlink=lambda branch, revision: self.remote_hgweb.format(revision),
+                pollinterval=10,
+            )
+            yield self.master.startService()

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -546,6 +546,23 @@ class TestP4Poller(
         with self.assertRaisesConfigError("You need to provide a valid callable for resolvewho"):
             P4Source(resolvewho=None)
 
+    @defer.inlineCallbacks
+    def test_deprecated_pollinterval(self):
+        with assertProducesWarnings(
+            DeprecatedApiWarning,
+            2,
+            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
+        ):
+            yield self.attachChangeSource(
+                P4Source(
+                    p4port=None,
+                    p4user=None,
+                    p4base='//depot/myproject/',
+                    split_file=lambda x: x.split('/', 1),
+                    pollinterval=10,
+                )
+            )
+
 
 class TestSplit(unittest.TestCase):
     def test_get_simple_split(self):

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -30,7 +30,9 @@ from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import config
+from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import datetime2epoch
+from buildbot.warnings import DeprecatedApiWarning
 
 first_p4changes = b"""Change 1 on 2006/04/13 by slamb@testclient 'first rev'
 """

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -26,6 +26,8 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 # this is the output of "svn info --xml
 # svn+ssh://svn.twistedmatrix.com/svn/Twisted/trunk"
@@ -662,7 +664,15 @@ class TestSVNPoller(
         self.assertEqual(len(self.flushLoggedErrors(ValueError)), 1)
 
     def test_constructor_pollinterval(self):
-        return self.attachSVNPoller(sample_base, pollinterval=100)  # just don't fail!
+        return self.attachSVNPoller(sample_base, pollInterval=100)  # just don't fail!
+
+    def test_deprecated_pollinterval(self):
+        with assertProducesWarnings(
+            DeprecatedApiWarning,
+            2,
+            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
+        ):
+            return self.attachSVNPoller(sample_base, pollinterval=100)
 
     @defer.inlineCallbacks
     def test_extra_args(self):


### PR DESCRIPTION
This PR fixes https://github.com/buildbot/buildbot/issues/7589.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
