### PR TITLE
db: implement upsert

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -46,6 +46,7 @@ from buildbot.db import test_results
 from buildbot.db import users
 from buildbot.db import workers
 from buildbot.util import service
+from buildbot.util.sautils import get_upsert_method
 
 upgrade_message = textwrap.dedent("""\
 
@@ -105,6 +106,7 @@ class DBConnector(AbstractDBConnector):
         # set up components
         self._engine = None  # set up in reconfigService
         self.pool = None  # set up in reconfigService
+        self.upsert = get_upsert_method(None)  # set up in reconfigService
 
     @defer.inlineCallbacks
     def setServiceParent(self, p):
@@ -143,6 +145,7 @@ class DBConnector(AbstractDBConnector):
 
         # set up the engine and pool
         self._engine = enginestrategy.create_engine(db_url, basedir=self.basedir)
+        self.upsert = get_upsert_method(self._engine)
         self.pool = pool.DBThreadPool(self._engine, reactor=self.master.reactor, verbose=verbose)
 
         # make sure the db is up to date, unless specifically asked not to

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import inspect
-import sqlite3
 import time
 import traceback
 from typing import TYPE_CHECKING
@@ -32,6 +31,7 @@ from buildbot.db.buildsets import AlreadyCompleteError
 from buildbot.db.changesources import ChangeSourceAlreadyClaimedError
 from buildbot.db.schedulers import SchedulerAlreadyClaimedError
 from buildbot.process import metrics
+from buildbot.util.sautils import get_sqlite_version
 
 if TYPE_CHECKING:
     from typing import Any
@@ -134,7 +134,7 @@ class DBThreadPool:
 
         self.engine = engine
         if engine.dialect.name == 'sqlite':
-            vers = self.get_sqlite_version()
+            vers = get_sqlite_version()
             if vers < (3, 7):
                 log_msg(f"Using SQLite Version {vers}")
                 log_msg(
@@ -312,6 +312,3 @@ class DBThreadPool:
         return threads.deferToThreadPool(
             self.reactor, self._pool, self.__thd, True, callable, args, kwargs
         )
-
-    def get_sqlite_version(self):
-        return sqlite3.sqlite_version_info

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -22,6 +22,7 @@ from buildbot.db import model
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import db
+from buildbot.util.sautils import get_upsert_method
 
 
 class FakeDBConnector:
@@ -52,6 +53,7 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
 
         self.db = FakeDBConnector()
         self.db.pool = self.db_pool
+        self.db.upsert = get_upsert_method(self.db_engine)
         self.db.master = fakemaster.make_master(self)
         self.db.model = model.Model(self.db)
         self.db._engine = types.SimpleNamespace(dialect=types.SimpleNamespace(name=dialect_name))

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -54,6 +54,7 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
         self.db = FakeDBConnector()
         self.db.pool = self.db_pool
         self.db.upsert = get_upsert_method(self.db_engine)
+        self.db.has_native_upsert = self.db.upsert != get_upsert_method(None)
         self.db.master = fakemaster.make_master(self)
         self.db.model = model.Model(self.db)
         self.db._engine = types.SimpleNamespace(dialect=types.SimpleNamespace(name=dialect_name))

--- a/master/buildbot/util/sautils.py
+++ b/master/buildbot/util/sautils.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from sqlalchemy.future.engine import Connection
 
 # from http:
-# //www.sqlalchemy.org/docs/core/compiler.html#compiling-sub-elements-of-a-custom-expression-construct  # noqa pylint: disable=line-too-long
+# www.sqlalchemy.org/docs/core/compiler.html#compiling-sub-elements-of-a-custom-expression-construct  # noqa pylint: disable=line-too-long
 # _execution_options per
 # http://docs.sqlalchemy.org/en/rel_0_7/core/compiler.html#enabling-compiled-autocommit
 # (UpdateBase requires sqlalchemy 0.7.0)
@@ -85,3 +85,9 @@ def withoutSqliteForeignKeys(connection: Connection):
     finally:
         connection.fk_disabled = False
         connection.exec_driver_sql('pragma foreign_keys=ON')
+
+
+def get_sqlite_version():
+    import sqlite3
+
+    return sqlite3.sqlite_version_info


### PR DESCRIPTION
Requires #7686

This implement upsert for case where a DB entry needs to be updated, and created if it does not exists.
This allow to replace manual implementation where race condition can happen.

Only implemented for MySQL, PSQL, and SQLite.
Fallback on manual implementation if driver or DB version is not compatible.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
