### PR TITLE
3.11 backports: Fix tests after migrating to new image

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -262,7 +262,7 @@ after_script:
         CODECOV_TOKEN="b80c80d7-689d-46d7-b1aa-59168bb4c9a9" ./codecov
       fi
   # List installed packages along with their versions.
-  - "pip list"
+  - "/tmp/bbvenv/bin/pip list"
 
 sudo: false
 branches:

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -81,7 +81,10 @@ install:
       rm -rf /tmp/bbvenv
       if [ "$PYTHON" = "2.7" ]; then
         # system virtualenv doesn't work properly with python installed via pyenv
-        virtualenv --python=python2.7 --pip=20.3.0 /tmp/bbvenv
+        rm -rf /tmp/bbinstallvenv
+        python3.6 -m venv /tmp/bbinstallvenv
+        /tmp/bbinstallvenv/bin/pip install virtualenv
+        /tmp/bbinstallvenv/bin/virtualenv --python=python2.7 --pip=20.3.0 /tmp/bbvenv
         /tmp/bbvenv/bin/pip install -U --force-reinstall pip setuptools
       else
         python$PYTHON -m venv /tmp/bbvenv
@@ -105,8 +108,11 @@ install:
       set -e
       rm -rf /tmp/bbworkervenv
       if [ "$PYTHON" = "2.7" ]; then
-        # system virtualenv doesn't work properly with python installed via pyenv
-        virtualenv --python=python2.7 --pip=20.3.0 /tmp/bbworkervenv
+        # use old Python venv to install 2.7 via virtualenv
+        rm -rf /tmp/bbinstallvenv
+        python3.6 -m venv /tmp/bbinstallvenv
+        /tmp/bbinstallvenv/bin/pip install virtualenv
+        /tmp/bbinstallvenv/bin/virtualenv --python=python2.7 --pip=20.3.0 /tmp/bbworkervenv
         /tmp/bbworkervenv/bin/pip install -U --force-reinstall pip setuptools
       else
         python$PYTHON -m venv /tmp/bbworkervenv

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -401,6 +401,7 @@ delayedcall
 denormalized
 dependabot
 deprecatedmoduleattribute
+desc
 descriptionsuffix
 desynchronization
 dev

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -110,6 +110,8 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
                 ``addMasterSideWorker``)
     """
 
+    timeout = 30
+
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
@@ -209,7 +211,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         def could_not_connect():
             self.fail("Worker never got connected to master")
 
-        timeout = reactor.callLater(10, could_not_connect)
+        timeout = reactor.callLater(self.timeout, could_not_connect)
         worker = self.addWorker()
         yield worker.startService()
         yield worker.tests_connected
@@ -232,7 +234,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
         self.assertTrue('bldr' in worker.bot.builders)
 
-        timeout = reactor.callLater(10, could_not_connect)
+        timeout = reactor.callLater(self.timeout, could_not_connect)
         yield self.workerSideDisconnect(worker)
         yield worker.tests_connected
 
@@ -264,7 +266,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
             password='pw2',
             update_port=False,  # don't know why, but it'd fail
             connection_string=f"tcp:{self.port}:interface=127.0.0.1")
-        timeout = reactor.callLater(10, could_not_connect)
+        timeout = reactor.callLater(self.timeout, could_not_connect)
         yield worker.tests_connected
 
         timeout.cancel()

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -19,7 +19,6 @@ from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest
 from twisted.web.resource import Resource
-from twisted.web.server import Site
 from twisted.web.util import redirectTo
 
 from buildbot.process import properties
@@ -28,6 +27,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps import http
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import TestBuildStepMixin
+from buildbot.test.util.site import SiteWithClose
 
 try:
     import txrequests
@@ -73,7 +73,8 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         session.trust_env = False
 
         # port 0 means random unused port
-        self.listener = reactor.listenTCP(0, Site(TestPage()))
+        self.site = SiteWithClose(TestPage())
+        self.listener = reactor.listenTCP(0, self.site)
         self.port = self.listener.getHost().port
         return self.setup_test_build_step()
 
@@ -82,6 +83,8 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         http.closeSession()
         try:
             yield self.listener.stopListening()
+            yield self.site.stopFactory()
+            yield self.site.close_connections()
         finally:
             yield self.tear_down_test_build_step()
 

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -25,7 +25,6 @@ from twisted.internet import threads
 from twisted.python import failure
 from twisted.trial import unittest
 from twisted.web.resource import Resource
-from twisted.web.server import Site
 
 import buildbot
 from buildbot.process.properties import Secret
@@ -34,6 +33,7 @@ from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
 from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.site import SiteWithClose
 from buildbot.util import bytes2unicode
 
 try:
@@ -579,8 +579,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin,
                 return (b"<html><script>setTimeout(close,1000)</script><body>WORKED: " +
                         info + b"</body></html>")
 
-        class MySite(Site):
-
+        class MySite(SiteWithClose):
             def makeSession(self):
                 uid = self._mkuid()
                 session = self.sessions[uid] = self.sessionFactory(self, uid)
@@ -601,6 +600,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin,
         res = yield d
         yield listener.stopListening()
         yield site.stopFactory()
+        yield site.close_connections()
 
         self.assertIn("full_name", res)
         self.assertIn("email", res)

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -182,7 +182,7 @@ class RunMasterBase(unittest.TestCase):
 
     # All tests that start master need higher timeout due to test runtime variability on
     # oversubscribed hosts.
-    timeout = 20
+    timeout = 40
 
     if Worker is None:
         skip = "buildbot-worker package is not installed"

--- a/master/buildbot/test/util/site.py
+++ b/master/buildbot/test/util/site.py
@@ -1,0 +1,38 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.python.failure import Failure
+from twisted.web.server import Site
+
+
+class SiteWithClose(Site):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._protocols = []
+
+    def buildProtocol(self, addr):
+        p = super().buildProtocol(addr)
+        self._protocols.append(p)
+        return p
+
+    def close_connections(self):
+        for p in self._protocols:
+            p.connectionLost(Failure(RuntimeError("Closing down at the end of test")))
+            # There is currently no other way to force all pending server-side connections to
+            # close.
+            p._channel.transport.connectionLost(
+                Failure(RuntimeError("Closing down at the end of test"))
+            )
+        self._protocols = []

--- a/smokes-react/tests/pages/base.ts
+++ b/smokes-react/tests/pages/base.ts
@@ -17,7 +17,7 @@
 
 import {expect, Page} from "@playwright/test";
 
-export const testPageUrl = 'http://localhost:8011'
+export const testPageUrl = 'http://127.0.0.1:8011'
 
 export class BasePage {
   // accessors for elements that all pages have (menu, login, etc)

--- a/smokes/e2e/pages/base.ts
+++ b/smokes/e2e/pages/base.ts
@@ -5,7 +5,7 @@
 
 import { bbrowser } from '../utils';
 
-export const testPageUrl = 'http://localhost:8011'
+export const testPageUrl = 'http://127.0.0.1:8011'
 
 export class BasePage {
     // accessors for elements that all pages have (menu, login, etc)

--- a/worker/buildbot_worker/test/test_util_hangcheck.py
+++ b/worker/buildbot_worker/test/test_util_hangcheck.py
@@ -15,8 +15,9 @@ from twisted.internet.task import Clock
 from twisted.python.failure import Failure
 from twisted.spread.pb import PBClientFactory
 from twisted.trial.unittest import TestCase
-from twisted.web.server import Site
 from twisted.web.static import Data
+
+from buildbot_worker.test.util.site import SiteWithClose
 
 from ..util import HangCheckFactory
 from ..util._hangcheck import HangCheckProtocol
@@ -232,7 +233,7 @@ class EndToEndHangCheckTests(TestCase):
         """
         result = defer.Deferred()
 
-        site = Site(Data("", "text/plain"))
+        site = SiteWithClose(Data("", "text/plain"))
         client = HangCheckFactory(
             PBClientFactory(), lambda: result.callback(None))
 
@@ -255,3 +256,5 @@ class EndToEndHangCheckTests(TestCase):
         finally:
             d_connected.cancel()
             timer.cancel()
+
+        yield site.close_connections()

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -473,6 +473,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
 
 class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
+    timeout = 60  # takes a while on oversubscribed test machines
 
     if runtime.platformType != "posix":
         skip = "not a POSIX platform"
@@ -516,7 +517,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
 
     def waitForPidfile(self, pidfile):
         # wait for a pidfile, and return the pid via a Deferred
-        until = time.time() + 10
+        until = time.time() + self.timeout
         d = defer.Deferred()
 
         def poll():

--- a/worker/buildbot_worker/test/util/site.py
+++ b/worker/buildbot_worker/test/util/site.py
@@ -1,0 +1,38 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.python.failure import Failure
+from twisted.web.server import Site
+
+
+class SiteWithClose(Site, object):
+    def __init__(self, *args, **kwargs):
+        super(SiteWithClose, self).__init__(*args, **kwargs)
+        self._protocols = []
+
+    def buildProtocol(self, addr):
+        p = super(SiteWithClose, self).buildProtocol(addr)
+        self._protocols.append(p)
+        return p
+
+    def close_connections(self):
+        for p in self._protocols:
+            p.connectionLost(Failure(RuntimeError("Closing down at the end of test")))
+            # There is currently no other way to force all pending server-side connections to
+            # close.
+            p._channel.transport.connectionLost(
+                Failure(RuntimeError("Closing down at the end of test"))
+            )
+        self._protocols = []


### PR DESCRIPTION
This PR backports #7703 to 3.11 branch