### PR TITLE
4.0.0 backports: gitpoller: remove '--' separator from git rev-parse command

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -395,7 +395,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
                     break
 
                 rev = yield self._dovccmd(
-                    'rev-parse', [self._tracker_ref(self.repourl, ref), '--'], path=self.workdir
+                    'rev-parse', [self._tracker_ref(self.repourl, ref)], path=self.workdir
                 )
                 revs[branch] = rev
                 yield self._process_changes(rev, branch)

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -257,7 +257,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -338,7 +337,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .exit(1),
@@ -375,7 +373,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -459,7 +456,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -516,7 +512,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -524,7 +519,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -572,7 +566,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -597,7 +590,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -735,7 +727,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -788,7 +779,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -888,7 +878,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -992,7 +981,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1088,7 +1076,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1199,7 +1186,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1247,7 +1233,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1272,7 +1257,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/release',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -1380,7 +1364,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1492,7 +1475,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/pull/410/head',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
@@ -1599,7 +1581,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1714,7 +1695,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
@@ -1839,7 +1819,6 @@ class TestGitPoller(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 f'refs/buildbot/{self.REPOURL_QUOTED}/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'fa3ae8ed68e664d4db24798611b352e3c6509930\n'),
@@ -1950,7 +1929,6 @@ class TestGitPollerDefaultBranch(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 f'refs/buildbot/{self.REPOURL_QUOTED}/heads/default_branch',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'737b94eca1ddde3dd4a0040b25c8a25fe973fe09\n'),
@@ -2001,7 +1979,6 @@ class TestGitPollerDefaultBranch(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 f'refs/buildbot/raw/{self.REPOURL_QUOTED}/HEAD',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'737b94eca1ddde3dd4a0040b25c8a25fe973fe09\n'),
@@ -2084,7 +2061,6 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -2133,7 +2109,6 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -2241,7 +2216,6 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
@@ -2315,7 +2289,6 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
                 'git',
                 'rev-parse',
                 'refs/buildbot/' + self.REPOURL_QUOTED + '/heads/master',
-                '--',
             ])
             .workdir(self.POLLER_WORKDIR)
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),

--- a/newsfragments/gitpoller-fix-polling-regression.bugfix
+++ b/newsfragments/gitpoller-fix-polling-regression.bugfix
@@ -1,0 +1,1 @@
+GitPoller would no longer register new changes (regression introduced in 3.11.3 in #7554)


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7664.
PR fixes https://github.com/buildbot/buildbot/issues/7614.
