### PR TITLE
Removal of scandir package from requirements-ci.txt

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -102,7 +102,6 @@ responses==0.25.0
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.1
-scandir==1.10.0
 service-identity==24.1.0
 setuptools-trial==0.6.0
 singledispatch==4.1.0


### PR DESCRIPTION
`scandir` has been included in the Python 3.5 standard library as os.scandir(), and the related performance improvements to os.walk() have also been included. see https://github.com/benhoyt/scandir?tab=readme-ov-file#now-included-in-a-python-near-you

As Buildbot now requires Python 3.8 or newer we can use standard library rather than package.

Fixes #7632

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
