### PR TITLE
changes: Add error handling for GerritEventLogPoller.getFiles

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -527,9 +527,12 @@ class GerritHttpEventLogPollerConnector:
     def get_files(self, change, patchset):
         res = yield self._http.get(f"/changes/{change}/revisions/{patchset}/files/")
         res = yield res.content()
-
-        res = res.splitlines()[1].decode('utf8')  # the first line of every response is `)]}'`
-        return list(json.loads(res))
+        try:
+            res = res.splitlines()[1].decode('utf8')  # the first line of every response is `)]}'`
+            return list(json.loads(res))
+        except Exception as e:
+            log.err(e, 'while getting files from connector')
+            return []
 
     @defer.inlineCallbacks
     def do_poll(self):

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -1189,6 +1189,21 @@ class TestGerritEventLogPoller(changesource.ChangeSourceMixin, TestReactorMixin,
         files = yield self.changesource.getFiles(100, 1)
         self.assertEqual(set(files), {'/COMMIT_MSG', 'file1'})
 
+    @defer.inlineCallbacks
+    def test_getFiles_handle_error(self):
+        yield self.newChangeSource(get_files=True)
+        yield self.startChangeSource()
+
+        self._http.expect(
+            method='get',
+            ep='/changes/100/revisions/1/files/',
+            content=b')]}\n',  # more than one line expected
+        )
+
+        files = yield self.changesource.getFiles(100, 1)
+        self.assertEqual(files, [])
+        self.assertEqual(len(self.flushLoggedErrors()), 1)
+
 
 class TestGerritChangeFilter(unittest.TestCase):
     def test_event_type(self):

--- a/newsfragments/GerritEventLogPoller-getFiles-fix-invalid-input-error.bugfix
+++ b/newsfragments/GerritEventLogPoller-getFiles-fix-invalid-input-error.bugfix
@@ -1,0 +1,1 @@
+GerritEventLogPoller.getFiles() function does not crash when invalid input (:issue:`7612`)


### PR DESCRIPTION
GerritEventLogPoller.getFiles() function does not crash when invalid input.
This PR fixes https://github.com/buildbot/buildbot/issues/7612.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
