### PR TITLE
process: Fix crash when collapseRequestsFn is None

### DIFF
--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -76,7 +76,7 @@ class BuildRequestCollapser:
             unclaim_brs = yield self._getUnclaimedBrs(builderid)
 
             # short circuit if there is no merging to do
-            if not unclaim_brs:
+            if not collapseRequestsFn or not unclaim_brs:
                 continue
 
             for unclaim_br in unclaim_brs:


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/pull/7607/commits/8e9df31ddee62b77997e6d771a60dcda68f59b10.

@tdesveaux this is perfect illustration why a single commit should change only single thing and any unrelated changes should be at least in separate commits. Large commits mean errors become easier to miss in review.