### PR TITLE
data: implement resultspecs dataclass compatibility

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -372,6 +372,7 @@ cvs
 cvsroot
 daemonize
 dan
+dataclasses
 darcs
 datafields
 datareceived


### PR DESCRIPTION
As mentioned in #7610

resultspecs were only really working with `dict` data. This fix them when used with `dataclass`.

Change to `includeFields` implements field filtering, which convert a dataclass to a dict.
I think this should just not work, but implementation was trivial so I'm still looking for feedback.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a?] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
