### PR TITLE
 typing: Add BuildModel dataclass

### DIFF
--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -50,7 +50,7 @@ class LogChunkEndpointBase(base.BuildNestingMixin, base.Endpoint):
             if builder_dict is not None:
                 log_prefix += f'Builder: {builder_dict.name}\n'
             if build_dict is not None:
-                log_prefix += f'Build number: {build_dict["number"]}\n'
+                log_prefix += f'Build number: {build_dict.number}\n'
             if worker_dict is not None:
                 log_prefix += f'Worker name: {worker_dict["name"]}\n'
 
@@ -60,7 +60,7 @@ class LogChunkEndpointBase(base.BuildNestingMixin, base.Endpoint):
         if builder_dict is not None:
             informative_parts += [builder_dict.name]
         if build_dict is not None:
-            informative_parts += ['build', str(build_dict['number'])]
+            informative_parts += ['build', str(build_dict.number)]
         if step_dict is not None:
             informative_parts += ['step', step_dict['name']]
         informative_parts += ['log', log_dict['slug']]

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -99,7 +99,7 @@ class FieldBase:
         fld = self.field
         v = self.values
         f = self.getOperator()
-        return (d for d in data if f(d[fld], v))
+        return (d for d in data if f((d[fld] if isinstance(d, dict) else getattr(d, fld)), v))
 
     def __repr__(self):
         return f"resultspec.{self.__class__.__name__}('{self.field}','{self.op}',{self.values})"

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -54,7 +54,7 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
             build_dbdict = yield self.master.db.builds.getBuild(step_dbdict['buildid'])
 
             sets = yield self.master.db.test_result_sets.getTestResultSets(
-                build_dbdict['builderid'],
+                build_dbdict.builderid,
                 buildid=step_dbdict['buildid'],
                 stepid=kwargs['stepid'],
                 complete=complete,
@@ -64,7 +64,7 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
             build_dbdict = yield self.master.db.builds.getBuild(kwargs['buildid'])
 
             sets = yield self.master.db.test_result_sets.getTestResultSets(
-                build_dbdict['builderid'],
+                build_dbdict.builderid,
                 buildid=kwargs['buildid'],
                 complete=complete,
                 result_spec=resultSpec,

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -201,10 +201,10 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
 
         # Get the last successful build on the same builder
         previousBuild = yield self.master.db.builds.getPrevSuccessfulBuild(
-            currentBuild['builderid'], currentBuild['number'], ssBuild
+            currentBuild.builderid, currentBuild.number, ssBuild
         )
         if previousBuild:
-            for ss in (yield gssfb(previousBuild['id'])):
+            for ss in (yield gssfb(previousBuild.id)):
                 toChanges[ss['codebase']] = yield self.getChangeFromSSid(ss['ssid'])
         else:
             # If no successful previous build, then we need to catch all

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -230,16 +230,16 @@ class Trigger(BuildStep):
                 for builderid, br in brids.items():
                     builds = yield self.master.db.builds.getBuilds(buildrequestid=br)
                     for build in builds:
-                        builderid = build['builderid']
+                        builderid = build.builderid
                         # When virtual builders are used, the builderid used for triggering
                         # is not the same as the one that the build actually got
                         if builderid not in builderNames:
                             builderDict = yield self.master.data.get(("builders", builderid))
                             builderNames[builderid] = builderDict["name"]
-                        num = build['number']
+                        num = build.number
                         url = getURLForBuild(self.master, builderid, num)
                         yield self.addURL(
-                            f'{statusToString(build["results"])}: '
+                            f'{statusToString(build.results)}: '
                             f'{builderNames[builderid]} #{num}',
                             url,
                         )
@@ -255,7 +255,7 @@ class Trigger(BuildStep):
         yield self.master.mq.waitUntilEvent(event, lambda: _is_buildrequest_complete(brid))
         builds = yield self.master.db.builds.getBuilds(buildrequestid=brid)
         for build in builds:
-            self._result_list.append(build["results"])
+            self._result_list.append(build.results)
         self.updateSummary()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/fakedb/sourcestamps.py
+++ b/master/buildbot/test/fakedb/sourcestamps.py
@@ -245,7 +245,7 @@ class FakeSourceStampsComponent(FakeDBComponent):
     @defer.inlineCallbacks
     def getSourceStampsForBuild(self, buildid):
         build = yield self.db.builds.getBuild(buildid)
-        breq = yield self.db.buildrequests.getBuildRequest(build['buildrequestid'])
+        breq = yield self.db.buildrequests.getBuildRequest(build.buildrequestid)
         bset = yield self.db.buildsets.getBuildset(breq.buildsetid)
 
         results = []

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -24,6 +24,7 @@ from twisted.python.reflect import namedModule
 
 from buildbot.process import buildstep
 from buildbot.process.results import EXCEPTION
+from buildbot.process.results import statusToString
 from buildbot.test.fake import connection
 from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
@@ -873,7 +874,11 @@ class TestBuildStepMixin:
         # in case of unexpected result, display logs in stdout for
         # debugging failing tests
         if result != self.exp_result:
-            msg = f"unexpected result from step; expected {self.exp_result}, got {result}"
+            msg = (
+                "unexpected result from step; "
+                f"expected {self.exp_result} ({statusToString(self.exp_result)}), "
+                f"got {result} ({statusToString(result)})"
+            )
             log.msg(f"{msg}; dumping logs")
             self._dump_logs()
             raise AssertionError(f"{msg}; see logs")

--- a/master/buildbot/test/unit/db/test_builds.py
+++ b/master/buildbot/test/unit/db/test_builds.py
@@ -21,7 +21,6 @@ from buildbot.db import builds
 from buildbot.test import fakedb
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
-from buildbot.test.util import validation
 from buildbot.util import epoch2datetime
 
 TIME1 = 1304262222
@@ -83,45 +82,45 @@ class Tests(interfaces.InterfaceTests):
     ]
 
     threeBdicts = {
-        50: {
-            "id": 50,
-            "buildrequestid": 42,
-            "builderid": 77,
-            "masterid": 88,
-            "number": 5,
-            "workerid": 13,
-            "started_at": epoch2datetime(TIME1),
-            "complete_at": None,
-            "locks_duration_s": 0,
-            "state_string": "build 5",
-            "results": None,
-        },
-        51: {
-            "id": 51,
-            "buildrequestid": 41,
-            "builderid": 88,
-            "masterid": 88,
-            "number": 6,
-            "workerid": 13,
-            "started_at": epoch2datetime(TIME2),
-            "complete_at": None,
-            "locks_duration_s": 0,
-            "state_string": "build 6",
-            "results": None,
-        },
-        52: {
-            "id": 52,
-            "buildrequestid": 42,
-            "builderid": 77,
-            "masterid": 88,
-            "number": 7,
-            "workerid": 12,
-            "started_at": epoch2datetime(TIME3),
-            "complete_at": epoch2datetime(TIME4),
-            "locks_duration_s": 0,
-            "state_string": "build 7",
-            "results": 5,
-        },
+        50: builds.BuildModel(
+            id=50,
+            buildrequestid=42,
+            builderid=77,
+            masterid=88,
+            number=5,
+            workerid=13,
+            started_at=epoch2datetime(TIME1),
+            complete_at=None,
+            locks_duration_s=0,
+            state_string="build 5",
+            results=None,
+        ),
+        51: builds.BuildModel(
+            id=51,
+            buildrequestid=41,
+            builderid=88,
+            masterid=88,
+            number=6,
+            workerid=13,
+            started_at=epoch2datetime(TIME2),
+            complete_at=None,
+            locks_duration_s=0,
+            state_string="build 6",
+            results=None,
+        ),
+        52: builds.BuildModel(
+            id=52,
+            buildrequestid=42,
+            builderid=77,
+            masterid=88,
+            number=7,
+            workerid=12,
+            started_at=epoch2datetime(TIME3),
+            complete_at=epoch2datetime(TIME4),
+            locks_duration_s=0,
+            state_string="build 7",
+            results=5,
+        ),
     }
 
     # signature tests
@@ -179,22 +178,22 @@ class Tests(interfaces.InterfaceTests):
     def test_getBuild(self):
         yield self.insert_test_data(self.backgroundData + [self.threeBuilds[0]])
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
             bdict,
-            {
-                "id": 50,
-                "number": 5,
-                "buildrequestid": 42,
-                "masterid": 88,
-                "builderid": 77,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": None,
-                "locks_duration_s": 0,
-                "state_string": 'build 5',
-                "results": None,
-            },
+            builds.BuildModel(
+                id=50,
+                number=5,
+                buildrequestid=42,
+                masterid=88,
+                builderid=77,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=None,
+                locks_duration_s=0,
+                state_string='build 5',
+                results=None,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -206,17 +205,17 @@ class Tests(interfaces.InterfaceTests):
     def test_getBuildByNumber(self):
         yield self.insert_test_data(self.backgroundData + [self.threeBuilds[0]])
         bdict = yield self.db.builds.getBuildByNumber(builderid=77, number=5)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
-        self.assertEqual(bdict['id'], 50)
+        self.assertIsInstance(bdict, builds.BuildModel)
+        self.assertEqual(bdict.id, 50)
 
     @defer.inlineCallbacks
     def test_getBuilds(self):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds()
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
+            self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
-            sorted(bdicts, key=lambda bd: bd['id']),
+            sorted(bdicts, key=lambda bd: bd.id),
             [self.threeBdicts[50], self.threeBdicts[51], self.threeBdicts[52]],
         )
 
@@ -225,17 +224,17 @@ class Tests(interfaces.InterfaceTests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(builderid=88)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
-        self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[51]])
+            self.assertIsInstance(bdict, builds.BuildModel)
+        self.assertEqual(sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[51]])
 
     @defer.inlineCallbacks
     def test_getBuilds_buildrequestid(self):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(buildrequestid=42)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
+            self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
-            sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[50], self.threeBdicts[52]]
+            sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[50], self.threeBdicts[52]]
         )
 
     @defer.inlineCallbacks
@@ -243,9 +242,9 @@ class Tests(interfaces.InterfaceTests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(workerid=13)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
+            self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
-            sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[50], self.threeBdicts[51]]
+            sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[50], self.threeBdicts[51]]
         )
 
     def test_signature_getBuildsForChange(self):
@@ -294,19 +293,19 @@ class Tests(interfaces.InterfaceTests):
         ]
 
         expected = [
-            {
-                'id': 50,
-                'number': 5,
-                'builderid': 77,
-                'buildrequestid': 19,
-                'workerid': 13,
-                'masterid': 88,
-                'started_at': epoch2datetime(1304262222),
-                'complete_at': None,
-                "locks_duration_s": 0,
-                'state_string': 'test',
-                'results': 1,
-            }
+            builds.BuildModel(
+                id=50,
+                number=5,
+                builderid=77,
+                buildrequestid=19,
+                workerid=13,
+                masterid=88,
+                started_at=epoch2datetime(1304262222),
+                complete_at=None,
+                locks_duration_s=0,
+                state_string='test',
+                results=1,
+            ),
         ]
 
         return self.do_test_getBuildsForChange(rows, 14, expected)
@@ -316,8 +315,8 @@ class Tests(interfaces.InterfaceTests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(complete=True)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
-        self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[52]])
+            self.assertIsInstance(bdict, builds.BuildModel)
+        self.assertEqual(sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[52]])
 
     @defer.inlineCallbacks
     def test_addBuild_first(self):
@@ -327,22 +326,22 @@ class Tests(interfaces.InterfaceTests):
             builderid=77, buildrequestid=41, workerid=13, masterid=88, state_string='test test2'
         )
         bdict = yield self.db.builds.getBuild(id)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
             bdict,
-            {
-                "buildrequestid": 41,
-                "builderid": 77,
-                "id": id,
-                "masterid": 88,
-                "number": number,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": None,
-                "locks_duration_s": 0,
-                "state_string": "test test2",
-                "results": None,
-            },
+            builds.BuildModel(
+                buildrequestid=41,
+                builderid=77,
+                id=id,
+                masterid=88,
+                number=number,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=None,
+                locks_duration_s=0,
+                state_string="test test2",
+                results=None,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -358,23 +357,23 @@ class Tests(interfaces.InterfaceTests):
             builderid=77, buildrequestid=41, workerid=13, masterid=88, state_string='test test2'
         )
         bdict = yield self.db.builds.getBuild(id)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(number, 11)
         self.assertEqual(
             bdict,
-            {
-                "buildrequestid": 41,
-                "builderid": 77,
-                "id": id,
-                "masterid": 88,
-                "number": number,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": None,
-                "locks_duration_s": 0,
-                "state_string": "test test2",
-                "results": None,
-            },
+            builds.BuildModel(
+                buildrequestid=41,
+                builderid=77,
+                id=id,
+                masterid=88,
+                number=number,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=None,
+                locks_duration_s=0,
+                state_string="test test2",
+                results=None,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -382,22 +381,22 @@ class Tests(interfaces.InterfaceTests):
         yield self.insert_test_data(self.backgroundData + [self.threeBuilds[0]])
         yield self.db.builds.setBuildStateString(buildid=50, state_string='test test2')
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
             bdict,
-            {
-                "id": 50,
-                "number": 5,
-                "buildrequestid": 42,
-                "masterid": 88,
-                "builderid": 77,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": None,
-                "locks_duration_s": 0,
-                "state_string": 'test test2',
-                "results": None,
-            },
+            builds.BuildModel(
+                id=50,
+                number=5,
+                buildrequestid=42,
+                masterid=88,
+                builderid=77,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=None,
+                locks_duration_s=0,
+                state_string='test test2',
+                results=None,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -405,22 +404,22 @@ class Tests(interfaces.InterfaceTests):
         yield self.insert_test_data(self.backgroundData + [self.threeBuilds[0]])
         yield self.db.builds.add_build_locks_duration(buildid=50, duration_s=12)
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
             bdict,
-            {
-                "id": 50,
-                "number": 5,
-                "buildrequestid": 42,
-                "masterid": 88,
-                "builderid": 77,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": None,
-                "locks_duration_s": 12,
-                "state_string": "build 5",
-                "results": None,
-            },
+            builds.BuildModel(
+                id=50,
+                number=5,
+                buildrequestid=42,
+                masterid=88,
+                builderid=77,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=None,
+                locks_duration_s=12,
+                state_string="build 5",
+                results=None,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -429,22 +428,22 @@ class Tests(interfaces.InterfaceTests):
         yield self.insert_test_data(self.backgroundData + [self.threeBuilds[0]])
         yield self.db.builds.finishBuild(buildid=50, results=7)
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
             bdict,
-            {
-                "id": 50,
-                "number": 5,
-                "buildrequestid": 42,
-                "masterid": 88,
-                "builderid": 77,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": epoch2datetime(TIME4),
-                "locks_duration_s": 0,
-                "state_string": 'build 5',
-                "results": 7,
-            },
+            builds.BuildModel(
+                id=50,
+                number=5,
+                buildrequestid=42,
+                masterid=88,
+                builderid=77,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=epoch2datetime(TIME4),
+                locks_duration_s=0,
+                state_string='build 5',
+                results=7,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -539,23 +538,23 @@ class RealTests(Tests):
             _race_hook=raceHook,
         )
         bdict = yield self.db.builds.getBuild(id)
-        validation.verifyDbDict(self, 'dbbuilddict', bdict)
+        self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(number, 8)
         self.assertEqual(
             bdict,
-            {
-                "buildrequestid": 41,
-                "builderid": 77,
-                "id": id,
-                "masterid": 88,
-                "number": number,
-                "workerid": 13,
-                "started_at": epoch2datetime(TIME1),
-                "complete_at": None,
-                "locks_duration_s": 0,
-                "state_string": "test test2",
-                "results": None,
-            },
+            builds.BuildModel(
+                buildrequestid=41,
+                builderid=77,
+                id=id,
+                masterid=88,
+                number=number,
+                workerid=13,
+                started_at=epoch2datetime(TIME1),
+                complete_at=None,
+                locks_duration_s=0,
+                state_string="test test2",
+                results=None,
+            ),
         )
 
     @defer.inlineCallbacks
@@ -565,8 +564,8 @@ class RealTests(Tests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
-        self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[52]])
+            self.assertIsInstance(bdict, builds.BuildModel)
+        self.assertEqual(sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[52]])
 
     @defer.inlineCallbacks
     def test_getBuilds_resultSpecOrder(self):
@@ -615,9 +614,9 @@ class RealTests(Tests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
+            self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
-            sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[51], self.threeBdicts[52]]
+            sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[51], self.threeBdicts[52]]
         )
 
     @defer.inlineCallbacks
@@ -627,8 +626,8 @@ class RealTests(Tests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
-        self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[50]])
+            self.assertIsInstance(bdict, builds.BuildModel)
+        self.assertEqual(sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[50]])
 
     @defer.inlineCallbacks
     def test_getBuilds_resultSpecFilterContainsOneValue(self):
@@ -637,8 +636,8 @@ class RealTests(Tests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
-        self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[52]])
+            self.assertIsInstance(bdict, builds.BuildModel)
+        self.assertEqual(sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[52]])
 
     @defer.inlineCallbacks
     def test_getBuilds_resultSpecFilterContainsTwoValues(self):
@@ -649,9 +648,9 @@ class RealTests(Tests):
         yield self.insert_test_data(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'dbbuilddict', bdict)
+            self.assertIsInstance(bdict, builds.BuildModel)
         self.assertEqual(
-            sorted(bdicts, key=lambda bd: bd['id']), [self.threeBdicts[50], self.threeBdicts[51]]
+            sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[50], self.threeBdicts[51]]
         )
 
 

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -207,7 +207,7 @@ class TestContact(ContactMixin, unittest.TestCase):
         buildFinished = self.contact.channel.subscribed[1].callback
         for buildid in (13, 14, 16):
             self.master.db.builds.finishBuild(buildid=buildid, results=SUCCESS)
-            build = yield self.master.db.builds.getBuild(buildid)
+            build = yield self.master.data.get(('builds', buildid))
             buildStarted("somekey", build)
             buildFinished("somekey", build)
 
@@ -576,7 +576,7 @@ class TestContact(ContactMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def sendBuildFinishedMessage(self, buildid, results=0):
         self.master.db.builds.finishBuild(buildid=buildid, results=SUCCESS)
-        build = yield self.master.db.builds.getBuild(buildid)
+        build = yield self.master.data.get(('builds', buildid))
         self.master.mq.callConsumer(
             ('builds', str(buildid), 'complete'),
             {
@@ -705,7 +705,7 @@ class TestContact(ContactMixin, unittest.TestCase):
     def test_buildStarted(self):
         self.setupSomeBuilds()
         self.patch_send()
-        build = yield self.master.db.builds.getBuild(13)
+        build = yield self.master.data.get(('builds', 13))
 
         self.bot.tags = None
         self.contact.channel.notify_for = lambda _: True

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -13,7 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest import mock
 
 from twisted.internet import defer
@@ -32,6 +34,9 @@ from buildbot.test.fake import fakestats
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import TestBuildStepMixin
 from buildbot.test.util import logging
+
+if TYPE_CHECKING:
+    from buildbot.db.builds import BuildModel
 
 
 class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
@@ -202,17 +207,17 @@ class TestStatsServicesConsumers(TestBuildStepMixin, TestStatsServicesBase):
         self.fake_storage_service.captures = captures
         yield self.stats_service.reconfigService([self.fake_storage_service])
 
-    def get_dict(self, build):
+    def get_dict(self, build: BuildModel):
         return {
             "buildid": 1,
-            "number": build['number'],
-            "builderid": build['builderid'],
-            "buildrequestid": build['buildrequestid'],
-            "workerid": build['workerid'],
-            "masterid": build['masterid'],
-            "started_at": build['started_at'],
+            "number": build.number,
+            "builderid": build.builderid,
+            "buildrequestid": build.buildrequestid,
+            "workerid": build.workerid,
+            "masterid": build.masterid,
+            "started_at": build.started_at,
             "complete": True,
-            "complete_at": build['complete_at'],
+            "complete_at": build.complete_at,
             "state_string": '',
             "results": 0,
         }

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -112,7 +112,7 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin, DebugIntegratio
     @defer.inlineCallbacks
     def assertBuildResults(self, build_id, result):
         dbdict = yield self.master.db.builds.getBuild(build_id)
-        self.assertEqual(result, dbdict['results'])
+        self.assertEqual(result, dbdict.results)
 
     @defer.inlineCallbacks
     def assertStepStateString(self, step_id, state_string):

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -539,10 +539,8 @@ message['builds'].add(
     None, MessageValidator(events=_buildEvents, messageValidator=DictValidator(**_build))
 )
 
-# As build's properties are fetched at DATA API level,
-# a distinction shall be made as both are not equal.
-# Validates DB layer
-dbdict['dbbuilddict'] = buildbase = DictValidator(
+# Validates DATA API layer
+dbdict['builddict'] = DictValidator(
     id=IntValidator(),
     number=IntValidator(),
     builderid=IntValidator(),
@@ -554,11 +552,7 @@ dbdict['dbbuilddict'] = buildbase = DictValidator(
     locks_duration_s=IntValidator(),
     state_string=StringValidator(),
     results=NoneOk(IntValidator()),
-)
-
-# Validates DATA API layer
-dbdict['builddict'] = DictValidator(
-    properties=NoneOk(SourcedPropertiesValidator()), **buildbase.keys
+    properties=NoneOk(SourcedPropertiesValidator()),
 )
 
 # build data

--- a/master/docs/developer/database/builds.rst
+++ b/master/docs/developer/database/builds.rst
@@ -15,7 +15,7 @@ Builds connector
 
     .. index:: bdict, buildid
 
-    Builds are indexed by *buildid* and their contents represented as *builddicts* (build dictionaries), with the following keys:
+    Builds are indexed by *buildid* and their contents represented as :class:`BuildModel` dataclass, with the following fields:
 
     * ``id`` (the build ID, globally unique)
     * ``number`` (the build number, unique only within the builder)
@@ -33,7 +33,7 @@ Builds connector
     .. py:method:: getBuild(buildid)
 
         :param integer buildid: build id
-        :returns: Build dictionary as above or ``None``, via Deferred
+        :returns: :class:`BuildModel` or ``None``, via Deferred
 
         Get a single build, in the format described above.
         Returns ``None`` if there is no such build.
@@ -42,7 +42,7 @@ Builds connector
 
         :param integer builder: builder id
         :param integer number: build number within that builder
-        :returns: Build dictionary as above or ``None``, via Deferred
+        :returns: :class:`BuildModel` or ``None``, via Deferred
 
         Get a single build, in the format described above, specified by builder and number, rather than build id.
         Returns ``None`` if there is no such build.
@@ -52,7 +52,7 @@ Builds connector
         :param integer builderid: builder to get builds for
         :param integer number: the current build number. Previous build will be taken from this number
         :param list ssBuild: the list of sourcestamps for the current build number
-        :returns: None or a build dictionary
+        :returns: :class:`BuildModel` or ``None``, via Deferred
 
         Returns the last successful build from the current build number with the same repository, branch, or codebase.
 
@@ -63,7 +63,7 @@ Builds connector
         :param boolean complete: if not None, filters results based on completeness
         :param resultSpec: result spec containing filters sorting and paging requests from data/REST API.
             If possible, the db layer can optimize the SQL query using this information.
-        :returns: list of build dictionaries as above, via Deferred
+        :returns: list of :class:`BuildModel`, via Deferred
 
         Get a list of builds, in the format described above.
         Each of the parameters limits the resulting set of builds.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -106,6 +106,7 @@ buildid
 buildmaster
 Buildmaster
 buildmasters
+BuildModel
 buildnumber
 buildrequest
 buildrequestid

--- a/newsfragments/db-introduce-BuildModel.change
+++ b/newsfragments/db-introduce-BuildModel.change
@@ -1,0 +1,1 @@
+:class:`BuildsConnectorComponent` `getBuild`, `getBuildByNumber`, `getPrevSuccessfulBuild`, `getBuildsForChange`, `getBuilds`, `_getRecentBuilds`, and `_getBuild` now return a :class`BuildModel` instead of a dictionary of Build data


### PR DESCRIPTION
Relates to #7591

Found more issues with DB queries using ResultSpec.
I'll make another PR with tests for this to be sure moving to dataclass doesn't introduce crashes.

Also found what looks to be an implementation error in `unit.reporters.test_words.TestContact.notify_build_test`

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
