### PR TITLE
tests: add a bare git repository

### DIFF
--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -156,7 +156,7 @@ def make_master(
         master.mq.setServiceParent(master)
     if wantDb:
         assert testcase is not None, "need testcase for wantDb"
-        master.db = fakedb.FakeDBConnector(testcase)
+        master.db = fakedb.FakeDBConnector(testcase, reactor=_reactor)
         master.db.setServiceParent(master)
     if wantData:
         master.data = fakedata.FakeDataConnector(master, testcase)

--- a/master/buildbot/test/fakedb/base.py
+++ b/master/buildbot/test/fakedb/base.py
@@ -19,10 +19,10 @@ from buildbot.data import resultspec
 class FakeDBComponent:
     data2db = {}
 
-    def __init__(self, db, testcase):
+    def __init__(self, db, testcase, reactor=None):
         self.db = db
         self.t = testcase
-        self.reactor = testcase.reactor
+        self.reactor = reactor if reactor is not None else testcase.reactor
         self.setUp()
 
     def mapFilter(self, f, fieldMapping):

--- a/master/buildbot/test/fakedb/connector.py
+++ b/master/buildbot/test/fakedb/connector.py
@@ -48,50 +48,52 @@ class FakeDBConnector(AbstractDBConnector):
     see their documentation for more.
     """
 
-    def __init__(self, testcase):
+    def __init__(self, testcase, reactor=None):
+        if reactor is None:
+            reactor = testcase.reactor
         super().__init__()
         # reset the id generator, for stable id's
         Row._next_id = 1000
         self.t = testcase
         self.checkForeignKeys = False
         self._components = []
-        self.changes = comp = FakeChangesComponent(self, testcase)
+        self.changes = comp = FakeChangesComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.changesources = comp = FakeChangeSourcesComponent(self, testcase)
+        self.changesources = comp = FakeChangeSourcesComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.schedulers = comp = FakeSchedulersComponent(self, testcase)
+        self.schedulers = comp = FakeSchedulersComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.sourcestamps = comp = FakeSourceStampsComponent(self, testcase)
+        self.sourcestamps = comp = FakeSourceStampsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.buildsets = comp = FakeBuildsetsComponent(self, testcase)
+        self.buildsets = comp = FakeBuildsetsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.workers = comp = FakeWorkersComponent(self, testcase)
+        self.workers = comp = FakeWorkersComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.state = comp = FakeStateComponent(self, testcase)
+        self.state = comp = FakeStateComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.buildrequests = comp = FakeBuildRequestsComponent(self, testcase)
+        self.buildrequests = comp = FakeBuildRequestsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.builds = comp = FakeBuildsComponent(self, testcase)
+        self.builds = comp = FakeBuildsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.build_data = comp = FakeBuildDataComponent(self, testcase)
+        self.build_data = comp = FakeBuildDataComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.steps = comp = FakeStepsComponent(self, testcase)
+        self.steps = comp = FakeStepsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.logs = comp = FakeLogsComponent(self, testcase)
+        self.logs = comp = FakeLogsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.users = comp = FakeUsersComponent(self, testcase)
+        self.users = comp = FakeUsersComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.masters = comp = FakeMastersComponent(self, testcase)
+        self.masters = comp = FakeMastersComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.projects = comp = FakeProjectsComponent(self, testcase)
+        self.projects = comp = FakeProjectsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.builders = comp = FakeBuildersComponent(self, testcase)
+        self.builders = comp = FakeBuildersComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.tags = comp = FakeTagsComponent(self, testcase)
+        self.tags = comp = FakeTagsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.test_results = comp = FakeTestResultsComponent(self, testcase)
+        self.test_results = comp = FakeTestResultsComponent(self, testcase, reactor)
         self._components.append(comp)
-        self.test_result_sets = comp = FakeTestResultSetsComponent(self, testcase)
+        self.test_result_sets = comp = FakeTestResultSetsComponent(self, testcase, reactor)
         self._components.append(comp)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -34,9 +34,11 @@ class ChangeSourceMixin:
     OTHER_MASTER_ID = 93
     DEFAULT_NAME = "ChangeSource"
 
-    def setUpChangeSource(self):
+    def setUpChangeSource(self, want_real_reactor: bool = False):
         "Set up the mixin - returns a deferred."
-        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
+        self.master = fakemaster.make_master(
+            self, wantDb=True, wantData=True, wantRealReactor=want_real_reactor
+        )
         assert not hasattr(self.master, 'addChange')  # just checking..
         return defer.succeed(None)
 

--- a/master/buildbot/test/util/git_repository.py
+++ b/master/buildbot/test/util/git_repository.py
@@ -1,0 +1,84 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+import datetime
+import shutil
+import subprocess
+from os import PathLike
+from pathlib import Path
+
+
+class TestGitRepository:
+    def __init__(self, repository_path: PathLike, git_bin: PathLike | None = None):
+        if git_bin is None:
+            git_bin = shutil.which('git')
+            if git_bin is None:
+                raise FileNotFoundError('Failed to find git')
+
+        self.git_bin = git_bin
+
+        self.repository_path = Path(repository_path)
+        self.repository_path.mkdir(parents=True, exist_ok=True)
+
+        self.exec_git(['init', '--quiet', '--initial-branch=main'])
+
+    def exec_git(self, args: list[str], env: dict[str] | None = None):
+        subprocess.check_call(
+            [str(self.git_bin), *args],
+            cwd=self.repository_path,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def commit(
+        self,
+        message: str,
+        files: list[PathLike] | None = None,
+        env: dict[str] | None = None,
+    ) -> str:
+        args = ['commit', '--quiet', f'--message={message}']
+        if files is not None:
+            args.extend(str(f) for f in files)
+
+        self.exec_git(args, env=env)
+
+        return subprocess.check_output(
+            [str(self.git_bin), 'rev-parse', 'HEAD'],
+            cwd=self.repository_path,
+            text=True,
+        ).strip()
+
+    @staticmethod
+    def git_author_env(author_name: str, author_mail: str):
+        return {
+            "GIT_AUTHOR_NAME": author_name,
+            "GIT_AUTHOR_EMAIL": author_mail,
+            "GIT_COMMITTER_NAME": author_name,
+            "GIT_COMMITTER_EMAIL": author_mail,
+        }
+
+    @staticmethod
+    def git_date_env(date: datetime.datetime):
+        def _format_date(_d: datetime.datetime) -> str:
+            # just in case, make sure we use UTC
+            return _d.astimezone(tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S +0000")
+
+        return {
+            "GIT_AUTHOR_DATE": _format_date(date),
+            "GIT_COMMITTER_DATE": _format_date(date),
+        }


### PR DESCRIPTION
This allow to implement GitPoller tests without faking git commands.

Closes #7666

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
