### PR TITLE
process: convert some methods to async

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -37,8 +37,8 @@ matrix:
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
-    - env: PYTHON=3.9 TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
-    - env: PYTHON=3.9 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=1.4.52 NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
@@ -56,7 +56,7 @@ matrix:
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
 
     # Worker tests on python and twisted package combinations.
-    - env: PYTHON=3.9 TWISTED=18.7.0 SQLALCHEMY=latest TESTS=trial_worker
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=18.7.0 SQLALCHEMY=latest TESTS=trial_worker
 
     # Configuration when SQLite database is persistent between running tests
     # (by default in other tests in-memory SQLite database is used which is
@@ -101,6 +101,9 @@ install:
   - title: pip installs for backward compat
     cmd: |
       # pip installs for backward compat
+      if [ ! -z "$TREQ" ]; then
+        /tmp/bbvenv/bin/pip install treq==$TREQ
+      fi
       if [ $TWISTED = trunk ]; then
           /tmp/bbvenv/bin/pip install git+https://github.com/twisted/twisted
       fi

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -37,7 +37,7 @@ matrix:
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=18.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=19.2.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=1.4.52 NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
@@ -56,7 +56,7 @@ matrix:
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
 
     # Worker tests on python and twisted package combinations.
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=18.7.0 SQLALCHEMY=latest TESTS=trial_worker
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=19.2.0 SQLALCHEMY=latest TESTS=trial_worker
 
     # Configuration when SQLite database is persistent between running tests
     # (by default in other tests in-memory SQLite database is used which is

--- a/master/setup.py
+++ b/master/setup.py
@@ -646,7 +646,7 @@ py_38 = sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_inf
 if not py_38:
     raise RuntimeError("Buildbot master requires at least Python-3.8")
 
-twisted_ver = ">= 18.7.0"
+twisted_ver = ">= 19.2.0"
 
 bundle_version = version.split("-")[0]
 

--- a/newsfragments/twisted-min-19.2.0.removal
+++ b/newsfragments/twisted-min-19.2.0.removal
@@ -1,0 +1,1 @@
+Buildbot now requires Twisted 19.2.0 or newer.

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -135,7 +135,7 @@ setup_args = {
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
-twisted_ver = ">= 18.7.0"
+twisted_ver = ">= 19.2.0"
 
 setup_args['install_requires'] = [
     'twisted ' + twisted_ver,


### PR DESCRIPTION
This is preparatory work for a PR that I'll submit soon which touch BuildRequestDistributor.
Splitting the PRs for simpler review.

Note: this bumps min required version of Twisted to 19.2 so DeferredLock can be used in an async context manager.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
