### PR TITLE
db: create SQLAlchemy Engine with future

### DIFF
--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -111,6 +111,7 @@ class DBConnectorComponent:
                 conn.commit()
                 return r.inserted_primary_key[0], False
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
+                conn.rollback()
                 # try it all over again, in case there was an overlapping,
                 # identical call, but only retry once.
                 if no_recurse:

--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -107,8 +107,8 @@ class DBConnectorComponent:
                 _race_hook(conn)
 
             try:
-                with conn.begin():
-                    r = conn.execute(tbl.insert(), [insert_values])
+                r = conn.execute(tbl.insert(), [insert_values])
+                conn.commit()
                 return r.inserted_primary_key[0], False
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 # try it all over again, in case there was an overlapping,

--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -103,7 +103,7 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
                     return
                 except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                     # there's been a competing insert, retry
-                    pass
+                    conn.rollback()
 
         yield self.db.pool.do(thd)
 

--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -88,8 +88,8 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
                     (build_data_table.c.buildid == buildid) & (build_data_table.c.name == name)
                 )
                 q = q.values(update_values)
-                with conn.begin():
-                    r = conn.execute(q)
+                r = conn.execute(q)
+                conn.commit()
                 if r.rowcount > 0:
                     return
                 r.close()
@@ -98,8 +98,8 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
 
                 try:
                     q = build_data_table.insert().values(insert_values)
-                    with conn.begin():
-                        r = conn.execute(q)
+                    r = conn.execute(q)
+                    conn.commit()
                     return
                 except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                     # there's been a competing insert, retry
@@ -193,8 +193,8 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
                 q = q.where(
                     (builds.c.complete_at >= older_than_timestamp) | (builds.c.complete_at == NULL)
                 )
-            with conn.begin():
-                res = conn.execute(q)
+            res = conn.execute(q)
+            conn.commit()
             res.close()
 
             count_after = count_build_datum(conn)

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -131,7 +131,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                 conn.execute(q.values(builderid=builderid, masterid=masterid))
                 conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
-                pass
+                conn.rollback()
 
         return self.db.pool.do(thd)
 

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -128,8 +128,8 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             try:
                 tbl = self.db.model.builder_masters
                 q = tbl.insert()
-                with conn.begin():
-                    conn.execute(q.values(builderid=builderid, masterid=masterid))
+                conn.execute(q.values(builderid=builderid, masterid=masterid))
+                conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 pass
 

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -232,21 +232,21 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
                     _race_hook(conn)
 
                 try:
-                    with conn.begin():
-                        r = conn.execute(
-                            self.db.model.builds.insert(),
-                            {
-                                "number": new_number,
-                                "builderid": builderid,
-                                "buildrequestid": buildrequestid,
-                                "workerid": workerid,
-                                "masterid": masterid,
-                                "started_at": started_at,
-                                "complete_at": None,
-                                "locks_duration_s": 0,
-                                "state_string": state_string,
-                            },
-                        )
+                    r = conn.execute(
+                        self.db.model.builds.insert(),
+                        {
+                            "number": new_number,
+                            "builderid": builderid,
+                            "buildrequestid": buildrequestid,
+                            "workerid": workerid,
+                            "masterid": masterid,
+                            "started_at": started_at,
+                            "complete_at": None,
+                            "locks_duration_s": 0,
+                            "state_string": state_string,
+                        },
+                    )
+                    conn.commit()
                 except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
                     # pg 9.5 gives this error which makes it pass some build
                     # numbers

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -248,6 +248,7 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
                     )
                     conn.commit()
                 except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
+                    conn.rollback()
                     # pg 9.5 gives this error which makes it pass some build
                     # numbers
                     if 'duplicate key value violates unique constraint "builds_pkey"' not in str(e):

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -205,8 +205,8 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
             q = tbl.update().where(
                 (tbl.c.id == bsid) & ((tbl.c.complete == NULL) | (tbl.c.complete != 1))
             )
-            with conn.begin():
-                res = conn.execute(q.values(complete=1, results=results, complete_at=complete_at))
+            res = conn.execute(q.values(complete=1, results=results, complete_at=complete_at))
+            conn.commit()
 
             if res.rowcount != 1:
                 # happens when two buildrequests finish at the same time

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -82,6 +82,7 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
                 conn.execute(q, {"changesourceid": changesourceid, "masterid": masterid})
                 conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
+                conn.rollback()
                 # someone already owns this changesource.
                 raise ChangeSourceAlreadyClaimedError from e
 

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -72,15 +72,15 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
             # handle the masterid=None case to get it out of the way
             if masterid is None:
                 q = cs_mst_tbl.delete().where(cs_mst_tbl.c.changesourceid == changesourceid)
-                with conn.begin():
-                    conn.execute(q)
+                conn.execute(q)
+                conn.commit()
                 return
 
             # try a blind insert..
             try:
                 q = cs_mst_tbl.insert()
-                with conn.begin():
-                    conn.execute(q, {"changesourceid": changesourceid, "masterid": masterid})
+                conn.execute(q, {"changesourceid": changesourceid, "masterid": masterid})
+                conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
                 # someone already owns this changesource.
                 raise ChangeSourceAlreadyClaimedError from e

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -64,6 +64,7 @@ class DbConfig:
             with db_engine.connect() as conn:
                 self.objectid = db.state.thdGetObjectId(conn, self.name, "DbConfig")['id']
         except (ProgrammingError, OperationalError):
+            conn.rollback()
             # ProgrammingError: mysql&pg, OperationalError: sqlite
             # assume db is not initialized
             db.pool.engine.dispose()

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -230,7 +230,7 @@ def create_engine(name_or_url, **kwargs):
     if max_conns is None:
         max_conns = kwargs.get('pool_size', 5) + kwargs.get('max_overflow', 10)
     driver_strategy = get_drivers_strategy(u.drivername)
-    engine = sa.create_engine(u, **kwargs)
+    engine = sa.create_engine(u, **kwargs, future=True)
     driver_strategy.set_up(u, engine)
     engine.should_retry = driver_strategy.should_retry
     # annotate the engine with the optimal thread pool size; this is used

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -192,6 +192,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 conn.commit()
                 return r.inserted_primary_key[0]
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
+                conn.rollback()
                 raise KeyError(f"log with slug '{slug!r}' already exists in this step") from e
 
         return self.db.pool.do(thdAddLog)

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -178,18 +178,18 @@ class LogsConnectorComponent(base.DBConnectorComponent):
 
         def thdAddLog(conn) -> int:
             try:
-                with conn.begin():
-                    r = conn.execute(
-                        self.db.model.logs.insert(),
-                        {
-                            "name": name,
-                            "slug": slug,
-                            "stepid": stepid,
-                            "complete": 0,
-                            "num_lines": 0,
-                            "type": type,
-                        },
-                    )
+                r = conn.execute(
+                    self.db.model.logs.insert(),
+                    {
+                        "name": name,
+                        "slug": slug,
+                        "stepid": stepid,
+                        "complete": 0,
+                        "num_lines": 0,
+                        "type": type,
+                    },
+                )
+                conn.commit()
                 return r.inserted_primary_key[0]
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
                 raise KeyError(f"log with slug '{slug!r}' already exists in this step") from e
@@ -223,24 +223,26 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             last_line = chunk_first_line + chunk.count(b'\n')
 
             chunk, compressed_id = self.thdCompressChunk(chunk)
-            with conn.begin():
-                conn.execute(
-                    self.db.model.logchunks.insert(),
-                    {
-                        "logid": logid,
-                        "first_line": chunk_first_line,
-                        "last_line": last_line,
-                        "content": chunk,
-                        "compressed": compressed_id,
-                    },
-                ).close()
+            res = conn.execute(
+                self.db.model.logchunks.insert(),
+                {
+                    "logid": logid,
+                    "first_line": chunk_first_line,
+                    "last_line": last_line,
+                    "content": chunk,
+                    "compressed": compressed_id,
+                },
+            )
+            conn.commit()
+            res.close()
             chunk_first_line = last_line + 1
-        with conn.begin():
-            conn.execute(
-                self.db.model.logs.update()
-                .where(self.db.model.logs.c.id == logid)
-                .values(num_lines=last_line + 1)
-            ).close()
+        res = conn.execute(
+            self.db.model.logs.update()
+            .where(self.db.model.logs.c.id == logid)
+            .values(num_lines=last_line + 1)
+        )
+        conn.commit()
+        res.close()
         return first_line, last_line
 
     def thdAppendLog(self, conn, logid: int, content: str) -> tuple[int, int] | None:
@@ -434,12 +436,12 @@ class LogsConnectorComponent(base.DBConnectorComponent):
 
             # UPDATE logs SET logs.type = 'd' WHERE logs.stepid <= stepid_max AND type != 'd';
             if stepid_max:
-                with conn.begin():
-                    res = conn.execute(
-                        model.logs.update()
-                        .where(sa.and_(model.logs.c.stepid <= stepid_max, model.logs.c.type != 'd'))
-                        .values(type='d')
-                    )
+                res = conn.execute(
+                    model.logs.update()
+                    .where(sa.and_(model.logs.c.stepid <= stepid_max, model.logs.c.type != 'd'))
+                    .values(type='d')
+                )
+                conn.commit()
                 res.close()
 
             # query all logs with type 'd' and delete their chunks.
@@ -457,8 +459,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 q = q.where(model.logs.c.id == model.logchunks.c.logid)
                 q = q.where(model.logs.c.type == 'd')
 
-            with conn.begin():
-                res = conn.execute(q)
+            res = conn.execute(q)
+            conn.commit()
             res.close()
             res = conn.execute(sa.select(sa.func.count(model.logchunks.c.logid)))
             count2 = res.fetchone()[0]

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -98,16 +98,16 @@ class MastersConnectorComponent(base.DBConnectorComponent):
                 # master
                 sch_mst_tbl = self.db.model.scheduler_masters
                 q = sch_mst_tbl.delete().where(sch_mst_tbl.c.masterid == masterid)
-                with conn.begin():
-                    conn.execute(q)
+                conn.execute(q)
+                conn.commit()
 
             # set the state (unconditionally, just to be safe)
             q = tbl.update().where(whereclause)
             q = q.values(active=1 if active else 0)
             if active:
                 q = q.values(last_active=int(self.master.reactor.seconds()))
-            with conn.begin():
-                conn.execute(q)
+            conn.execute(q)
+            conn.commit()
 
             # return True if there was a change in state
             return was_active != bool(active)

--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -31,15 +31,15 @@ def test_unicode(migrate_engine):
         sa.Column('u', sa.Unicode(length=100)),
         sa.Column('b', sa.LargeBinary),
     )
-    with migrate_engine.begin():
-        test_unicode.create(bind=migrate_engine)
+    test_unicode.create(bind=migrate_engine)
+    migrate_engine.commit()
 
     # insert a unicode value in there
     u = "Frosty the \N{SNOWMAN}"
     b = b'\xff\xff\x00'
     ins = test_unicode.insert().values(u=u, b=b)
-    with migrate_engine.begin():
-        migrate_engine.execute(ins)
+    migrate_engine.execute(ins)
+    migrate_engine.commit()
 
     # see if the data is intact
     row = migrate_engine.execute(test_unicode.select()).fetchall()[0]
@@ -49,5 +49,5 @@ def test_unicode(migrate_engine):
     assert row.b == b
 
     # drop the test table
-    with migrate_engine.begin():
-        test_unicode.drop(bind=migrate_engine)
+    test_unicode.drop(bind=migrate_engine)
+    migrate_engine.commit()

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -1145,8 +1145,8 @@ class Model(base.DBConnectorComponent):
 
     def alembic_stamp(self, conn, alembic_scripts, revision):
         context = alembic.runtime.migration.MigrationContext.configure(conn)
-        with conn.begin():
-            context.stamp(alembic_scripts, revision)
+        context.stamp(alembic_scripts, revision)
+        conn.commit()
 
     @defer.inlineCallbacks
     def is_current(self):
@@ -1194,8 +1194,8 @@ class Model(base.DBConnectorComponent):
                     raise UpgradeFromBefore3p0Error()
 
                 self.alembic_stamp(conn, alembic_scripts, alembic_scripts.get_base())
-                with conn.begin():
-                    conn.execute(sa.text('drop table migrate_version'))
+                conn.execute(sa.text('drop table migrate_version'))
+                conn.commit()
 
             if not self.table_exists(conn, 'alembic_version'):
                 log.msg("Initializing empty database")
@@ -1203,8 +1203,8 @@ class Model(base.DBConnectorComponent):
                 # Do some tests first
                 test_unicode(conn)
 
-                with conn.begin():
-                    Model.metadata.create_all(conn)
+                Model.metadata.create_all(conn)
+                conn.commit()
                 self.alembic_stamp(conn, alembic_scripts, current_script_rev_head)
                 return
 

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -166,15 +166,15 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
             # handle the masterid=None case to get it out of the way
             if masterid is None:
                 q = sch_mst_tbl.delete().where(sch_mst_tbl.c.schedulerid == schedulerid)
-                with conn.begin():
-                    conn.execute(q).close()
+                conn.execute(q).close()
+                conn.commit()
                 return None
 
             # try a blind insert..
             try:
                 q = sch_mst_tbl.insert()
-                with conn.begin():
-                    conn.execute(q, {"schedulerid": schedulerid, "masterid": masterid}).close()
+                conn.execute(q, {"schedulerid": schedulerid, "masterid": masterid}).close()
+                conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
                 # someone already owns this scheduler, but who?
                 join = self.db.model.masters.outerjoin(

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -176,6 +176,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 conn.execute(q, {"schedulerid": schedulerid, "masterid": masterid}).close()
                 conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
+                conn.rollback()
                 # someone already owns this scheduler, but who?
                 join = self.db.model.masters.outerjoin(
                     sch_mst_tbl, (self.db.model.masters.c.id == sch_mst_tbl.c.masterid)

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -156,17 +156,17 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
                 patch_body_bytes = unicode2bytes(patch_body)
                 patch_base64_bytes = base64.b64encode(patch_body_bytes)
                 ins = self.db.model.patches.insert()
-                with conn.begin():
-                    r = conn.execute(
-                        ins,
-                        {
-                            "patchlevel": patch_level,
-                            "patch_base64": bytes2unicode(patch_base64_bytes),
-                            "patch_author": patch_author,
-                            "patch_comment": patch_comment,
-                            "subdir": patch_subdir,
-                        },
-                    )
+                r = conn.execute(
+                    ins,
+                    {
+                        "patchlevel": patch_level,
+                        "patch_base64": bytes2unicode(patch_base64_bytes),
+                        "patch_author": patch_author,
+                        "patch_comment": patch_comment,
+                        "subdir": patch_subdir,
+                    },
+                )
+                conn.commit()
                 patchid = r.inserted_primary_key[0]
             return patchid
 

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -66,8 +66,8 @@ class StateConnectorComponent(base.DBConnectorComponent):
             return row.id
 
         def insert():
-            with conn.begin():
-                res = conn.execute(objects_tbl.insert().values(name=name, class_name=class_name))
+            res = conn.execute(objects_tbl.insert().values(name=name, class_name=class_name))
+            conn.commit()
             return res.inserted_primary_key[0]
 
         # we want to try selecting, then inserting, but if the insert fails
@@ -140,19 +140,19 @@ class StateConnectorComponent(base.DBConnectorComponent):
             q = object_state_tbl.update().where(
                 object_state_tbl.c.objectid == objectid, object_state_tbl.c.name == name
             )
-            with conn.begin():
-                res = conn.execute(q.values(value_json=value_json))
+            res = conn.execute(q.values(value_json=value_json))
+            conn.commit()
 
             # check whether that worked
             return res.rowcount > 0
 
         def insert():
-            with conn.begin():
-                conn.execute(
-                    object_state_tbl.insert().values(
-                        objectid=objectid, name=name, value_json=value_json
-                    )
+            conn.execute(
+                object_state_tbl.insert().values(
+                    objectid=objectid, name=name, value_json=value_json
                 )
+            )
+            conn.commit()
 
         # try updating; if that fails, try inserting; if that fails, then
         # we raced with another instance to insert, so let that instance
@@ -186,14 +186,14 @@ class StateConnectorComponent(base.DBConnectorComponent):
                     raise TypeError(f"Error encoding JSON for {repr(res)}") from e
                 self._test_timing_hook(conn)
                 try:
-                    with conn.begin():
-                        conn.execute(
-                            object_state_tbl.insert().values(
-                                objectid=objectid,
-                                name=name,
-                                value_json=value_json,
-                            )
+                    conn.execute(
+                        object_state_tbl.insert().values(
+                            objectid=objectid,
+                            name=name,
+                            value_json=value_json,
                         )
+                    )
+                    conn.commit()
                 except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError):
                     # someone beat us to it - oh well return that value
                     return self.thdGetState(conn, objectid, name)

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -83,7 +83,7 @@ class StateConnectorComponent(base.DBConnectorComponent):
         try:
             return ObjDict(id=insert())
         except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError):
-            pass
+            conn.rollback()
 
         return ObjDict(id=select())
 
@@ -166,7 +166,7 @@ class StateConnectorComponent(base.DBConnectorComponent):
         try:
             insert()
         except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError):
-            pass  # someone beat us to it - oh well
+            conn.rollback()  # someone beat us to it - oh well
 
     def _test_timing_hook(self, conn):
         # called so tests can simulate another process inserting a database row
@@ -195,6 +195,7 @@ class StateConnectorComponent(base.DBConnectorComponent):
                     )
                     conn.commit()
                 except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError):
+                    conn.rollback()
                     # someone beat us to it - oh well return that value
                     return self.thdGetState(conn, objectid, name)
             return res

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -162,6 +162,7 @@ class StepsConnectorComponent(base.DBConnectorComponent):
                 conn.commit()
                 got_id = r.inserted_primary_key[0]
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
+                conn.rollback()
                 got_id = None
 
             if got_id:

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -158,8 +158,8 @@ class StepsConnectorComponent(base.DBConnectorComponent):
                 "name": name,
             }
             try:
-                with conn.begin():
-                    r = conn.execute(self.db.model.steps.insert(), insert_row)
+                r = conn.execute(self.db.model.steps.insert(), insert_row)
+                conn.commit()
                 got_id = r.inserted_primary_key[0]
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 got_id = None
@@ -180,8 +180,8 @@ class StepsConnectorComponent(base.DBConnectorComponent):
                     break
                 num += 1
             insert_row['name'] = newname
-            with conn.begin():
-                r = conn.execute(self.db.model.steps.insert(), insert_row)
+            r = conn.execute(self.db.model.steps.insert(), insert_row)
+            conn.commit()
             got_id = r.inserted_primary_key[0]
             return (got_id, number, newname)
 
@@ -243,8 +243,8 @@ class StepsConnectorComponent(base.DBConnectorComponent):
             if url_item not in urls:
                 urls.append(url_item)
                 q = tbl.update().where(wc)
-                with conn.begin():
-                    conn.execute(q.values(urls_json=json.dumps(urls)))
+                conn.execute(q.values(urls_json=json.dumps(urls)))
+                conn.commit()
 
         return self.url_lock.run(self.db.pool.do, thd)
 

--- a/master/buildbot/db/test_result_sets.py
+++ b/master/buildbot/db/test_result_sets.py
@@ -84,8 +84,8 @@ class TestResultSetsConnectorComponent(base.DBConnectorComponent):
             }
 
             q = sets_table.insert().values(insert_values)
-            with conn.begin():
-                r = conn.execute(q)
+            r = conn.execute(q)
+            conn.commit()
             return r.inserted_primary_key[0]
 
         return self.db.pool.do(thd)
@@ -141,8 +141,8 @@ class TestResultSetsConnectorComponent(base.DBConnectorComponent):
             q = sets_table.update().values(values)
             q = q.where((sets_table.c.id == test_result_setid) & (sets_table.c.complete == 0))
 
-            with conn.begin():
-                res = conn.execute(q)
+            res = conn.execute(q)
+            conn.commit()
             if res.rowcount == 0:
                 raise TestResultSetAlreadyCompleted(
                     f'Test result set {test_result_setid} '

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -98,14 +98,14 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                             # Use RETURNING, this way we won't need an additional select query
                             q = q.returning(paths_table.c.id, paths_table.c.path)
 
-                            with conn.begin():
-                                res = conn.execute(q)
+                            res = conn.execute(q)
+                            conn.commit()
                             for row in res.fetchall():
                                 paths_to_ids[row.path] = row.id
                                 path_batch.remove(row.path)
                         else:
-                            with conn.begin():
-                                conn.execute(q)
+                            conn.execute(q)
+                            conn.commit()
 
                     except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                         # There was a competing addCodePaths() call that added a path for the same
@@ -168,14 +168,14 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                             # Use RETURNING, this way we won't need an additional select query
                             q = q.returning(names_table.c.id, names_table.c.name)
 
-                            with conn.begin():
-                                res = conn.execute(q)
+                            res = conn.execute(q)
+                            conn.commit()
                             for row in res.fetchall():
                                 names_to_ids[row.name] = row.id
                                 name_batch.remove(row.name)
                         else:
-                            with conn.begin():
-                                conn.execute(q)
+                            conn.execute(q)
+                            conn.commit()
 
                     except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                         # There was a competing addNames() call that added a name for the same

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -111,7 +111,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                         # There was a competing addCodePaths() call that added a path for the same
                         # builder. Depending on the DB driver, none or some rows were inserted, but
                         # we will re-check what's got inserted in the next iteration of the loop
-                        pass
+                        conn.rollback()
 
             return paths_to_ids
 
@@ -181,7 +181,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                         # There was a competing addNames() call that added a name for the same
                         # builder. Depending on the DB driver, none or some rows were inserted, but
                         # we will re-check what's got inserted in the next iteration of the loop
-                        pass
+                        conn.rollback()
 
             return names_to_ids
 

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -94,7 +94,7 @@ class UsersConnectorComponent(base.DBConnectorComponent):
             # try to do both of these inserts in a transaction, so that both
             # the new user and the corresponding attributes appear at the same
             # time from the perspective of other masters.
-            transaction = conn.begin()
+            transaction = conn.begin_nested()
             inserted_user = False
             try:
                 r = conn.execute(tbl.insert(), {"identifier": identifier})
@@ -124,6 +124,7 @@ class UsersConnectorComponent(base.DBConnectorComponent):
 
                 return thd(conn, no_recurse=no_recurse, identifier=identifier)
 
+            conn.commit()
             return uid
 
         return self.db.pool.do(thd)

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -288,16 +288,16 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
             conn_tbl = self.db.model.connected_workers
             q = conn_tbl.insert()
             try:
-                with conn.begin():
-                    conn.execute(q, {'workerid': workerid, 'masterid': masterid})
+                conn.execute(q, {'workerid': workerid, 'masterid': masterid})
+                conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 # if the row is already present, silently fail..
                 pass
 
             bs_tbl = self.db.model.workers
             q = bs_tbl.update().where(bs_tbl.c.id == workerid)
-            with conn.begin():
-                conn.execute(q.values(info=workerinfo))
+            conn.execute(q.values(info=workerinfo))
+            conn.commit()
 
         return self.db.pool.do(thd)
 

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -292,7 +292,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                 conn.commit()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 # if the row is already present, silently fail..
-                pass
+                conn.rollback()
 
             bs_tbl = self.db.model.workers
             q = bs_tbl.update().where(bs_tbl.c.id == workerid)

--- a/master/buildbot/test/unit/db/test_base.py
+++ b/master/buildbot/test/unit/db/test_base.py
@@ -101,12 +101,12 @@ class TestBaseAsConnectorComponent(unittest.TestCase, connector_component.Connec
         hash = hashlib.sha1(b'somemaster').hexdigest()
 
         def race_thd(conn: Connection):
-            with conn.begin():
-                conn.execute(
-                    tbl.insert().values(
-                        id=5, name='somemaster', name_hash=hash, active=1, last_active=1
-                    )
+            conn.execute(
+                tbl.insert().values(
+                    id=5, name='somemaster', name_hash=hash, active=1, last_active=1
                 )
+            )
+            conn.commit()
 
         id = yield self.db.base.findSomethingId(
             tbl=self.db.model.masters,

--- a/master/buildbot/test/unit/db/test_base.py
+++ b/master/buildbot/test/unit/db/test_base.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 import hashlib
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import sqlalchemy as sa
@@ -25,6 +27,9 @@ from buildbot.db import base
 from buildbot.test import fakedb
 from buildbot.test.util import connector_component
 from buildbot.util import sautils
+
+if TYPE_CHECKING:
+    from sqlalchemy.future.engine import Connection
 
 
 class TestBase(unittest.TestCase):
@@ -95,7 +100,7 @@ class TestBaseAsConnectorComponent(unittest.TestCase, connector_component.Connec
         tbl = self.db.model.masters
         hash = hashlib.sha1(b'somemaster').hexdigest()
 
-        def race_thd(conn: sa.engine.base.Connection):
+        def race_thd(conn: Connection):
             with conn.begin():
                 conn.execute(
                     tbl.insert().values(

--- a/master/buildbot/test/unit/db/test_builds.py
+++ b/master/buildbot/test/unit/db/test_builds.py
@@ -515,20 +515,20 @@ class RealTests(Tests):
         def raceHook(conn):
             if not numbers:
                 return
-            with conn.begin():
-                conn.execute(
-                    self.db.model.builds.insert(),
-                    {
-                        "number": numbers.pop(0),
-                        "buildrequestid": 41,
-                        "masterid": 88,
-                        "workerid": 13,
-                        "builderid": 77,
-                        "started_at": TIME1,
-                        "locks_duration_s": 0,
-                        "state_string": "hi",
-                    },
-                )
+            conn.execute(
+                self.db.model.builds.insert(),
+                {
+                    "number": numbers.pop(0),
+                    "buildrequestid": 41,
+                    "masterid": 88,
+                    "workerid": 13,
+                    "builderid": 77,
+                    "started_at": TIME1,
+                    "locks_duration_s": 0,
+                    "state_string": "hi",
+                },
+            )
+            conn.commit()
 
         id, number = yield self.db.builds.addBuild(
             builderid=77,

--- a/master/buildbot/test/unit/db/test_pool.py
+++ b/master/buildbot/test/unit/db/test_pool.py
@@ -107,14 +107,16 @@ class Basic(unittest.TestCase):
         # transaction runs.  This is why we set optimal_thread_pool_size in
         # setUp.
         def create_table(engine):
-            with engine.connect() as conn, conn.begin():
+            with engine.connect() as conn:
                 conn.execute(sa.text("CREATE TABLE tmp ( a integer )"))
+                conn.commit()
 
         yield self.pool.do_with_engine(create_table)
 
         def insert_into_table(engine):
-            with engine.connect() as conn, conn.begin():
+            with engine.connect() as conn:
                 conn.execute(sa.text("INSERT INTO tmp values ( 1 )"))
+                conn.commit()
 
         yield self.pool.do_with_engine(insert_into_table)
 

--- a/master/buildbot/test/unit/db/test_pool.py
+++ b/master/buildbot/test/unit/db/test_pool.py
@@ -31,7 +31,7 @@ class Basic(unittest.TestCase):
     # basic tests, just using an in-memory SQL db and one thread
 
     def setUp(self):
-        self.engine = sa.create_engine('sqlite://')
+        self.engine = sa.create_engine('sqlite://', future=True)
         self.engine.should_retry = lambda _: False
         self.engine.optimal_thread_pool_size = 1
         self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
@@ -123,11 +123,11 @@ class Basic(unittest.TestCase):
 
 class Stress(unittest.TestCase):
     def setUp(self):
-        setup_engine = sa.create_engine('sqlite:///test.sqlite')
+        setup_engine = sa.create_engine('sqlite:///test.sqlite', future=True)
         setup_engine.execute("pragma journal_mode = wal")
         setup_engine.execute("CREATE TABLE test (a integer, b integer)")
 
-        self.engine = sa.create_engine('sqlite:///test.sqlite')
+        self.engine = sa.create_engine('sqlite:///test.sqlite', future=True)
         self.engine.optimal_thread_pool_size = 2
         self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
 

--- a/master/buildbot/test/unit/db/test_state.py
+++ b/master/buildbot/test/unit/db/test_state.py
@@ -60,12 +60,10 @@ class TestStateConnectorComponent(connector_component.ConnectorComponentMixin, d
         # and adding a new one, triggering the fallback to re-running
         # the select.
         def hook(conn):
-            with conn.begin():
-                conn.execute(
-                    self.db.model.objects.insert().values(
-                        id=27, name='someobj', class_name='someclass'
-                    )
-                )
+            conn.execute(
+                self.db.model.objects.insert().values(id=27, name='someobj', class_name='someclass')
+            )
+            conn.commit()
 
         self.db.state._test_timing_hook = hook
 
@@ -166,12 +164,10 @@ class TestStateConnectorComponent(connector_component.ConnectorComponentMixin, d
     @defer.inlineCallbacks
     def test_setState_conflict(self):
         def hook(conn):
-            with conn.begin():
-                conn.execute(
-                    self.db.model.object_state.insert().values(
-                        objectid=10, name='x', value_json='22'
-                    )
-                )
+            conn.execute(
+                self.db.model.object_state.insert().values(objectid=10, name='x', value_json='22')
+            )
+            conn.commit()
 
         self.db.state._test_timing_hook = hook
 
@@ -204,12 +200,10 @@ class TestStateConnectorComponent(connector_component.ConnectorComponentMixin, d
         ])
 
         def hook(conn):
-            with conn.begin():
-                conn.execute(
-                    self.db.model.object_state.insert().values(
-                        objectid=10, name='x', value_json='22'
-                    )
-                )
+            conn.execute(
+                self.db.model.object_state.insert().values(objectid=10, name='x', value_json='22')
+            )
+            conn.commit()
 
         self.db.state._test_timing_hook = hook
 

--- a/master/buildbot/test/unit/db/test_users.py
+++ b/master/buildbot/test/unit/db/test_users.py
@@ -171,15 +171,15 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin, u
             # This is the case for DB engines that support transactions, but
             # not for MySQL.  so this test does not detect the potential MySQL
             # failure, which will generally result in a spurious failure.
-            with conn.begin():
-                conn.execute(self.db.model.users.insert().values(uid=99, identifier='soap'))
-                conn.execute(
-                    self.db.model.users_info.insert().values(
-                        uid=99,
-                        attr_type='subspace_net_handle',
-                        attr_data='Durden0924',
-                    )
+            conn.execute(self.db.model.users.insert().values(uid=99, identifier='soap'))
+            conn.execute(
+                self.db.model.users_info.insert().values(
+                    uid=99,
+                    attr_type='subspace_net_handle',
+                    attr_data='Durden0924',
                 )
+            )
+            conn.commit()
 
         uid = yield self.db.users.findUserByAttr(
             identifier='soap',
@@ -402,13 +402,13 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin, u
         def race_thd(conn):
             conn = self.db.pool.engine.connect()
             try:
-                with conn.begin():
-                    r = conn.execute(
-                        self.db.model.users_info.insert().values(
-                            uid=1, attr_type='IPv4', attr_data='8.8.8.8'
-                        )
+                r = conn.execute(
+                    self.db.model.users_info.insert().values(
+                        uid=1, attr_type='IPv4', attr_data='8.8.8.8'
                     )
-                    r.close()
+                )
+                conn.commit()
+                r.close()
             except sqlalchemy.exc.OperationalError:
                 # some engine (mysql innodb) will enforce lock until the transaction is over
                 transaction_wins.append(True)

--- a/master/buildbot/test/unit/db_migrate/test_versions_060_add_builder_projects.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_060_add_builder_projects.py
@@ -41,20 +41,20 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column('description', sa.Text, nullable=True),
             sa.Column('name_hash', sa.String(40), nullable=False),
         )
-        with conn.begin():
-            builders.create(bind=conn)
+        builders.create(bind=conn)
 
-            conn.execute(
-                builders.insert(),
-                [
-                    {
-                        "id": 3,
-                        "name": "foo",
-                        "description": "foo_description",
-                        "name_hash": hashlib.sha1(b'foo').hexdigest(),
-                    }
-                ],
-            )
+        conn.execute(
+            builders.insert(),
+            [
+                {
+                    "id": 3,
+                    "name": "foo",
+                    "description": "foo_description",
+                    "name_hash": hashlib.sha1(b'foo').hexdigest(),
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):

--- a/master/buildbot/test/unit/db_migrate/test_versions_061_add_builder_description_format.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_061_add_builder_description_format.py
@@ -42,21 +42,21 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column('projectid', sa.Integer, nullable=True),
             sa.Column('name_hash', sa.String(40), nullable=False),
         )
-        with conn.begin():
-            builders.create(bind=conn)
+        builders.create(bind=conn)
 
-            conn.execute(
-                builders.insert(),
-                [
-                    {
-                        "id": 3,
-                        "name": "foo",
-                        "description": "foo_description",
-                        "projectid": None,
-                        "name_hash": hashlib.sha1(b'foo').hexdigest(),
-                    }
-                ],
-            )
+        conn.execute(
+            builders.insert(),
+            [
+                {
+                    "id": 3,
+                    "name": "foo",
+                    "description": "foo_description",
+                    "projectid": None,
+                    "name_hash": hashlib.sha1(b'foo').hexdigest(),
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):

--- a/master/buildbot/test/unit/db_migrate/test_versions_062_add_project_description_format.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_062_add_project_description_format.py
@@ -44,23 +44,23 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column('slug', sa.String(50), nullable=False),
             sa.Column('description', sa.Text, nullable=True),
         )
-        with conn.begin():
-            projects.create(bind=conn)
+        projects.create(bind=conn)
 
-            conn.execute(
-                projects.insert(),
-                [
-                    {
-                        "id": 4,
-                        "name": "foo",
-                        "description": "foo_description",
-                        "description_html": None,
-                        "description_format": None,
-                        "slug": "foo",
-                        "name_hash": hashlib.sha1(b'foo').hexdigest(),
-                    }
-                ],
-            )
+        conn.execute(
+            projects.insert(),
+            [
+                {
+                    "id": 4,
+                    "name": "foo",
+                    "description": "foo_description",
+                    "description_html": None,
+                    "description_format": None,
+                    "slug": "foo",
+                    "name_hash": hashlib.sha1(b'foo').hexdigest(),
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):

--- a/master/buildbot/test/unit/db_migrate/test_versions_063_add_steps_locks_acquired_at.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_063_add_steps_locks_acquired_at.py
@@ -46,26 +46,26 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column('urls_json', sa.Text, nullable=False),
             sa.Column('hidden', sa.SmallInteger, nullable=False, server_default='0'),
         )
-        with conn.begin():
-            steps.create(bind=conn)
+        steps.create(bind=conn)
 
-            conn.execute(
-                steps.insert(),
-                [
-                    {
-                        "id": 4,
-                        "number": 123,
-                        "name": "step",
-                        "buildid": 12,
-                        "started_at": 1690848000,
-                        "complete_at": 1690848030,
-                        "state_string": "state",
-                        "results": 0,
-                        "urls_json": "",
-                        "hidden": 0,
-                    }
-                ],
-            )
+        conn.execute(
+            steps.insert(),
+            [
+                {
+                    "id": 4,
+                    "number": 123,
+                    "name": "step",
+                    "buildid": 12,
+                    "started_at": 1690848000,
+                    "complete_at": 1690848030,
+                    "state_string": "state",
+                    "results": 0,
+                    "urls_json": "",
+                    "hidden": 0,
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):

--- a/master/buildbot/test/unit/db_migrate/test_versions_064_add_worker_pause_reason.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_064_add_worker_pause_reason.py
@@ -41,21 +41,21 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column("paused", sa.SmallInteger, nullable=False, server_default="0"),
             sa.Column("graceful", sa.SmallInteger, nullable=False, server_default="0"),
         )
-        with conn.begin():
-            workers.create(bind=conn)
+        workers.create(bind=conn)
 
-            conn.execute(
-                workers.insert(),
-                [
-                    {
-                        "id": 4,
-                        "name": "worker1",
-                        "info": "{\"key\": \"value\"}",
-                        "paused": 0,
-                        "graceful": 0,
-                    }
-                ],
-            )
+        conn.execute(
+            workers.insert(),
+            [
+                {
+                    "id": 4,
+                    "name": "worker1",
+                    "info": "{\"key\": \"value\"}",
+                    "paused": 0,
+                    "graceful": 0,
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):

--- a/master/buildbot/test/unit/db_migrate/test_versions_065_add_buildsets_rebuilt_buildid.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_065_add_buildsets_rebuilt_buildid.py
@@ -47,37 +47,37 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column("results", sa.SmallInteger),
             sa.Column("parent_relationship", sa.Text),
         )
-        with conn.begin():
-            buildsets.create(bind=conn)
+        buildsets.create(bind=conn)
 
-            conn.execute(
-                buildsets.insert(),
-                [
-                    {
-                        "id": 4,
-                        "external_idstring": 5,
-                        "reason": "rebuild",
-                        "submitted_at": 1695730972,
-                        "complete": 1,
-                        "complete_at": 1695730977,
-                        "results": 0,
-                        "parent_relationship": "Triggered from",
-                    }
-                ],
-            )
+        conn.execute(
+            buildsets.insert(),
+            [
+                {
+                    "id": 4,
+                    "external_idstring": 5,
+                    "reason": "rebuild",
+                    "submitted_at": 1695730972,
+                    "complete": 1,
+                    "complete_at": 1695730977,
+                    "results": 0,
+                    "parent_relationship": "Triggered from",
+                }
+            ],
+        )
+        conn.commit()
 
         builds = sautils.Table("builds", metadata, sa.Column("id", sa.Integer, primary_key=True))
-        with conn.begin():
-            builds.create(bind=conn)
+        builds.create(bind=conn)
 
-            conn.execute(
-                builds.insert(),
-                [
-                    {
-                        "id": 123,
-                    }
-                ],
-            )
+        conn.execute(
+            builds.insert(),
+            [
+                {
+                    "id": 123,
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):
@@ -103,23 +103,23 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
                 # verify that a foreign with name "fk_buildsets_rebuilt_buildid" was found
                 self.assertEqual(len(fk_in_search), 1)
 
-            with conn.begin():
-                conn.execute(
-                    buildsets.insert(),
-                    [
-                        {
-                            "id": 5,
-                            "external_idstring": 6,
-                            "reason": "rebuild",
-                            "submitted_at": 1695730973,
-                            "complete": 1,
-                            "complete_at": 1695730978,
-                            "results": 0,
-                            "rebuilt_buildid": 123,
-                            "parent_relationship": "Triggered from",
-                        }
-                    ],
-                )
+            conn.execute(
+                buildsets.insert(),
+                [
+                    {
+                        "id": 5,
+                        "external_idstring": 6,
+                        "reason": "rebuild",
+                        "submitted_at": 1695730973,
+                        "complete": 1,
+                        "complete_at": 1695730978,
+                        "results": 0,
+                        "rebuilt_buildid": 123,
+                        "parent_relationship": "Triggered from",
+                    }
+                ],
+            )
+            conn.commit()
 
             rebuilt_buildid_list = []
             for row in conn.execute(q):

--- a/master/buildbot/test/unit/db_migrate/test_versions_066_add_build_locks_duration_s.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_066_add_build_locks_duration_s.py
@@ -43,22 +43,22 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             sa.Column('state_string', sa.Text, nullable=False),
             sa.Column('results', sa.Integer),
         )
-        with conn.begin():
-            builds.create(bind=conn)
+        builds.create(bind=conn)
 
-            conn.execute(
-                builds.insert(),
-                [
-                    {
-                        "id": 4,
-                        "number": 5,
-                        "started_at": 1695730972,
-                        "complete_at": 1695730975,
-                        "state_string": "test build",
-                        "results": 0,
-                    }
-                ],
-            )
+        conn.execute(
+            builds.insert(),
+            [
+                {
+                    "id": 4,
+                    "number": 5,
+                    "started_at": 1695730972,
+                    "complete_at": 1695730975,
+                    "state_string": "test build",
+                    "results": 0,
+                }
+            ],
+        )
+        conn.commit()
 
     def test_update(self):
         def setup_thd(conn):
@@ -71,21 +71,20 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             builds = sautils.Table('builds', metadata, autoload_with=conn)
             self.assertIsInstance(builds.c.locks_duration_s.type, sa.Integer)
 
-            with conn.begin():
-                conn.execute(
-                    builds.insert(),
-                    [
-                        {
-                            "id": 5,
-                            "number": 6,
-                            "started_at": 1695730982,
-                            "complete_at": 1695730985,
-                            "locks_duration_s": 12,
-                            "state_string": "test build",
-                            "results": 0,
-                        }
-                    ],
-                )
+            conn.execute(
+                builds.insert(),
+                [
+                    {
+                        "id": 5,
+                        "number": 6,
+                        "started_at": 1695730982,
+                        "complete_at": 1695730985,
+                        "locks_duration_s": 12,
+                        "state_string": "test build",
+                        "results": 0,
+                    }
+                ],
+            )
 
             durations = []
             for row in conn.execute(sa.select(builds.c.locks_duration_s)):

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -16,6 +16,7 @@
 
 import os
 
+import sqlalchemy as sa
 from sqlalchemy.schema import MetaData
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -185,7 +186,7 @@ class RealDatabaseMixin:
             # sometimes this goes badly wrong; being able to see the schema
             # can be a big help
             if conn.engine.dialect.name == 'sqlite':
-                r = conn.execute("select sql from sqlite_master where type='table'")
+                r = conn.execute(sa.text("select sql from sqlite_master where type='table'"))
                 log.msg("Current schema:")
                 for row in r.fetchall():
                     log.msg(row.sql)

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -179,8 +179,9 @@ class RealDatabaseMixin:
             # SQLAlchemy wouldn't be able to break circular references.
             # Sqlalchemy fk support with sqlite is not yet perfect, so we must deactivate fk during
             # that operation, even though we made our possible to use use_alter
-            with withoutSqliteForeignKeys(conn), conn.begin():
+            with withoutSqliteForeignKeys(conn):
                 meta.drop_all(bind=conn)
+                conn.commit()
 
         except Exception:
             # sometimes this goes badly wrong; being able to see the schema
@@ -198,8 +199,8 @@ class RealDatabaseMixin:
         # Create tables using create_all() method. This way not only tables
         # and direct indices are created, but also deferred references
         # (that use use_alter=True in definition).
-        with conn.begin():
-            model.Model.metadata.create_all(bind=conn, tables=tables, checkfirst=True)
+        model.Model.metadata.create_all(bind=conn, tables=tables, checkfirst=True)
+        conn.commit()
 
     @defer.inlineCallbacks
     def setUpRealDatabase(
@@ -272,8 +273,8 @@ class RealDatabaseMixin:
                 for row in [r for r in rows if r.table == tbl.name]:
                     tbl = model.Model.metadata.tables[row.table]
                     try:
-                        with conn.begin():
-                            conn.execute(tbl.insert().values(row.values))
+                        conn.execute(tbl.insert().values(row.values))
+                        conn.commit()
                     except Exception:
                         log.msg(f"while inserting {row} - {row.values}")
                         raise

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -70,9 +70,9 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
                 metadata,
                 sa.Column("version_num", sa.String(32), nullable=False),
             )
-            with conn.begin():
-                table.create(bind=conn)
-                conn.execute(table.insert().values(version_num=base_revision))
+            table.create(bind=conn)
+            conn.execute(table.insert().values(version_num=base_revision))
+            conn.commit()
             setup_thd_cb(conn)
 
         yield self.db.pool.do(setup_thd)

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -94,6 +94,8 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
                             with context.begin_transaction():
                                 context.run_migrations()
 
+                        conn.commit()
+
         yield self.db.pool.do_with_engine(upgrade_thd)
 
         def check_table_charsets_thd(conn: Connection):

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from alembic.operations import Operations
@@ -30,6 +31,10 @@ from buildbot.test.util import db
 from buildbot.test.util import dirs
 from buildbot.test.util import querylog
 from buildbot.util import sautils
+
+if TYPE_CHECKING:
+    from sqlalchemy.future.engine import Connection
+
 
 # test_upgrade vs. migration tests
 #
@@ -91,7 +96,7 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
 
         yield self.db.pool.do_with_engine(upgrade_thd)
 
-        def check_table_charsets_thd(conn: sa.engine.base.Connection):
+        def check_table_charsets_thd(conn: Connection):
             # charsets are only a problem for MySQL
             if conn.dialect.name != 'mysql':
                 return

--- a/master/buildbot/util/sautils.py
+++ b/master/buildbot/util/sautils.py
@@ -24,7 +24,7 @@ from sqlalchemy.sql.expression import ClauseElement
 from sqlalchemy.sql.expression import Executable
 
 if TYPE_CHECKING:
-    from sqlalchemy.engine.base import Connection
+    from sqlalchemy.future.engine import Connection
 
 # from http:
 # //www.sqlalchemy.org/docs/core/compiler.html#compiling-sub-elements-of-a-custom-expression-construct  # noqa pylint: disable=line-too-long

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -138,7 +138,7 @@ A connector method should look like this::
 
 Picking that apart, the body of the method defines a function named ``thd``
 taking one argument, a :class:`Connection
-<sqlalchemy:sqlalchemy.engine.base.Connection>` object.  It then calls
+<sqlalchemy:sqlalchemy.future.engine.Connection>` object.  It then calls
 ``self.db.pool.do``, passing the ``thd`` function.  This function is called in
 a thread, and can make blocking calls to SQLAlchemy as desired.  The ``do``
 method will return a Deferred that will fire with the return value of ``thd``,


### PR DESCRIPTION
This should allow to remove the upper bound on the SQLAlchemy dependency as this is the last step applicable to Buildbot in the [migration's guide](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine).

Included changes basically revert #7674, see the commit message `db: use commit-as-you-go pattern ` as to why.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
