### PR TITLE
typing: convert db.buildrequests.BrDict to dataclass

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -204,6 +204,7 @@ buildrequestid
 buildrequestresults
 buildrequests
 buildrequestsconnectorcomponent
+buildrequestmodel
 buildresult
 buildroot
 build's

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -29,22 +29,23 @@ if TYPE_CHECKING:
     from typing import Sequence
 
     from buildbot.data.resultspec import ResultSpec
+    from buildbot.db.buildrequests import BuildRequestModel
 
 
-def _db2data(dbdict: dict, properties: dict | None):
+def _db2data(dbmodel: BuildRequestModel, properties: dict | None):
     return {
-        'buildrequestid': dbdict['buildrequestid'],
-        'buildsetid': dbdict['buildsetid'],
-        'builderid': dbdict['builderid'],
-        'priority': dbdict['priority'],
-        'claimed': dbdict['claimed'],
-        'claimed_at': dbdict['claimed_at'],
-        'claimed_by_masterid': dbdict['claimed_by_masterid'],
-        'complete': dbdict['complete'],
-        'results': dbdict['results'],
-        'submitted_at': dbdict['submitted_at'],
-        'complete_at': dbdict['complete_at'],
-        'waited_for': dbdict['waited_for'],
+        'buildrequestid': dbmodel.buildrequestid,
+        'buildsetid': dbmodel.buildsetid,
+        'builderid': dbmodel.builderid,
+        'priority': dbmodel.priority,
+        'claimed': dbmodel.claimed,
+        'claimed_at': dbmodel.claimed_at,
+        'claimed_by_masterid': dbmodel.claimed_by_masterid,
+        'complete': dbmodel.complete,
+        'results': dbmodel.results,
+        'submitted_at': dbmodel.submitted_at,
+        'complete_at': dbmodel.complete_at,
+        'waited_for': dbmodel.waited_for,
         'properties': properties,
     }
 
@@ -104,9 +105,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
             return None
 
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
-        properties = yield self.get_buildset_properties_filtered(
-            buildrequest['buildsetid'], filters
-        )
+        properties = yield self.get_buildset_properties_filtered(buildrequest.buildsetid, filters)
         return _db2data(buildrequest, properties)
 
     @defer.inlineCallbacks
@@ -163,7 +162,7 @@ class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
         results = []
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
         for br in buildrequests:
-            properties = yield self.get_buildset_properties_filtered(br['buildsetid'], filters)
+            properties = yield self.get_buildset_properties_filtered(br.buildsetid, filters)
             results.append(_db2data(br, properties))
         return results
 
@@ -261,7 +260,7 @@ class BuildRequest(base.ResourceType):
             brdict = yield self.master.db.buildrequests.getBuildRequest(brid)
 
             if brdict:
-                bsid = brdict['buildsetid']
+                bsid = brdict.buildsetid
                 if bsid in seen_bsids:
                     continue
                 seen_bsids.add(bsid)

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -13,6 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from twisted.internet import defer
 
 from buildbot.data import base
@@ -21,51 +25,55 @@ from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.db.buildrequests import NotClaimedError
 from buildbot.process.results import RETRY
 
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from buildbot.data.resultspec import ResultSpec
+
+
+def _db2data(dbdict: dict, properties: dict | None):
+    return {
+        'buildrequestid': dbdict['buildrequestid'],
+        'buildsetid': dbdict['buildsetid'],
+        'builderid': dbdict['builderid'],
+        'priority': dbdict['priority'],
+        'claimed': dbdict['claimed'],
+        'claimed_at': dbdict['claimed_at'],
+        'claimed_by_masterid': dbdict['claimed_by_masterid'],
+        'complete': dbdict['complete'],
+        'results': dbdict['results'],
+        'submitted_at': dbdict['submitted_at'],
+        'complete_at': dbdict['complete_at'],
+        'waited_for': dbdict['waited_for'],
+        'properties': properties,
+    }
+
+
+def _generate_filtered_properties(props: dict, filters: Sequence) -> dict | None:
+    """
+    This method returns Build's properties according to property filters.
+
+    :param props: Properties as a dict (from db)
+    :param filters: Desired properties keys as a list (from API URI)
+    """
+    # by default no properties are returned
+    if not props and not filters:
+        return None
+
+    set_filters = set(filters)
+    if '*' in set_filters:
+        return props
+
+    return {k: v for k, v in props.items() if k in set_filters}
+
 
 class Db2DataMixin:
-    def _generate_filtered_properties(self, props, filters):
-        """
-        This method returns Build's properties according to property filters.
-
-        :param props: Properties as a dict (from db)
-        :param filters: Desired properties keys as a list (from API URI)
-        """
-        # by default no properties are returned
-        if props and filters:
-            return (
-                props
-                if '*' in filters
-                else dict(((k, v) for k, v in props.items() if k in filters))
-            )
-        return None
-
     @defer.inlineCallbacks
-    def addPropertiesToBuildRequest(self, buildrequest, filters):
+    def get_buildset_properties_filtered(self, buildsetid: int, filters: Sequence):
         if not filters:
             return None
-        props = yield self.master.db.buildsets.getBuildsetProperties(buildrequest['buildsetid'])
-        filtered_properties = self._generate_filtered_properties(props, filters)
-        if filtered_properties:
-            buildrequest['properties'] = filtered_properties
-        return None
-
-    def db2data(self, dbdict):
-        data = {
-            'buildrequestid': dbdict['buildrequestid'],
-            'buildsetid': dbdict['buildsetid'],
-            'builderid': dbdict['builderid'],
-            'priority': dbdict['priority'],
-            'claimed': dbdict['claimed'],
-            'claimed_at': dbdict['claimed_at'],
-            'claimed_by_masterid': dbdict['claimed_by_masterid'],
-            'complete': dbdict['complete'],
-            'results': dbdict['results'],
-            'submitted_at': dbdict['submitted_at'],
-            'complete_at': dbdict['complete_at'],
-            'waited_for': dbdict['waited_for'],
-            'properties': dbdict.get('properties'),
-        }
-        return defer.succeed(data)
+        props = yield self.master.db.buildsets.getBuildsetProperties(buildsetid)
+        return _generate_filtered_properties(props, filters)
 
     fieldMapping = {
         'buildrequestid': 'buildrequests.id',
@@ -90,14 +98,16 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
     """
 
     @defer.inlineCallbacks
-    def get(self, resultSpec, kwargs):
+    def get(self, resultSpec: ResultSpec, kwargs):
         buildrequest = yield self.master.db.buildrequests.getBuildRequest(kwargs['buildrequestid'])
+        if not buildrequest:
+            return None
 
-        if buildrequest:
-            filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
-            yield self.addPropertiesToBuildRequest(buildrequest, filters)
-            return (yield self.db2data(buildrequest))
-        return None
+        filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
+        properties = yield self.get_buildset_properties_filtered(
+            buildrequest['buildsetid'], filters
+        )
+        return _db2data(buildrequest, properties)
 
     @defer.inlineCallbacks
     def set_request_priority(self, brid, args, kwargs):
@@ -153,8 +163,8 @@ class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
         results = []
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
         for br in buildrequests:
-            yield self.addPropertiesToBuildRequest(br, filters)
-            results.append((yield self.db2data(br)))
+            properties = yield self.get_buildset_properties_filtered(br['buildsetid'], filters)
+            results.append(_db2data(br, properties))
         return results
 
 

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -226,7 +226,7 @@ class Buildset(base.ResourceType):
         # figure out the overall results of the buildset:
         cumulative_results = SUCCESS
         for brdict in brdicts:
-            cumulative_results = worst_status(cumulative_results, brdict['results'])
+            cumulative_results = worst_status(cumulative_results, brdict.results)
 
         # get a copy of the buildset
         bsdict = yield self.master.db.buildsets.getBuildset(bsid)

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -170,7 +170,7 @@ class Master(base.ResourceType):
             complete=False, claimed=masterid
         )
         yield self.master.db.buildrequests.unclaimBuildRequests(
-            brids=[br['buildrequestid'] for br in buildrequests]
+            brids=[br.buildrequestid for br in buildrequests]
         )
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -419,8 +419,7 @@ class ResultSpec:
                     Do a multi-level sort by passing in the keys
                     to sort by.
 
-                    @param elem: each item in the list to sort.  It must be
-                              a C{dict}
+                    @param elem: each item in the list to sort.
                     @param order: a list of keys to sort by, such as:
                                 ('lastName', 'firstName', 'age')
                     @return: a key used by sorted(). This will be a
@@ -436,7 +435,8 @@ class ResultSpec:
                             # it means sort by 'lastName' in reverse.
                             k = k[1:]
                             doReverse = True
-                        val = NoneComparator(elem[k])
+                        val = elem[k] if isinstance(elem, dict) else getattr(elem, k)
+                        val = NoneComparator(val)
                         if doReverse:
                             val = ReverseComparator(val)
                         compareKey.append(val)

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import sqlalchemy as sa
 from twisted.python import log
 
@@ -71,10 +73,12 @@ class FieldBase:
         # only support string values, because currently there are no queries against lists in SQL
     }
 
-    def __init__(self, field, op, values):
+    # can't type `values` as `Sequence` as `str` is one as well...
+    def __init__(self, field: bytes, op: str, values: list | tuple):
         self.field = field
         self.op = op
         self.values = values
+        assert isinstance(values, (list, tuple))
 
     def getOperator(self, sqlMode=False):
         v = self.values

--- a/master/buildbot/reporters/generators/buildrequest.py
+++ b/master/buildbot/reporters/generators/buildrequest.py
@@ -54,7 +54,7 @@ class BuildRequestGenerator(BuildStatusGeneratorMixin):
 
         props = Properties()
         buildrequest = yield BuildRequest.fromBrdict(master, brdict)
-        builder = yield master.botmaster.getBuilderById(brdict['builderid'])
+        builder = yield master.botmaster.getBuilderById(brdict.builderid)
 
         yield Build.setup_properties_known_before_build_starts(props, [buildrequest], builder)
         Build.setupBuildProperties(props, [buildrequest])

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -13,7 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+import dataclasses
 from collections import UserList
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.python import log
@@ -22,6 +26,9 @@ from buildbot.data import resultspec
 from buildbot.process.properties import renderer
 from buildbot.process.results import RETRY
 from buildbot.util import flatten
+
+if TYPE_CHECKING:
+    from buildbot.db.buildrequests import BuildRequestModel
 
 
 @defer.inlineCallbacks
@@ -119,15 +126,15 @@ def getDetailsForBuild(
 
 
 @defer.inlineCallbacks
-def get_details_for_buildrequest(master, buildrequest, build):
-    buildset = yield master.data.get(("buildsets", buildrequest['buildsetid']))
-    builder = yield master.data.get(("builders", buildrequest['builderid']))
+def get_details_for_buildrequest(master, buildrequest: BuildRequestModel, build):
+    buildset = yield master.data.get(("buildsets", buildrequest.buildsetid))
+    builder = yield master.data.get(("builders", buildrequest.builderid))
 
-    build['buildrequest'] = buildrequest
+    build['buildrequest'] = dataclasses.asdict(buildrequest)
     build['buildset'] = buildset
-    build['builderid'] = buildrequest['builderid']
+    build['builderid'] = buildrequest.builderid
     build['builder'] = builder
-    build['url'] = getURLForBuildrequest(master, buildrequest['buildrequestid'])
+    build['url'] = getURLForBuildrequest(master, buildrequest.buildrequestid)
     build['results'] = None
     build['complete'] = False
 

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -249,7 +249,7 @@ class Trigger(BuildStep):
         @defer.inlineCallbacks
         def _is_buildrequest_complete(brid):
             buildrequest = yield self.master.db.buildrequests.getBuildRequest(brid)
-            return buildrequest['complete']
+            return buildrequest.complete
 
         event = ('buildrequests', str(brid), 'complete')
         yield self.master.mq.waitUntilEvent(event, lambda: _is_buildrequest_complete(brid))

--- a/master/buildbot/test/fakedb/builds.py
+++ b/master/buildbot/test/fakedb/builds.py
@@ -207,8 +207,8 @@ class FakeBuildsComponent(FakeDBComponent):
 
         for breq in breqs:
             for result in results:
-                if result['buildsetid'] == breq['buildsetid']:
-                    result['buildrequestid'] = breq['buildrequestid']
+                if result['buildsetid'] == breq.buildsetid:
+                    result['buildrequestid'] = breq.buildrequestid
 
         for build in builds:
             for result in results:

--- a/master/buildbot/test/fakedb/sourcestamps.py
+++ b/master/buildbot/test/fakedb/sourcestamps.py
@@ -246,7 +246,7 @@ class FakeSourceStampsComponent(FakeDBComponent):
     def getSourceStampsForBuild(self, buildid):
         build = yield self.db.builds.getBuild(buildid)
         breq = yield self.db.buildrequests.getBuildRequest(build['buildrequestid'])
-        bset = yield self.db.buildsets.getBuildset(breq['buildsetid'])
+        bset = yield self.db.buildsets.getBuildset(breq.buildsetid)
 
         results = []
         for ssid in bset['sourcestamps']:

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -98,7 +98,7 @@ class TestBuildRequestEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testGetProperty(self):
-        prop = resultspec.Property(b'property', 'eq', 'prop1')
+        prop = resultspec.Property(b'property', 'eq', ['prop1'])
         buildrequest = yield self.callGet(
             ('buildrequests', 44), resultSpec=resultspec.ResultSpec(properties=[prop])
         )
@@ -107,7 +107,7 @@ class TestBuildRequestEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testGetProperties(self):
-        prop = resultspec.Property(b'property', 'eq', '*')
+        prop = resultspec.Property(b'property', 'eq', ['*'])
         buildrequest = yield self.callGet(
             ('buildrequests', 44), resultSpec=resultspec.ResultSpec(properties=[prop])
         )
@@ -190,7 +190,7 @@ class TestBuildRequestsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
                 buildsetid=8822, property_name='prop2', property_value='["two", "fake2"]'
             ),
         ])
-        prop = resultspec.Property(b'property', 'eq', '*')
+        prop = resultspec.Property(b'property', 'eq', ['*'])
         buildrequests = yield self.callGet(
             ('builders', 78, 'buildrequests'), resultSpec=resultspec.ResultSpec(properties=[prop])
         )

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -99,7 +99,7 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_properties_injection(self):
         resultSpec = resultspec.OptimisedResultSpec(
-            properties=[resultspec.Property(b'property', 'eq', 'reason')]
+            properties=[resultspec.Property(b'property', 'eq', ['reason'])]
         )
         build = yield self.callGet(('builders', 77, 'builds', 3), resultSpec=resultSpec)
         self.validateData(build)
@@ -285,7 +285,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_properties_injection(self):
         resultSpec = resultspec.OptimisedResultSpec(
-            properties=[resultspec.Property(b'property', 'eq', 'reason')]
+            properties=[resultspec.Property(b'property', 'eq', ['reason'])]
         )
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
 

--- a/master/buildbot/test/unit/db/test_buildrequests.py
+++ b/master/buildbot/test/unit/db/test_buildrequests.py
@@ -84,21 +84,20 @@ class Tests(interfaces.InterfaceTests):
 
         yield self.assertEqual(
             brdict,
-            {
-                "buildrequestid": 44,
-                "buildsetid": self.BSID,
-                "builderid": self.BLDRID1,
-                "buildername": "builder1",
-                "priority": 7,
-                "claimed": True,
-                "claimed_by_masterid": self.MASTER_ID,
-                "complete": True,
-                "results": 75,
-                "claimed_at": self.CLAIMED_AT,
-                "submitted_at": self.SUBMITTED_AT,
-                "complete_at": self.COMPLETE_AT,
-                "waited_for": False,
-            },
+            buildrequests.BuildRequestModel(
+                buildrequestid=44,
+                buildsetid=self.BSID,
+                builderid=self.BLDRID1,
+                buildername="builder1",
+                priority=7,
+                claimed_by_masterid=self.MASTER_ID,
+                complete=True,
+                results=75,
+                claimed_at=self.CLAIMED_AT,
+                submitted_at=self.SUBMITTED_AT,
+                complete_at=self.COMPLETE_AT,
+                waited_for=False,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -128,7 +127,7 @@ class Tests(interfaces.InterfaceTests):
         ])
         brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]), sorted(expected))
+        self.assertEqual(sorted([br.buildrequestid for br in brlist]), sorted(expected))
 
     def test_getBuildRequests_no_claimed_arg(self):
         return self.do_test_getBuildRequests_claim_args(expected=[50, 51, 52, 53])
@@ -155,7 +154,7 @@ class Tests(interfaces.InterfaceTests):
         ])
         brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]), sorted(expected))
+        self.assertEqual(sorted([br.buildrequestid for br in brlist]), sorted(expected))
 
     @defer.inlineCallbacks
     def do_test_getBuildRequests_complete_arg(self, **kwargs):
@@ -188,7 +187,7 @@ class Tests(interfaces.InterfaceTests):
         ])
         brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]), sorted(expected))
+        self.assertEqual(sorted([br.buildrequestid for br in brlist]), sorted(expected))
 
     def test_getBuildRequests_complete_none(self):
         return self.do_test_getBuildRequests_complete_arg(expected=[70, 80, 81, 82])
@@ -220,7 +219,7 @@ class Tests(interfaces.InterfaceTests):
         ])
         brlist = yield self.db.buildrequests.getBuildRequests(bsid=self.BSID)
 
-        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]), sorted([70, 72]))
+        self.assertEqual(sorted([br.buildrequestid for br in brlist]), sorted([70, 72]))
 
     @defer.inlineCallbacks
     def test_getBuildRequests_combo(self):
@@ -299,7 +298,7 @@ class Tests(interfaces.InterfaceTests):
             builderid=self.BLDRID1, claimed=self.MASTER_ID, complete=True, bsid=self.BSID
         )
 
-        self.assertEqual([br['buildrequestid'] for br in brlist], [44])
+        self.assertEqual([br.buildrequestid for br in brlist], [44])
 
     @defer.inlineCallbacks
     def do_test_getBuildRequests_branch_arg(self, **kwargs):
@@ -323,7 +322,7 @@ class Tests(interfaces.InterfaceTests):
         ])
         brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]), sorted(expected))
+        self.assertEqual(sorted([br.buildrequestid for br in brlist]), sorted(expected))
 
     def test_getBuildRequests_branch(self):
         return self.do_test_getBuildRequests_branch_arg(branch='branch_A', expected=[70, 90])
@@ -368,10 +367,7 @@ class Tests(interfaces.InterfaceTests):
 
             self.assertNotEqual(expected, None, "unexpected success from claimBuildRequests")
             self.assertEqual(
-                sorted([
-                    (r['buildrequestid'], r['claimed_at'], r['claimed_by_masterid'])
-                    for r in results
-                ]),
+                sorted([(r.buildrequestid, r.claimed_at, r.claimed_by_masterid) for r in results]),
                 sorted(expected),
             )
         except Exception as e:
@@ -461,9 +457,7 @@ class Tests(interfaces.InterfaceTests):
 
         # check that [1,1000) were not claimed, and 1000 is still claimed
         self.assertEqual(
-            [(r['buildrequestid'], r['claimed_by_masterid'], r['claimed_at']) for r in results][
-                :10
-            ],
+            [(r.buildrequestid, r.claimed_by_masterid, r.claimed_at) for r in results][:10],
             [(1000, self.OTHER_MASTER_ID, epoch2datetime(1300103810))],
         )
 
@@ -499,10 +493,7 @@ class Tests(interfaces.InterfaceTests):
 
             self.assertNotEqual(expected, None, "unexpected success from completeBuildRequests")
             self.assertEqual(
-                sorted(
-                    (r['buildrequestid'], r['complete'], r['results'], r['complete_at'])
-                    for r in results
-                ),
+                sorted((r.buildrequestid, r.complete, r.results, r.complete_at) for r in results),
                 sorted(expected),
             )
 
@@ -664,7 +655,7 @@ class Tests(interfaces.InterfaceTests):
         # just select the unclaimed requests
         results = yield self.db.buildrequests.getBuildRequests(claimed=False)
 
-        self.assertEqual(sorted([r['buildrequestid'] for r in results]), sorted(expected))
+        self.assertEqual(sorted([r.buildrequestid for r in results]), sorted(expected))
 
     def test_unclaimBuildRequests(self):
         to_unclaim = [

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -742,7 +742,6 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
         Merge cannot be performed and raises error:
           Merging requests requires both requests to have the same codebases
         """
-        brDicts = []  # list of buildrequests dictionary
         master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insert_test_data([
             fakedb.Builder(id=77, name='bldr'),
@@ -787,14 +786,8 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
             fakedb.BuildsetSourceStamp(buildsetid=540, sourcestampid=239),
             fakedb.BuildRequest(id=289, buildsetid=540, builderid=77),
         ])
-        # use getBuildRequest to minimize the risk from changes to the format
-        # of the brdict
-        req = yield master.db.buildrequests.getBuildRequest(288)
-        brDicts.append(req)
-        req = yield master.db.buildrequests.getBuildRequest(289)
-        brDicts.append(req)
-        can_collapse = yield buildrequest.BuildRequest.canBeCollapsed(
-            master, brDicts[0], brDicts[1]
-        )
+        old_br = yield master.data.get(('buildrequests', 288))
+        new_br = yield master.data.get(('buildrequests', 289))
+        can_collapse = yield buildrequest.BuildRequest.canBeCollapsed(master, new_br, old_br)
 
         self.assertEqual(can_collapse, False)

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -17,6 +17,7 @@ from twisted.internet import defer
 from twisted.python import log
 from twisted.trial import unittest
 
+from buildbot.db.buildrequests import BuildRequestModel
 from buildbot.process import properties
 from buildbot.schedulers import triggerable
 from buildbot.test import fakedb
@@ -107,21 +108,20 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
             buildrequest = yield self.master.db.buildrequests.getBuildRequest(brid)
             self.assertEqual(
                 buildrequest,
-                {
-                    'buildrequestid': brid,
-                    'buildername': 'b',
-                    'builderid': 77,
-                    'buildsetid': bsid,
-                    'claimed': False,
-                    'claimed_at': None,
-                    'complete': False,
-                    'complete_at': None,
-                    'claimed_by_masterid': None,
-                    'priority': 0,
-                    'results': -1,
-                    'submitted_at': datetime(1999, 12, 31, 23, 59, 59, tzinfo=UTC),
-                    'waited_for': waited_for,
-                },
+                BuildRequestModel(
+                    buildrequestid=brid,
+                    buildername='b',
+                    builderid=77,
+                    buildsetid=bsid,
+                    claimed_at=None,
+                    complete=False,
+                    complete_at=None,
+                    claimed_by_masterid=None,
+                    priority=0,
+                    results=-1,
+                    submitted_at=datetime(1999, 12, 31, 23, 59, 59, tzinfo=UTC),
+                    waited_for=waited_for,
+                ),
             )
 
     def sendCompletionMessage(self, bsid, results=3):

--- a/master/docs/developer/database/buildrequests.rst
+++ b/master/docs/developer/database/buildrequests.rst
@@ -25,9 +25,8 @@ Buildrequests connector
 
     .. index:: brdict, brid
 
-    Build requests are indexed by an ID referred to as a *brid*.  The contents
-    of a request are represented as build request dictionaries (brdicts) with
-    keys
+    Build requests are indexed by an ID referred to as a *brid*.  The contents of a
+    request are represented by a :class:`BuildRequestModel` dataclass with the following fields:
 
     * ``buildrequestid``
     * ``buildsetid``
@@ -46,7 +45,7 @@ Buildrequests connector
     .. py:method:: getBuildRequest(brid)
 
         :param brid: build request id to look up
-        :returns: brdict or ``None``, via Deferred
+        :returns: :class:`BuildRequestModel` or ``None``, via Deferred
 
         Get a single BuildRequest, in the format described above.  This method
         returns ``None`` if there is no such buildrequest.  Note that build
@@ -65,7 +64,7 @@ Buildrequests connector
         :param branch: the branch associated with the sourcestamps originating the requests
         :param resultSpec: resultSpec containing filters sorting and paging request from data/REST API.
             If possible, the db layer can optimize the SQL query using this information.
-        :returns: list of brdicts, via Deferred
+        :returns: list of :class:`BuildRequestModel`, via Deferred
 
         Get a list of build requests matching the given characteristics.
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -109,6 +109,7 @@ buildnumber
 buildrequest
 buildrequestid
 buildrequests
+BuildRequestModel
 buildset
 Buildset
 buildsetid

--- a/newsfragments/db-brdict.removal
+++ b/newsfragments/db-brdict.removal
@@ -1,0 +1,1 @@
+:class:`buildbot.db.buildrequests.BrDict` is deprecated in favor of :class:`buildbot.db.buildrequests.BuildRequestModel`

--- a/newsfragments/db-introduce-BuildRequestModel.change
+++ b/newsfragments/db-introduce-BuildRequestModel.change
@@ -1,0 +1,1 @@
+:class:`BuildRequestsConnectorComponent` `getBuildRequest`, and `getBuildRequests` now return a :class`BuildRequestModel` instead of a dictionary of BuildRequest data


### PR DESCRIPTION
Relates to #7591

This one was a bit more annoying.
Contains some fixes/improvements.

Not super happy about the change in `_getBuildRequestForBrdict` so let me know if you see something better.

Also, since this is planned to be in 3.12, if you create the branch, I can take care of rebase + PR against it.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
