### PR TITLE
Remove deprecated ShellArg.logfile

### DIFF
--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -21,29 +21,18 @@ from twisted.python import log
 from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process import results
-from buildbot.warnings import warn_deprecated
 
 
 class ShellArg(results.ResultComputingConfigMixin):
     publicAttributes = results.ResultComputingConfigMixin.resultConfig + ["command", "logname"]
 
-    def __init__(self, command=None, logname=None, logfile=None, **kwargs):
+    def __init__(self, command=None, logname=None, **kwargs):
         name = self.__class__.__name__
         if command is None:
             config.error(f"the 'command' parameter of {name} must not be None")
         self.command = command
 
         self.logname = logname
-        if logfile is not None:
-            warn_deprecated('2.10.0', "{}: logfile is deprecated, use logname")
-            if self.logname is not None:
-                config.error(
-                    (
-                        "{}: the 'logfile' parameter must not be specified when 'logname' "
-                        + "is set"
-                    ).format(name)
-                )
-            self.logname = logfile
 
         for k, v in kwargs.items():
             if k not in self.resultConfig:

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -26,8 +26,6 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import ExpectShell
 from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import config as configmixin
-from buildbot.test.util.warnings import assertProducesWarnings
-from buildbot.warnings import DeprecatedApiWarning
 
 
 class DynamicRun(shellsequence.ShellSequence):
@@ -44,21 +42,6 @@ class TestOneShellCommand(
 
     def tearDown(self):
         return self.tear_down_test_build_step()
-
-    def test_shell_arg_warn_deprecated_logfile(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning, message_pattern="logfile is deprecated, use logname"
-        ):
-            shellsequence.ShellArg(command="command", logfile="logfile")
-
-    def test_shell_arg_error_logfile_and_logname(self):
-        with assertProducesWarnings(
-            DeprecatedApiWarning, message_pattern="logfile is deprecated, use logname"
-        ):
-            with self.assertRaisesConfigError(
-                "the 'logfile' parameter must not be specified when 'logname' is set"
-            ):
-                shellsequence.ShellArg(command="command", logname="logname", logfile="logfile")
 
     def testShellArgInput(self):
         with self.assertRaisesConfigError("the 'command' parameter of ShellArg must not be None"):


### PR DESCRIPTION
This PR removes usages of deprecated ShellArg.logfile.
PR is partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
