### PR TITLE
process: remove Build.setBuilder, Builder should be provided in ctor

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -83,8 +83,11 @@ class Build(properties.PropertiesMixin):
 
     _sentinel = Sentinel()  # used as a sentinel to indicate unspecified initial_value
 
-    def __init__(self, requests):
+    def __init__(self, requests, builder: Builder) -> None:
         self.requests = requests
+        self.builder = builder
+        self.master = builder.master
+
         self.locks = []  # list of lock accesses
         self._locks_to_acquire = []  # list of (real_lock, access) tuples
         # build a source stamp
@@ -119,20 +122,10 @@ class Build(properties.PropertiesMixin):
         self._is_substantiating = False
 
         # tracks the config version for locks
-        self.config_version = None
+        self.config_version = builder.config_version
 
     def getProperties(self):
         return self.properties
-
-    def setBuilder(self, builder: Builder) -> None:
-        """
-        Set the given builder as our builder.
-
-        @type  builder: L{buildbot.process.builder.Builder}
-        """
-        self.builder = builder
-        self.master = builder.master
-        self.config_version = builder.config_version
 
     def setLocks(self, lockList):
         self.locks = lockList

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -375,8 +375,7 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
 
     @defer.inlineCallbacks
     def _startBuildFor(self, workerforbuilder, buildrequests):
-        build = self.config.factory.newBuild(buildrequests)
-        build.setBuilder(self)
+        build = self.config.factory.newBuild(buildrequests, self)
 
         props = build.getProperties()
 

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from twisted.python import deprecate
 from twisted.python import versions
@@ -32,6 +34,9 @@ from buildbot.steps.shell import ShellCommand
 from buildbot.steps.shell import Test
 from buildbot.steps.source.cvs import CVS
 from buildbot.steps.source.svn import SVN
+
+if TYPE_CHECKING:
+    from buildbot.process.builder import Builder
 
 
 # deprecated, use BuildFactory.addStep
@@ -58,13 +63,13 @@ class BuildFactory(util.ComparableMixin):
         if steps:
             self.addSteps(steps)
 
-    def newBuild(self, requests):
+    def newBuild(self, requests, builder: Builder) -> None:
         """Create a new Build instance.
 
         @param requests: a list of buildrequest dictionaries describing what is
         to be built
         """
-        b = self.buildClass(requests)
+        b = self.buildClass(requests, builder)
         b.useProgress = self.useProgress
         b.workdir = self.workdir
         b.setStepFactories(self.steps)


### PR DESCRIPTION
Similar to #7551

Doesn't seem to make conceptual sense to have a build without a Builder.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
