### PR TITLE
reporters: Remove deprecated usage of GerritStatusPush arguments

### DIFF
--- a/master/docs/manual/configuration/reporters/gerrit_status.rst
+++ b/master/docs/manual/configuration/reporters/gerrit_status.rst
@@ -14,83 +14,10 @@ GerritStatusPush can send a separate review for each build that completes, or a 
    :param string username: Gerrit SSH server's username.
    :param identity_file: (optional) Gerrit SSH identity file.
    :param int port: (optional) Gerrit SSH server's port (default: 29418)
-   :param reviewCB: (optional) Called each time a build finishes. Build properties are available. Can be a deferred.
-   :param reviewArg: (optional) Argument passed to the review callback.
-
-                    :: If :py:func:`reviewCB` callback is specified, it must return a dictionary.
-                    If no message is specified in the dictionary, nothing will be sent to Gerrit.
-
-                    .. code-block:: python
-
-                        {'message': message,
-                         'labels': {label-name: label-score,
-                                    ...}
-                        }
-
-                    For example:
-
-                    .. literalinclude:: /examples/git_gerrit.cfg
-                       :pyobject: gerritReviewCB
-                       :language: python
-
-                    Which require an extra import in the config:
-
-                    .. code-block:: python
-
-                       from buildbot.plugins import util
-
-   :param startCB: (optional) Called each time a build is started. Build properties are available. Can be a deferred.
-   :param startArg: (optional) Argument passed to the start callback.
-
-                    If :py:func:`startCB` is specified, it must return a dictionary.
-                    If no message is specified in the dictionary, nothing will be sent to Gerrit.
-
-                    .. code-block:: python
-
-                        {'message': message,
-                         'labels': {label-name: label-score,
-                                    ...}
-                        }
-
-                    For example:
-
-                    .. literalinclude:: /examples/git_gerrit.cfg
-                       :pyobject: gerritStartCB
-                       :language: python
-
-   :param summaryCB: (optional) Called each time a buildset finishes. Each build in the buildset has properties available. Can be a deferred.
-   :param summaryArg: (optional) Argument passed to the summary callback.
-
-                      If :py:func:`summaryCB` callback is specified, it must return a dictionary.
-                      If no message is specified in the dictionary, nothing will be sent to Gerrit.
-                      The message and labels should be a summary of all the builds within the buildset.
-
-                      .. code-block:: python
-
-                          {'message': message,
-                           'labels': {label-name: label-score,
-                                      ...}
-                          }
-
-                      For example:
-
-                      .. literalinclude:: /examples/git_gerrit.cfg
-                         :pyobject: gerritSummaryCB
-                         :language: python
-
-   :param builders: (optional) List of builders to send results for.
-                    This method allows to filter results for a specific set of builder.
-                    By default, or if builders is None, then no filtering is performed.
    :param notify: (optional) Control who gets notified by Gerrit once the status is posted.
                   The possible values for `notify` can be found in your version of the
                   Gerrit documentation for the `gerrit review` command.
 
-   :param wantSteps: (optional, defaults to False) Extends the given ``build`` object with information about steps of the build.
-                     Use it only when necessary as this increases the overhead in term of CPU and memory on the master.
-
-   :param wantLogs: (optional, default to False) Extends the steps of the given ``build`` object with the full logs of the build.
-                    This requires ``wantSteps`` to be True.
-                    Use it only when mandatory as this increases the overhead in term of CPU and memory on the master greatly.
 
 .. note::
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -728,6 +728,8 @@ repourl
 reStructuredText
 resultSpec
 revertive
+reviewArg
+reviewCB
 revlink
 revlinks
 rmdir
@@ -799,6 +801,8 @@ ssdict
 sse
 sshd
 ssid
+startArg
+startCB
 startService
 startsWith
 startup
@@ -837,6 +841,8 @@ subunit
 successCb
 sucessful
 summarization
+summaryArg
+summaryCB
 superclass
 superproject
 superset
@@ -976,6 +982,7 @@ Vixie
 vpc
 wamp
 Wamp
+wantLogs
 wantSteps
 warner
 warningPattern

--- a/newsfragments/deprecated-GerritStatusPush-arguments.removal
+++ b/newsfragments/deprecated-GerritStatusPush-arguments.removal
@@ -1,0 +1,1 @@
+GerritStatusPush now does not accept deprecated arguments: reviewCB, startCB, reviewArg, startArg, summaryCB, summaryArg, builders, wantSteps, wantLogs.


### PR DESCRIPTION
This PR removes usages of deprecated GerritStatusPush arguments: `reviewCB`, `startCB`, `reviewArg`, `startArg`, `summaryCB`, `summaryArg`, `builders`, `wantSteps`, `wantLogs`.
PR is a partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
