### PR TITLE
Issue #3383: clean shutdown hangs

### DIFF
--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -15,10 +15,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from twisted.python import log
 
 from buildbot.data import base
+
+if TYPE_CHECKING:
+    from typing import Sequence
 
 
 class FieldBase:
@@ -73,12 +78,12 @@ class FieldBase:
         # only support string values, because currently there are no queries against lists in SQL
     }
 
-    # can't type `values` as `Sequence` as `str` is one as well...
-    def __init__(self, field: bytes, op: str, values: list | tuple):
+    def __init__(self, field: bytes, op: str, values: Sequence):
         self.field = field
         self.op = op
         self.values = values
-        assert isinstance(values, (list, tuple))
+        # `str` is a Sequence as well...
+        assert not isinstance(values, str)
 
     def getOperator(self, sqlMode=False):
         v = self.values

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -211,6 +211,9 @@ class BasicBuildChooser(BuildChooserBase):
             if not breq:
                 break
 
+            if not self.workerpool and not self.preferredWorkers:
+                self.workerpool = self.bldr.getAvailableWorkers()
+
             #  2. pick a worker
             worker = yield self._popNextWorker(breq)
             if not worker:

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -13,14 +13,34 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 
 from buildbot.config import BuilderConfig
+from buildbot.data import resultspec
 from buildbot.process.factory import BuildFactory
+from buildbot.process.results import SUCCESS
 from buildbot.process.workerforbuilder import PingException
+from buildbot.schedulers import triggerable
+from buildbot.steps import trigger
 from buildbot.test.fake.worker import WorkerController
 from buildbot.test.util.integration import RunFakeMasterTestCase
+from buildbot.util.twisted import async_to_deferred
+
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Awaitable
+    from typing import Callable
+    from typing import Coroutine
+    from typing import TypeVar
+
+    from typing_extensions import ParamSpec
+
+    _T = TypeVar('_T')
+    _P = ParamSpec('_P')
 
 
 class Tests(RunFakeMasterTestCase):
@@ -57,3 +77,137 @@ class Tests(RunFakeMasterTestCase):
 
     def test_terminates_ping_on_shutdown_slow_mode(self):
         return self.do_terminates_ping_on_shutdown(quick_mode=False)
+
+    def _wait_step(self, wait_step: float = 0.1, timeout_seconds: float = 5.0):
+        for _ in range(0, int(timeout_seconds * 1000), int(wait_step * 1000)):
+            self.reactor.advance(wait_step)
+            yield
+
+    async def _query_until_result(
+        self,
+        fn: Callable[_P, Coroutine[Any, Any, Awaitable[_T]]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> _T:
+        for _ in self._wait_step():
+            result = await fn(*args, **kwargs)
+            if result:
+                return result
+        self.fail('Fail to get result in appropriate timeout')
+
+    @async_to_deferred
+    async def test_shutdown_busy_with_child(self):
+        """
+        Test that clean shutdown complete correctly
+        even when a running Build trigger another
+        and wait for it's completion
+        """
+
+        parent_controller = WorkerController(self, 'parent_worker')
+        child_controller = WorkerController(self, 'child_worker')
+
+        config_dict = {
+            'builders': [
+                BuilderConfig(
+                    name="parent",
+                    workernames=[parent_controller.worker.name],
+                    factory=BuildFactory([
+                        trigger.Trigger(schedulerNames=['triggerable'], waitForFinish=True)
+                    ]),
+                ),
+                BuilderConfig(
+                    name="child", workernames=[child_controller.worker.name], factory=BuildFactory()
+                ),
+            ],
+            'workers': [parent_controller.worker, child_controller.worker],
+            'schedulers': [triggerable.Triggerable(name='triggerable', builderNames=['child'])],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+            'collapseRequests': False,
+        }
+        await self.setup_master(config_dict)
+
+        parent_builder_id = await self.master.data.updates.findBuilderId('parent')
+        child_builder_id = await self.master.data.updates.findBuilderId('child')
+
+        await parent_controller.connect_worker()
+        # Pause worker of Child builder so we know the build won't start before we start shutdown
+        await child_controller.disconnect_worker()
+
+        # Create a Child build without Parent so we can later make sure it was not executed
+        _, first_child_brids = await self.create_build_request([child_builder_id])
+        self.assertEqual(len(first_child_brids), 1)
+
+        _, _parent_brids = await self.create_build_request([parent_builder_id])
+        self.assertEqual(len(_parent_brids), 1)
+        parent_brid = _parent_brids[parent_builder_id]
+
+        # wait until Parent trigger it's Child build
+        parent_buildid = (
+            await self._query_until_result(
+                self.master.data.get,
+                ("builds",),
+                filters=[resultspec.Filter('buildrequestid', 'eq', [parent_brid])],
+            )
+        )[0]['buildid']
+
+        # now get the child_buildset
+        child_buildsetid = (
+            await self._query_until_result(
+                self.master.data.get,
+                ("buildsets",),
+                filters=[resultspec.Filter('parent_buildid', 'eq', [parent_buildid])],
+            )
+        )[0]['bsid']
+
+        # and finally, the child BuildReques
+        child_buildrequest = (
+            await self._query_until_result(
+                self.master.data.get,
+                ("buildrequests",),
+                filters=[resultspec.Filter('buildsetid', 'eq', [child_buildsetid])],
+            )
+        )[0]
+
+        # now we know the Parent's Child BuildRequest exists,
+        # create a second Child without Parent for good measure
+        _, second_child_brids = await self.create_build_request([child_builder_id])
+        self.assertEqual(len(second_child_brids), 1)
+
+        # Now start the clean shutdown
+        shutdown_deferred: defer.Deferred[None] = self.master.botmaster.cleanShutdown(
+            quickMode=False,
+            stopReactor=False,
+        )
+
+        # Connect back Child worker so the build can happen
+        await child_controller.connect_worker()
+
+        # wait for the child request to be claimed, and completed
+        for _ in self._wait_step():
+            if child_buildrequest['claimed'] and child_buildrequest['complete']:
+                break
+            child_buildrequest = await self.master.data.get(
+                ("buildrequests", child_buildrequest['buildrequestid']),
+            )
+            self.assertIsNotNone(child_buildrequest)
+        self.assertEqual(child_buildrequest['results'], SUCCESS)
+
+        # make sure parent-less BuildRequest weren't built
+        first_child_request = await self.master.data.get(
+            ("buildrequests", first_child_brids[child_builder_id]),
+        )
+        self.assertIsNotNone(first_child_request)
+        self.assertFalse(first_child_request['claimed'])
+        self.assertFalse(first_child_request['complete'])
+
+        second_child_request = await self.master.data.get(
+            ("buildrequests", second_child_brids[child_builder_id]),
+        )
+        self.assertIsNotNone(second_child_request)
+        self.assertFalse(second_child_request['claimed'])
+        self.assertFalse(second_child_request['complete'])
+
+        # confirm Master shutdown
+        await shutdown_deferred
+        self.assertTrue(shutdown_deferred.called)

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -128,8 +128,11 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         # build.
         self.assertReactorNotStopped()
 
-        # but the BuildRequestDistributor should not be running
-        self.assertFalse(self.botmaster.brd.running)
+        # the BuildRequestDistributor is still running
+        # distributing child BuildRequests blocking
+        # parent Build from finishing
+        self.assertTrue(self.botmaster.brd.running)
+        self.assertTrue(self.botmaster.brd.distribute_only_waited_childs)
 
         # Cancel the shutdown
         self.botmaster.cancelCleanShutdown()
@@ -141,7 +144,9 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         self.assertReactorNotStopped()
 
         # and the BuildRequestDistributor should be, as well
+        # no longer limiting builds to those with parents
         self.assertTrue(self.botmaster.brd.running)
+        self.assertFalse(self.botmaster.brd.distribute_only_waited_childs)
 
 
 class TestBotMaster(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -108,6 +108,7 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
         self.builders[name] = bldr
 
         def maybeStartBuild(worker, builds):
+            worker.isAvailable.return_value = False
             self.startedBuilds.append((worker.name, builds))
             d = defer.Deferred()
             self.reactor.callLater(0, d.callback, True)

--- a/newsfragments/master-clean-shutdown.bugfix
+++ b/newsfragments/master-clean-shutdown.bugfix
@@ -1,0 +1,1 @@
+`buildbot stop --clean` would hang if a in progress build was waiting on a not yet started BuildRequest that it triggered.


### PR DESCRIPTION
Require #7688
Fixes #3383 

This add a `distribute_only_waited_childs` to `BuildRequestDistributor` that when `True` will make it only distribute BuildRequest if they have a parent, and that parent is waiting on them.
This 'edge-case' is for a context of clean shutdown of the master.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
