### PR TITLE
3.11 backports: changes:  Re-format gitpoller with ruff

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -34,19 +34,30 @@ from buildbot.util.state import StateMixin
 
 
 class GitError(Exception):
-
     """Raised when git exits with code 128."""
 
 
 class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
-
     """This source will poll a remote git repo for changes and submit
     them to the change master."""
 
-    compare_attrs = ("repourl", "branches", "workdir", "pollInterval", "gitbin", "usetimestamps",
-                     "category", "project", "pollAtLaunch", "buildPushesWithNoCommits",
-                     "sshPrivateKey", "sshHostKey", "sshKnownHosts", "pollRandomDelayMin",
-                     "pollRandomDelayMax")
+    compare_attrs = (
+        "repourl",
+        "branches",
+        "workdir",
+        "pollInterval",
+        "gitbin",
+        "usetimestamps",
+        "category",
+        "project",
+        "pollAtLaunch",
+        "buildPushesWithNoCommits",
+        "sshPrivateKey",
+        "sshHostKey",
+        "sshKnownHosts",
+        "pollRandomDelayMin",
+        "pollRandomDelayMax",
+    )
 
     secrets = ("sshPrivateKey", "sshHostKey", "sshKnownHosts")
 
@@ -56,13 +67,30 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             kwargs["name"] = repourl
         super().__init__(repourl, **kwargs)
 
-    def checkConfig(self, repourl, branches=None, branch=None, workdir=None,
-                    pollInterval=10 * 60, gitbin="git", usetimestamps=True, category=None,
-                    project=None, pollinterval=-2, fetch_refspec=None, encoding="utf-8",
-                    name=None, pollAtLaunch=False, buildPushesWithNoCommits=False,
-                    only_tags=False, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
-                    pollRandomDelayMin=0, pollRandomDelayMax=0):
-
+    def checkConfig(
+        self,
+        repourl,
+        branches=None,
+        branch=None,
+        workdir=None,
+        pollInterval=10 * 60,
+        gitbin="git",
+        usetimestamps=True,
+        category=None,
+        project=None,
+        pollinterval=-2,
+        fetch_refspec=None,
+        encoding="utf-8",
+        name=None,
+        pollAtLaunch=False,
+        buildPushesWithNoCommits=False,
+        only_tags=False,
+        sshPrivateKey=None,
+        sshHostKey=None,
+        sshKnownHosts=None,
+        pollRandomDelayMin=0,
+        pollRandomDelayMax=0,
+    ):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
@@ -78,25 +106,47 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         self.setupGit(logname='GitPoller')  # check the configuration
 
         if fetch_refspec is not None:
-            config.error("GitPoller: fetch_refspec is no longer supported. "
-                         "Instead, only the given branches are downloaded.")
+            config.error(
+                "GitPoller: fetch_refspec is no longer supported. "
+                "Instead, only the given branches are downloaded."
+            )
 
         if name is None:
             name = repourl
 
-        super().checkConfig(name=name,
-                            pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
-                            pollRandomDelayMin=pollRandomDelayMin,
-                            pollRandomDelayMax=pollRandomDelayMax)
+        super().checkConfig(
+            name=name,
+            pollInterval=pollInterval,
+            pollAtLaunch=pollAtLaunch,
+            pollRandomDelayMin=pollRandomDelayMin,
+            pollRandomDelayMax=pollRandomDelayMax,
+        )
 
     @defer.inlineCallbacks
-    def reconfigService(self, repourl, branches=None, branch=None, workdir=None,
-                        pollInterval=10 * 60, gitbin="git", usetimestamps=True, category=None,
-                        project=None, pollinterval=-2, fetch_refspec=None, encoding="utf-8",
-                        name=None, pollAtLaunch=False, buildPushesWithNoCommits=False,
-                        only_tags=False, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None,
-                        pollRandomDelayMin=0, pollRandomDelayMax=0):
-
+    def reconfigService(
+        self,
+        repourl,
+        branches=None,
+        branch=None,
+        workdir=None,
+        pollInterval=10 * 60,
+        gitbin="git",
+        usetimestamps=True,
+        category=None,
+        project=None,
+        pollinterval=-2,
+        fetch_refspec=None,
+        encoding="utf-8",
+        name=None,
+        pollAtLaunch=False,
+        buildPushesWithNoCommits=False,
+        only_tags=False,
+        sshPrivateKey=None,
+        sshHostKey=None,
+        sshKnownHosts=None,
+        pollRandomDelayMin=0,
+        pollRandomDelayMax=0,
+    ):
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
@@ -122,8 +172,9 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         self.gitbin = gitbin
         self.workdir = workdir
         self.usetimestamps = usetimestamps
-        self.category = category if callable(
-            category) else bytes2unicode(category, encoding=self.encoding)
+        self.category = (
+            category if callable(category) else bytes2unicode(category, encoding=self.encoding)
+        )
         self.project = bytes2unicode(project, encoding=self.encoding)
         self.changeCount = 0
         self.lastRev = {}
@@ -141,10 +192,13 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             self.workdir = os.path.join(self.master.basedir, self.workdir)
             log.msg(f"gitpoller: using workdir '{self.workdir}'")
 
-        yield super().reconfigService(name=name,
-                                      pollInterval=pollInterval, pollAtLaunch=pollAtLaunch,
-                                      pollRandomDelayMin=pollRandomDelayMin,
-                                      pollRandomDelayMax=pollRandomDelayMax)
+        yield super().reconfigService(
+            name=name,
+            pollInterval=pollInterval,
+            pollAtLaunch=pollAtLaunch,
+            pollRandomDelayMin=pollRandomDelayMin,
+            pollRandomDelayMax=pollRandomDelayMax,
+        )
 
     @defer.inlineCallbacks
     def _checkGitFeatures(self):
@@ -154,8 +208,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         if not self.gitInstalled:
             raise EnvironmentError('Git is not installed')
 
-        if (self.sshPrivateKey is not None and
-                not self.supportsSshPrivateKeyAsEnvOption):
+        if self.sshPrivateKey is not None and not self.supportsSshPrivateKeyAsEnvOption:
             raise EnvironmentError('SSH private keys require Git 2.3.0 or newer')
 
     @defer.inlineCallbacks
@@ -168,8 +221,9 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             log.err(e, 'while initializing GitPoller repository')
 
     def describe(self):
-        str = ('GitPoller watching the remote git repository ' +
-               bytes2unicode(self.repourl, self.encoding))
+        str = 'GitPoller watching the remote git repository ' + bytes2unicode(
+            self.repourl, self.encoding
+        )
 
         if self.branches:
             if self.branches is True:
@@ -195,6 +249,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                 _, ref = row.split("\t")
                 branches.append(ref)
             return branches
+
         return d
 
     def _headsFilter(self, branch):
@@ -242,13 +297,11 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             branches = sorted(list(set(branches) & set(remote_branches)))
 
         refspecs = [
-            f'+{self._removeHeads(branch)}:{self._trackerBranch(branch)}'
-            for branch in branches
+            f'+{self._removeHeads(branch)}:{self._trackerBranch(branch)}' for branch in branches
         ]
 
         try:
-            yield self._dovccmd('fetch', ['--progress', self.repourl] + refspecs,
-                                path=self.workdir)
+            yield self._dovccmd('fetch', ['--progress', self.repourl] + refspecs, path=self.workdir)
         except GitError as e:
             log.msg(e.args[0])
             return
@@ -263,7 +316,8 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                     break
 
                 rev = yield self._dovccmd(
-                    'rev-parse', [self._trackerBranch(branch)], path=self.workdir)
+                    'rev-parse', [self._trackerBranch(branch)], path=self.workdir
+                )
                 revs[branch] = bytes2unicode(rev, self.encoding)
                 yield self._process_changes(revs[branch], branch)
             except Exception:
@@ -288,11 +342,14 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                 try:
                     stamp = int(git_output)
                 except Exception as e:
-                    log.msg(f'gitpoller: caught exception converting output \'{git_output}\' to '
-                            'timestamp')
+                    log.msg(
+                        f'gitpoller: caught exception converting output \'{git_output}\' to '
+                        'timestamp'
+                    )
                     raise e
                 return stamp
             return None
+
         return d
 
     def _get_commit_files(self, rev):
@@ -303,16 +360,18 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             # git use octal char sequences in quotes when non ASCII
             match = re.match('^"(.*)"$', file)
             if match:
-                file = bytes2unicode(match.groups()[0], encoding=self.encoding,
-                                     errors='unicode_escape')
+                file = bytes2unicode(
+                    match.groups()[0], encoding=self.encoding, errors='unicode_escape'
+                )
             return bytes2unicode(file, encoding=self.encoding)
 
         @d.addCallback
         def process(git_output):
-            fileList = [decode_file(file)
-                        for file in
-                        [s for s in git_output.splitlines() if len(s)]]
+            fileList = [
+                decode_file(file) for file in [s for s in git_output.splitlines() if len(s)]
+            ]
             return fileList
+
         return d
 
     def _get_commit_author(self, rev):
@@ -324,6 +383,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             if not git_output:
                 raise EnvironmentError('could not get commit author for rev')
             return git_output
+
         return d
 
     @defer.inlineCallbacks
@@ -349,11 +409,12 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             return
 
         # get the change list
-        revListArgs = (['--ignore-missing'] +
-                       ['--format=%H', f'{newRev}'] +
-                       ['^' + rev
-                        for rev in sorted(self.lastRev.values())] +
-                       ['--'])
+        revListArgs = (
+            ['--ignore-missing']
+            + ['--format=%H', f'{newRev}']
+            + ['^' + rev for rev in sorted(self.lastRev.values())]
+            + ['--']
+        )
         self.changeCount = 0
         results = yield self._dovccmd('log', revListArgs, path=self.workdir)
 
@@ -377,17 +438,22 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         self.lastRev[branch] = newRev
 
         if self.changeCount:
-            log.msg(f'gitpoller: processing {self.changeCount} changes: {revList} from '
-                    f'"{self.repourl}" branch "{branch}"')
+            log.msg(
+                f'gitpoller: processing {self.changeCount} changes: {revList} from '
+                f'"{self.repourl}" branch "{branch}"'
+            )
 
         for rev in revList:
-            dl = defer.DeferredList([
-                self._get_commit_timestamp(rev),
-                self._get_commit_author(rev),
-                self._get_commit_committer(rev),
-                self._get_commit_files(rev),
-                self._get_commit_comments(rev),
-            ], consumeErrors=True)
+            dl = defer.DeferredList(
+                [
+                    self._get_commit_timestamp(rev),
+                    self._get_commit_author(rev),
+                    self._get_commit_committer(rev),
+                    self._get_commit_files(rev),
+                    self._get_commit_comments(rev),
+                ],
+                consumeErrors=True,
+            )
 
             results = yield dl
 
@@ -405,11 +471,15 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                 author=author,
                 committer=committer,
                 revision=bytes2unicode(rev, encoding=self.encoding),
-                files=files, comments=comments, when_timestamp=timestamp,
+                files=files,
+                comments=comments,
+                when_timestamp=timestamp,
                 branch=bytes2unicode(self._removeHeads(branch)),
                 project=self.project,
                 repository=bytes2unicode(self.repourl, encoding=self.encoding),
-                category=self.category, src='git')
+                category=self.category,
+                src='git',
+            )
 
     def _isSshPrivateKeyNeededForCommand(self, command):
         commandsThatNeedKey = [
@@ -443,7 +513,8 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
     def _dovccmd(self, command, args, path=None):
         if self._isSshPrivateKeyNeededForCommand(command):
             with private_tempdir.PrivateTemporaryDirectory(
-                    dir=self.workdir, prefix='.buildbot-ssh') as tmp_path:
+                dir=self.workdir, prefix='.buildbot-ssh'
+            ) as tmp_path:
                 stdout = yield self._dovccmdImpl(command, args, path, tmp_path)
         else:
             stdout = yield self._dovccmdImpl(command, args, path, None)
@@ -463,21 +534,26 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                 known_hosts_path = self._getSshKnownHostsPath(ssh_workdir)
                 self._downloadSshKnownHosts(known_hosts_path)
 
-            self.adjustCommandParamsForSshPrivateKey(full_args, full_env,
-                                                     key_path, None,
-                                                     known_hosts_path)
+            self.adjustCommandParamsForSshPrivateKey(
+                full_args, full_env, key_path, None, known_hosts_path
+            )
 
         full_args += [command] + args
 
-        res = yield runprocess.run_process(self.master.reactor, [self.gitbin] + full_args, path,
-                                           env=full_env)
+        res = yield runprocess.run_process(
+            self.master.reactor, [self.gitbin] + full_args, path, env=full_env
+        )
         (code, stdout, stderr) = res
         stdout = bytes2unicode(stdout, self.encoding)
         stderr = bytes2unicode(stderr, self.encoding)
         if code != 0:
             if code == 128:
-                raise GitError(f'command {full_args} in {path} on repourl {self.repourl} failed '
-                               f'with exit code {code}: {stderr}')
-            raise EnvironmentError(f'command {full_args} in {path} on repourl {self.repourl} '
-                                   f'failed with exit code {code}: {stderr}')
+                raise GitError(
+                    f'command {full_args} in {path} on repourl {self.repourl} failed '
+                    f'with exit code {code}: {stderr}'
+                )
+            raise EnvironmentError(
+                f'command {full_args} in {path} on repourl {self.repourl} '
+                f'failed with exit code {code}: {stderr}'
+            )
         return stdout.strip()

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -35,12 +35,13 @@ from buildbot.util import unicode2bytes
 os.environ['TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'] = 'TRUE'
 
 
-class TestGitPollerBase(MasterRunProcessMixin,
-                        changesource.ChangeSourceMixin,
-                        logging.LoggingMixin,
-                        TestReactorMixin,
-                        unittest.TestCase):
-
+class TestGitPollerBase(
+    MasterRunProcessMixin,
+    changesource.ChangeSourceMixin,
+    logging.LoggingMixin,
+    TestReactorMixin,
+    unittest.TestCase,
+):
     REPOURL = 'git@example.com:~foo/baz.git'
     REPOURL_QUOTED = 'git%40example.com%3A%7Efoo%2Fbaz.git'
 
@@ -66,17 +67,14 @@ class TestGitPollerBase(MasterRunProcessMixin,
 
 
 class TestGitPoller(TestGitPollerBase):
-
     dummyRevStr = '12345abcde'
 
     @defer.inlineCallbacks
-    def _perform_git_output_test(self, methodToTest, args,
-                                 desiredGoodOutput, desiredGoodResult,
-                                 emptyRaisesException=True):
-
+    def _perform_git_output_test(
+        self, methodToTest, args, desiredGoodOutput, desiredGoodResult, emptyRaisesException=True
+    ):
         self.expect_commands(
-            ExpectMasterShell(['git'] + args)
-            .workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell(['git'] + args).workdir(self.POLLER_WORKDIR),
         )
 
         # we should get an Exception with empty output from git
@@ -87,6 +85,7 @@ class TestGitPoller(TestGitPollerBase):
         except Exception as e:
             if not emptyRaisesException:
                 import traceback
+
                 traceback.print_exc()
                 self.fail("run_process should NOT have failed on empty output: " + repr(e))
 
@@ -94,9 +93,7 @@ class TestGitPoller(TestGitPollerBase):
 
         # and the method shouldn't suppress any exceptions
         self.expect_commands(
-            ExpectMasterShell(['git'] + args)
-            .workdir(self.POLLER_WORKDIR)
-            .exit(1),
+            ExpectMasterShell(['git'] + args).workdir(self.POLLER_WORKDIR).exit(1),
         )
 
         try:
@@ -109,9 +106,7 @@ class TestGitPoller(TestGitPollerBase):
 
         # finally we should get what's expected from good output
         self.expect_commands(
-            ExpectMasterShell(['git'] + args)
-            .workdir(self.POLLER_WORKDIR)
-            .stdout(desiredGoodOutput)
+            ExpectMasterShell(['git'] + args).workdir(self.POLLER_WORKDIR).stdout(desiredGoodOutput)
         )
 
         r = yield methodToTest(self.dummyRevStr)
@@ -129,47 +124,56 @@ class TestGitPoller(TestGitPollerBase):
     def test_get_commit_author(self):
         authorStr = 'Sammy Jankis <email@example.com>'
         authorBytes = unicode2bytes(authorStr)
-        return self._perform_git_output_test(self.poller._get_commit_author,
-                                             ['log', '--no-walk', '--format=%aN <%aE>',
-                                                 self.dummyRevStr, '--'],
-                                             authorBytes, authorStr)
+        return self._perform_git_output_test(
+            self.poller._get_commit_author,
+            ['log', '--no-walk', '--format=%aN <%aE>', self.dummyRevStr, '--'],
+            authorBytes,
+            authorStr,
+        )
 
     def test_get_commit_committer(self):
         committerStr = 'Sammy Jankis <email@example.com>'
         committerBytes = unicode2bytes(committerStr)
-        return self._perform_git_output_test(self.poller._get_commit_committer,
-                                             ['log', '--no-walk', '--format=%cN <%cE>',
-                                                 self.dummyRevStr, '--'],
-                                             committerBytes, committerStr)
+        return self._perform_git_output_test(
+            self.poller._get_commit_committer,
+            ['log', '--no-walk', '--format=%cN <%cE>', self.dummyRevStr, '--'],
+            committerBytes,
+            committerStr,
+        )
 
     def _test_get_commit_comments(self, commentStr):
         commentBytes = unicode2bytes(commentStr)
-        return self._perform_git_output_test(self.poller._get_commit_comments,
-                                             ['log', '--no-walk', '--format=%s%n%b',
-                                                 self.dummyRevStr, '--'],
-                                             commentBytes, commentStr, emptyRaisesException=False)
+        return self._perform_git_output_test(
+            self.poller._get_commit_comments,
+            ['log', '--no-walk', '--format=%s%n%b', self.dummyRevStr, '--'],
+            commentBytes,
+            commentStr,
+            emptyRaisesException=False,
+        )
 
     def test_get_commit_comments(self):
-        comments = ['this is a commit message\n\nthat is multiline',
-                    'single line message', '']
-        return defer.DeferredList([self._test_get_commit_comments(commentStr)
-                                  for commentStr in comments])
+        comments = ['this is a commit message\n\nthat is multiline', 'single line message', '']
+        return defer.DeferredList([
+            self._test_get_commit_comments(commentStr) for commentStr in comments
+        ])
 
     def test_get_commit_files(self):
         filesBytes = b'\n\nfile1\nfile2\n"\146ile_octal"\nfile space'
         filesRes = ['file1', 'file2', 'file_octal', 'file space']
-        return self._perform_git_output_test(self.poller._get_commit_files,
-                                             ['log', '--name-only', '--no-walk',
-                                              '--format=%n', self.dummyRevStr, '--'],
-                                             filesBytes, filesRes, emptyRaisesException=False)
+        return self._perform_git_output_test(
+            self.poller._get_commit_files,
+            ['log', '--name-only', '--no-walk', '--format=%n', self.dummyRevStr, '--'],
+            filesBytes,
+            filesRes,
+            emptyRaisesException=False,
+        )
 
     def test_get_commit_files_with_space_in_changed_files(self):
         filesBytes = b'normal_directory/file1\ndirectory with space/file2'
         filesStr = bytes2unicode(filesBytes)
         return self._perform_git_output_test(
             self.poller._get_commit_files,
-            ['log', '--name-only', '--no-walk',
-             '--format=%n', self.dummyRevStr, '--'],
+            ['log', '--name-only', '--no-walk', '--format=%n', self.dummyRevStr, '--'],
             filesBytes,
             [l for l in filesStr.splitlines() if l.strip()],
             emptyRaisesException=False,
@@ -178,17 +182,18 @@ class TestGitPoller(TestGitPollerBase):
     def test_get_commit_timestamp(self):
         stampBytes = b'1273258009'
         stampStr = bytes2unicode(stampBytes)
-        return self._perform_git_output_test(self.poller._get_commit_timestamp,
-                                             ['log', '--no-walk', '--format=%ct',
-                                                 self.dummyRevStr, '--'],
-                                             stampBytes, float(stampStr))
+        return self._perform_git_output_test(
+            self.poller._get_commit_timestamp,
+            ['log', '--no-walk', '--format=%ct', self.dummyRevStr, '--'],
+            stampBytes,
+            float(stampStr),
+        )
 
     def test_describe(self):
         self.assertSubstring("GitPoller", self.poller.describe())
 
     def test_name(self):
-        self.assertEqual(bytes2unicode(self.REPOURL),
-                         bytes2unicode(self.poller.name))
+        self.assertEqual(bytes2unicode(self.REPOURL), bytes2unicode(self.poller.name))
 
         # and one with explicit name...
         other = gitpoller.GitPoller(self.REPOURL, name="MyName")
@@ -198,21 +203,16 @@ class TestGitPoller(TestGitPollerBase):
     def test_checkGitFeatures_git_not_installed(self):
         self.setUpLogging()
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'Command not found'),
+            ExpectMasterShell(['git', '--version']).stdout(b'Command not found'),
         )
 
-        yield self.assertFailure(self.poller._checkGitFeatures(),
-                                 EnvironmentError)
+        yield self.assertFailure(self.poller._checkGitFeatures(), EnvironmentError)
         self.assert_all_commands_ran()
 
     @defer.inlineCallbacks
     def test_checkGitFeatures_git_bad_version(self):
         self.setUpLogging()
-        self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git ')
-        )
+        self.expect_commands(ExpectMasterShell(['git', '--version']).stdout(b'git '))
 
         with self.assertRaises(EnvironmentError):
             yield self.poller._checkGitFeatures()
@@ -222,17 +222,23 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_initial(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
@@ -241,24 +247,23 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'}
+        )
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'},
+        )
 
     @defer.inlineCallbacks
     def test_poll_initial_poller_not_running(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
         )
 
         self.poller.doPoll.running = False
@@ -269,10 +274,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_failInit(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
-            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR])
-            .exit(1),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]).exit(1),
         )
 
         self.poller.doPoll.running = True
@@ -283,12 +286,16 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_failFetch(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
             ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
@@ -301,17 +308,23 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_failRevParse(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED +
-                               '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
@@ -326,48 +339,55 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_failLog(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
 
         # do the poll
-        self.poller.lastRev = {
-            'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930'
-        }
+        self.poller.lastRev = {'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930'}
 
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
         self.assertEqual(len(self.flushLoggedErrors()), 1)
-        self.assertEqual(self.poller.lastRev, {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
 
     @defer.inlineCallbacks
     def test_poll_GitError(self):
         # Raised when git exits with status code 128. See issue 2468
         self.expect_commands(
-            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR])
-            .exit(128),
+            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]).exit(128),
         )
 
         with self.assertRaises(gitpoller.GitError):
@@ -379,10 +399,8 @@ class TestGitPoller(TestGitPollerBase):
     def test_poll_GitError_log(self):
         self.setUpLogging()
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
-            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR])
-            .exit(128),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]).exit(128),
         )
 
         self.poller.doPoll.running = True
@@ -399,64 +417,83 @@ class TestGitPoller(TestGitPollerBase):
         self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
-        self.poller.lastRev = {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        }
+        self.poller.lastRev = {'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
 
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'},
+        )
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_initial(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
-                    b'refs/heads/release\n'
-                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
+                b'refs/heads/release\n'
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
+                b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
         )
@@ -467,166 +504,208 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-            'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
-        })
+        self.assertEqual(
+            self.poller.lastRev,
+            {
+                'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+            },
+        )
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
-                    b'refs/heads/release\n'
-                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
+                b'refs/heads/release\n'
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
+                b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            .stdout(
+                b'\n'.join([
+                    b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                ])
+            ),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
-            ])),
+            .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
 
         # and patch out the _get_commit_foo methods which were already tested
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
         self.poller.branches = ['master', 'release']
         self.poller.lastRev = {
             'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
-            'release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+            'release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
         }
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-            'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
-        })
+        self.assertEqual(
+            self.poller.lastRev,
+            {
+                'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+            },
+        )
 
-        self.assertEqual(self.master.data.updates.changesAdded, [
-            {
-                'author': 'by:4423cdbc',
-                'committer': 'by:4423cdbc',
-                'branch': 'master',
-                'category': None,
-                'codebase': None,
-                'comments': 'hello!',
-                'files': ['/etc/442'],
-                'project': '',
-                'properties': {},
-                'repository': 'git@example.com:~foo/baz.git',
-                'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                'revlink': '',
-                'src': 'git',
-                'when_timestamp': 1273258009,
-            },
-            {
-                'author': 'by:64a5dc2a',
-                'committer': 'by:64a5dc2a',
-                'branch': 'master',
-                'category': None,
-                'codebase': None,
-                'comments': 'hello!',
-                'files': ['/etc/64a'],
-                'project': '',
-                'properties': {},
-                'repository': 'git@example.com:~foo/baz.git',
-                'revision': '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                'revlink': '',
-                'src': 'git',
-                'when_timestamp': 1273258009,
-            },
-            {
-                'author': 'by:9118f4ab',
-                'committer': 'by:9118f4ab',
-                'branch': 'release',
-                'category': None,
-                'codebase': None,
-                'comments': 'hello!',
-                'files': ['/etc/911'],
-                'project': '',
-                'properties': {},
-                'repository': 'git@example.com:~foo/baz.git',
-                'revision': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                'revlink': '',
-                'src': 'git',
-                'when_timestamp': 1273258009,
-            }
-        ])
+        self.assertEqual(
+            self.master.data.updates.changesAdded,
+            [
+                {
+                    'author': 'by:4423cdbc',
+                    'committer': 'by:4423cdbc',
+                    'branch': 'master',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/442'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                },
+                {
+                    'author': 'by:64a5dc2a',
+                    'committer': 'by:64a5dc2a',
+                    'branch': 'master',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/64a'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                },
+                {
+                    'author': 'by:9118f4ab',
+                    'committer': 'by:9118f4ab',
+                    'branch': 'release',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/911'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                },
+            ],
+        )
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_default(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/release\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
@@ -635,39 +714,47 @@ class TestGitPoller(TestGitPollerBase):
         self.poller.branches = ['release']
         self.poller.lastRev = {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-
         }
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
         self.assertEqual(len(self.master.data.updates.changesAdded), 0)
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/release\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
@@ -676,29 +763,33 @@ class TestGitPoller(TestGitPollerBase):
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
         self.poller.branches = ['release']
         self.poller.lastRev = {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-
         }
 
         self.poller.buildPushesWithNoCommits = True
@@ -706,49 +797,63 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
-        self.assertEqual(self.master.data.updates.changesAdded, [
-            {'author': 'by:4423cdbc',
-             'committer': 'by:4423cdbc',
-             'branch': 'release',
-             'category': None,
-             'codebase': None,
-             'comments': 'hello!',
-             'files': ['/etc/442'],
-             'project': '',
-             'properties': {},
-             'repository': 'git@example.com:~foo/baz.git',
-             'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-             'revlink': '',
-             'src': 'git',
-             'when_timestamp': 1273258009}]
+        self.assertEqual(
+            self.poller.lastRev, {'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
+        self.assertEqual(
+            self.master.data.updates.changesAdded,
+            [
+                {
+                    'author': 'by:4423cdbc',
+                    'committer': 'by:4423cdbc',
+                    'branch': 'release',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/442'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                }
+            ],
         )
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true_fast_forward(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/release\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
@@ -757,30 +862,34 @@ class TestGitPoller(TestGitPollerBase):
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
         self.poller.branches = ['release']
         self.poller.lastRev = {
             'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-            'release': '0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c'
-
+            'release': '0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
         }
 
         self.poller.buildPushesWithNoCommits = True
@@ -788,48 +897,62 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
-        self.assertEqual(self.master.data.updates.changesAdded, [
-            {'author': 'by:4423cdbc',
-             'committer': 'by:4423cdbc',
-             'branch': 'release',
-             'category': None,
-             'codebase': None,
-             'comments': 'hello!',
-             'files': ['/etc/442'],
-             'project': '',
-             'properties': {},
-             'repository': 'git@example.com:~foo/baz.git',
-             'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-             'revlink': '',
-             'src': 'git',
-             'when_timestamp': 1273258009}]
+        self.assertEqual(
+            self.poller.lastRev, {'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
+        self.assertEqual(
+            self.master.data.updates.changesAdded,
+            [
+                {
+                    'author': 'by:4423cdbc',
+                    'committer': 'by:4423cdbc',
+                    'branch': 'release',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/442'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                }
+            ],
         )
 
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true_not_tip(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/release\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
@@ -838,29 +961,33 @@ class TestGitPoller(TestGitPollerBase):
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
         self.poller.branches = ['release']
         self.poller.lastRev = {
             'master': '0ba9d553b7217ab4bbad89ad56dc0332c7d57a8c',
-
         }
 
         self.poller.buildPushesWithNoCommits = True
@@ -868,72 +995,96 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
-        self.assertEqual(self.master.data.updates.changesAdded, [
-            {'author': 'by:4423cdbc',
-             'committer': 'by:4423cdbc',
-             'branch': 'release',
-             'category': None,
-             'codebase': None,
-             'comments': 'hello!',
-             'files': ['/etc/442'],
-             'project': '',
-             'properties': {},
-             'repository': 'git@example.com:~foo/baz.git',
-             'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-             'revlink': '',
-             'src': 'git',
-             'when_timestamp': 1273258009}]
+        self.assertEqual(
+            self.poller.lastRev, {'release': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
+        self.assertEqual(
+            self.master.data.updates.changesAdded,
+            [
+                {
+                    'author': 'by:4423cdbc',
+                    'committer': 'by:4423cdbc',
+                    'branch': 'release',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/442'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                }
+            ],
         )
 
     @defer.inlineCallbacks
     def test_poll_allBranches_single(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing', '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
+            .stdout(
+                b'\n'.join([
+                    b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                ])
+            ),
         )
 
         # and patch out the _get_commit_foo methods which were already tested
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
@@ -945,10 +1096,12 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'refs/heads/master':
-            '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-        })
+        self.assertEqual(
+            self.poller.lastRev,
+            {
+                'refs/heads/master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+            },
+        )
 
         added = self.master.data.updates.changesAdded
         self.assertEqual(len(added), 2)
@@ -976,77 +1129,109 @@ class TestGitPoller(TestGitPollerBase):
         self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b''),
         )
 
-        self.poller.lastRev = {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        }
+        self.poller.lastRev = {'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
 
     @defer.inlineCallbacks
     def test_poll_allBranches_multiple(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'\n'.join([
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
-                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
-            ])),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                          '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'\n'.join([
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
+                    b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
+                ])
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing', '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
-            ExpectMasterShell(['git', 'rev-parse', 'refs/buildbot/' + self.REPOURL_QUOTED +
-                               '/release'])
+            .stdout(
+                b'\n'.join([
+                    b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                ])
+            ),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing', '--format=%H',
-                          '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                          '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                '^4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
@@ -1055,40 +1240,46 @@ class TestGitPoller(TestGitPollerBase):
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
         self.poller.branches = True
         self.poller.lastRev = {
             'refs/heads/master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
-            'refs/heads/release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+            'refs/heads/release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
         }
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'refs/heads/master':
-            '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-            'refs/heads/release':
-            '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
-        })
+        self.assertEqual(
+            self.poller.lastRev,
+            {
+                'refs/heads/master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                'refs/heads/release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+            },
+        )
 
         added = self.master.data.updates.changesAdded
         self.assertEqual(len(added), 3)
@@ -1118,64 +1309,83 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_callableFilteredBranches(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'\n'.join([
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
-                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
-            ])),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'\n'.join([
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
+                    b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
+                ])
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing', '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241']))
+            .stdout(
+                b'\n'.join([
+                    b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                ])
+            ),
         )
 
         # and patch out the _get_commit_foo methods which were already tested
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
         class TestCallable:
-
             def __call__(self, branch):
                 return branch == "refs/heads/master"
 
         self.poller.branches = TestCallable()
         self.poller.lastRev = {
             'refs/heads/master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
-            'refs/heads/release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+            'refs/heads/release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
         }
         self.poller.doPoll.running = True
         yield self.poller.poll()
@@ -1184,9 +1394,9 @@ class TestGitPoller(TestGitPollerBase):
 
         # The release branch id should remain unchanged,
         # because it was ignored.
-        self.assertEqual(self.poller.lastRev, {
-            'refs/heads/master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'refs/heads/master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
 
         added = self.master.data.updates.changesAdded
         self.assertEqual(len(added), 2)
@@ -1209,29 +1419,38 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_branchFilter(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'\n'.join([
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                b'refs/pull/410/merge',
-                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
-                b'refs/pull/410/head',
-            ])),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED +
-                          '/refs/pull/410/head'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'\n'.join([
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/pull/410/merge',
+                    b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t' b'refs/pull/410/head',
+                ])
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing', '--format=%H',
-                          '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
-                          '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                '^bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'\n'.join([b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'])),
         )
@@ -1240,22 +1459,27 @@ class TestGitPoller(TestGitPollerBase):
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         def pullFilter(branch):
@@ -1269,15 +1493,15 @@ class TestGitPoller(TestGitPollerBase):
         self.poller.branches = pullFilter
         self.poller.lastRev = {
             'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
-            'refs/pull/410/head': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+            'refs/pull/410/head': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5',
         }
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'refs/pull/410/head': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'refs/pull/410/head': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'}
+        )
 
         added = self.master.data.updates.changesAdded
         self.assertEqual(len(added), 1)
@@ -1297,150 +1521,191 @@ class TestGitPoller(TestGitPollerBase):
         self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing',
-                          '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241'
-            ])),
+            .stdout(
+                b'\n'.join([
+                    b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                ])
+            ),
         )
 
         # and patch out the _get_commit_foo methods which were already tested
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
-        self.poller.lastRev = {
-            'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930'
-        }
+        self.poller.lastRev = {'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930'}
         self.poller.doPoll.running = True
         yield self.poller.poll()
 
         # check the results
-        self.assertEqual(self.poller.lastRev, {
-            'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-        })
-        self.assertEqual(self.master.data.updates.changesAdded, [{
-            'author': 'by:4423cdbc',
-            'committer': 'by:4423cdbc',
-            'branch': 'master',
-            'category': None,
-            'codebase': None,
-            'comments': 'hello!',
-            'files': ['/etc/442'],
-            'project': '',
-            'properties': {},
-            'repository': 'git@example.com:~foo/baz.git',
-            'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-            'revlink': '',
-            'src': 'git',
-            'when_timestamp': 1273258009,
-        }, {
-            'author': 'by:64a5dc2a',
-            'committer': 'by:64a5dc2a',
-            'branch': 'master',
-            'category': None,
-            'codebase': None,
-            'comments': 'hello!',
-            'files': ['/etc/64a'],
-            'project': '',
-            'properties': {},
-            'repository': 'git@example.com:~foo/baz.git',
-            'revision': '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-            'revlink': '',
-            'src': 'git',
-            'when_timestamp': 1273258009,
-        }])
+        self.assertEqual(
+            self.poller.lastRev, {'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'}
+        )
+        self.assertEqual(
+            self.master.data.updates.changesAdded,
+            [
+                {
+                    'author': 'by:4423cdbc',
+                    'committer': 'by:4423cdbc',
+                    'branch': 'master',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/442'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                },
+                {
+                    'author': 'by:64a5dc2a',
+                    'committer': 'by:64a5dc2a',
+                    'branch': 'master',
+                    'category': None,
+                    'codebase': None,
+                    'comments': 'hello!',
+                    'files': ['/etc/64a'],
+                    'project': '',
+                    'properties': {},
+                    'repository': 'git@example.com:~foo/baz.git',
+                    'revision': '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    'revlink': '',
+                    'src': 'git',
+                    'when_timestamp': 1273258009,
+                },
+            ],
+        )
         self.assert_all_commands_ran()
 
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'},
+        )
 
     @defer.inlineCallbacks
     def test_poll_callableCategory(self):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
-            ExpectMasterShell(['git', 'log', '--ignore-missing', '--format=%H',
-                          '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-                          '^fa3ae8ed68e664d4db24798611b352e3c6509930',
-                          '--'])
+            ExpectMasterShell([
+                'git',
+                'log',
+                '--ignore-missing',
+                '--format=%H',
+                '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                '^fa3ae8ed68e664d4db24798611b352e3c6509930',
+                '--',
+            ])
             .workdir(self.POLLER_WORKDIR)
-            .stdout(b'\n'.join([
-                b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
+            .stdout(
+                b'\n'.join([
+                    b'64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                    b'4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                ])
+            ),
         )
 
         # and patch out the _get_commit_foo methods which were already tested
         # above
         def timestamp(rev):
             return defer.succeed(1273258009)
+
         self.patch(self.poller, '_get_commit_timestamp', timestamp)
 
         def author(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_author', author)
 
         def committer(rev):
             return defer.succeed('by:' + rev[:8])
+
         self.patch(self.poller, '_get_commit_committer', committer)
 
         def files(rev):
             return defer.succeed(['/etc/' + rev[:3]])
+
         self.patch(self.poller, '_get_commit_files', files)
 
         def comments(rev):
             return defer.succeed('hello!')
+
         self.patch(self.poller, '_get_commit_comments', comments)
 
         # do the poll
@@ -1458,10 +1723,12 @@ class TestGitPoller(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'refs/heads/master':
-            '4423cdbcbb89c14e50dd5f4152415afd686c5241',
-        })
+        self.assertEqual(
+            self.poller.lastRev,
+            {
+                'refs/heads/master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+            },
+        )
 
         added = self.master.data.updates.changesAdded
         self.assertEqual(len(added), 2)
@@ -1497,25 +1764,24 @@ class TestGitPoller(TestGitPollerBase):
 
         yield self.poller.startService()
 
-        self.assertEqual(self.poller.lastRev, {
-            "master": "fa3ae8ed68e664d4db24798611b352e3c6509930"
-        })
+        self.assertEqual(
+            self.poller.lastRev, {"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"}
+        )
 
 
 class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
-
     def createPoller(self):
         return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key')
 
-    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
-                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
-    def test_check_git_features_ssh_1_7(self, write_local_file_mock,
-                                        temp_dir_mock):
+    def test_check_git_features_ssh_1_7(self, write_local_file_mock, temp_dir_mock):
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 1.7.5\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
         )
 
         yield self.assertFailure(self.poller._checkGitFeatures(), EnvironmentError)
@@ -1525,27 +1791,40 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.assertEqual(len(temp_dir_mock.dirs), 0)
         write_local_file_mock.assert_not_called()
 
-    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
-                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
         key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 2.10.0\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 2.10.0\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
-                          'ls-remote', '--refs', self.REPOURL]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
-                          'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+            ]),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
@@ -1554,42 +1833,48 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'}
+        )
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'},
+        )
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs,
-                         [(temp_dir_path, 0o700),
-                          (temp_dir_path, 0o700)])
-        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n',
-                                                 mode=0o400)
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n', mode=0o400)
 
-    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
-                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
     def test_poll_initial_2_3(self, write_local_file_mock, temp_dir_mock):
         key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 2.3.0\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 2.3.0\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL])
-            .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
-                    b'refs/heads/master\n'),
-            ExpectMasterShell(['git', 'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ),
+            ExpectMasterShell([
+                'git',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .env({'GIT_SSH_COMMAND': f'ssh -o "BatchMode=yes" -i "{key_path}"'}),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
@@ -1598,42 +1883,49 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'}
+        )
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'},
+        )
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs,
-                         [(temp_dir_path, 0o700),
-                          (temp_dir_path, 0o700)])
-        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n',
-                                                 mode=0o400)
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n', mode=0o400)
 
-    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
-                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
-    def test_poll_failFetch_git_2_10(self, write_local_file_mock,
-                                     temp_dir_mock):
+    def test_poll_failFetch_git_2_10(self, write_local_file_mock, temp_dir_mock):
         key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
 
         # make sure we cleanup the private key when fetch fails
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 2.10.0\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 2.10.0\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
-                          'ls-remote', '--refs', self.REPOURL]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
-                          'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+            ]),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}"',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
         )
@@ -1644,45 +1936,53 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.assert_all_commands_ran()
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs,
-                         [(temp_dir_path, 0o700),
-                          (temp_dir_path, 0o700)])
-        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n',
-                                                 mode=0o400)
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        write_local_file_mock.assert_called_with(key_path, 'ssh-key\n', mode=0o400)
 
 
 class TestGitPollerWithSshHostKey(TestGitPollerBase):
-
     def createPoller(self):
-        return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key',
-                                   sshHostKey='ssh-host-key')
+        return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key', sshHostKey='ssh-host-key')
 
-    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
-                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
-
         key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
-        known_hosts_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@',
-                                        'ssh-known-hosts')
+        known_hosts_path = os.path.join(
+            'basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-known-hosts'
+        )
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 2.10.0\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 2.10.0\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
-                          f'-o "UserKnownHostsFile={known_hosts_path}"',
-                          'ls-remote', '--refs', self.REPOURL]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
-                          f'-o "UserKnownHostsFile={known_hosts_path}"',
-                          'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
+                f'-o "UserKnownHostsFile={known_hosts_path}"',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+            ]),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
+                f'-o "UserKnownHostsFile={known_hosts_path}"',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
@@ -1691,19 +1991,17 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'}
+        )
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'},
+        )
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs,
-                         [(temp_dir_path, 0o700),
-                          (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
 
         expected_file_writes = [
             mock.call(key_path, 'ssh-key\n', mode=0o400),
@@ -1712,41 +2010,54 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
             mock.call(known_hosts_path, '* ssh-host-key'),
         ]
 
-        self.assertEqual(expected_file_writes,
-                         write_local_file_mock.call_args_list)
+        self.assertEqual(expected_file_writes, write_local_file_mock.call_args_list)
 
 
 class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
     def createPoller(self):
-        return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key\n',
-                                   sshKnownHosts='ssh-known-hosts')
+        return gitpoller.GitPoller(
+            self.REPOURL, sshPrivateKey='ssh-key\n', sshKnownHosts='ssh-known-hosts'
+        )
 
-    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
-                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
     @mock.patch('buildbot.changes.gitpoller.writeLocalFile')
     @defer.inlineCallbacks
     def test_poll_initial_2_10(self, write_local_file_mock, temp_dir_mock):
-
         key_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-key')
-        known_hosts_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@',
-                                        'ssh-known-hosts')
+        known_hosts_path = os.path.join(
+            'basedir', 'gitpoller-work', '.buildbot-ssh@@@', 'ssh-known-hosts'
+        )
 
         self.expect_commands(
-            ExpectMasterShell(['git', '--version'])
-            .stdout(b'git version 2.10.0\n'),
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 2.10.0\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
-                          f'-o "UserKnownHostsFile={known_hosts_path}"',
-                          'ls-remote', '--refs', self.REPOURL]),
-            ExpectMasterShell(['git',
-                          '-c', f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
-                          f'-o "UserKnownHostsFile={known_hosts_path}"',
-                          'fetch', '--progress', self.REPOURL,
-                          '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
-            .workdir(self.POLLER_WORKDIR),
-            ExpectMasterShell(['git', 'rev-parse',
-                          'refs/buildbot/' + self.REPOURL_QUOTED + '/master'])
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
+                f'-o "UserKnownHostsFile={known_hosts_path}"',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+            ]),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                f'core.sshCommand=ssh -o "BatchMode=yes" -i "{key_path}" '
+                f'-o "UserKnownHostsFile={known_hosts_path}"',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+            ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
@@ -1755,19 +2066,17 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
         yield self.poller.poll()
 
         self.assert_all_commands_ran()
-        self.assertEqual(self.poller.lastRev, {
-            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-        })
+        self.assertEqual(
+            self.poller.lastRev, {'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'}
+        )
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
-            lastRev={
-                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
-            })
+            name=bytes2unicode(self.REPOURL),
+            class_name='GitPoller',
+            lastRev={'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'},
+        )
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs,
-                         [(temp_dir_path, 0o700),
-                          (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
 
         expected_file_writes = [
             mock.call(key_path, 'ssh-key\n', mode=0o400),
@@ -1776,13 +2085,12 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
             mock.call(known_hosts_path, 'ssh-known-hosts'),
         ]
 
-        self.assertEqual(expected_file_writes,
-                         write_local_file_mock.call_args_list)
+        self.assertEqual(expected_file_writes, write_local_file_mock.call_args_list)
 
 
-class TestGitPollerConstructor(unittest.TestCase, TestReactorMixin, changesource.ChangeSourceMixin,
-                               config.ConfigErrorsMixin):
-
+class TestGitPollerConstructor(
+    unittest.TestCase, TestReactorMixin, changesource.ChangeSourceMixin, config.ConfigErrorsMixin
+):
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
@@ -1796,10 +2104,10 @@ class TestGitPollerConstructor(unittest.TestCase, TestReactorMixin, changesource
 
     @defer.inlineCallbacks
     def test_deprecatedFetchRefspec(self):
-        with self.assertRaisesConfigError(
-                "fetch_refspec is no longer supported"):
-            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git",
-                                          fetch_refspec='not-supported'))
+        with self.assertRaisesConfigError("fetch_refspec is no longer supported"):
+            yield self.attachChangeSource(
+                gitpoller.GitPoller("/tmp/git.git", fetch_refspec='not-supported')
+            )
 
     @defer.inlineCallbacks
     def test_oldPollInterval(self):
@@ -1818,8 +2126,9 @@ class TestGitPollerConstructor(unittest.TestCase, TestReactorMixin, changesource
 
     @defer.inlineCallbacks
     def test_branches(self):
-        poller = yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git",
-                                                                   branches=['magic', 'marker']))
+        poller = yield self.attachChangeSource(
+            gitpoller.GitPoller("/tmp/git.git", branches=['magic', 'marker'])
+        )
         self.assertEqual(poller.branches, ["magic", "marker"])
 
     @defer.inlineCallbacks
@@ -1834,24 +2143,24 @@ class TestGitPollerConstructor(unittest.TestCase, TestReactorMixin, changesource
 
     @defer.inlineCallbacks
     def test_branches_andBranch(self):
-        with self.assertRaisesConfigError(
-                "can't specify both branch and branches"):
-            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", branch='bad',
-                                                              branches=['listy']))
+        with self.assertRaisesConfigError("can't specify both branch and branches"):
+            yield self.attachChangeSource(
+                gitpoller.GitPoller("/tmp/git.git", branch='bad', branches=['listy'])
+            )
 
     @defer.inlineCallbacks
     def test_branches_and_only_tags(self):
-        with self.assertRaisesConfigError(
-                "can't specify only_tags and branch/branches"):
-            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", only_tags=True,
-                                                              branches=['listy']))
+        with self.assertRaisesConfigError("can't specify only_tags and branch/branches"):
+            yield self.attachChangeSource(
+                gitpoller.GitPoller("/tmp/git.git", only_tags=True, branches=['listy'])
+            )
 
     @defer.inlineCallbacks
     def test_branch_and_only_tags(self):
-        with self.assertRaisesConfigError(
-                "can't specify only_tags and branch/branches"):
-            yield self.attachChangeSource(gitpoller.GitPoller("/tmp/git.git", only_tags=True,
-                                                              branch='bad'))
+        with self.assertRaisesConfigError("can't specify only_tags and branch/branches"):
+            yield self.attachChangeSource(
+                gitpoller.GitPoller("/tmp/git.git", only_tags=True, branch='bad')
+            )
 
     @defer.inlineCallbacks
     def test_gitbin_default(self):


### PR DESCRIPTION
Re-format with ruff is needed to avoid merge conflicts when backporting other changes.
