### PR TITLE
Remove remaining pollinterval

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1063,7 +1063,6 @@ pollatlaunch
 pollatreconfigure
 poller
 pollers
-pollinterval
 popnextbuild
 portstr
 portstrs

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -34,7 +34,6 @@ from buildbot.util.git import GitServiceAuth
 from buildbot.util.git import check_ssh_config
 from buildbot.util.state import StateMixin
 from buildbot.util.twisted import async_to_deferred
-from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -86,7 +85,6 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         usetimestamps=True,
         category=None,
         project=None,
-        pollinterval=-2,
         fetch_refspec=None,
         encoding="utf-8",
         name=None,
@@ -99,11 +97,6 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         if only_tags and (branch or branches):
             config.error("GitPoller: can't specify only_tags and branch/branches")
         if branch and branches:
@@ -151,7 +144,6 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         usetimestamps=True,
         category=None,
         project=None,
-        pollinterval=-2,
         fetch_refspec=None,
         encoding="utf-8",
         name=None,
@@ -164,11 +156,6 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         if name is None:
             name = repourl
 

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -25,7 +25,6 @@ from buildbot.util import bytes2unicode
 from buildbot.util import deferredLocked
 from buildbot.util import runprocess
 from buildbot.util.state import StateMixin
-from buildbot.warnings import warn_deprecated
 
 
 class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
@@ -72,7 +71,6 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         usetimestamps=True,
         category=None,
         project="",
-        pollinterval=-2,
         encoding="utf-8",
         name=None,
         pollAtLaunch=False,
@@ -80,11 +78,6 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         if branch and branches:
             config.error("HgPoller: can't specify both branch and branches")
 
@@ -117,7 +110,6 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         usetimestamps=True,
         category=None,
         project="",
-        pollinterval=-2,
         encoding="utf-8",
         name=None,
         pollAtLaunch=False,
@@ -125,11 +117,6 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         self.repourl = repourl
 
         self.branches = self.build_branches(branch, branches)

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -40,7 +40,7 @@ from buildbot.util.maildir import MaildirService
 class MaildirSource(MaildirService, util.ComparableMixin):
     """Generic base class for Maildir-based change sources"""
 
-    compare_attrs = ("basedir", "pollinterval", "prefix")
+    compare_attrs = ("basedir", "pollInterval", "prefix")
     name = 'MaildirSource'
 
     def __init__(self, maildir, prefix=None, category='', repository=''):

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -32,7 +32,6 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
-from buildbot.warnings import warn_deprecated
 
 debug_logging = False
 
@@ -144,7 +143,6 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         split_file=lambda branchfile: (None, branchfile),
         pollInterval=60 * 10,
         histmax=None,
-        pollinterval=-2,
         encoding="utf8",
         project=None,
         name=None,
@@ -157,11 +155,6 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         name = self.build_name(name, p4port, p4base)
 
         if use_tickets and not p4passwd:
@@ -195,7 +188,6 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         split_file=lambda branchfile: (None, branchfile),
         pollInterval=60 * 10,
         histmax=None,
-        pollinterval=-2,
         encoding="utf8",
         project=None,
         name=None,
@@ -208,11 +200,6 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         name = self.build_name(name, p4port, p4base)
 
         if project is None:

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -27,7 +27,6 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
-from buildbot.warnings import warn_deprecated
 
 # these split_file_* functions are available for use as values to the
 # split_file= argument.
@@ -112,18 +111,12 @@ class SVNPoller(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         category=None,
         project="",
         cachepath=None,
-        pollinterval=-2,
         extra_args=None,
         name=None,
         pollAtLaunch=False,
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         if name is None:
             name = repourl
 
@@ -149,18 +142,12 @@ class SVNPoller(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
         category=None,
         project="",
         cachepath=None,
-        pollinterval=-2,
         extra_args=None,
         name=None,
         pollAtLaunch=False,
         pollRandomDelayMin=0,
         pollRandomDelayMax=0,
     ):
-        # for backward compatibility; the parameter used to be spelled with 'i'
-        if pollinterval != -2:
-            pollInterval = pollinterval
-            warn_deprecated('3.11.2', 'pollinterval has been deprecated: please use pollInterval')
-
         if name is None:
             name = repourl
 

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -23,7 +23,6 @@ from buildbot.config.master import FileLoader
 from buildbot.scripts import runner
 from buildbot.test.util import dirs
 from buildbot.test.util.warnings import assertNotProducesWarnings
-from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.warnings import DeprecatedApiWarning
 
 
@@ -44,8 +43,7 @@ class RealConfigs(dirs.DirsMixin, unittest.TestCase):
     def test_0_9_0b5_api_renamed_config(self):
         with open(self.filename, "w", encoding='utf-8') as f:
             f.write(sample_0_9_0b5_api_renamed)
-        with assertProducesWarning(DeprecatedApiWarning):
-            FileLoader(self.basedir, self.filename).loadConfig()
+        FileLoader(self.basedir, self.filename).loadConfig()
 
 
 # sample.cfg from various versions, with comments stripped.  Adjustments made
@@ -65,7 +63,7 @@ c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
         'https://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
-        pollinterval=300))
+        pollInterval=300))
 
 c['schedulers'] = []
 c['schedulers'].append(schedulers.SingleBranchScheduler(

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -30,11 +30,9 @@ from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import config
 from buildbot.test.util import logging
-from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.util.twisted import async_to_deferred
-from buildbot.warnings import DeprecatedApiWarning
 
 # Test that environment variables get propagated to subprocesses (See #2116)
 os.environ['TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'] = 'TRUE'
@@ -2191,18 +2189,6 @@ class TestGitPollerConstructor(
             yield self.attachChangeSource(
                 gitpoller.GitPoller("/tmp/git.git", fetch_refspec='not-supported')
             )
-
-    @defer.inlineCallbacks
-    def test_deprecated_pollinterval(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning,
-            2,
-            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
-        ):
-            poller = yield self.attachChangeSource(
-                gitpoller.GitPoller("/tmp/git.git", pollinterval=10)
-            )
-            self.assertEqual(poller.pollInterval, 10)
 
     @defer.inlineCallbacks
     def test_branches_default(self):

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -23,8 +23,6 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.warnings import DeprecatedApiWarning
 
 ENVIRON_2116_KEY = 'TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'
 LINESEP_BYTES = os.linesep.encode("ascii")
@@ -462,40 +460,3 @@ class HgPollerNoTimestamp(TestHgPoller):
     """Test HgPoller() without parsing revision commit timestamp"""
 
     usetimestamps = False
-
-
-class TestHgPollerPollIntervalDeprecated(
-    MasterRunProcessMixin, changesource.ChangeSourceMixin, TestReactorMixin, unittest.TestCase
-):
-    usetimestamps = True
-    branches = None
-    bookmarks = None
-
-    @defer.inlineCallbacks
-    def setUp(self):
-        self.setup_test_reactor()
-        self.setup_master_run_process()
-        yield self.setUpChangeSource()
-        self.remote_repo = 'ssh://example.com/foo/baz'
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.master.stopService()
-        yield self.tearDownChangeSource()
-
-    @defer.inlineCallbacks
-    def test_deprecatedPollInterval(self):
-        with assertProducesWarning(
-            DeprecatedApiWarning,
-            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
-        ):
-            self.poller = hgpoller.HgPoller(
-                self.remote_repo,
-                usetimestamps=self.usetimestamps,
-                workdir='/some/dir',
-                branches=self.branches,
-                bookmarks=self.bookmarks,
-                revlink=lambda branch, revision: self.remote_hgweb.format(revision),
-                pollinterval=10,
-            )
-            yield self.master.startService()

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -30,9 +30,7 @@ from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
 from buildbot.test.util import config
-from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import datetime2epoch
-from buildbot.warnings import DeprecatedApiWarning
 
 first_p4changes = b"""Change 1 on 2006/04/13 by slamb@testclient 'first rev'
 """
@@ -545,23 +543,6 @@ class TestP4Poller(
     def test_resolveWho_callable(self):
         with self.assertRaisesConfigError("You need to provide a valid callable for resolvewho"):
             P4Source(resolvewho=None)
-
-    @defer.inlineCallbacks
-    def test_deprecated_pollinterval(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning,
-            2,
-            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
-        ):
-            yield self.attachChangeSource(
-                P4Source(
-                    p4port=None,
-                    p4user=None,
-                    p4base='//depot/myproject/',
-                    split_file=lambda x: x.split('/', 1),
-                    pollinterval=10,
-                )
-            )
 
 
 class TestSplit(unittest.TestCase):

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -26,8 +26,6 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
-from buildbot.test.util.warnings import assertProducesWarnings
-from buildbot.warnings import DeprecatedApiWarning
 
 # this is the output of "svn info --xml
 # svn+ssh://svn.twistedmatrix.com/svn/Twisted/trunk"
@@ -663,16 +661,8 @@ class TestSVNPoller(
         # it should have called log.err once with a ValueError
         self.assertEqual(len(self.flushLoggedErrors(ValueError)), 1)
 
-    def test_constructor_pollinterval(self):
+    def test_constructor_pollInterval(self):
         return self.attachSVNPoller(sample_base, pollInterval=100)  # just don't fail!
-
-    def test_deprecated_pollinterval(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning,
-            2,
-            message_pattern='pollinterval has been deprecated: ' + 'please use pollInterval',
-        ):
-            return self.attachSVNPoller(sample_base, pollinterval=100)
 
     @defer.inlineCallbacks
     def test_extra_args(self):

--- a/master/buildbot/util/maildir.py
+++ b/master/buildbot/util/maildir.py
@@ -43,7 +43,7 @@ class NoSuchMaildir(Exception):
 
 
 class MaildirService(service.BuildbotService):
-    pollinterval = 10  # only used if we don't have DNotify
+    pollInterval = 10  # only used if we don't have DNotify
     name = 'MaildirService'
 
     def __init__(self, basedir=None):
@@ -80,7 +80,7 @@ class MaildirService(service.BuildbotService):
             # because of a python bug
             log.msg("DNotify failed, falling back to polling")
         if not self.dnotify:
-            self.timerService = internet.TimerService(self.pollinterval, self.poll)
+            self.timerService = internet.TimerService(self.pollInterval, self.poll)
             yield self.timerService.setServiceParent(self)
         self.poll()
         yield super().startService()

--- a/master/docs/tutorial/fiveminutes.rst
+++ b/master/docs/tutorial/fiveminutes.rst
@@ -220,7 +220,7 @@ To complete our example, here's a change source that polls a SVN repository ever
     svnpoller = changes.SVNPoller(repourl="svn://myrepo/projects/coolproject",
                                   svnuser="foo",
                                   svnpasswd="bar",
-                                  pollinterval=120,
+                                  pollInterval=120,
                                   split_file=util.svn.split_file_branches)
 
     c['change_source'] = svnpoller


### PR DESCRIPTION
This PR removes usages of deprecated `pollinterval`.
PR is partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
