### PR TITLE
www: Add a way to configure text in build links

### DIFF
--- a/newsfragments/www-build-link-configurable.feature
+++ b/newsfragments/www-build-link-configurable.feature
@@ -1,0 +1,2 @@
+The text displayed in build links is now configurable and can use any build property.
+It was showing build number or branch and build number before.

--- a/www/base/src/components/BuildersTable/BuildersTable.tsx
+++ b/www/base/src/components/BuildersTable/BuildersTable.tsx
@@ -28,6 +28,7 @@ import {
 } from "buildbot-data-js";
 import {Link} from "react-router-dom";
 import {
+  getBuildLinkDisplayProperties,
   BuildLinkWithSummaryTooltip,
   WorkerBadge,
   TagFilterManager,
@@ -63,7 +64,7 @@ export const BuildersTable = observer(
             limit: buildFetchLimit,
             order: '-started_at',
             builderid__eq: builderIds,
-            property: 'branch',
+            property: ['branch', ...getBuildLinkDisplayProperties()],
           }})
       });
 

--- a/www/base/src/views/BuilderView/BuilderView.tsx
+++ b/www/base/src/views/BuilderView/BuilderView.tsx
@@ -28,7 +28,7 @@ import {
   useDataAccessor,
   useDataApiQuery
 } from "buildbot-data-js";
-import {TopbarAction, useTopbarItems, useTopbarActions, WorkerBadge} from "buildbot-ui";
+import {getBuildLinkDisplayProperties, TopbarAction, useTopbarItems, useTopbarActions, WorkerBadge} from "buildbot-ui";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {BuildRequestsTable} from "../../components/BuildrequestsTable/BuildrequestsTable";
 import {useNavigate, useParams} from "react-router-dom";
@@ -104,7 +104,7 @@ export const BuilderView = observer(() => {
   const buildsQuery = useDataApiQuery(() =>
     buildersQuery.getRelated(builder => Build.getAll(accessor, {query: {
         builderid: builder.builderid,
-        property: ["owners", "workername", "branch", "revision"],
+        property: ["owners", "workername", "branch", "revision", ...getBuildLinkDisplayProperties()],
         limit: numBuilds,
         order: '-number'
       }

--- a/www/base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
+++ b/www/base/src/views/ChangeBuildsView/ChangeBuildsView.tsx
@@ -28,7 +28,7 @@ import {
 } from "buildbot-data-js";
 import {useParams} from "react-router-dom";
 import {useState} from "react";
-import {ChangeDetails} from "buildbot-ui";
+import {getBuildLinkDisplayProperties, ChangeDetails} from "buildbot-ui";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {LoadingDiv} from "../../components/LoadingDiv/LoadingDiv";
 
@@ -44,7 +44,7 @@ export const ChangeBuildsView = observer(() => {
 
   const buildsQuery = useDataApiSingleElementQuery(change,
     c => c.getBuilds({query: {
-        property: ["owners", "workername", "branch", "revision"],
+        property: ["owners", "workername", "branch", "revision", ...getBuildLinkDisplayProperties()],
         limit: buildsFetchLimit
       }}));
 

--- a/www/base/src/views/WorkerView/WorkerView.tsx
+++ b/www/base/src/views/WorkerView/WorkerView.tsx
@@ -27,6 +27,7 @@ import {
 } from "buildbot-data-js";
 import {useParams} from "react-router-dom";
 import {buildbotSetupPlugin} from "buildbot-plugin-support";
+import {getBuildLinkDisplayProperties} from "buildbot-ui";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
 import {BuildsTable} from "../../components/BuildsTable/BuildsTable";
 import {WorkerActionsModal} from "../../components/WorkerActionsModal/WorkerActionsModal";
@@ -40,7 +41,7 @@ export const WorkerView = observer(() => {
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const buildsQuery = useDataApiQuery(() =>
     Build.getAll(accessor, {query: {
-        property: ["owners", "workername", "branch", "revision"],
+        property: ["owners", "workername", "branch", "revision", ...getBuildLinkDisplayProperties()],
         workerid__eq: workerid,
         limit: 100,
         order: "-buildid",

--- a/www/base/src/views/WorkersView/WorkersView.tsx
+++ b/www/base/src/views/WorkersView/WorkersView.tsx
@@ -29,6 +29,7 @@ import {
 } from "buildbot-data-js";
 import {WorkerActionsModal} from "../../components/WorkerActionsModal/WorkerActionsModal";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
+import {getBuildLinkDisplayProperties} from "buildbot-ui";
 
 const isWorkerFiltered = (worker: Worker, showOldWorkers: boolean) => {
   if (showOldWorkers) {
@@ -77,7 +78,7 @@ export const WorkersView = observer(() => {
   const mastersQuery = useDataApiQuery(() => Master.getAll(accessor));
   const buildsQuery = useDataApiQuery(() =>
     Build.getAll(accessor, {query: {
-        property: ["owners", "workername", "branch"],
+        property: ["owners", "workername", "branch", ...getBuildLinkDisplayProperties()],
         limit: 200,
         order: '-buildid'
       }

--- a/www/ui/src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx
+++ b/www/ui/src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx
@@ -19,8 +19,10 @@ import './BuildLinkWithSummaryTooltip.scss';
 import {Link} from "react-router-dom";
 import {OverlayTrigger, Tooltip} from "react-bootstrap";
 import {Build, results2class} from "buildbot-data-js";
+import {buildbotGetSettings, buildbotSetupPlugin} from "buildbot-plugin-support";
 import {observer} from "mobx-react";
 import {Builder} from "buildbot-data-js";
+import {fillTemplate, parseTemplate} from "../../util/TemplateFormat";
 import {BuildSummaryTooltip} from "../BuildSummaryTooltip/BuildSummaryTooltip";
 import {BadgeRound} from "../BadgeRound/BadgeRound";
 
@@ -28,6 +30,35 @@ type BuildLinkWithSummaryTooltipProps = {
   build: Build;
   builder?: Builder | null;
 };
+
+export const getBuildLinkDisplayProperties = () => {
+  var template = buildbotGetSettings().getStringSetting('Links.build_link_template');
+  if (template === "")
+    return [];
+  return [...parseTemplate(template).replacements.values()]
+    .filter(x => x.startsWith("prop:"))
+    .map(x => x.substring(5));
+}
+
+export const formatBuildLinkText = (build: Build): string => {
+  var template = buildbotGetSettings().getStringSetting('Links.build_link_template');
+  if (template === "") {
+    return `${build.number}`;
+  }
+  var replacements = new Map<string, string>([['build_number', `${build.number}`]]);
+  for (const repl of parseTemplate(template).replacements.values()) {
+    if (repl.startsWith("prop:")) {
+      const prop = repl.substring(5);
+      const value = build.properties[prop];
+      if (value === undefined || value === null || value === '') {
+        continue;
+      }
+      replacements.set(repl, value);
+    }
+  }
+
+  return fillTemplate(template, replacements);
+}
 
 export const BuildLinkWithSummaryTooltip =
   observer(({build, builder}: BuildLinkWithSummaryTooltipProps) => {
@@ -43,10 +74,7 @@ export const BuildLinkWithSummaryTooltip =
     </Tooltip>
   );
 
-  const buildText = ('branch' in build.properties) && (build.properties['branch'][0] !== null) &&
-                    (build.properties['branch'][0] !== "")
-    ? `${build.properties['branch'][0]} (${build.number})`
-    : `${build.number}`;
+  const buildText = formatBuildLinkText(build);
 
   const linkText = builder !== undefined
     ? `${builder.name} / ${buildText}`
@@ -62,4 +90,18 @@ export const BuildLinkWithSummaryTooltip =
       </OverlayTrigger>
     </Link>
   );
+});
+
+buildbotSetupPlugin((reg) => {
+  reg.registerSettingGroup({
+    name: 'Links',
+    caption: 'Settings related to links between pages',
+    items: [{
+      type: 'string',
+      name: 'build_link_template',
+      caption: 'Format of data displayed in build badges. Use %(prop:build_property) to include ' +
+        'build properties, %(build_number) to include build number',
+      defaultValue: '%(prop:branch) (%(build_number))'
+    }
+  ]});
 });

--- a/www/ui/src/util/TemplateFormat.test.ts
+++ b/www/ui/src/util/TemplateFormat.test.ts
@@ -1,0 +1,137 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {describe, expect, it} from "vitest";
+import {fillTemplate, parseTemplate} from "./TemplateFormat";
+
+describe('TemplateFormat', () => {
+  describe('parseTemplate', () => {
+    it('empty', () => {
+      expect(parseTemplate('')).toEqual({
+        template: '',
+        replacements: new Set<string>(),
+        errors: []
+      });
+    });
+
+    it('no replacements', () => {
+      expect(parseTemplate('no replacements')).toEqual({
+        template: 'no replacements',
+        replacements: new Set<string>(),
+        errors: []
+      });
+    });
+
+    it('single replacement', () => {
+      expect(parseTemplate('%(replacement)')).toEqual({
+        template: '%(replacement)',
+        replacements: new Set(['replacement']),
+        errors: []
+      });
+      expect(parseTemplate('abc%(replacement)')).toEqual({
+        template: 'abc%(replacement)',
+        replacements: new Set(['replacement']),
+        errors: []
+      });
+      expect(parseTemplate('%(replacement)abc')).toEqual({
+        template: '%(replacement)abc',
+        replacements: new Set(['replacement']),
+        errors: []
+      });
+    });
+
+    it('empty replacement', () => {
+      expect(parseTemplate('%()')).toEqual({
+        template: '%()',
+        replacements: new Set(),
+        errors: ['Empty replacement at position 0']
+      });
+    });
+
+    it('two replacements', () => {
+      expect(parseTemplate('%(r1)%(r2)')).toEqual({
+        template: '%(r1)%(r2)',
+        replacements: new Set(['r1', 'r2']),
+        errors: []
+      });
+      expect(parseTemplate('%(r1)a%(r2)')).toEqual({
+        template: '%(r1)a%(r2)',
+        replacements: new Set(['r1', 'r2']),
+        errors: []
+      });
+      expect(parseTemplate('a%(r1)%(r2)')).toEqual({
+        template: 'a%(r1)%(r2)',
+        replacements: new Set(['r1', 'r2']),
+        errors: []
+      });
+      expect(parseTemplate('%(r1)%(r2)a')).toEqual({
+        template: '%(r1)%(r2)a',
+        replacements: new Set(['r1', 'r2']),
+        errors: []
+      });
+    });
+  });
+
+  describe('fillTemplate', () => {
+    it('empty', () => {
+      expect(fillTemplate('', new Map<string, string>())).toEqual('');
+    });
+
+    it('no replacements', () => {
+      expect(fillTemplate('no replacements', new Map<string, string>())).toEqual('no replacements');
+      expect(fillTemplate('no replacements', new Map<string, string>([['no', 'with']])))
+        .toEqual('no replacements');
+    });
+
+    it('single replacement', () => {
+      expect(fillTemplate('%(repl)', new Map<string, string>([['repl', 'value']])))
+        .toEqual('value');
+      expect(fillTemplate('%(repl)', new Map<string, string>()))
+        .toEqual('');
+      expect(fillTemplate('abc%(repl)', new Map<string, string>([['repl', 'value']])))
+        .toEqual('abcvalue');
+      expect(fillTemplate('abc%(repl)', new Map<string, string>()))
+        .toEqual('abc');
+      expect(fillTemplate('%(repl)abc', new Map<string, string>([['repl', 'value']])))
+        .toEqual('valueabc');
+      expect(fillTemplate('%(repl)abc', new Map<string, string>()))
+        .toEqual('abc');
+    });
+
+    it('two replacements', () => {
+      expect(fillTemplate(
+        '%(r1)%(r2)',
+        new Map<string, string>([['r1', 'value1'], ['r2', 'value2']])
+      )).toEqual('value1value2');
+
+      expect(fillTemplate(
+        '%(r1)a%(r2)',
+        new Map<string, string>([['r1', 'value1'], ['r2', 'value2']])
+      )).toEqual('value1avalue2');
+
+      expect(fillTemplate(
+        'a%(r1)%(r2)',
+        new Map<string, string>([['r1', 'value1'], ['r2', 'value2']])
+      )).toEqual('avalue1value2');
+
+      expect(fillTemplate(
+        '%(r1)%(r2)a',
+        new Map<string, string>([['r1', 'value1'], ['r2', 'value2']])
+      )).toEqual('value1value2a');
+    });
+  });
+});

--- a/www/ui/src/util/TemplateFormat.ts
+++ b/www/ui/src/util/TemplateFormat.ts
@@ -1,0 +1,76 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+export type ParsedTemplate = {
+  template: string;
+  replacements: Set<string>;
+  errors: string[]
+}
+
+export function parseTemplate(template: string) : ParsedTemplate {
+  const replacements = new Set<string>();
+  const errors: string[] = [];
+
+  let i = template.indexOf("%(");
+  while (i >= 0) {
+    let iend = template.indexOf(")", i + 2);
+    if (iend < 0) {
+      errors.push(`Unclosed replacement field at position ${i}`);
+      break;
+    }
+    if (i + 2 === iend) {
+      errors.push(`Empty replacement at position ${i}`);
+      break;
+    }
+    replacements.add(template.substring(i + 2, iend));
+    i = template.indexOf("%(", iend + 1);
+  }
+  return {
+    template: template,
+    replacements: replacements,
+    errors: errors
+  }
+}
+
+export function fillTemplate(template: string, replacements: Map<string, string>) {
+  let result = '';
+  let i = template.indexOf("%(");
+  if (i >= 0) {
+    result += template.substring(0, i);
+  } else {
+    result += template;
+  }
+
+  while (i >= 0) {
+    let iend = template.indexOf(")", i + 2);
+    if (iend < 0) {
+      return result;
+    }
+    if (i + 2 === iend) {
+      return result;
+    }
+    const key = template.substring(i + 2, iend);
+    result += replacements.get(key) ?? '';
+    i = template.indexOf("%(", iend + 1);
+    if (i >= 0) {
+      result += template.substring(iend + 1, i);
+    } else {
+      result += template.substring(iend + 1);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
This allows to customize Buildbot deployments without having to modify Buildbot code.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
