### PR TITLE
typing: add mypy conf

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -98,21 +98,21 @@ class ISourceStamp(Interface):
     @type repository: string
     """
 
-    def canBeMergedWith(self, other):
+    def canBeMergedWith(other):
         """
         Can this SourceStamp be merged with OTHER?
         """
 
-    def mergeWith(self, others):
+    def mergeWith(others):
         """Generate a SourceStamp for the merger of me and all the other
         SourceStamps. This is called by a Build when it starts, to figure
         out what its sourceStamp should be."""
 
-    def getAbsoluteSourceStamp(self, got_revision):
+    def getAbsoluteSourceStamp(got_revision):
         """Get a new SourceStamp object reflecting the actual revision found
         by a Source step."""
 
-    def getText(self):
+    def getText():
         """Returns a list of strings to describe the stamp. These are
         intended to be displayed in a narrow column. If more space is
         available, the caller should join them together with spaces before
@@ -189,7 +189,7 @@ class IMachine(Interface):
 
 
 class IMachineAction(Interface):
-    def perform(self, manager):
+    def perform(manager):
         """Perform an action on the machine managed by manager. Returns a
         deferred evaluating to True if it was possible to execute the
         action.
@@ -320,7 +320,7 @@ class IConfigured(Interface):
 
 
 class IReportGenerator(Interface):
-    def generate(self, master, reporter, key, build):
+    def generate(master, reporter, key, build):
         pass
 
 

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import calendar
 import datetime
 import itertools
@@ -23,6 +25,7 @@ import sys
 import textwrap
 import time
 from builtins import bytes
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
@@ -35,6 +38,10 @@ from buildbot.util.giturlparse import giturlparse
 from buildbot.util.misc import deferredLocked
 
 from ._notifier import Notifier
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+    from typing import Sequence
 
 
 def naturalSort(array):
@@ -144,7 +151,7 @@ def fuzzyInterval(seconds):
 
 @implementer(IConfigured)
 class ComparableMixin:
-    compare_attrs = ()
+    compare_attrs: ClassVar[Sequence[str]] = ()
 
     class _None:
         pass

--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -24,8 +24,9 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Coroutine
-    from typing import ParamSpec
     from typing import TypeVar
+
+    from typing_extensions import ParamSpec
 
     _T = TypeVar('_T')
     _P = ParamSpec('_P')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,8 @@ quote-style = "preserve"
         directory = "misc"
         name = "Misc"
         showcontent = false
+
+[tool.mypy]
+python_version = "3.8"
+namespace_packages = true
+plugins = "mypy_zope:plugin"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,6 +11,8 @@ msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.2
 ruff==0.4.3
+mypy==1.9.0
+mypy-zope==1.0.4
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests
 # are reproducible. The versions should be upgraded whenever we see new versions to catch problems


### PR DESCRIPTION
While a long way to enable mypy in CI, this configuration will help guide typing.

The mypy-zope plugin allows to type with an interface type.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
