### PR TITLE
Fix: git-archive archives are not reproducible

### DIFF
--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -59,14 +59,15 @@ def mTimeVersion(init_file):
     return d.strftime("%Y.%m.%d")
 
 
-def getVersionFromArchiveId(git_archive_id='$Format:%ct %d$'):
+def getVersionFromArchiveId(git_archive_id='$Format:%ct %(describe:abbrev=10)$'):
     """Extract the tag if a source is from git archive.
 
     When source is exported via `git archive`, the git_archive_id init value is modified
     and placeholders are expanded to the "archived" revision:
 
         %ct: committer date, UNIX timestamp
-        %d: ref names, like the --decorate option of git-log
+        %(describe:abbrev=10): git-describe output, always abbreviating to 10 characters of commit ID.
+                               e.g. v3.10.0-850-g5bf957f89
 
     See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
     """
@@ -75,13 +76,12 @@ def getVersionFromArchiveId(git_archive_id='$Format:%ct %d$'):
         # source was modified by git archive, try to parse the version from
         # the value of git_archive_id
 
-        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
-        if match:
+        tstamp, _, describe_output = git_archive_id.strip().partition(' ')
+        if describe_output:
             # archived revision is tagged, use the tag
-            return gitDescribeToPep440(match.group(1))
+            return gitDescribeToPep440(describe_output)
 
         # archived revision is not tagged, use the commit date
-        tstamp = git_archive_id.strip().split()[0]
         d = datetime.datetime.fromtimestamp(int(tstamp), datetime.timezone.utc)
         return d.strftime('%Y.%m.%d')
     return None

--- a/master/buildbot/test/unit/test_version.py
+++ b/master/buildbot/test/unit/test_version.py
@@ -41,11 +41,11 @@ class VersioningUtilsTests(unittest.SynchronousTestCase):
         self.assertEqual(self.m.gitDescribeToPep440("v0.9.9.post1-20-gf0f45ca"), "0.9.10.dev20")
 
     def test_getVersionFromArchiveIdNoTag(self):
-        version = self.m.getVersionFromArchiveId("1514651968  (git-archive-version)")
-        self.assertEqual(version, "2017.12.30")
+        version = self.m.getVersionFromArchiveId("1514651968 v0.9.9.post1-20-gf0f45ca")
+        self.assertEqual(version, "0.9.10.dev20")
 
     def test_getVersionFromArchiveIdtag(self):
-        version = self.m.getVersionFromArchiveId('1514808197  (HEAD -> master, tag: v1.0.0)')
+        version = self.m.getVersionFromArchiveId('1514808197 v1.0.0')
         self.assertEqual(version, "1.0.0")
 
 

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -88,29 +88,29 @@ def mTimeVersion(init_file):
     return d.strftime("%Y.%m.%d")
 
 
-def getVersionFromArchiveId(git_archive_id='$Format:%ct %d$'):
+def getVersionFromArchiveId(git_archive_id='$Format:%ct %(describe:abbrev=10)$'):
     """Extract the tag if a source is from git archive.
 
     When source is exported via `git archive`, the git_archive_id init value is modified
     and placeholders are expanded to the "archived" revision:
 
         %ct: committer date, UNIX timestamp
-        %d: ref names, like the --decorate option of git-log
+        %(describe:abbrev=10): git-describe output, always abbreviating to 10 characters of commit ID.
+                               e.g. v3.10.0-850-g5bf957f89
 
     See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
     """
     # mangle the magic string to make sure it is not replaced by git archive
-    if not git_archive_id.startswith('$Format:'):
+    if not git_archive_id.startswith('$For' + 'mat:'):
         # source was modified by git archive, try to parse the version from
         # the value of git_archive_id
 
-        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
-        if match:
+        tstamp, _, describe_output = git_archive_id.strip().partition(' ')
+        if describe_output:
             # archived revision is tagged, use the tag
-            return gitDescribeToPep440(match.group(1))
+            return gitDescribeToPep440(describe_output)
 
         # archived revision is not tagged, use the commit date
-        tstamp = git_archive_id.strip().split()[0]
         d = datetime.datetime.fromtimestamp(int(tstamp), datetime.timezone.utc)
         return d.strftime('%Y.%m.%d')
     return None


### PR DESCRIPTION
What happened:
%d would expand to `(tag: v3.11.3, 3.11.x)`, but once 3.11.3 is not the latest in the 3.11 series, 3.11.x will cease applying, resulting in the archive not being reproducible.

The fix:
Use a describe specifier, which is *slightly* more sound. It still would break if someone tags an ancestor of a commit, but it should never break on tagged versions, assuming they have just one tag.

Testing conducted (without tagging the version, then after tagging it): $ git archive --format=tar.gz --prefix buildbot-src/ @ > buildbot.tar.gz $ tar xf buildbot.tar.gz
$ cd buildbot-src/master
$ python -c 'import buildbot; print(buildbot.getVersionFromArchiveId())'

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory) - seems unnecessary given it is a packaging change that should not be visible
* [ ] I have updated the appropriate documentation
