### PR TITLE
Fail fast if yarn or yarnpkg is not present.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ PIP ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/pip
 VENV_PYTHON ?= $(ROOT_DIR)/$(VENV_NAME)/$(VENV_BIN_DIR)/python
 YARN := $(shell which yarnpkg || which yarn)
 
+ifeq ($(YARN),)
+  $(error "yarnpkg or yarn is not installed")
+endif
+
 WWW_PKGS := www/base www/console_view www/grid_view www/waterfall_view www/wsgi_dashboards www/badges
 WWW_EX_PKGS := www/nestedexample
 WWW_DEP_PKGS := www/plugin_support www/data-module www/ui


### PR DESCRIPTION
I tried to build buildbot on a "blank slate" machine with not much installed. In particular, with no yarn install. I noticed a failure with an "install" instruction. The YARN makefile variable was in fact set to an empty string and what should have been "yarn install" became interpolated into "install". This PR adds a check to make if "fail fast" with an error message that is more palatable that a badly interpolated "install" instruction in some shell scripting.
