### PR TITLE
git: fetching, and submodules - use shallowClone

### DIFF
--- a/newsfragments/git-step-shallow-fetch.feature
+++ b/newsfragments/git-step-shallow-fetch.feature
@@ -1,0 +1,2 @@
+
+:bb:step:`Git` now honors the shallow option in fetching in addition to clone and submodules.


### PR DESCRIPTION
It isn't just the clone stage that should use shallowClone, the fetching and submodule retrieval should also use the same option.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
