### PR TITLE
setup: remove sqlalchemy version upper limit (v2.0 compat)

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -39,6 +39,7 @@ matrix:
     # that the codecov.io service would wait until this build is finished before creating report.
     - env: PYTHON=3.9 TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=1.4.52 NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.10 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -53,7 +53,7 @@ def doCleanupDatabase(config, master_cfg):
 
         # sqlite vacuum function rebuild the whole database to claim
         # free disk space back
-        def thd(engine):
+        def thd(conn):
             # In Python 3.6 and higher, sqlite3 no longer commits an
             # open transaction before DDL statements.
             # It is necessary to set the isolation_level to none
@@ -61,7 +61,7 @@ def doCleanupDatabase(config, master_cfg):
             # See: https://bugs.python.org/issue28518
 
             # Get the underlying sqlite connection from SQLAlchemy.
-            sqlite_conn = engine.connection.connection
+            sqlite_conn = conn.connection
             # Set isolation_level to 'auto-commit mode'
             sqlite_conn.isolation_level = None
             sqlite_conn.execute("vacuum;").close()

--- a/master/buildbot/test/unit/db/test_enginestrategy.py
+++ b/master/buildbot/test/unit/db/test_enginestrategy.py
@@ -20,6 +20,7 @@ from twisted.python import runtime
 from twisted.trial import unittest
 
 from buildbot.db import enginestrategy
+from buildbot.util.sautils import sa_version
 
 
 class BuildbotCreateEngineTest(unittest.TestCase):
@@ -111,7 +112,11 @@ class BuildbotCreateEngineTest(unittest.TestCase):
         self.assertEqual(
             [str(u), max_conns, self.filter_kwargs(kwargs)],
             [
-                "mysql://user:pass@host:1234/dbname?charset=utf8&use_unicode=True",
+                (
+                    "mysql://user:pass@host:1234/dbname?charset=utf8&use_unicode=True"
+                    if sa_version()[0] < 2
+                    else "mysql://user:***@host:1234/dbname?charset=utf8&use_unicode=True"
+                ),
                 None,
                 self.mysql_kwargs,
             ],

--- a/master/setup.py
+++ b/master/setup.py
@@ -660,7 +660,7 @@ setup_args['install_requires'] = [
     'importlib-resources >= 5; python_version < "3.9"',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
-    'sqlalchemy >= 1.4.0, < 1.5',
+    'sqlalchemy >= 1.4.0',
     'alembic >= 1.6.0',
     'python-dateutil>=1.5',
     "txaio >= 2.2.2",

--- a/newsfragments/sqlalchemy-2.0.misc
+++ b/newsfragments/sqlalchemy-2.0.misc
@@ -1,0 +1,1 @@
+Buildbot is now compatible with SQLAlchemy v2.0+

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -109,8 +109,7 @@ setuptools-trial==0.6.0
 singledispatch==4.1.0
 six==1.16.0
 snowballstemmer==2.2.0
-# Buildbot supports only sqlalchemy >= 1.3.0, < 1.5
-SQLAlchemy==1.4.52  # pyup: ignore
+SQLAlchemy==2.0.30
 sqlparse==0.5.0
 termcolor==2.4.0
 testtools==2.7.1


### PR DESCRIPTION
Is a newsfragment necessary for this?

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
