### PR TITLE
4.0 backports: reporters: Remove _handleLegacyResult as callback must return a dict now

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -53,23 +53,6 @@ def makeReviewResult(message, *labels):
     return {"message": message, "labels": dict(labels)}
 
 
-def _handleLegacyResult(result):
-    """
-    make sure the result is backward compatible
-    """
-    if not isinstance(result, dict):
-        warnings.warn(
-            'The Gerrit status callback uses the old way to '
-            'communicate results.  The outcome might be not what is '
-            'expected.'
-        )
-        message, verified, reviewed = result
-        result = makeReviewResult(
-            message, (GERRIT_LABEL_VERIFIED, verified), (GERRIT_LABEL_REVIEWED, reviewed)
-        )
-    return result
-
-
 def _old_add_label(label, value):
     if label == GERRIT_LABEL_VERIFIED:
         return [f"--verified {int(value)}"]
@@ -264,8 +247,6 @@ class GerritBuildSetStatusGenerator(GerritStatusGeneratorBase):
             build_info_list, Results[buildset["results"]], master, self.callback_arg
         )
 
-        result = _handleLegacyResult(result)
-
         return {
             "body": result.get("message", None),
             "extra_info": {
@@ -293,8 +274,6 @@ class GerritBuildStartStatusGenerator(GerritStatusGeneratorBase):
             return None
 
         result = yield self.callback(build["builder"]["name"], build, self.callback_arg)
-
-        result = _handleLegacyResult(result)
 
         return {
             "body": result.get("message", None),
@@ -325,8 +304,6 @@ class GerritBuildEndStatusGenerator(GerritStatusGeneratorBase):
         result = yield self.callback(
             build['builder']['name'], build, build['results'], master, self.callback_arg
         )
-
-        result = _handleLegacyResult(result)
 
         return {
             "body": result.get("message", None),

--- a/master/docs/manual/configuration/reporters/gerrit_status.rst
+++ b/master/docs/manual/configuration/reporters/gerrit_status.rst
@@ -17,8 +17,8 @@ GerritStatusPush can send a separate review for each build that completes, or a 
    :param reviewCB: (optional) Called each time a build finishes. Build properties are available. Can be a deferred.
    :param reviewArg: (optional) Argument passed to the review callback.
 
-                    :: If :py:func:`reviewCB` callback is specified, it must return a message and optionally labels. If no message is specified, nothing will be sent to Gerrit.
-                    It should return a dictionary:
+                    :: If :py:func:`reviewCB` callback is specified, it must return a dictionary.
+                    If no message is specified in the dictionary, nothing will be sent to Gerrit.
 
                     .. code-block:: python
 
@@ -42,8 +42,8 @@ GerritStatusPush can send a separate review for each build that completes, or a 
    :param startCB: (optional) Called each time a build is started. Build properties are available. Can be a deferred.
    :param startArg: (optional) Argument passed to the start callback.
 
-                    If :py:func:`startCB` is specified, it must return a message and optionally labels. If no message is specified, nothing will be sent to Gerrit.
-                    It should return a dictionary:
+                    If :py:func:`startCB` is specified, it must return a dictionary.
+                    If no message is specified in the dictionary, nothing will be sent to Gerrit.
 
                     .. code-block:: python
 
@@ -61,9 +61,9 @@ GerritStatusPush can send a separate review for each build that completes, or a 
    :param summaryCB: (optional) Called each time a buildset finishes. Each build in the buildset has properties available. Can be a deferred.
    :param summaryArg: (optional) Argument passed to the summary callback.
 
-                      If :py:func:`summaryCB` callback is specified, it must return a message and optionally labels. If no message is specified, nothing will be sent to Gerrit.
+                      If :py:func:`summaryCB` callback is specified, it must return a dictionary.
+                      If no message is specified in the dictionary, nothing will be sent to Gerrit.
                       The message and labels should be a summary of all the builds within the buildset.
-                      It should return a dictionary:
 
                       .. code-block:: python
 

--- a/newsfragments/gerrit-callback-only-dictionary.removal
+++ b/newsfragments/gerrit-callback-only-dictionary.removal
@@ -1,0 +1,1 @@
+Gerrit status callback functions now can only return dictionary type.


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7616.
PR partially fixes https://github.com/buildbot/buildbot/issues/7614.