### PR TITLE
test: fix SQLAlchemy 'Using non-integer/slice indices on Row is deprecated'

### DIFF
--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -196,7 +196,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             rv: list[BuilderModel] = []
             last: BuilderModel | None = None
             for row in conn.execute(q).fetchall():
-                if not last or row['id'] != last.id:
+                if not last or row.id != last.id:
                     last = BuilderModel(
                         id=row.id,
                         name=row.name,
@@ -207,8 +207,8 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                         tags=bldr_id_to_tags[row.id],
                     )
                     rv.append(last)
-                if row['masterid']:
-                    last.masterids.append(row['masterid'])
+                if row.masterid:
+                    last.masterids.append(row.masterid)
             return rv
 
         return self.db.pool.do(thd)

--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -41,10 +41,10 @@ def test_unicode(migrate_engine):
 
     # see if the data is intact
     row = migrate_engine.execute(test_unicode.select()).fetchall()[0]
-    assert isinstance(row['u'], str)
-    assert row['u'] == u
-    assert isinstance(row['b'], bytes)
-    assert row['b'] == b
+    assert isinstance(row.u, str)
+    assert row.u == u
+    assert isinstance(row.b, bytes)
+    assert row.b == b
 
     # drop the test table
     test_unicode.drop()

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -149,9 +149,9 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 )
                 row = conn.execute(q).fetchone()
                 # ok, that was us, so we just do nothing
-                if row['masterid'] == masterid:
+                if row.masterid == masterid:
                     return None
-                raise SchedulerAlreadyClaimedError(f"already claimed by {row['name']}") from e
+                raise SchedulerAlreadyClaimedError(f"already claimed by {row.name}") from e
             return None
 
         return self.db.pool.do(thd)

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -126,7 +126,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
             if result_spec is not None:
                 return result_spec.thd_execute(conn, q, lambda x: x['path'])
             res = conn.execute(q)
-            return [row['path'] for row in res.fetchall()]
+            return [row.path for row in res.fetchall()]
 
         return self.db.pool.do(thd)
 
@@ -192,9 +192,9 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
             if name_prefix is not None:
                 q = q.where(names_table.c.name.startswith(name_prefix))
             if result_spec is not None:
-                return result_spec.thd_execute(conn, q, lambda x: x['name'])
+                return result_spec.thd_execute(conn, q, lambda x: x.name)
             res = conn.execute(q)
-            return [row['name'] for row in res.fetchall()]
+            return [row.name for row in res.fetchall()]
 
         return self.db.pool.do(thd)
 

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -123,7 +123,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
             q = sa.select(cfg_tbl.c.buildermasterid).select_from(j).distinct()
             q = q.where(bm_tbl.c.masterid == masterid)
             res = conn.execute(q)
-            buildermasterids = [row['buildermasterid'] for row in res]
+            buildermasterids = [row.buildermasterid for row in res]
             res.close()
             self._deleteFromConfiguredWorkers_thd(conn, buildermasterids)
 
@@ -141,7 +141,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                 q = q.where(bm_tbl.c.masterid == masterid)
                 q = q.where(bm_tbl.c.builderid.in_(builderids))
                 res = conn.execute(q)
-                buildermasterids = {row['id'] for row in res}
+                buildermasterids = {row.id for row in res}
                 res.close()
             else:
                 buildermasterids = set([])
@@ -152,7 +152,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
             q = q.where(bm_tbl.c.masterid == masterid)
             q = q.where(cfg_tbl.c.workerid == workerid)
             res = conn.execute(q)
-            oldbuildermasterids = {row['buildermasterid'] for row in res}
+            oldbuildermasterids = {row.buildermasterid for row in res}
             res.close()
 
             todeletebuildermasterids = oldbuildermasterids - buildermasterids

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -174,11 +174,6 @@ warnings.filterwarnings(
 )
 warnings.filterwarnings(
     'ignore',
-    "Using non-integer/slice indices on Row is deprecated and will be removed in version 2.0",
-    category=RemovedIn20Warning,
-)
-warnings.filterwarnings(
-    'ignore',
     "The ``bind`` argument for schema methods that invoke SQL against an engine or connection will be required in SQLAlchemy 2.0.",
     category=RemovedIn20Warning,
 )


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
