### PR TITLE
master: Allow `db_url` config to be a renderable

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -20,6 +20,7 @@ from twisted.application import internet
 from twisted.internet import defer
 from twisted.python import log
 
+from buildbot import config
 from buildbot import util
 from buildbot.db import build_data
 from buildbot.db import builders
@@ -58,7 +59,29 @@ upgrade_message = textwrap.dedent("""\
     """).strip()
 
 
-class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+class AbstractDBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.configured_url = None
+
+    def setup(self):
+        self.configured_url = self.master.config.db['db_url']
+        return defer.succeed(None)
+
+    @defer.inlineCallbacks
+    def reconfigServiceWithBuildbotConfig(self, new_config):
+        new_db_url = new_config.db['db_url']
+        if self.configured_url is None:
+            self.configured_url = new_db_url
+        elif self.configured_url != new_db_url:
+            config.error(
+                "Cannot change c['db']['db_url'] after the master has started",
+            )
+
+        return (yield super().reconfigServiceWithBuildbotConfig(new_config))
+
+
+class DBConnector(AbstractDBConnector):
     # The connection between Buildbot and its backend database.  This is
     # generally accessible as master.db, but is also used during upgrades.
     #
@@ -113,7 +136,8 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
 
     @defer.inlineCallbacks
     def setup(self, check_version=True, verbose=True):
-        db_url = self.configured_url = self.master.config.db['db_url']
+        super().setup()
+        db_url = self.configured_url
 
         log.msg(f"Setting up database with URL {repr(util.stripUrlPassword(db_url))}")
 
@@ -133,12 +157,6 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
                 for l in upgrade_message.format(basedir=self.master.basedir).split('\n'):
                     log.msg(l)
                 raise exceptions.DatabaseNotReadyError()
-
-    def reconfigServiceWithBuildbotConfig(self, new_config):
-        # double-check -- the master ensures this in config checks
-        assert self.configured_url == new_config.db['db_url']
-
-        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     def _doCleanup(self):
         """

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -64,13 +64,13 @@ class AbstractDBConnector(service.ReconfigurableServiceMixin, service.AsyncMulti
         super().__init__()
         self.configured_url = None
 
+    @defer.inlineCallbacks
     def setup(self):
-        self.configured_url = self.master.config.db['db_url']
-        return defer.succeed(None)
+        self.configured_url = yield self.master.get_db_url(self.master.config)
 
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
-        new_db_url = new_config.db['db_url']
+        new_db_url = yield self.master.get_db_url(new_config)
         if self.configured_url is None:
             self.configured_url = new_db_url
         elif self.configured_url != new_db_url:

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -191,7 +191,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.secrets_manager = SecretManager()
         yield self.secrets_manager.setServiceParent(self)
-        self.secrets_manager.reconfig_priority = 2000
+        self.secrets_manager.reconfig_priority = self.db.reconfig_priority - 1
 
         self.service_manager = service.BuildbotServiceManager()
         yield self.service_manager.setServiceParent(self)
@@ -265,6 +265,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
             # set up services that need access to the config before everything
             # else gets told to reconfig
+            yield self.secrets_manager.setup()
             try:
                 yield self.db.setup()
             except exceptions.DatabaseNotReadyError:

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -452,13 +452,6 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         log.msg(f"{msg} (took {(self.reactor.seconds() - time_started):.3f} seconds)")
 
     def reconfigServiceWithBuildbotConfig(self, new_config):
-        if self.configured_db_url is None:
-            self.configured_db_url = new_config.db['db_url']
-        elif self.configured_db_url != new_config.db['db_url']:
-            config.error(
-                "Cannot change c['db']['db_url'] after the master has started",
-            )
-
         if self.config.mq['type'] != new_config.mq['type']:
             raise config.ConfigErrors([
                 "Cannot change c['mq']['type'] after the master has started",

--- a/master/buildbot/secrets/manager.py
+++ b/master/buildbot/secrets/manager.py
@@ -18,6 +18,7 @@ manage providers and handle secrets
 
 from twisted.internet import defer
 
+from buildbot.secrets.providers.base import SecretProviderBase
 from buildbot.secrets.secret import SecretDetails
 from buildbot.util import service
 
@@ -29,6 +30,15 @@ class SecretManager(service.BuildbotServiceManager):
 
     name = 'secrets'
     config_attr = "secretsProviders"
+
+    @defer.inlineCallbacks
+    def setup(self):
+        configuredProviders = self.get_service_config(self.master.config)
+
+        for child in configuredProviders.values():
+            assert isinstance(child, SecretProviderBase)
+            yield child.setServiceParent(self)
+            yield child.configureService()
 
     @defer.inlineCallbacks
     def get(self, secret, *args, **kwargs):

--- a/master/buildbot/test/fakedb/connector.py
+++ b/master/buildbot/test/fakedb/connector.py
@@ -15,6 +15,7 @@
 
 from twisted.internet import defer
 
+from buildbot.db.connector import AbstractDBConnector
 from buildbot.test.fakedb.build_data import FakeBuildDataComponent
 from buildbot.test.fakedb.builders import FakeBuildersComponent
 from buildbot.test.fakedb.buildrequests import FakeBuildRequestsComponent
@@ -35,10 +36,9 @@ from buildbot.test.fakedb.test_result_sets import FakeTestResultSetsComponent
 from buildbot.test.fakedb.test_results import FakeTestResultsComponent
 from buildbot.test.fakedb.users import FakeUsersComponent
 from buildbot.test.fakedb.workers import FakeWorkersComponent
-from buildbot.util import service
 
 
-class FakeDBConnector(service.AsyncMultiService):
+class FakeDBConnector(AbstractDBConnector):
     """
     A stand-in for C{master.db} that operates without an actual database
     backend.  This also implements a test-data interface similar to the
@@ -94,9 +94,10 @@ class FakeDBConnector(service.AsyncMultiService):
         self.test_result_sets = comp = FakeTestResultSetsComponent(self, testcase)
         self._components.append(comp)
 
+    @defer.inlineCallbacks
     def setup(self):
+        yield super().setup()
         self.is_setup = True
-        return defer.succeed(None)
 
     def insert_test_data(self, rows):
         """Insert a list of Row instances into the database; this method can be

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -31,6 +31,7 @@ from buildbot.config.master import FileLoader
 from buildbot.config.master import MasterConfig
 from buildbot.db import exceptions
 from buildbot.interfaces import IConfigLoader
+from buildbot.secrets.manager import SecretManager
 from buildbot.test import fakedb
 from buildbot.test.fake import fakedata
 from buildbot.test.fake import fakemq
@@ -91,6 +92,8 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
         )
         self.master.sendBuildbotNetUsageData = mock.Mock()
         self.master.botmaster = FakeBotMaster()
+        self.secrets_manager = self.master.secrets_manager = SecretManager()
+        yield self.secrets_manager.setServiceParent(self.master)
         self.db = self.master.db = fakedb.FakeDBConnector(self)
         yield self.db.setServiceParent(self.master)
         self.mq = self.master.mq = fakemq.FakeMQConnector(self)

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -31,11 +31,13 @@ from buildbot.config.master import FileLoader
 from buildbot.config.master import MasterConfig
 from buildbot.db import exceptions
 from buildbot.interfaces import IConfigLoader
+from buildbot.process.properties import Interpolate
 from buildbot.secrets.manager import SecretManager
 from buildbot.test import fakedb
 from buildbot.test.fake import fakedata
 from buildbot.test.fake import fakemq
 from buildbot.test.fake.botmaster import FakeBotMaster
+from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import dirs
 from buildbot.test.util import logging
@@ -50,7 +52,12 @@ class FailingLoader:
 @implementer(IConfigLoader)
 class DefaultLoader:
     def loadConfig(self):
-        return MasterConfig()
+        master_cfg = MasterConfig()
+        master_cfg.db['db_url'] = Interpolate(
+            "postgresql+psycopg2://buildbot:%(secret:db_pwd)s@localhost:3306/bbtest"
+        )
+        master_cfg.secretsProviders = [FakeSecretStorage(secretdict={'db_pwd': 's3cr3t'})]
+        return master_cfg
 
 
 class InitTests(unittest.SynchronousTestCase):
@@ -146,6 +153,11 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
     def test_startup_ok(self):
         yield self.master.startService()
 
+        self.assertEqual(
+            self.master.db.configured_url,
+            'postgresql+psycopg2://buildbot:s3cr3t@localhost:3306/bbtest',
+        )
+
         self.assertTrue(self.master.data.updates.thisMasterActive)
         d = self.master.stopService()
         self.assertTrue(d.called)
@@ -210,11 +222,16 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def test_reconfigService_db_url_changed(self):
         old = self.master.config = MasterConfig()
-        old.db['db_url'] = 'aaaa'
+        old.db['db_url'] = Interpolate('%(secret:db_pwd)s')
+        old.secretsProviders = [FakeSecretStorage(secretdict={'db_pwd': 's3cr3t'})]
+        yield self.master.secrets_manager.setup()
+        yield self.master.db.setup()
         yield self.master.reconfigServiceWithBuildbotConfig(old)
+        self.assertEqual(self.master.db.configured_url, 's3cr3t')
 
         new = MasterConfig()
-        new.db['db_url'] = 'bbbb'
+        new.db['db_url'] = old.db['db_url']
+        new.secretsProviders = [FakeSecretStorage(secretdict={'db_pwd': 'other-s3cr3t'})]
 
         with self.assertRaises(config.ConfigErrors):
             yield self.master.reconfigServiceWithBuildbotConfig(new)

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -217,4 +217,4 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
         new.db['db_url'] = 'bbbb'
 
         with self.assertRaises(config.ConfigErrors):
-            self.master.reconfigServiceWithBuildbotConfig(new)
+            yield self.master.reconfigServiceWithBuildbotConfig(new)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -25,6 +25,7 @@ from twisted.python import reflect
 from twisted.python.reflect import accumulateClassList
 
 from buildbot import util
+from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
@@ -132,6 +133,11 @@ class MasterService(AsyncMultiService):
     def master(self):
         return self
 
+    def get_db_url(self, new_config) -> defer.Deferred:
+        p = Properties()
+        p.master = self
+        return p.render(new_config.db['db_url'])
+
 
 class SharedService(AsyncMultiService):
     """a service that is created only once per parameter set in a parent service"""
@@ -211,8 +217,6 @@ class BuildbotService(
             return None
         self.configured = True
         # render renderables in parallel
-        # Properties import to resolve cyclic import issue
-        from buildbot.process.properties import Properties
 
         p = Properties()
         p.master = self.master
@@ -254,9 +258,6 @@ class BuildbotService(
         return defer.succeed(None)
 
     def renderSecrets(self, *args):
-        # Properties import to resolve cyclic import issue
-        from buildbot.process.properties import Properties
-
         p = Properties()
         p.master = self.master
 

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import hashlib
 
 from twisted.application import service
@@ -442,18 +444,21 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin, Reconfig
             'childs': [v.getConfigDict() for v in self.namedServices.values()],
         }
 
+    def get_service_config(self, new_config) -> dict[str, AsyncService]:
+        new_config_attr = getattr(new_config, self.config_attr)
+        if isinstance(new_config_attr, list):
+            return {s.name: s for s in new_config_attr}
+        if isinstance(new_config_attr, dict):
+            return new_config_attr
+
+        raise TypeError(f"config.{self.config_attr} should be a list or dictionary")
+
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
         # arrange childs by name
         old_by_name = self.namedServices
         old_set = set(old_by_name)
-        new_config_attr = getattr(new_config, self.config_attr)
-        if isinstance(new_config_attr, list):
-            new_by_name = {s.name: s for s in new_config_attr}
-        elif isinstance(new_config_attr, dict):
-            new_by_name = new_config_attr
-        else:
-            raise TypeError(f"config.{self.config_attr} should be a list or dictionary")
+        new_by_name = self.get_service_config(new_config)
         new_set = set(new_by_name)
 
         # calculate new childs, by name, and removed childs

--- a/newsfragments/db-url-renderable.feature
+++ b/newsfragments/db-url-renderable.feature
@@ -1,0 +1,2 @@
+The `db_url` config value can now be a renderable, allowing usage of secrets from secrets providers.
+eg. `util.Interpolate("postgresql+psycopg2://db_user:%(secret:db_password)s@db_host:db_port/db_name")`


### PR DESCRIPTION
Implements feature request #3627 

This is touch to a pretty core part of the master, I welcome a thorough review.
I also welcome any idea of additional unit tests to implement.

I tried a simple setup with a PSQL database and a `SecretInAFile` provider.
upgrade-master, start, restart, reconfig all went ok.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
