### PR TITLE
Fail fast if yarn or yarnpkg is not installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ PIP ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/pip
 VENV_PYTHON ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/python
 YARN := $(shell which yarnpkg || which yarn)
 
+ifeq ($(YARN),)
+  $(error "yarnpkg or yarn is not installed")
+endif
+
 WWW_PKGS := www/base www/console_view www/grid_view www/waterfall_view www/wsgi_dashboards www/badges
 WWW_EX_PKGS := www/nestedexample
 WWW_DEP_PKGS := www/plugin_support www/data-module www/ui


### PR DESCRIPTION
After having tried to build buildbot in a newly created unix user from sratch with 'make tarballs', it failed in a `do (cd $i;  install --pure-lockfile;  run build); done` step. The YARN variable was not properly set, and thus not interpolated into "yarn install", which led to a mere "install" that behaved erratically. This PR makes the build fail fast if yarn or yarnpkg cannot be found.
