### PR TITLE
Remove deprecated module attributes

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -401,7 +401,6 @@ defertothread
 delayedcall
 denormalized
 dependabot
-deprecatedmoduleattribute
 descriptionsuffix
 desynchronization
 dev

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -23,8 +23,6 @@ Define the interfaces that are implemented by various buildbot classes.
 # pylint: disable=no-method-argument
 # pylint: disable=inherit-non-class
 
-from twisted.python.deprecate import deprecatedModuleAttribute
-from twisted.python.versions import Version
 from zope.interface import Attribute
 from zope.interface import Interface
 
@@ -37,15 +35,6 @@ class BuilderInUseError(Exception):
 
 class WorkerSetupError(Exception):
     pass
-
-
-WorkerTooOldError = WorkerSetupError
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 9, 0),
-    message="Use WorkerSetupError instead.",
-    moduleName="buildbot.interfaces",
-    name="WorkerTooOldError",
-)
 
 
 class LatentWorkerFailedToSubstantiate(Exception):

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -24,10 +24,8 @@ from twisted.internet import error
 from twisted.python import deprecate
 from twisted.python import log
 from twisted.python import versions
-from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.failure import Failure
 from twisted.python.reflect import accumulateClassList
-from twisted.python.versions import Version
 from twisted.web.util import formatFailure
 from zope.interface import implementer
 
@@ -43,7 +41,6 @@ from buildbot.db.model import Model
 from buildbot.interfaces import IRenderable
 from buildbot.interfaces import WorkerSetupError
 from buildbot.process import log as plog
-from buildbot.process import logobserver
 from buildbot.process import properties
 from buildbot.process import remotecommand
 from buildbot.process import results
@@ -83,56 +80,6 @@ class BuildStepCancelled(Exception):
 class CallableAttributeError(Exception):
     # attribute error raised from a callable run inside a property
     pass
-
-
-# old import paths for these classes
-RemoteCommand = remotecommand.RemoteCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 10, 1),
-    message="Use buildbot.process.remotecommand.RemoteCommand instead.",
-    moduleName="buildbot.process.buildstep",
-    name="RemoteCommand",
-)
-
-LoggedRemoteCommand = remotecommand.LoggedRemoteCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 10, 1),
-    message="Use buildbot.process.remotecommand.LoggedRemoteCommand instead.",
-    moduleName="buildbot.process.buildstep",
-    name="LoggedRemoteCommand",
-)
-
-RemoteShellCommand = remotecommand.RemoteShellCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 10, 1),
-    message="Use buildbot.process.remotecommand.RemoteShellCommand instead.",
-    moduleName="buildbot.process.buildstep",
-    name="RemoteShellCommand",
-)
-
-LogObserver = logobserver.LogObserver
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 10, 1),
-    message="Use buildbot.process.logobserver.LogObserver instead.",
-    moduleName="buildbot.process.buildstep",
-    name="LogObserver",
-)
-
-LogLineObserver = logobserver.LogLineObserver
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 10, 1),
-    message="Use buildbot.util.LogLineObserver instead.",
-    moduleName="buildbot.process.buildstep",
-    name="LogLineObserver",
-)
-
-OutputProgressObserver = logobserver.OutputProgressObserver
-deprecatedModuleAttribute(
-    Version("buildbot", 2, 10, 1),
-    message="Use buildbot.process.logobserver.OutputProgressObserver instead.",
-    moduleName="buildbot.process.buildstep",
-    name="OutputProgressObserver",
-)
 
 
 @implementer(interfaces.IBuildStepFactory)

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -16,8 +16,6 @@
 import re
 
 from twisted.internet import defer
-from twisted.python.deprecate import deprecatedModuleAttribute
-from twisted.python.versions import Version
 
 from buildbot import config
 from buildbot.process import buildstep
@@ -150,15 +148,6 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
         if cmd.didFail():
             return FAILURE
         return SUCCESS
-
-
-SetProperty = SetPropertyFromCommand
-deprecatedModuleAttribute(
-    Version("Buildbot", 0, 8, 8),
-    "It has been renamed to SetPropertyFromCommand",
-    "buildbot.steps.shell",
-    "SetProperty",
-)
 
 
 class ShellCommand(buildstep.ShellMixin, buildstep.BuildStep):

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -89,7 +89,6 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.steps.download_secret_to_worker.RemoveWorkerFileSecret',
             'buildbot.steps.source.base.Source',
             'buildbot.steps.download_secret_to_worker.DownloadSecretsToWorker',
-            'buildbot.steps.shell.SetProperty',
             'buildbot.steps.worker.WorkerBuildStep',
             'buildbot.steps.vstudio.VisualStudio',
         }

--- a/master/buildbot/test/regressions/test_oldpaths.py
+++ b/master/buildbot/test/regressions/test_oldpaths.py
@@ -14,8 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-import warnings
-
 from twisted.trial import unittest
 
 from buildbot.warnings import DeprecatedApiWarning
@@ -115,26 +113,3 @@ class OldImportPaths(unittest.TestCase):
         from buildbot.steps.source import Source
 
         assert Source
-
-    def test_buildstep_remotecommand(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecatedApiWarning)
-            warnings.simplefilter("ignore", DeprecationWarning)
-            from buildbot.process.buildstep import LoggedRemoteCommand
-            from buildbot.process.buildstep import RemoteCommand
-            from buildbot.process.buildstep import RemoteShellCommand
-
-            assert RemoteCommand
-            assert LoggedRemoteCommand
-            assert RemoteShellCommand
-
-    def test_buildstep_logobserver(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecatedApiWarning)
-            warnings.simplefilter("ignore", DeprecationWarning)
-            from buildbot.process.buildstep import LogLineObserver
-            from buildbot.process.buildstep import LogObserver
-            from buildbot.process.buildstep import OutputProgressObserver
-        assert LogObserver
-        assert LogLineObserver
-        assert OutputProgressObserver

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -463,26 +463,6 @@ class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
 
-class SetPropertyDeprecation(unittest.TestCase):
-    """
-    Tests for L{shell.SetProperty}
-    """
-
-    def test_deprecated(self):
-        """
-        Accessing L{shell.SetProperty} reports a deprecation error.
-        """
-        shell.SetProperty
-        warnings = self.flushWarnings([self.test_deprecated])
-        self.assertEqual(len(warnings), 1)
-        self.assertIdentical(warnings[0]['category'], DeprecationWarning)
-        self.assertEqual(
-            warnings[0]['message'],
-            "buildbot.steps.shell.SetProperty was deprecated in Buildbot 0.8.8: "
-            "It has been renamed to SetPropertyFromCommand",
-        )
-
-
 class Configure(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -28,8 +28,6 @@ from urllib.parse import urlunsplit
 
 import dateutil.tz
 from twisted.python import reflect
-from twisted.python.deprecate import deprecatedModuleAttribute
-from twisted.python.versions import Version
 from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
@@ -269,13 +267,6 @@ def bytes2unicode(x, encoding='utf-8', errors='strict'):
 
 
 _hush_pyflakes = [json]
-
-deprecatedModuleAttribute(
-    Version("buildbot", 0, 9, 4),
-    message="Use json from the standard library instead.",
-    moduleName="buildbot.util",
-    name="json",
-)
 
 
 def toJson(obj):

--- a/newsfragments/deprecated-module-attributes.removal
+++ b/newsfragments/deprecated-module-attributes.removal
@@ -1,0 +1,1 @@
+Deprecated module attributes have been deleted.


### PR DESCRIPTION
This PR removes deprecated module attributes.
PR is a partially addressing https://github.com/buildbot/buildbot/issues/7567.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
