### PR TITLE
Add git describe options first-parent and exclude

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -66,6 +66,7 @@ git_describe_flags = [
     ('first-parent', lambda v: ['--first-parent'] if v else None),
     # string parameter
     ('match', lambda v: ['--match', v] if v else None),
+    ('exclude', lambda v: ['--exclude', v] if v else None),
     # numeric parameter
     ('abbrev', lambda v: [f'--abbrev={v}'] if isTrueOrIsExactlyZero(v) else None),
     ('candidates', lambda v: [f'--candidates={v}'] if isTrueOrIsExactlyZero(v) else None),

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -63,6 +63,7 @@ git_describe_flags = [
     ('long', lambda v: ['--long'] if v else None),
     ('exact-match', lambda v: ['--exact-match'] if v else None),
     ('tags', lambda v: ['--tags'] if v else None),
+    ('first-parent', lambda v: ['--first-parent'] if v else None),
     # string parameter
     ('match', lambda v: ['--match', v] if v else None),
     # numeric parameter

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -3440,6 +3440,16 @@ class TestGit(
         self.setup_getDescription_test(setup_args={'match': None}, output_args=[])
         return self.run_step()
 
+    def test_getDescription_exclude(self):
+        self.setup_getDescription_test(
+            setup_args={'exclude': 'stuff-*'}, output_args=['--exclude', 'stuff-*']
+        )
+        return self.run_step()
+
+    def test_getDescription_exclude_false(self):
+        self.setup_getDescription_test(setup_args={'exclude': None}, output_args=[])
+        return self.run_step()
+
     def test_getDescription_tags(self):
         self.setup_getDescription_test(setup_args={'tags': True}, output_args=['--tags'])
         return self.run_step()

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -3526,6 +3526,16 @@ class TestGit(
         self.setup_getDescription_test(setup_args={'exact-match': False}, output_args=[])
         return self.run_step()
 
+    def test_getDescription_first_parent(self):
+        self.setup_getDescription_test(
+            setup_args={'first-parent': True}, output_args=['--first-parent']
+        )
+        return self.run_step()
+
+    def test_getDescription_first_parent_false(self):
+        self.setup_getDescription_test(setup_args={'first-parent': False}, output_args=[])
+        return self.run_step()
+
     def test_getDescription_debug(self):
         self.setup_getDescription_test(setup_args={'debug': True}, output_args=['--debug'])
         return self.run_step()

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -121,6 +121,7 @@ The Git step takes the following arguments:
       * ``debug``: `--debug`
       * ``long``: `--long``
       * ``exact-match``: `--exact-match`
+      * ``first-parent``: `--first-parent`
       * ``tags``: `--tags`
       * ``dirty``: `--dirty`
 

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -129,6 +129,7 @@ The Git step takes the following arguments:
      Examples show the key-value pair:
 
       * ``match=foo``: `--match foo`
+      * ``exclude=foo``: `--exclude foo`
       * ``abbrev=7``: `--abbrev=7`
       * ``candidates=7``: `--candidates=7`
       * ``dirty=foo``: `--dirty=foo`

--- a/newsfragments/git-step-describe-options.feature
+++ b/newsfragments/git-step-describe-options.feature
@@ -1,1 +1,1 @@
-:bb:step:`Git`'s ``getDescription`` configuration now supports the first-parent argument.
+:bb:step:`Git`'s ``getDescription`` configuration now supports the first-parent and exclude arguments.

--- a/newsfragments/git-step-describe-options.feature
+++ b/newsfragments/git-step-describe-options.feature
@@ -1,0 +1,1 @@
+:bb:step:`Git`'s ``getDescription`` configuration now supports the first-parent argument.


### PR DESCRIPTION
Add support for the git-describe options `--first-parent` and `--exclude`.

## Contributor Checklist:

* [ x] I have updated the unit tests
* [ x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ x] I have updated the appropriate documentation
