### PR TITLE
3.11 backports:  Change GitPoller tracker branch name format

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -26,6 +26,7 @@ from twisted.python import log
 from buildbot import config
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
+from buildbot.util import giturlparse
 from buildbot.util import private_tempdir
 from buildbot.util import runprocess
 from buildbot.util.git import GitMixin
@@ -270,9 +271,30 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
             branch = branch[11:]
         return branch
 
-    def _trackerBranch(self, branch):
-        url = urlquote(self.repourl, '').replace('~', '%7E')
-        return f"refs/buildbot/{url}/{self._trim_prefix(branch, 'refs/')}"
+    @staticmethod
+    def _tracker_ref(repourl: str, ref: str) -> str:
+        def _sanitize(value: str) -> str:
+            return urlquote(value, '').replace('~', '%7E')
+
+        tracker_prefix = "refs/buildbot"
+        # if ref is not a Git ref, store under a different path to avoid collision
+        if not ref.startswith('refs/'):
+            tracker_prefix += "/raw"
+
+        git_url = giturlparse(repourl)
+        if git_url is None:
+            # fallback to using the whole repourl
+            url_identifier = _sanitize(repourl)
+        else:
+            url_identifier = f"{git_url.proto}/{_sanitize(git_url.domain)}"
+            if git_url.port is not None:
+                url_identifier += f":{git_url.port}"
+
+            if git_url.owner is not None:
+                url_identifier += f"/{_sanitize(git_url.owner)}"
+            url_identifier += f"/{_sanitize(git_url.repo)}"
+
+        return f"{tracker_prefix}/{url_identifier}/{GitPoller._trim_prefix(ref, 'refs/')}"
 
     def poll_should_exit(self):
         # A single gitpoller loop may take a while on a loaded master, which would block
@@ -309,7 +331,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         if self.poll_should_exit():
             return
 
-        refspecs = [f'+{ref}:{self._trackerBranch(ref)}' for ref in refs]
+        refspecs = [f'+{ref}:{self._tracker_ref(self.repourl, ref)}' for ref in refs]
 
         try:
             yield self._dovccmd(
@@ -333,7 +355,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                     break
 
                 rev = yield self._dovccmd(
-                    'rev-parse', [self._trackerBranch(ref), '--'], path=self.workdir
+                    'rev-parse', [self._tracker_ref(self.repourl, ref), '--'], path=self.workdir
                 )
                 revs[branch] = rev
                 yield self._process_changes(rev, branch)

--- a/master/buildbot/test/unit/util/test_giturlparse.py
+++ b/master/buildbot/test/unit/util/test_giturlparse.py
@@ -109,3 +109,16 @@ class Tests(unittest.TestCase):
         self.assertEqual(giturlparse("git://bitbucket.org/org/repo.git").proto, "git")
         self.assertEqual(giturlparse("ssh://git@bitbucket.org:org/repo.git").proto, "ssh")
         self.assertEqual(giturlparse("git@bitbucket.org:org/repo.git").proto, "ssh")
+
+    def test_user_password(self):
+        for u, expected_user, expected_password in [
+            ("https://user@github.com/buildbot/buildbot", "user", None),
+            ("https://user:password@github.com/buildbot/buildbot", "user", "password"),
+        ]:
+            u = giturlparse(u)
+            self.assertEqual(u.user, expected_user)
+            self.assertEqual(u.password, expected_password)
+            self.assertEqual(u.domain, "github.com")
+            self.assertEqual(u.owner, "buildbot")
+            self.assertEqual(u.repo, "buildbot")
+            self.assertIsNone(u.port)

--- a/master/buildbot/util/giturlparse.py
+++ b/master/buildbot/util/giturlparse.py
@@ -24,7 +24,7 @@ from typing import NamedTuple
 
 _giturlmatcher = re.compile(
     r'(?P<proto>(https?://|ssh://|git://|))'
-    r'((?P<user>.*)@)?'
+    r'((?P<user>[^:@]*)(:(?P<password>.*))?@)?'
     r'(?P<domain>[^\/:]+)(:((?P<port>[0-9]+)/)?|/)'
     r'((?P<owner>.+)/)?(?P<repo>[^/]+?)(\.git)?$')
 
@@ -32,6 +32,7 @@ _giturlmatcher = re.compile(
 class GitUrl(NamedTuple):
     proto: str
     user: str | None
+    password: str | None
     domain: str
     port: int | None
     owner: str | None
@@ -54,6 +55,7 @@ def giturlparse(url: str) -> GitUrl | None:
     return GitUrl(
         proto=proto,
         user=res.group('user'),
+        password=res.group('password'),
         domain=res.group("domain"),
         port=port,
         owner=res.group('owner'),

--- a/master/buildbot/util/giturlparse.py
+++ b/master/buildbot/util/giturlparse.py
@@ -13,9 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 import re
-from collections import namedtuple
+from typing import NamedTuple
 
 # The regex is matching more than it should and is not intended to be an url validator.
 # It is intended to efficiently and reliably extract information from the various examples
@@ -27,10 +28,17 @@ _giturlmatcher = re.compile(
     r'(?P<domain>[^\/:]+)(:((?P<port>[0-9]+)/)?|/)'
     r'((?P<owner>.+)/)?(?P<repo>[^/]+?)(\.git)?$')
 
-GitUrl = namedtuple('GitUrl', ['proto', 'user', 'domain', 'port', 'owner', 'repo'])
+
+class GitUrl(NamedTuple):
+    proto: str
+    user: str | None
+    domain: str
+    port: int | None
+    owner: str | None
+    repo: str
 
 
-def giturlparse(url):
+def giturlparse(url: str) -> GitUrl | None:
     res = _giturlmatcher.match(url)
     if res is None:
         return None
@@ -43,5 +51,11 @@ def giturlparse(url):
         proto = proto[:-3]
     else:
         proto = 'ssh'  # implicit proto is ssh
-    return GitUrl(proto, res.group('user'), res.group("domain"),
-                  port, res.group('owner'), res.group('repo'))
+    return GitUrl(
+        proto=proto,
+        user=res.group('user'),
+        domain=res.group("domain"),
+        port=port,
+        owner=res.group('owner'),
+        repo=res.group('repo'),
+    )

--- a/newsfragments/gitpoller-tracker-branch-format.bugfix
+++ b/newsfragments/gitpoller-tracker-branch-format.bugfix
@@ -1,0 +1,2 @@
+Changed ``GitPoller`` tracker branch naming to reduce directory name which could cause issues.
+Also remove credentials from ``repourl`` used in the tracker branch name.


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7577.
PR partially fixes https://github.com/buildbot/buildbot/issues/7584.