### PR TITLE
test: Implement support for testing multiple steps in same unit test

### DIFF
--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -270,8 +270,12 @@ class TestBuildStep(
 
         self.assertEqual(len(lock_accesses), 2)
 
-        self.assertTrue(self.step._locks_to_acquire[0][0].isAvailable(self, lock_accesses[0]))
-        self.assertTrue(self.step._locks_to_acquire[1][0].isAvailable(self, lock_accesses[1]))
+        self.assertTrue(
+            self.get_nth_step(0)._locks_to_acquire[0][0].isAvailable(self, lock_accesses[0])
+        )
+        self.assertTrue(
+            self.get_nth_step(0)._locks_to_acquire[1][0].isAvailable(self, lock_accesses[1])
+        )
 
     def test_compare(self):
         lbs1 = buildstep.BuildStep(name="me")
@@ -299,8 +303,12 @@ class TestBuildStep(
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
 
-        self.assertTrue(self.step._locks_to_acquire[0][0].isAvailable(self, lock_accesses[0]))
-        self.assertTrue(self.step._locks_to_acquire[1][0].isAvailable(self, lock_accesses[1]))
+        self.assertTrue(
+            self.get_nth_step(0)._locks_to_acquire[0][0].isAvailable(self, lock_accesses[0])
+        )
+        self.assertTrue(
+            self.get_nth_step(0)._locks_to_acquire[1][0].isAvailable(self, lock_accesses[1])
+        )
 
     @defer.inlineCallbacks
     def test_regular_locks_skip_step(self):
@@ -562,20 +570,20 @@ class TestBuildStep(
     @defer.inlineCallbacks
     def test_start_returns_SKIPPED(self):
         self.setup_step(self.SkippingBuildStep())
-        self.step.finished = mock.Mock()
+        self.get_nth_step(0).finished = mock.Mock()
         self.expect_outcome(result=SKIPPED, state_string='finished (skipped)')
         yield self.run_step()
         # 837: we want to specifically avoid calling finished() if skipping
-        self.step.finished.assert_not_called()
+        self.get_nth_step(0).finished.assert_not_called()
 
     @defer.inlineCallbacks
     def test_doStepIf_false(self):
         self.setup_step(self.FakeBuildStep(doStepIf=False))
-        self.step.finished = mock.Mock()
+        self.get_nth_step(0).finished = mock.Mock()
         self.expect_outcome(result=SKIPPED, state_string='finished (skipped)')
         yield self.run_step()
         # 837: we want to specifically avoid calling finished() if skipping
-        self.step.finished.assert_not_called()
+        self.get_nth_step(0).finished.assert_not_called()
 
     @defer.inlineCallbacks
     def test_doStepIf_renderable_false(self):
@@ -584,29 +592,29 @@ class TestBuildStep(
             return False
 
         self.setup_step(self.FakeBuildStep(doStepIf=dostepif))
-        self.step.finished = mock.Mock()
+        self.get_nth_step(0).finished = mock.Mock()
         self.expect_outcome(result=SKIPPED, state_string='finished (skipped)')
         yield self.run_step()
         # 837: we want to specifically avoid calling finished() if skipping
-        self.step.finished.assert_not_called()
+        self.get_nth_step(0).finished.assert_not_called()
 
     @defer.inlineCallbacks
     def test_doStepIf_returns_false(self):
         self.setup_step(self.FakeBuildStep(doStepIf=lambda step: False))
-        self.step.finished = mock.Mock()
+        self.get_nth_step(0).finished = mock.Mock()
         self.expect_outcome(result=SKIPPED, state_string='finished (skipped)')
         yield self.run_step()
         # 837: we want to specifically avoid calling finished() if skipping
-        self.step.finished.assert_not_called()
+        self.get_nth_step(0).finished.assert_not_called()
 
     @defer.inlineCallbacks
     def test_doStepIf_returns_deferred_false(self):
         self.setup_step(self.FakeBuildStep(doStepIf=lambda step: defer.succeed(False)))
-        self.step.finished = mock.Mock()
+        self.get_nth_step(0).finished = mock.Mock()
         self.expect_outcome(result=SKIPPED, state_string='finished (skipped)')
         yield self.run_step()
         # 837: we want to specifically avoid calling finished() if skipping
-        self.step.finished.assert_not_called()
+        self.get_nth_step(0).finished.assert_not_called()
 
     def test_hideStepIf_False(self):
         self._setupWaterfallTest(False, False)
@@ -622,7 +630,7 @@ class TestBuildStep(
 
         def shouldHide(result, step):
             called[0] = True
-            self.assertTrue(step is self.step)
+            self.assertTrue(step is self.get_nth_step(0))
             self.assertEqual(result, SUCCESS)
             return False
 
@@ -637,7 +645,7 @@ class TestBuildStep(
 
         def shouldHide(result, step):
             called[0] = True
-            self.assertTrue(step is self.step)
+            self.assertTrue(step is self.get_nth_step(0))
             self.assertEqual(result, SUCCESS)
             return True
 
@@ -651,7 +659,7 @@ class TestBuildStep(
         # 0/0 causes DivideByZeroError, which should be flagged as an exception
 
         self._setupWaterfallTest(lambda x, y: 0 / 0, False, expectedResult=EXCEPTION)
-        self.step.addLogWithFailure = mock.Mock()
+        self.get_nth_step(0).addLogWithFailure = mock.Mock()
         yield self.run_step()
         self.assertEqual(len(self.flushLoggedErrors(ZeroDivisionError)), 1)
 
@@ -661,7 +669,7 @@ class TestBuildStep(
 
         def shouldHide(result, step):
             called[0] = True
-            self.assertTrue(step is self.step)
+            self.assertTrue(step is self.get_nth_step(0))
             self.assertEqual(result, EXCEPTION)
             return True
 
@@ -702,7 +710,7 @@ class TestBuildStep(
         self.build.setProperty('fOF', 'yes', 'test')
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertEqual(self.step.flunkOnFailure, 'yes')
+        self.assertEqual(self.get_nth_step(0).flunkOnFailure, 'yes')
 
     def test_hasStatistic(self):
         step = buildstep.BuildStep()
@@ -980,90 +988,90 @@ class InterfaceTests(interfaces.InterfaceTests):
             'progress',
             'stopped',
         ]:
-            self.assertTrue(hasattr(self.step, attr))
+            self.assertTrue(hasattr(self.get_nth_step(0), attr))
 
     def test_signature_setBuild(self):
-        @self.assertArgSpecMatches(self.step.setBuild)
+        @self.assertArgSpecMatches(self.get_nth_step(0).setBuild)
         def setBuild(self, build):
             pass
 
     def test_signature_setWorker(self):
-        @self.assertArgSpecMatches(self.step.setWorker)
+        @self.assertArgSpecMatches(self.get_nth_step(0).setWorker)
         def setWorker(self, worker):
             pass
 
     def test_signature_setupProgress(self):
-        @self.assertArgSpecMatches(self.step.setupProgress)
+        @self.assertArgSpecMatches(self.get_nth_step(0).setupProgress)
         def setupProgress(self):
             pass
 
     def test_signature_startStep(self):
-        @self.assertArgSpecMatches(self.step.startStep)
+        @self.assertArgSpecMatches(self.get_nth_step(0).startStep)
         def startStep(self, remote):
             pass
 
     def test_signature_run(self):
-        @self.assertArgSpecMatches(self.step.run)
+        @self.assertArgSpecMatches(self.get_nth_step(0).run)
         def run(self):
             pass
 
     def test_signature_interrupt(self):
-        @self.assertArgSpecMatches(self.step.interrupt)
+        @self.assertArgSpecMatches(self.get_nth_step(0).interrupt)
         def interrupt(self, reason):
             pass
 
     def test_signature_setProgress(self):
-        @self.assertArgSpecMatches(self.step.setProgress)
+        @self.assertArgSpecMatches(self.get_nth_step(0).setProgress)
         def setProgress(self, metric, value):
             pass
 
     def test_signature_workerVersion(self):
-        @self.assertArgSpecMatches(self.step.workerVersion)
+        @self.assertArgSpecMatches(self.get_nth_step(0).workerVersion)
         def workerVersion(self, command, oldversion=None):
             pass
 
     def test_signature_workerVersionIsOlderThan(self):
-        @self.assertArgSpecMatches(self.step.workerVersionIsOlderThan)
+        @self.assertArgSpecMatches(self.get_nth_step(0).workerVersionIsOlderThan)
         def workerVersionIsOlderThan(self, command, minversion):
             pass
 
     def test_signature_getWorkerName(self):
-        @self.assertArgSpecMatches(self.step.getWorkerName)
+        @self.assertArgSpecMatches(self.get_nth_step(0).getWorkerName)
         def getWorkerName(self):
             pass
 
     def test_signature_runCommand(self):
-        @self.assertArgSpecMatches(self.step.runCommand)
+        @self.assertArgSpecMatches(self.get_nth_step(0).runCommand)
         def runCommand(self, command):
             pass
 
     def test_signature_addURL(self):
-        @self.assertArgSpecMatches(self.step.addURL)
+        @self.assertArgSpecMatches(self.get_nth_step(0).addURL)
         def addURL(self, name, url):
             pass
 
     def test_signature_addLog(self):
-        @self.assertArgSpecMatches(self.step.addLog)
+        @self.assertArgSpecMatches(self.get_nth_step(0).addLog)
         def addLog(self, name, type='s', logEncoding=None):
             pass
 
     def test_signature_getLog(self):
-        @self.assertArgSpecMatches(self.step.getLog)
+        @self.assertArgSpecMatches(self.get_nth_step(0).getLog)
         def getLog(self, name):
             pass
 
     def test_signature_addCompleteLog(self):
-        @self.assertArgSpecMatches(self.step.addCompleteLog)
+        @self.assertArgSpecMatches(self.get_nth_step(0).addCompleteLog)
         def addCompleteLog(self, name, text):
             pass
 
     def test_signature_addHTMLLog(self):
-        @self.assertArgSpecMatches(self.step.addHTMLLog)
+        @self.assertArgSpecMatches(self.get_nth_step(0).addHTMLLog)
         def addHTMLLog(self, name, html):
             pass
 
     def test_signature_addLogObserver(self):
-        @self.assertArgSpecMatches(self.step.addLogObserver)
+        @self.assertArgSpecMatches(self.get_nth_step(0).addLogObserver)
         def addLogObserver(self, logname, observer):
             pass
 
@@ -1079,6 +1087,9 @@ class TestRealItfc(unittest.TestCase, InterfaceTests):
     def setUp(self):
         self.step = buildstep.BuildStep()
 
+    def get_nth_step(self, index):
+        return self.step
+
 
 class CommandMixinExample(buildstep.CommandMixin, buildstep.BuildStep):
     @defer.inlineCallbacks
@@ -1093,62 +1104,63 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()
         yield self.setup_test_build_step()
-        self.step = CommandMixinExample()
-        self.setup_step(self.step)
+        self.setup_step(CommandMixinExample())
 
     def tearDown(self):
         return self.tear_down_test_build_step()
 
     @defer.inlineCallbacks
     def test_runRmdir(self):
-        self.step.testMethod = lambda: self.step.runRmdir('/some/path')
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).runRmdir('/some/path')
         self.expect_commands(ExpectRmdir(dir='/some/path', log_environ=False).exit(0))
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertTrue(self.step.method_return_value)
+        self.assertTrue(self.get_nth_step(0).method_return_value)
 
     @defer.inlineCallbacks
     def test_runMkdir(self):
-        self.step.testMethod = lambda: self.step.runMkdir('/some/path')
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).runMkdir('/some/path')
         self.expect_commands(ExpectMkdir(dir='/some/path', log_environ=False).exit(0))
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertTrue(self.step.method_return_value)
+        self.assertTrue(self.get_nth_step(0).method_return_value)
 
     @defer.inlineCallbacks
     def test_runMkdir_fails(self):
-        self.step.testMethod = lambda: self.step.runMkdir('/some/path')
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).runMkdir('/some/path')
         self.expect_commands(ExpectMkdir(dir='/some/path', log_environ=False).exit(1))
         self.expect_outcome(result=FAILURE)
         yield self.run_step()
 
     @defer.inlineCallbacks
     def test_runMkdir_fails_no_abandon(self):
-        self.step.testMethod = lambda: self.step.runMkdir('/some/path', abandonOnFailure=False)
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).runMkdir(
+            '/some/path', abandonOnFailure=False
+        )
         self.expect_commands(ExpectMkdir(dir='/some/path', log_environ=False).exit(1))
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertFalse(self.step.method_return_value)
+        self.assertFalse(self.get_nth_step(0).method_return_value)
 
     @defer.inlineCallbacks
     def test_pathExists(self):
-        self.step.testMethod = lambda: self.step.pathExists('/some/path')
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).pathExists('/some/path')
         self.expect_commands(ExpectStat(file='/some/path', log_environ=False).exit(0))
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertTrue(self.step.method_return_value)
+        self.assertTrue(self.get_nth_step(0).method_return_value)
 
     @defer.inlineCallbacks
     def test_pathExists_doesnt(self):
-        self.step.testMethod = lambda: self.step.pathExists('/some/path')
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).pathExists('/some/path')
         self.expect_commands(ExpectStat(file='/some/path', log_environ=False).exit(1))
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertFalse(self.step.method_return_value)
+        self.assertFalse(self.get_nth_step(0).method_return_value)
 
     @defer.inlineCallbacks
     def test_pathExists_logging(self):
-        self.step.testMethod = lambda: self.step.pathExists('/some/path')
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).pathExists('/some/path')
         self.expect_commands(
             ExpectStat(file='/some/path', log_environ=False)
             .log('stdio', header='NOTE: never mind\n')
@@ -1156,19 +1168,19 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         )
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertFalse(self.step.method_return_value)
+        self.assertFalse(self.get_nth_step(0).method_return_value)
         self.assertEqual(
-            self.step.getLog('stdio').header,
+            self.get_nth_step(0).getLog('stdio').header,
             'NOTE: never mind\nprogram finished with exit code 1\n',
         )
 
     def test_glob(self):
         @defer.inlineCallbacks
         def testFunc():
-            res = yield self.step.runGlob("*.pyc")
+            res = yield self.get_nth_step(0).runGlob("*.pyc")
             self.assertEqual(res, ["one.pyc", "two.pyc"])
 
-        self.step.testMethod = testFunc
+        self.get_nth_step(0).testMethod = testFunc
         self.expect_commands(
             ExpectGlob(path='*.pyc', log_environ=False).files(["one.pyc", "two.pyc"]).exit(0)
         )
@@ -1176,13 +1188,13 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_glob_empty(self):
-        self.step.testMethod = lambda: self.step.runGlob("*.pyc")
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).runGlob("*.pyc")
         self.expect_commands(ExpectGlob(path='*.pyc', log_environ=False).files().exit(0))
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
     def test_glob_fail(self):
-        self.step.testMethod = lambda: self.step.runGlob("*.pyc")
+        self.get_nth_step(0).testMethod = lambda: self.get_nth_step(0).runGlob("*.pyc")
         self.expect_commands(ExpectGlob(path='*.pyc', log_environ=False).exit(1))
         self.expect_outcome(result=FAILURE)
         return self.run_step()
@@ -1365,7 +1377,7 @@ class TestShellMixin(
         )
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertEqual(self.step.getLog('logname').stdout, 'logline\nlogline2\n')
+        self.assertEqual(self.get_nth_step(0).getLog('logname').stdout, 'logline\nlogline2\n')
 
     @defer.inlineCallbacks
     def test_lazy_logfiles_stdout_has_stdout(self):
@@ -1375,7 +1387,7 @@ class TestShellMixin(
         )
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertEqual(self.step.getLog('stdio').stdout, 'some log\n')
+        self.assertEqual(self.get_nth_step(0).getLog('stdio').stdout, 'some log\n')
 
     @defer.inlineCallbacks
     def test_lazy_logfiles_stdout_no_stdout(self):
@@ -1384,7 +1396,7 @@ class TestShellMixin(
         self.expect_commands(ExpectShell(workdir='wkdir', command=['cmd', 'arg']).exit(0))
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertEqual(self.step.getLog('stdio').stdout, '')
+        self.assertEqual(self.get_nth_step(0).getLog('stdio').stdout, '')
 
     @defer.inlineCallbacks
     def test_lazy_logfiles_logfile(self):
@@ -1402,7 +1414,7 @@ class TestShellMixin(
         )
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertEqual(self.step.getLog('logname').stdout, 'logline\nlogline2\n')
+        self.assertEqual(self.get_nth_step(0).getLog('logname').stdout, 'logline\nlogline2\n')
 
     @defer.inlineCallbacks
     def test_lazy_logfiles_no_logfile(self):
@@ -1419,7 +1431,7 @@ class TestShellMixin(
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
         with self.assertRaises(KeyError):
-            self.step.getLog('logname')
+            self.get_nth_step(0).getLog('logname')
 
     @defer.inlineCallbacks
     def test_env(self):
@@ -1446,7 +1458,7 @@ class TestShellMixin(
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
         self.assertEqual(
-            self.step.getLog('stdio').header,
+            self.get_nth_step(0).getLog('stdio').header,
             'NOTE: worker does not allow master to override usePTY\n'
             'NOTE: worker does not allow master to specify interruptSignal\n'
             'program finished with exit code 0\n',
@@ -1465,7 +1477,9 @@ class TestShellMixin(
         )
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
-        self.assertEqual(self.step.getLog('stdio').header, 'program finished with exit code 0\n')
+        self.assertEqual(
+            self.get_nth_step(0).getLog('stdio').header, 'program finished with exit code 0\n'
+        )
 
     @defer.inlineCallbacks
     def test_description(self):
@@ -1488,5 +1502,5 @@ class TestShellMixin(
 
     def test_getResultSummary(self):
         self.setup_step(SimpleShellCommand(command=['a', ['b', 'c']]))
-        self.step.results = SUCCESS
-        self.assertEqual(self.step.getResultSummary(), {'step': "'a b ...'"})
+        self.get_nth_step(0).results = SUCCESS
+        self.assertEqual(self.get_nth_step(0).getResultSummary(), {'step': "'a b ...'"})

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1435,9 +1435,9 @@ class TestShellMixin(
 
     @defer.inlineCallbacks
     def test_old_worker_args(self):
+        self.setup_build(worker_version={'*': "1.1"})
         self.setup_step(
-            SimpleShellCommand(command=['cmd', 'arg'], usePTY=False, interruptSignal='DIE'),
-            worker_version={'*': "1.1"},
+            SimpleShellCommand(command=['cmd', 'arg'], usePTY=False, interruptSignal='DIE')
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['cmd', 'arg']).exit(0)
@@ -1454,9 +1454,9 @@ class TestShellMixin(
 
     @defer.inlineCallbacks
     def test_new_worker_args(self):
+        self.setup_build(worker_version={'*': "3.0"})
         self.setup_step(
-            SimpleShellCommand(command=['cmd', 'arg'], usePTY=False, interruptSignal='DIE'),
-            worker_version={'*': "3.0"},
+            SimpleShellCommand(command=['cmd', 'arg'], usePTY=False, interruptSignal='DIE')
         )
         self.expect_commands(
             ExpectShell(

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -210,8 +210,8 @@ OK:key1=value1""",
         self.expect_log_file('log', f"URL: {url}\nStatus: 200\n ------ Content ------\nTrue")
         self.expect_outcome(result=SUCCESS, state_string="Status code: 200")
         yield self.run_step()
-        self.assertIn("X-Test: <HIDDEN>", self.step.logs['log'].header)
-        self.assertIn("Content-Length: <HIDDEN>", self.step.logs['log'].header)
+        self.assertIn("X-Test: <HIDDEN>", self.get_nth_step(0).logs['log'].header)
+        self.assertIn("Content-Length: <HIDDEN>", self.get_nth_step(0).logs['log'].header)
 
     def test_params_renderable(self):
         url = self.getURL()

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -51,7 +51,7 @@ class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
         **kwargs,
     ):
         self.setup_step(mswin.Robocopy(source, destination, **kwargs))
-        self.step.rendered = True
+        self.get_nth_step(0).rendered = True
 
         command = ['robocopy', source, destination]
         if expected_args:

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from parameterized import parameterized
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -137,26 +138,18 @@ class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
             expected_args=['*.foo', '/V', '/TS', '/FP'],
         )
 
-    @defer.inlineCallbacks
-    def test_codes(self):
+    @parameterized.expand(
         # Codes that mean uneventful copies (including no copy at all).
-        for i in [0, 1]:
-            yield self._run_simple_test(
-                r'D:\source', r'E:\dest', expected_code=i, expected_res=SUCCESS
-            )
-
+        [(c, SUCCESS) for c in range(0, 2)]
         # Codes that mean some mismatched or extra files were found.
-        for i in range(2, 8):
-            yield self._run_simple_test(
-                r'D:\source', r'E:\dest', expected_code=i, expected_res=WARNINGS
-            )
+        + [(c, WARNINGS) for c in range(2, 8)]
         # Codes that mean errors have been encountered.
-        for i in range(8, 32):
-            yield self._run_simple_test(
-                r'D:\source', r'E:\dest', expected_code=i, expected_res=FAILURE
-            )
-
+        + [(c, FAILURE) for c in range(8, 32)]
         # bit 32 is meaningless
+        + [(32, EXCEPTION)]
+    )
+    @defer.inlineCallbacks
+    def test_codes(self, code, expected_result):
         yield self._run_simple_test(
-            r'D:\source', r'E:\dest', expected_code=32, expected_res=EXCEPTION
+            r'D:\source', r'E:\dest', expected_code=code, expected_res=expected_result
         )

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -591,7 +591,7 @@ class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_log_file("warnings", warnings)
         yield self.run_step()
 
-        self.assertEqual(self.step.statistics, {'warnings': 2})
+        self.assertEqual(self.get_nth_step(0).statistics, {'warnings': 2})
 
     def test_constr_args(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -235,9 +235,9 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_build_changed_files(self):
+        self.setup_build(build_files=['my/test/file.py', 'my/test/file2.py'])
         self.setup_step(
             python_twisted.Trial(workdir='build', testChanges=True, testpath=None),
-            build_files=['my/test/file.py', 'my/test/file2.py'],
         )
 
         self.expect_commands(
@@ -404,7 +404,8 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.tear_down_test_build_step()
 
     def test_run_ok(self):
-        self.setup_step(python_twisted.HLint(workdir='build'), build_files=['foo.xhtml'])
+        self.setup_build(build_files=['foo.xhtml'])
+        self.setup_step(python_twisted.HLint(workdir='build'))
         self.expect_commands(
             ExpectShell(
                 workdir='build',
@@ -418,9 +419,8 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_custom_python(self):
-        self.setup_step(
-            python_twisted.HLint(workdir='build', python='/bin/mypython'), build_files=['foo.xhtml']
-        )
+        self.setup_build(build_files=['foo.xhtml'])
+        self.setup_step(python_twisted.HLint(workdir='build', python='/bin/mypython'))
         self.expect_commands(
             ExpectShell(
                 workdir='build',
@@ -432,7 +432,8 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_command_failure(self):
-        self.setup_step(python_twisted.HLint(workdir='build'), build_files=['foo.xhtml'])
+        self.setup_build(build_files=['foo.xhtml'])
+        self.setup_step(python_twisted.HLint(workdir='build'))
         self.expect_commands(
             ExpectShell(
                 workdir='build',
@@ -449,7 +450,8 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_run_warnings(self):
-        self.setup_step(python_twisted.HLint(workdir='build'), build_files=['foo.xhtml'])
+        self.setup_build(build_files=['foo.xhtml'])
+        self.setup_step(python_twisted.HLint(workdir='build'))
         self.expect_commands(
             ExpectShell(
                 workdir='build', command=['bin/lore', '-p', '--output', 'lint', 'foo.xhtml']

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -122,9 +122,8 @@ class TestShellCommandExecution(
         return self.run_step()
 
     def test_run_env(self):
-        self.setup_step(
-            shell.ShellCommand(workdir='build', command="echo hello"), worker_env={"DEF": 'HERE'}
-        )
+        self.setup_build(worker_env={"DEF": 'HERE'})
+        self.setup_step(shell.ShellCommand(workdir='build', command="echo hello"))
         self.expect_commands(
             ExpectShell(workdir='build', command='echo hello', env={"DEF": 'HERE'}).exit(0)
         )
@@ -132,9 +131,9 @@ class TestShellCommandExecution(
         return self.run_step()
 
     def test_run_env_override(self):
+        self.setup_build(worker_env={"ABC": 'XXX', "DEF": 'HERE'})
         self.setup_step(
             shell.ShellCommand(workdir='build', env={'ABC': '123'}, command="echo hello"),
-            worker_env={"ABC": 'XXX', "DEF": 'HERE'},
         )
         self.expect_commands(
             ExpectShell(
@@ -153,10 +152,8 @@ class TestShellCommandExecution(
         return self.run_step()
 
     def test_run_usePTY_old_worker(self):
-        self.setup_step(
-            shell.ShellCommand(workdir='build', command="echo hello", usePTY=True),
-            worker_version={"shell": '1.1'},
-        )
+        self.setup_build(worker_version={"shell": '1.1'})
+        self.setup_step(shell.ShellCommand(workdir='build', command="echo hello", usePTY=True))
         self.expect_commands(ExpectShell(workdir='build', command='echo hello').exit(0))
         self.expect_outcome(result=SUCCESS)
         return self.run_step()

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -247,12 +247,12 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_mode_full_clean_patch_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             bzr.Bzr(
                 repourl='http://bzr.squid-cache.org/bzr/squid3/trunk', mode='full', method='clean'
             ),
             patch=(1, 'patch'),
-            worker_version={'*': '2.16'},
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['bzr', '--version']).exit(0),

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -154,6 +154,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_mode_full_clean_and_login_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             cvs.CVS(
                 cvsroot=":pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot",
@@ -161,8 +162,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                 mode='full',
                 method='clean',
                 login="a password",
-            ),
-            worker_version={'*': '2.16'},
+            )
         )
 
         self.expect_commands(
@@ -291,6 +291,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_mode_full_clean_patch_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             cvs.CVS(
                 cvsroot=":pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot",
@@ -299,7 +300,6 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                 method='clean',
             ),
             patch=(1, 'patch'),
-            worker_version={'*': '2.16'},
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['cvs', '--version']).exit(0),

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -293,10 +293,10 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase
         return self.run_step()
 
     def test_mode_full_clobber_revision_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             darcs.Darcs(repourl='http://localhost/darcs', mode='full', method='clobber'),
             {"revision": 'abcdef01'},
-            worker_version={'*': '2.16'},
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['darcs', '--version']).exit(0),

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -1069,12 +1069,12 @@ class TestGit(
         return self.run_step()
 
     def test_mode_full_clean_patch_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             self.stepClass(
                 repourl='http://github.com/buildbot/buildbot.git', mode='full', method='clean'
             ),
             patch=(1, 'patch'),
-            worker_version={'*': '2.16'},
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['git', '--version'])

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -1765,7 +1765,7 @@ class TestGit(
                 repourl='http://github.com/buildbot/buildbot.git', mode='incremental', progress=True
             )
         )
-        self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
+        self.get_nth_step(0).build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expect_commands(
             ExpectShell(workdir='wkdir', interrupt_signal='TERM', command=['git', '--version'])
             .stdout('git version 1.7.5')
@@ -2787,7 +2787,7 @@ class TestGit(
         self.setup_step(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git', mode='incremental')
         )
-        self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
+        self.get_nth_step(0).build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expect_commands(
             ExpectShell(workdir='wkdir', interrupt_signal='TERM', command=['git', '--version'])
             .stdout('git version 1.7.5')

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -249,12 +249,12 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.Test
         return self.run_step()
 
     def test_mode_full_clean_patch_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             mercurial.Mercurial(
                 repourl='http://hg.mozilla.org', mode='full', method='clean', branchType='inrepo'
             ),
             patch=(1, 'patch'),
-            worker_version={'*': '2.16'},
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['hg', '--verbose', '--version']).exit(0),

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -162,12 +162,12 @@ class TestMonotone(
         return self.run_step()
 
     def test_mode_full_clean_patch_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             mtn.Monotone(
                 repourl='mtn://localhost/monotone', mode='full', method='clean', branch='master'
             ),
             patch=(1, 'patch'),
-            worker_version={'*': '2.16'},
         )
 
         self.expect_commands(

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -790,6 +790,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin, u
         self._full(client_stdin=client_stdin)
 
     def test_mode_full_p4base_not_obfuscated(self):
+        self.setup_build(worker_version={'*': '2.15'})
         self.setup_step(
             P4(
                 p4port='localhost:12000',
@@ -799,8 +800,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin, u
                 p4user='user',
                 p4client='p4_client1',
                 p4passwd='pass',
-            ),
-            worker_version={'*': '2.15'},
+            )
         )
 
         root_dir = '/home/user/workspace/wkdir'

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -131,7 +131,7 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase)
             override_commands = []
         commands = (
             [
-                self.ExpectShell(command=['bash', '-c', self.step._getCleanupCommand()]),
+                self.ExpectShell(command=['bash', '-c', self.get_nth_step(0)._getCleanupCommand()]),
                 self.ExpectShell(
                     command=[
                         'repo',
@@ -405,7 +405,9 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase)
         self.build.setProperty("repo_download2", "repo download manifest 565/12", "test")
         self.expectnoClobber()
         self.expect_commands(
-            self.ExpectShell(command=['bash', '-c', self.step._getCleanupCommand()]).exit(0),
+            self.ExpectShell(
+                command=['bash', '-c', self.get_nth_step(0)._getCleanupCommand()]
+            ).exit(0),
             self.ExpectShell(
                 command=[
                     'repo',
@@ -441,7 +443,7 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase)
         """repo downloads, with mirror synchronization issues"""
         self.mySetupStep()
         # we don't really want the test to wait...
-        self.step.mirror_sync_sleep = 0.001
+        self.get_nth_step(0).mirror_sync_sleep = 0.001
         self.build.setProperty("repo_download", "repo download test/bla 564/12", "test")
         self.expectnoClobber()
         self.expectRepoSync()
@@ -460,8 +462,8 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase)
         """repo downloads, with no actual mirror synchronization issues (still retries 2 times)"""
         self.mySetupStep()
         # we don't really want the test to wait...
-        self.step.mirror_sync_sleep = 0.001
-        self.step.mirror_sync_retry = 1  # on retry once
+        self.get_nth_step(0).mirror_sync_sleep = 0.001
+        self.get_nth_step(0).mirror_sync_retry = 1  # on retry once
         self.build.setProperty("repo_download", "repo download test/bla 564/12", "test")
         self.expectnoClobber()
         self.expectRepoSync()

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -196,7 +196,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_property('got_revision', 'a10', 'SVN')
         yield self.run_step()
 
-        revision = self.step.getProperty('got_revision')
+        revision = self.get_nth_step(0).getProperty('got_revision')
         with self.assertRaises(ValueError):
             int(revision)
 

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -1337,10 +1337,10 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         return self.run_step()
 
     def test_mode_full_export_patch_worker_2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             svn.SVN(repourl='http://svn.local/app/trunk', mode='full', method='export'),
             patch=(1, 'patch'),
-            worker_version={'*': '2.16'},
         )
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['svn', '--version']).exit(0),

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -79,10 +79,8 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         return d
 
     def testWorker2_16(self):
-        self.setup_step(
-            transfer.FileUpload(workersrc='srcfile', masterdest=self.destfile),
-            worker_version={'*': '2.16'},
-        )
+        self.setup_build(worker_version={'*': '2.16'})
+        self.setup_step(transfer.FileUpload(workersrc='srcfile', masterdest=self.destfile))
 
         self.expect_commands(
             ExpectUploadFile(
@@ -345,9 +343,9 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
         return d
 
     def testWorker2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             transfer.DirectoryUpload(workersrc="srcdir", masterdest=self.destdir),
-            worker_version={'*': '2.16'},
         )
 
         self.expect_commands(
@@ -672,9 +670,9 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
         return d
 
     def testFileWorker2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             transfer.MultipleFileUpload(workersrcs=["srcfile"], masterdest=self.destdir),
-            worker_version={'*': '2.16'},
         )
 
         self.expect_commands(
@@ -696,9 +694,9 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
         return d
 
     def testDirectoryWorker2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             transfer.MultipleFileUpload(workersrcs=["srcdir"], masterdest=self.destdir),
-            worker_version={'*': '2.16'},
         )
 
         self.expect_commands(
@@ -720,9 +718,9 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
         return d
 
     def testMultipleWorker2_16(self):
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             transfer.MultipleFileUpload(workersrcs=["srcfile", "srcdir"], masterdest=self.destdir),
-            worker_version={'*': '2.16'},
         )
 
         self.expect_commands(
@@ -999,9 +997,9 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def testBasicWorker2_16(self):
         master_file = __file__
+        self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(
             transfer.FileDownload(mastersrc=master_file, workerdest=self.destfile),
-            worker_version={'*': '2.16'},
         )
 
         # A place to store what gets read
@@ -1093,9 +1091,8 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def testBasicWorker2_16(self):
-        self.setup_step(
-            transfer.StringDownload("Hello World", "hello.txt"), worker_version={'*': '2.16'}
-        )
+        self.setup_build(worker_version={'*': '2.16'})
+        self.setup_step(transfer.StringDownload("Hello World", "hello.txt"))
 
         self.step.worker = Mock()
         self.step.remote = Mock()

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -142,7 +142,7 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectUploadFile(
@@ -170,7 +170,7 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectUploadFile(
@@ -189,7 +189,7 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         yield self.run_step()
 
-        self.step.addURL.assert_called_once_with(
+        self.get_nth_step(0).addURL.assert_called_once_with(
             os.path.basename(self.destfile), "http://server/file"
         )
 
@@ -204,7 +204,7 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectUploadFile(
@@ -223,7 +223,7 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         yield self.run_step()
 
-        self.step.addURL.assert_called_once_with("testfile", "http://server/file")
+        self.get_nth_step(0).addURL.assert_called_once_with("testfile", "http://server/file")
 
     def testFailure(self):
         self.setup_step(transfer.FileUpload(workersrc='srcfile', masterdest=self.destfile))
@@ -373,7 +373,7 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectUploadDirectory(
@@ -392,7 +392,7 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
         yield self.run_step()
 
-        self.step.addURL.assert_called_once_with("destdir", "http://server/dir")
+        self.get_nth_step(0).addURL.assert_called_once_with("destdir", "http://server/dir")
 
     @defer.inlineCallbacks
     def test_url_text(self):
@@ -405,7 +405,7 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectUploadDirectory(
@@ -424,7 +424,7 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
         yield self.run_step()
 
-        self.step.addURL.assert_called_once_with("url text", "http://server/dir")
+        self.get_nth_step(0).addURL.assert_called_once_with("url text", "http://server/dir")
 
     @defer.inlineCallbacks
     def testFailure(self):
@@ -760,7 +760,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectStat(file='srcfile', workdir='wkdir').stat_file().exit(0),
@@ -780,7 +780,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
         yield self.run_step()
 
-        self.step.addURL.assert_called_once_with("destdir", "http://server/dir")
+        self.get_nth_step(0).addURL.assert_called_once_with("destdir", "http://server/dir")
 
     @defer.inlineCallbacks
     def test_url_text(self):
@@ -793,7 +793,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
             )
         )
 
-        self.step.addURL = Mock()
+        self.get_nth_step(0).addURL = Mock()
 
         self.expect_commands(
             ExpectStat(file='srcfile', workdir='wkdir').stat_file().exit(0),
@@ -813,7 +813,7 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
         yield self.run_step()
 
-        self.step.addURL.assert_called_once_with("url text", "http://server/dir")
+        self.get_nth_step(0).addURL.assert_called_once_with("url text", "http://server/dir")
 
     def testFailure(self):
         self.setup_step(
@@ -1065,8 +1065,8 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
     def testBasic(self):
         self.setup_step(transfer.StringDownload("Hello World", "hello.txt"))
 
-        self.step.worker = Mock()
-        self.step.remote = Mock()
+        self.get_nth_step(0).worker = Mock()
+        self.get_nth_step(0).remote = Mock()
 
         # A place to store what gets read
         read = []
@@ -1094,8 +1094,8 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
         self.setup_build(worker_version={'*': '2.16'})
         self.setup_step(transfer.StringDownload("Hello World", "hello.txt"))
 
-        self.step.worker = Mock()
-        self.step.remote = Mock()
+        self.get_nth_step(0).worker = Mock()
+        self.get_nth_step(0).remote = Mock()
 
         # A place to store what gets read
         read = []
@@ -1165,8 +1165,8 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.Test
         msg = {"message": 'Hello World'}
         self.setup_step(transfer.JSONStringDownload(msg, "hello.json"))
 
-        self.step.worker = Mock()
-        self.step.remote = Mock()
+        self.get_nth_step(0).worker = Mock()
+        self.get_nth_step(0).remote = Mock()
 
         # A place to store what gets read
         read = []
@@ -1194,8 +1194,8 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.Test
         msg = {"message": Interpolate('Hello World')}
         self.setup_step(transfer.JSONStringDownload(msg, "hello.json"))
 
-        self.step.worker = Mock()
-        self.step.remote = Mock()
+        self.get_nth_step(0).worker = Mock()
+        self.get_nth_step(0).remote = Mock()
 
         # A place to store what gets read
         read = []
@@ -1264,7 +1264,7 @@ class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.
     @defer.inlineCallbacks
     def testBasic(self):
         self.setup_step(transfer.JSONPropertiesDownload("props.json"))
-        self.step.build.setProperty('key1', 'value1', 'test')
+        self.get_nth_step(0).build.setProperty('key1', 'value1', 'test')
         read = []
         self.expect_commands(
             ExpectDownloadFile(

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -175,7 +175,7 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         def getAllGotRevisions():
             return got_revisions
 
-        self.step.getAllGotRevisions = getAllGotRevisions
+        self.get_nth_step(0).getAllGotRevisions = getAllGotRevisions
 
         self.exp_add_sourcestamp = None
         self.exp_a_trigger = None
@@ -187,7 +187,7 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def run_step(self, results_dict=None):
         if results_dict is None:
             results_dict = {}
-        if self.step.waitForFinish:
+        if self.get_nth_step(0).waitForFinish:
             for i in [11, 22, 33, 44]:
                 yield self.master.db.builds.finishBuild(
                     BRID_TO_BID(i), results_dict.get(i, SUCCESS)
@@ -195,7 +195,7 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         d = super().run_step()
         # the build doesn't finish until after a callLater, so this has the
         # effect of checking whether the deferred has been fired already;
-        if self.step.waitForFinish:
+        if self.get_nth_step(0).waitForFinish:
             self.assertFalse(d.called)
         else:
             self.assertTrue(d.called)
@@ -528,13 +528,13 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_waitForFinish_exception(self):
         yield self.setup_step(trigger.Trigger(schedulerNames=['a', 'b'], waitForFinish=True))
-        self.step.addCompleteLog = Mock()
+        self.get_nth_step(0).addCompleteLog = Mock()
         self.scheduler_b.exception = True
         self.expect_outcome(result=EXCEPTION, state_string='triggered a, b')
         self.expectTriggeredWith(a=(True, [], {}), b=(True, [], {}))
         self.expectTriggeredLinks('a')  # b doesn't return a brid
         yield self.run_step()
-        self.assertEqual(len(self.step.addCompleteLog.call_args_list), 1)
+        self.assertEqual(len(self.get_nth_step(0).addCompleteLog.call_args_list), 1)
 
     @defer.inlineCallbacks
     def test_virtual_builder(self):
@@ -585,7 +585,7 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         # interrupt before the callLater representing the Triggerable
         # schedulers completes
-        self.step.interrupt(failure.Failure(RuntimeError('oh noes')))
+        self.get_nth_step(0).interrupt(failure.Failure(RuntimeError('oh noes')))
 
         yield d
 
@@ -601,7 +601,7 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         # interrupt before the callLater representing the Triggerable
         # schedulers completes
         self.build.conn = None
-        self.step.interrupt(failure.Failure(RuntimeError('oh noes')))
+        self.get_nth_step(0).interrupt(failure.Failure(RuntimeError('oh noes')))
 
         yield d
 

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -253,11 +253,11 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_installdir(self):
         self.setup_step(VCx(installdir=r'C:\I'))
-        self.step.exp_installdir = r'C:\I'
+        self.get_nth_step(0).exp_installdir = r'C:\I'
         self.expect_commands(ExpectShell(workdir='wkdir', command=['command', 'here']).exit(0))
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
         yield self.run_step()
-        self.assertEqual(self.step.installdir, r'C:\I')
+        self.assertEqual(self.get_nth_step(0).installdir, r'C:\I')
 
     def test_evaluate_result_failure(self):
         self.setup_step(VCx())
@@ -343,9 +343,8 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
         yield self.run_step()
 
-        self.assertEqual(
-            [self.step.projectfile, self.step.config, self.step.project], ['aa', 'bb', 'cc']
-        )
+        step = self.get_nth_step(0)
+        self.assertEqual([step.projectfile, step.config, step.project], ['aa', 'bb', 'cc'])
 
 
 class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
@@ -639,7 +638,7 @@ class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
         self.expect_outcome(result=SUCCESS, state_string="compile 0 projects 0 files")
         yield self.run_step()
 
-        self.assertEqual(self.step.arch, 'x64')
+        self.assertEqual(self.get_nth_step(0).arch, 'x64')
 
 
 class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -114,7 +114,8 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_old_version(self):
-        self.setup_step(worker.FileExists(file="x"), worker_version={})
+        self.setup_build(worker_version={})
+        self.setup_step(worker.FileExists(file="x"))
         self.expect_outcome(result=EXCEPTION, state_string="finished (exception)")
         yield self.run_step()
         self.flushLoggedErrors(WorkerSetupError)
@@ -372,7 +373,8 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.Test
             res = yield x.getFileContentFromWorker("file.txt")
             self.assertEqual(res, "Hello world!")
 
-        self.setup_step(CompositeUser(testFunc), worker_version={'*': '2.16'})
+        self.setup_build(worker_version={'*': '2.16'})
+        self.setup_step(CompositeUser(testFunc))
         self.expect_commands(
             ExpectUploadFile(
                 slavesrc="file.txt",

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -89,12 +89,12 @@ class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin, TestReactorMixin, 
         return self.tear_down_test_build_step()
 
     def testBasic(self):
+        self.setup_build(worker_version={'*': '3.0'})
         self.setup_step(
             RemoveWorkerFileSecret([
                 (os.path.join(self.temp_path, "pathA"), "something"),
                 (os.path.join(self.temp_path, "pathB"), "somethingmore"),
             ]),
-            worker_version={'*': '3.0'},
         )
 
         self.expect_commands(

--- a/master/buildbot/test/unit/test_steps_mixin.py
+++ b/master/buildbot/test/unit/test_steps_mixin.py
@@ -1,0 +1,99 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.process import buildstep
+from buildbot.process.results import SUCCESS
+from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.steps import ExpectShell
+from buildbot.test.steps import TestBuildStepMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
+
+
+class TestStep(buildstep.ShellMixin, buildstep.BuildStep):
+    def __init__(self, text):
+        self.setupShellMixin({})
+        super().__init__()
+        self.text = text
+
+    @defer.inlineCallbacks
+    def run(self):
+        for file in self.build.allFiles():
+            cmd = yield self.makeRemoteShellCommand(command=["echo", "build_file", file])
+            yield self.runCommand(cmd)
+        version = self.build.getWorkerCommandVersion("shell", None)
+        cmd = yield self.makeRemoteShellCommand(command=["echo", "version", version])
+        yield self.runCommand(cmd)
+        cmd = yield self.makeRemoteShellCommand(command=["echo", "done", self.text])
+        yield self.runCommand(cmd)
+        return SUCCESS
+
+
+class TestTestBuildStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
+    def setUp(self):
+        self.setup_test_reactor()
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    @defer.inlineCallbacks
+    def test_setup_build(self):
+        self.setup_build(
+            worker_version={"*": "2.9"}, worker_env={"key": "value"}, build_files=["build.txt"]
+        )
+        self.setup_step(TestStep("step1"))
+        self.expect_commands(
+            ExpectShell(
+                workdir="wkdir", command=["echo", "build_file", "build.txt"], env={"key": "value"}
+            ).exit(0),
+            ExpectShell(
+                workdir="wkdir", command=["echo", "version", "2.9"], env={"key": "value"}
+            ).exit(0),
+            ExpectShell(
+                workdir="wkdir", command=["echo", "done", "step1"], env={"key": "value"}
+            ).exit(0),
+        )
+        self.expect_outcome(SUCCESS)
+        yield self.run_step()
+
+    @defer.inlineCallbacks
+    def test_old_setup_step_args(self):
+        with assertProducesWarnings(
+            DeprecatedApiWarning,
+            num_warnings=3,
+            message_pattern=".*has been deprecated, use setup_build\\(\\) to pass this information",
+        ):
+            self.setup_step(
+                TestStep("step1"),
+                worker_version={"*": "2.9"},
+                worker_env={"key": "value"},
+                build_files=["build.txt"],
+            )
+        self.expect_commands(
+            ExpectShell(
+                workdir="wkdir", command=["echo", "build_file", "build.txt"], env={"key": "value"}
+            ).exit(0),
+            ExpectShell(
+                workdir="wkdir", command=["echo", "version", "2.9"], env={"key": "value"}
+            ).exit(0),
+            ExpectShell(workdir="wkdir", command=["echo", "done", "step1"], env={"key": "value"}).exit(0),
+        )
+        self.expect_outcome(SUCCESS)
+
+        yield self.run_step()

--- a/master/docs/manual/configuration/tests/steps.rst
+++ b/master/docs/manual/configuration/tests/steps.rst
@@ -40,6 +40,9 @@ TestBuildStepMixin
 
      * In ``setUp()`` of test case call ``self.setup_test_build_step()``.
 
+     * In unit test first optionally call ``self.setup_build(...)`` function to setup information
+        that will be available to the step during the test.
+
      * In unit test call ``self.setup_step(step)`` which will setup the step for testing.
 
      * Call ``self.expect_commands(commands)`` to specify commands that the step is expected to run and the results of these commands.
@@ -58,10 +61,17 @@ TestBuildStepMixin
 
         Call this function in the ``tearDown()`` of the test case to destroy step testing machinery.
 
-    .. py:method:: setup_step(step, worker_env=None, build_files=None)
+    .. py:method:: setup_build(worker_env=None, build_files=None)
 
         :param dict worker_env: An optional dictionary of environment variables on the mock worker.
         :param list build_files: An optional list of source files that were changed in the build.
+
+        Sets up build and worker information that will be available to the tested step.
+
+    .. py:method:: setup_step(step, worker_env=None, build_files=None)
+
+        :param dict worker_env: An optional dictionary of environment variables on the mock worker (deprecated).
+        :param list build_files: An optional list of source files that were changed in the build (deprecated).
         :returns: An instance of prepared step (not the same as the ``step`` argument).
 
         Prepares the given step for testing.

--- a/master/docs/manual/configuration/tests/steps.rst
+++ b/master/docs/manual/configuration/tests/steps.rst
@@ -70,17 +70,26 @@ TestBuildStepMixin
 
     .. py:method:: setup_step(step, worker_env=None, build_files=None)
 
+        :param BuildStep step: An instance of ``BuildStep`` to test.
         :param dict worker_env: An optional dictionary of environment variables on the mock worker (deprecated).
         :param list build_files: An optional list of source files that were changed in the build (deprecated).
         :returns: An instance of prepared step (not the same as the ``step`` argument).
 
-        Prepares the given step for testing.
-        The method mimics how Buildbot instantiates steps in reality and thus the ``step`` parameter is used only as a factory for creating the real step.
+        Prepares the given step for testing. This function may be invoked multiple times.
+        The ``step`` argument is used as a step factory, just like in real Buildbot.
 
     .. py:attribute:: step
 
-        The step under test.
+        (deprecated) The step under test.
         This attribute is available after ``setup_step()`` is run.
+
+        This function has been deprecated, use ``get_nth_step(0)`` as a replacement
+
+    .. py:method:: get_nth_step(index)
+
+        :param int index: The index of the step to retrieve
+
+        Retrieves the instance of a step that has been created by ``setup_step()``.
 
     ..
         TODO: build, progress, worker attributes
@@ -96,7 +105,9 @@ TestBuildStepMixin
         :param result: A result from `buildbot.process.results`.
         :param str state_string: An optional status text.
 
-        Sets up an expectation of the step result.
+        Sets up an expectation of the step result. If there are multiple steps registered to the
+        test, then there must be as many calls to ``expect_outcome`` as there are steps, in the
+        same order.
 
     .. py:method:: expect_property(property, value, source=None)
 
@@ -104,27 +115,32 @@ TestBuildStepMixin
         :param str value: The value of the property
         :param str source: An optional source of the property
 
-        Sets up an expectation of a property set by the step
+        Sets up an expectation of a property set by the step. If there are multiple steps
+        registered to the test, then this function tests the cumulative set of properties set
+        on the build.
 
     .. py:method:: expect_no_property(self, property)
 
         :param str property: The name of the property
 
-        Sets up an expectation of an absence of a property set by the step.
+        Sets up an expectation of an absence of a property set by the step. If there are multiple
+        steps registered to the test, then this function expects that no tests set the property.
 
-    .. py:method:: expect_log_file(self, logfile, contents)
+    .. py:method:: expect_log_file(self, logfile, contents, step_index=0)
 
         :param str logfile: The name of the log file
         :param str contents: The contents of the log file
+        :param int step_index: The index of the step whose logs to investigate.
 
         Sets up an expectation of a log file being produced by the step.
         Only the ``stdout`` associated with the log file is checked.
         To check the ``stderr`` see ``expect_log_file_stderr()``
 
-    .. py:method:: expect_log_file_stderr(self, logfile, contents)
+    .. py:method:: expect_log_file_stderr(self, logfile, contents, step_index=0)
 
         :param str logfile: The name of the log file
         :param str contents: The contents of the log file
+        :param int step_index: The index of the step whose logs to investigate.
 
         Sets up an expectation of a ``stderr`` output in log file being produced by the step.
 
@@ -134,7 +150,9 @@ TestBuildStepMixin
         :param str value: The value of the build data.
         :param str source: The source of the build data.
 
-        Sets up an expectation of build data produced by the step.
+        Sets up an expectation of build data produced by the step. If there are multiple steps
+        registered to the test, then this function tests the cumulative set of build data added to
+        the build.
 
     .. py:method:: expect_hidden(hidden=True)
 
@@ -156,4 +174,4 @@ TestBuildStepMixin
 
     .. py:method:: run_step()
 
-        Runs the step and validates the expectations setup before this function.
+        Runs the steps and validates the expectations setup before this function.

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -1,0 +1,27 @@
+.. _5.0_Upgrading:
+
+Upgrading to Buildbot 5.0 (not released)
+========================================
+
+Upgrading a Buildbot instance from 4.x to 5.0 may require some work to achieve.
+
+The recommended upgrade procedure is as follows:
+
+  - Upgrade to the last released BuildBot version in 4.x series.
+
+  - Remove usage of the deprecated APIs.
+    All usages of deprecated APIs threw a deprecation warning at the point of use.
+    If the code does not emit deprecation warnings, it's in a good shape in this regard.
+    You may need to run the master on a real workload in order to force all deprecated code paths to be exercised.
+
+  - Upgrade to the latest Buildbot 5.0.x release.
+
+  - (Optional) Upgrade to newest Buildbot 5.x.
+    The newest point release will contain bug fixes and functionality improvements.
+
+Testing support
+===============
+
+The ``build_files``, ``worker_env`` and ``worker_version`` arguments of
+``TestBuildStepMixin.setup_step()`` have been removed. As a replacement, call
+``TestBuildStepMixin.setup_build()`` before ``setup_step``.

--- a/master/docs/manual/upgrading/index.rst
+++ b/master/docs/manual/upgrading/index.rst
@@ -37,6 +37,7 @@ Finally, upgrade to the next major release.
 .. toctree::
    :maxdepth: 1
 
+   5.0-upgrade
    4.0-upgrade
    3.0-upgrade
    2.0-upgrade

--- a/newsfragments/test-setup-step-params.removal
+++ b/newsfragments/test-setup-step-params.removal
@@ -1,0 +1,3 @@
+The ``build_files``, ``worker_env`` and ``worker_version`` arguments of
+``TestBuildStepMixin.setup_step()`` have been deprecated. As a replacement, call
+``TestBuildStepMixin.setup_build()`` before ``setup_step``.

--- a/newsfragments/test-step-attr.removal
+++ b/newsfragments/test-step-attr.removal
@@ -1,0 +1,2 @@
+The ``step`` attribute of ``TestBuildStepMixin`` has been deprecated. As a replacement, call
+``TestBuildStepMixin.get_nth_step()``.

--- a/newsfragments/test-step-multiple-steps.feature
+++ b/newsfragments/test-step-multiple-steps.feature
@@ -1,0 +1,2 @@
+``TestBuildStepMixin`` now supports testing multiple steps added via ``setup_step()`` in a single
+unit test.


### PR DESCRIPTION
This PR removes the current limitation of being able to run only single step in a unit test created via `TestBuildStepMixin`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
