### PR TITLE
test: await TCPPort.stopListening

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -62,8 +62,6 @@ warnings.filterwarnings(
     'ignore', "Not importing directory.*docker': missing __init__.py", category=ImportWarning
 )
 
-warnings.filterwarnings('ignore', "unclosed <socket.socket", category=Warning)
-
 # FIXME: needs to be sorted out (#3666)
 warnings.filterwarnings('ignore', "1300 Invalid utf8 character string")
 

--- a/master/buildbot/test/unit/util/test_httpclientservice.py
+++ b/master/buildbot/test/unit/util/test_httpclientservice.py
@@ -345,7 +345,7 @@ class HTTPClientServiceTestTxRequestE2E(unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.listenport.stopListening()
+        yield self.listenport.stopListening()
         yield self.parent.stopService()
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Fixes #7273

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
