### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 24"

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -77,7 +77,7 @@ mccabe==0.7.0
 more-itertools==10.3.0
 moto==5.0.9
 olefile==0.47
-packaging==24.0
+packaging==24.1
 parameterized==0.9.0
 pathlib2==2.3.7.post1
 pbr==6.0.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -99,7 +99,7 @@ python-dateutil==2.9.0.post0
 python-subunit==1.4.4
 pytz==2024.1
 PyYAML==6.0.1
-requests==2.32.0
+requests==2.32.3
 responses==0.25.0
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==3.11.1
+buildbot-www==3.11.3
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -132,5 +132,5 @@ websocket-client==1.8.0
 Werkzeug==3.0.3
 wrapt==1.16.0
 xmltodict==0.13.0
-zipp==3.18.1
+zipp==3.19.2
 zope.interface==6.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,7 +39,7 @@ click==8.1.7
 configparser==7.0.0
 constantly==23.10.4
 cookies==2.2.1
-coverage==7.5.1
+coverage==7.5.3
 croniter==2.0.5
 cryptography==42.0.6
 decorator==5.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -82,7 +82,7 @@ parameterized==0.9.0
 pathlib2==2.3.7.post1
 pbr==6.0.0
 Pillow==10.3.0
-platformdirs==4.2.1
+platformdirs==4.2.2
 psutil==5.9.8
 pyaml==24.4.0
 pyasn1==0.6.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,7 +9,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 boto3==1.34.127
 msgpack==1.0.8
 Markdown==3.6
-pylint==3.2.2
+pylint==3.2.3
 ruff==0.4.3
 mypy==1.9.0
 mypy-zope==1.0.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -100,7 +100,7 @@ python-subunit==1.4.4
 pytz==2024.1
 PyYAML==6.0.1
 requests==2.32.3
-responses==0.25.0
+responses==0.25.3
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
 s3transfer==0.10.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -45,7 +45,7 @@ cryptography==42.0.8
 decorator==5.1.1
 dicttoxml==1.7.16
 dill==0.3.8
-docker==7.0.0
+docker==7.1.0
 docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
 extras==1.0.0
 fixtures==4.1.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -31,7 +31,7 @@ Babel==2.15.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
 botocore==1.34.127
-certifi==2024.2.2
+certifi==2024.6.2
 cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -74,7 +74,7 @@ Mako==1.3.5
 markdown2==2.4.13
 MarkupSafe==2.1.5
 mccabe==0.7.0
-more-itertools==10.2.0
+more-itertools==10.3.0
 moto==5.0.6
 olefile==0.47
 packaging==24.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -112,7 +112,7 @@ snowballstemmer==2.2.0
 SQLAlchemy==2.0.30
 sqlparse==0.5.0
 termcolor==2.4.0
-testtools==2.7.1
+testtools==2.7.2
 toml==0.10.2
 tomli==2.0.1
 tomlkit==0.12.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -94,7 +94,7 @@ pyflakes==3.2.0
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
 pyparsing==3.1.2
-pypugjs==5.9.12
+pypugjs==5.11.0
 python-dateutil==2.9.0.post0
 python-subunit==1.4.4
 pytz==2024.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -115,7 +115,7 @@ termcolor==2.4.0
 testtools==2.7.2
 toml==0.10.2
 tomli==2.0.1
-tomlkit==0.12.4
+tomlkit==0.12.5
 towncrier==23.11.0
 treq==23.11.0;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -70,7 +70,7 @@ jsonref==1.1.0
 lazy-object-proxy==1.9.0  # pyup: ignore (required by astroid)
 ldap3==2.9.1
 lz4==4.3.3
-Mako==1.3.3
+Mako==1.3.5
 markdown2==2.4.13
 MarkupSafe==2.1.5
 mccabe==0.7.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,7 +10,7 @@ boto3==1.34.127
 msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.3
-ruff==0.4.3
+ruff==0.4.9
 mypy==1.9.0
 mypy-zope==1.0.4
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -127,7 +127,7 @@ typing_extensions==4.12.2
 unidiff==0.7.5
 # botocore depends on urllib3<1.27
 urllib3==1.26.19  # pyup: ignore
-webcolors==1.13
+webcolors==24.6.0
 websocket-client==1.8.0
 Werkzeug==3.0.3
 wrapt==1.16.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -75,7 +75,7 @@ markdown2==2.4.13
 MarkupSafe==2.1.5
 mccabe==0.7.0
 more-itertools==10.3.0
-moto==5.0.6
+moto==5.0.9
 olefile==0.47
 packaging==24.0
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -123,7 +123,7 @@ Twisted==24.3.0
 txaio==23.1.1
 txrequests==0.9.6
 types-PyYAML==6.0.12.20240311
-typing_extensions==4.11.0
+typing_extensions==4.12.2
 unidiff==0.7.5
 # botocore depends on urllib3<1.27
 urllib3==1.26.19  # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -133,4 +133,4 @@ Werkzeug==3.0.3
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.19.2
-zope.interface==6.3
+zope.interface==6.4.post2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -30,7 +30,7 @@ Automat==22.10.0
 Babel==2.15.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
-botocore==1.34.98
+botocore==1.34.127
 certifi==2024.2.2
 cffi==1.16.0
 chardet==5.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -87,7 +87,7 @@ psutil==5.9.8
 pyaml==24.4.0
 pyasn1==0.6.0
 pyasn1-modules==0.4.0
-pycodestyle==2.11.1;  python_version >= "3.8.1"
+pycodestyle==2.12.0;  python_version >= "3.8.1"
 pycparser==2.22
 pyenchant==3.2.2
 pyflakes==3.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ buildbot-www==3.11.3
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-boto3==1.34.98
+boto3==1.34.127
 msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -41,7 +41,7 @@ constantly==23.10.4
 cookies==2.2.1
 coverage==7.5.3
 croniter==2.0.5
-cryptography==42.0.6
+cryptography==42.0.8
 decorator==5.1.1
 dicttoxml==1.7.16
 dill==0.3.8

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -8,7 +8,7 @@ Automat==22.10.0;  python_version >= "3.6"
 cffi==1.16.0;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==42.0.6;  python_version >= "3.6"
+cryptography==42.0.8;  python_version >= "3.6"
 funcsigs==1.0.2
 future==1.0.0
 hyperlink==21.0.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -28,7 +28,7 @@ six==1.16.0
 Twisted==24.3.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
 txaio==23.1.1;  python_version >= "3.6"
-typing-extensions==4.11.0;  python_version >= "3.7"
+typing-extensions==4.12.2;  python_version >= "3.7"
 typing-extensions==4.11.0;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
 zope.interface==6.4.post2;  python_version >= "3.6"

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -29,7 +29,7 @@ Twisted==24.3.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
 txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.12.2;  python_version >= "3.7"
-typing-extensions==4.11.0;  python_version < "3.7" and python_version >= "3.5"
+typing-extensions==4.12.2;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
 zope.interface==6.4.post2;  python_version >= "3.6"
 -e worker

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -31,5 +31,5 @@ txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.11.0;  python_version >= "3.7"
 typing-extensions==4.11.0;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
-zope.interface==6.3;  python_version >= "3.6"
+zope.interface==6.4.post2;  python_version >= "3.6"
 -e worker

--- a/requirements-master-docker-extras.txt
+++ b/requirements-master-docker-extras.txt
@@ -1,4 +1,4 @@
-requests==2.32.0
+requests==2.32.3
 psycopg2==2.9.9
 txrequests==0.9.6
 pycairo==1.26.0


### PR DESCRIPTION
This PR is based on #7697 and removes 
- 715e2f6c2 Update mypy from 1.9.0 to 1.10.0 (note problem seems to be in mypy-zope https://github.com/Shoobx/mypy-zope/pull/115)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
