### PR TITLE
www: Improve Settings UI

### DIFF
--- a/newsfragments/www-settings-ui.change
+++ b/newsfragments/www-settings-ui.change
@@ -1,0 +1,1 @@
+Improve settings UI (reduce group header size and add space between groups).

--- a/www/react-base/src/views/SettingsView/SettingsView.scss
+++ b/www/react-base/src/views/SettingsView/SettingsView.scss
@@ -1,0 +1,23 @@
+.bb-settings-view {
+  .card {
+    margin-bottom: 1.25rem;
+   }
+
+  .card-header {
+    margin-bottom: 0;
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+  }
+
+  .card-title {
+    margin-bottom: 0;
+  }
+
+  .h5 {
+    font-size: 1rem;
+  }
+
+  .card-body {
+    padding: 0.5rem;
+  }
+}

--- a/www/react-base/src/views/SettingsView/SettingsView.tsx
+++ b/www/react-base/src/views/SettingsView/SettingsView.tsx
@@ -15,6 +15,7 @@
   Copyright Buildbot Team Members
 */
 
+import './SettingsView.scss';
 import {observer} from "mobx-react";
 import {Card} from "react-bootstrap";
 import {FaSlidersH} from "react-icons/fa";
@@ -112,7 +113,7 @@ export const SettingsView = observer(() => {
   }
 
   return (
-    <div className="container">
+    <div className="bb-settings-view container">
       {Object.values(globalSettings.groups).map(group => renderGroup(group))}
       <Card>
         <Card.Header>


### PR DESCRIPTION
- reduce group header size (reduced padding and removed extra bottom margin)
- add space between groups

Before change: 
![image](https://github.com/buildbot/buildbot/assets/14224662/5f1b58d7-786f-4c79-84cf-a3a6bbe27200)

After change:
![image](https://github.com/buildbot/buildbot/assets/14224662/2afb5f1f-e5c1-40a7-90a2-8797edc61a82)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
