### PR TITLE
react-base: Improve BuildView 'Rebuild' topbar action

### DIFF
--- a/newsfragments/react-base-BuildView-improve-rebuild-ui.feature
+++ b/newsfragments/react-base-BuildView-improve-rebuild-ui.feature
@@ -1,0 +1,1 @@
+The Rebuild button on a Build's view now redirect to the Buildrequest corresponding to the latest rebuild.

--- a/www/react-base/src/views/BuildView/BuildView.tsx
+++ b/www/react-base/src/views/BuildView/BuildView.tsx
@@ -20,7 +20,7 @@ import {observer} from "mobx-react";
 import {FaSpinner} from "react-icons/fa";
 import {AlertNotification} from "../../components/AlertNotification/AlertNotification";
 import {useEffect, useState} from "react";
-import {Link, useNavigate, useParams} from "react-router-dom";
+import {Link, NavigateFunction, useNavigate, useParams} from "react-router-dom";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
 import {
   Build,
@@ -62,19 +62,35 @@ import {Tab, Table, Tabs} from "react-bootstrap";
 import {buildTopbarItemsForBuilder} from "../../util/TopbarUtils";
 import {BuildViewDebugTab} from "./BuildViewDebugTab";
 
-const buildTopbarActions = (build: Build | null, isRebuilding: boolean, isStopping: boolean,
-                            doRebuild: () => void, doStop: () => void) => {
+const buildTopbarActions = (
+  build: Build | null,
+  isRebuilding: boolean, rebuiltBuildRequest: Buildrequest | null,
+  isStopping: boolean,
+  doRebuild: () => void, doStop: () => void,
+  navigate: NavigateFunction,
+) => {
   const actions: TopbarAction[] = [];
   if (build === null) {
     return actions;
   }
 
   if (build.complete) {
-    if (isRebuilding) {
+    if (rebuiltBuildRequest !== null) {
+      const caption = rebuiltBuildRequest.complete ? "Rebuilt" : (rebuiltBuildRequest.claimed ? "Rebuilding..." : "Rebuild pending");
+      actions.push({
+        caption: caption,
+        icon: (rebuiltBuildRequest.complete ? undefined : <FaSpinner />),
+        action: () => {
+          navigate(`/buildrequests/${rebuiltBuildRequest.id}?redirect_to_build=true`);
+        }
+      })
+    }
+    else if (isRebuilding) {
       actions.push({
         caption: "Rebuilding...",
-        icon: <FaSpinner/>,
-        action: doRebuild
+        icon: <FaSpinner />,
+        // do nothing, wait for 'rebuiltBuildRequest'
+        action: () => { },
       });
     } else {
       actions.push({
@@ -172,11 +188,49 @@ const BuildView = observer(() => {
       : Project.getAll(accessor, {id: builder.projectid.toString()})
   }));
 
-  const buildrequest = buildrequestsQuery.getNthOrNull(0);
   const buildset = buildsetsQuery.getNthOrNull(0);
+
+  // Get rebuilt Build if it exists
+  const rebuiltBuildsetQuery = useDataApiDynamicQuery(
+    [buildset ?? build],
+    () => {
+      const rebuilt_buildid = buildset?.rebuilt_buildid ?? build?.buildid;
+      if (rebuilt_buildid === undefined) {
+        return new DataCollection<Buildset>();
+      }
+      return Buildset.getAll(
+      accessor,
+        {
+          query: {
+            rebuilt_buildid: rebuilt_buildid,
+            // don't query the same buildset, use gt as we only want newests
+            bsid__gt: buildset !== null ? buildset.bsid : null,
+            // only get the most recent one
+            // NOTE: this will navigate straight to the newest rebuild
+            // we can flip the 'order' here to go to the first rebuild
+            limit: 1, order: '-bsid',
+          }
+        }
+      );
+    }
+  );
+  const rebuiltBuildRequestQuery = useDataApiSingleElementQuery(
+    rebuiltBuildsetQuery.getNthOrNull(0),
+    (bs: Buildset) => Buildrequest.getAll(
+      accessor, {
+      query: {
+        buildsetid: bs.bsid,
+        // newest only
+        limit: 1, order: '-buildsetid',
+      }
+    })
+  );
+
+  const buildrequest = buildrequestsQuery.getNthOrNull(0);
   const parentBuild = parentBuildQuery.getNthOrNull(0);
   const worker = workersQuery.getNthOrNull(0);
   const project = projectsQuery.getNthOrNull(0);
+  const rebuiltBuildRequest = rebuiltBuildRequestQuery.getNthOrNull(0);
 
   useEffect(() => {
     // note that in case buildsQuery.array was updated, we have to recalculate build value
@@ -222,7 +276,7 @@ const BuildView = observer(() => {
     {caption: buildnumber.toString(), route: `/builders/${builderid}/builds/${buildnumber}`}
   ]));
 
-  const actions = buildTopbarActions(build, isRebuilding, isStopping, doRebuild, doStop);
+  const actions = buildTopbarActions(build, isRebuilding, rebuiltBuildRequest, isStopping, doRebuild, doStop, navigate);
 
   useTopbarActions(actions);
   useFavIcon(getBuildOrStepResults(build, UNKNOWN));


### PR DESCRIPTION
Provide better feedback to user with the following changes:
- Caption is now one of 'Rebuilt' (finished rebuild), 'Rebuilding' (rebuild in progress), 'Rebuild pending' (rebuild requested but not started).
- Button now redirect to the Buildrequest for the rebuild, which, in turn, will redirect to the Build if it started.
- If multiple rebuild were issued, redirection is done to the newest one (can be changed to the one closest to the Build viewed, see NOTE in code).
- When 'Rebuild' button is clicked but new Buildrequest wasn't found yet, caption is 'Rebuilding' as before, but button is a noop.

Closes #7450

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
