### PR TITLE
Fix SqlLiteStrategy

### DIFF
--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -51,7 +51,7 @@ class Strategy:
 
 
 class SqlLiteStrategy(Strategy):
-    def set_up(self, u, engine):
+    def set_up(self, u, engine: sa.engine.base.Engine):
         """Special setup for sqlite engines"""
 
         def connect_listener_enable_fk(connection, record):
@@ -71,7 +71,8 @@ class SqlLiteStrategy(Strategy):
 
             log.msg("setting database journal mode to 'wal'")
             try:
-                engine.exec_driver_sql("pragma journal_mode = wal")
+                with engine.connect() as conn:
+                    conn.exec_driver_sql("pragma journal_mode = wal")
             except Exception:
                 log.msg("failed to set journal mode - database may fail")
 

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 import os
 
@@ -89,13 +90,14 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
 
         yield self.db.pool.do_with_engine(upgrade_thd)
 
-        def check_table_charsets_thd(engine):
+        def check_table_charsets_thd(conn: sa.engine.base.Connection):
             # charsets are only a problem for MySQL
-            if engine.dialect.name != 'mysql':
+            if conn.dialect.name != 'mysql':
                 return
-            dbs = [r[0] for r in engine.exec_driver_sql("show tables")]
+
+            dbs = [r[0] for r in conn.exec_driver_sql("show tables")]
             for tbl in dbs:
-                r = engine.exec_driver_sql(f"show create table {tbl}")
+                r = conn.exec_driver_sql(f"show create table {tbl}")
                 create_table = r.fetchone()[1]
                 self.assertIn(
                     'DEFAULT CHARSET=utf8',


### PR DESCRIPTION
Fix issue introduced in #7592

SqlAlchemy `exec_driver_sql` is not a method of Engine, but of Connection.
Since there is a broad exception catching,  I missed it and it didn't appear in tests.
Only got it by change from the log when testing something else.

I don't think #7592 was backported and release, so a newsfragment should not be needed.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
