### PR TITLE
remove pipes module usage which is deprecated

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -140,13 +140,6 @@ warnings.filterwarnings(
     'ignore', ".*'urllib3.contrib.pyopenssl' module is deprecated", category=DeprecationWarning
 )
 
-# pipes is still used in astroid and buildbot_worker in default installation
-warnings.filterwarnings(
-    'ignore',
-    "'pipes' is deprecated and slated for removal in Python 3.13",
-    category=DeprecationWarning,
-)
-
 # boto3 shows this warning when on old Python
 warnings.filterwarnings('ignore', ".*Boto3 will no longer support Python .*", category=Warning)
 

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -20,6 +20,7 @@ Support for running 'shell commands'
 import os
 import pprint
 import re
+import shlex
 import signal
 import stat
 import subprocess
@@ -65,13 +66,10 @@ def win32_batch_quote(cmd_list, unicode_encoding='utf-8'):
 
 def shell_quote(cmd_list, unicode_encoding='utf-8'):
     # attempt to quote cmd_list such that a shell will properly re-interpret
-    # it.  The pipes module is only available on UNIX; also, the quote
-    # function is undocumented (although it looks like it will be documented
-    # soon: http://bugs.python.org/issue9723). Finally, it has a nasty bug
-    # in some versions where an empty string is not quoted.
+    # it.  The shlex module is only designed for UNIX;
     #
     # So:
-    #  - use pipes.quote on UNIX, handling '' as a special case
+    #  - use shlex.quote on UNIX, handling '' as a special case
     #  - use our own custom function on Windows
     if isinstance(cmd_list, bytes):
         cmd_list = bytes2unicode(cmd_list, unicode_encoding)
@@ -79,16 +77,13 @@ def shell_quote(cmd_list, unicode_encoding='utf-8'):
     if runtime.platformType == 'win32':
         return win32_batch_quote(cmd_list, unicode_encoding)
 
-    # only available on unix
-    import pipes  # pylint: disable=import-outside-toplevel
-
     def quote(e):
         if not e:
             return '""'
         e = bytes2unicode(e, unicode_encoding)
-        return pipes.quote(e)
+        return shlex.quote(e)
 
-    return " ".join([quote(e) for e in cmd_list])
+    return " ".join(quote(e) for e in cmd_list)
 
 
 class LogFileWatcher(object):


### PR DESCRIPTION
Replace `pipes.quote` with `shlex.quote`

Another candidate could be `subprocess.list2cmdline` but it is undocumented.
More on it not being documented: https://discuss.python.org/t/why-is-subprocess-list2cmdline-not-documented/25044/15

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
