### PR TITLE
3.11 backports: gitpoller: use full ref in fetch refspecs

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -255,6 +255,13 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
 
         return branches
 
+    @staticmethod
+    def _trim_prefix(value: str, prefix: str) -> str:
+        """Remove prefix from value."""
+        if value.startswith(prefix):
+            return value[len(prefix):]
+        return value
+
     def _removeHeads(self, branch):
         """Remove 'refs/heads/' prefix from remote references."""
         if branch.startswith("refs/heads/"):
@@ -263,7 +270,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
 
     def _trackerBranch(self, branch):
         url = urlquote(self.repourl, '').replace('~', '%7E')
-        return f"refs/buildbot/{url}/{self._removeHeads(branch)}"
+        return f"refs/buildbot/{url}/{self._trim_prefix(branch, 'refs/')}"
 
     def poll_should_exit(self):
         # A single gitpoller loop may take a while on a loaded master, which would block
@@ -280,38 +287,40 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             log.msg(e.args[0])
             return
 
-        branches: list[str] = []
+        refs: list[str] = []
+        trim_ref_head = False
         if callable(self.branches):
             # Get all refs and let callback filter them
             remote_refs = yield self._get_refs()
-            branches = [b for b in remote_refs if self.branches(b)]
+            refs = [b for b in remote_refs if self.branches(b)]
         elif self.branches is True:
             # Get all branch refs
-            branches = yield self._get_refs(["refs/heads/*"])
+            refs = yield self._get_refs(["refs/heads/*"])
         elif self.branches:
             refs = yield self._get_refs([f"refs/heads/{b}" for b in self.branches])
-            branches = [self._removeHeads(b) for b in refs]
+            trim_ref_head = True
 
         # Nothing to fetch and process.
-        if not branches:
+        if not refs:
             return
 
         if self.poll_should_exit():
             return
 
-        refspecs = [
-            f'+{self._removeHeads(branch)}:{self._trackerBranch(branch)}' for branch in branches
-        ]
+        refspecs = [f'+{ref}:{self._trackerBranch(ref)}' for ref in refs]
 
         try:
-            yield self._dovccmd('fetch', ['--progress', self.repourl] + refspecs, path=self.workdir)
+            yield self._dovccmd(
+                'fetch', ['--progress', self.repourl] + refspecs + ['--'], path=self.workdir
+            )
         except GitError as e:
             log.msg(e.args[0])
             return
 
         revs = {}
         log.msg(f'gitpoller: processing changes from "{self.repourl}"')
-        for branch in branches:
+        for ref in refs:
+            branch = ref if not trim_ref_head else self._trim_prefix(ref, 'refs/heads/')
             try:
                 if self.poll_should_exit():  # pragma: no cover
                     # Note that we still want to update the last known revisions for the branches
@@ -319,10 +328,10 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                     break
 
                 rev = yield self._dovccmd(
-                    'rev-parse', [self._trackerBranch(branch)], path=self.workdir
+                    'rev-parse', [self._trackerBranch(ref), '--'], path=self.workdir
                 )
-                revs[branch] = bytes2unicode(rev, self.encoding)
-                yield self._process_changes(revs[branch], branch)
+                revs[branch] = rev
+                yield self._process_changes(rev, branch)
             except Exception:
                 log.err(_why=f"trying to poll branch {branch} of {self.repourl}")
 

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -236,12 +236,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -322,12 +324,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
@@ -357,12 +361,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -439,14 +445,16 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -499,20 +507,23 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -555,13 +566,15 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -585,7 +598,8 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -719,12 +733,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -772,12 +788,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -874,12 +892,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -978,12 +998,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1076,12 +1098,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1186,14 +1210,16 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1235,13 +1261,15 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-                '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '+refs/heads/release:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1265,7 +1293,8 @@ class TestGitPoller(TestGitPollerBase):
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/release',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -1369,12 +1398,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1479,12 +1510,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head',
+                '+refs/pull/410/head:refs/buildbot/' + self.REPOURL_QUOTED + '/pull/410/head',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/refs/pull/410/head',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/pull/410/head',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -1582,14 +1615,16 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'no interesting output'),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1705,12 +1740,14 @@ class TestGitPoller(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1870,12 +1907,14 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -1922,14 +1961,16 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .env({'GIT_SSH_COMMAND': f'ssh -o "BatchMode=yes" -i "{key_path}"'}),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -1981,7 +2022,8 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
@@ -2034,12 +2076,14 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -2110,12 +2154,14 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                 'fetch',
                 '--progress',
                 self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                '+refs/heads/master:refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ]).workdir(self.POLLER_WORKDIR),
             ExpectMasterShell([
                 'git',
                 'rev-parse',
-                'refs/buildbot/' + self.REPOURL_QUOTED + '/master',
+                'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
+                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -224,9 +224,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -261,9 +265,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
         )
 
         self.poller.doPoll.running = False
@@ -284,35 +292,31 @@ class TestGitPoller(TestGitPollerBase):
         d.addCallback(lambda _: self.assert_all_commands_ran())
         return d
 
-    def test_poll_failFetch(self):
+    @defer.inlineCallbacks
+    def test_poll_branch_do_not_exist(self):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]),
-            ExpectMasterShell([
-                'git',
-                'fetch',
-                '--progress',
-                self.REPOURL,
-                '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
-            ])
-            .workdir(self.POLLER_WORKDIR)
-            .exit(1),
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL, 'refs/heads/master']),
         )
 
         self.poller.doPoll.running = True
-        d = self.assertFailure(self.poller.poll(), EnvironmentError)
-        d.addCallback(lambda _: self.assert_all_commands_ran())
-        return d
+        yield self.poller.poll()
+
+        self.assert_all_commands_ran()
 
     @defer.inlineCallbacks
     def test_poll_failRevParse(self):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -341,9 +345,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -419,9 +427,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -468,11 +480,19 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
-                b'refs/heads/release\n'
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+                'refs/heads/release',
+                'refs/heads/not_on_remote',
+            ]).stdout(
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                 b'refs/heads/master\n'
+                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
+                b'refs/heads/release\n'
             ),
             ExpectMasterShell([
                 'git',
@@ -517,11 +537,18 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
-                b'refs/heads/release\n'
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+                'refs/heads/release',
+            ]).stdout(
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                 b'refs/heads/master\n'
+                b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\t'
+                b'refs/heads/release\n'
             ),
             ExpectMasterShell([
                 'git',
@@ -680,9 +707,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/release',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/release\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -729,9 +760,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/release',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/release\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -827,9 +862,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/release',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/release\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -927,9 +966,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/release\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/release',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/release\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -1025,8 +1068,8 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL, 'refs/heads/*']).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'
             ),
             ExpectMasterShell([
                 'git',
@@ -1131,9 +1174,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -1177,7 +1224,7 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL, 'refs/heads/*']).stdout(
                 b'\n'.join([
                     b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                     b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
@@ -1523,9 +1570,13 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -1646,8 +1697,8 @@ class TestGitPoller(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
+            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL, 'refs/heads/*']).stdout(
+                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'
             ),
             ExpectMasterShell([
                 'git',
@@ -1810,7 +1861,8 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'ls-remote',
                 '--refs',
                 self.REPOURL,
-            ]),
+                "refs/heads/master",
+            ]).stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 '-c',
@@ -1858,9 +1910,13 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 2.3.0\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
-            ExpectMasterShell(['git', 'ls-remote', '--refs', self.REPOURL]).stdout(
-                b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t' b'refs/heads/master\n'
-            ),
+            ExpectMasterShell([
+                'git',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                "refs/heads/master",
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 'fetch',
@@ -1916,7 +1972,8 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'ls-remote',
                 '--refs',
                 self.REPOURL,
-            ]),
+                "refs/heads/master",
+            ]).stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 '-c',
@@ -1967,7 +2024,8 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
                 'ls-remote',
                 '--refs',
                 self.REPOURL,
-            ]),
+                "refs/heads/master",
+            ]).stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 '-c',
@@ -2042,7 +2100,8 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                 'ls-remote',
                 '--refs',
                 self.REPOURL,
-            ]),
+                'refs/heads/master',
+            ]).stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\trefs/heads/master\n'),
             ExpectMasterShell([
                 'git',
                 '-c',

--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from functools import wraps
+
+from twisted.internet import defer
+
+
+def async_to_deferred(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return defer.ensureDeferred(fn(*args, **kwargs))
+        except Exception as e:
+            return defer.fail(e)
+
+    return wrapper

--- a/newsfragments/gitpoller-fix-issue-6591.bugfix
+++ b/newsfragments/gitpoller-fix-issue-6591.bugfix
@@ -1,0 +1,2 @@
+Fix ``GitPoller`` run with git config ``fetch.prune=true`` pruning of local ref on fetch.
+Issue would cause rev-parse to fail as it would be run on a non-existing local ref.


### PR DESCRIPTION
This PR backports #7554.
PR partially fixes https://github.com/buildbot/buildbot/issues/7584.