### PR TITLE
bbtravis: Limit the maximum number of threads for www unit tests

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -144,6 +144,8 @@ script:
     condition: TESTS == "js_unit"
     cmd: |
       export PATH=/tmp/bbvenv/bin/:$PATH
+      export VITEST_MIN_THREADS=1
+      export VITEST_MAX_THREADS=8
       make frontend_tests
 
   - title: master and worker tests


### PR DESCRIPTION
When tests are run in containers on a large machine, vitest will fire up as many threads as there are CPU cores even if there is no intention to allow the test to do so. On gvisor this results in severely reduced performance.
