### PR TITLE
oauth2: better error if client credentials are incorrect

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -25,6 +25,7 @@ import requests
 from twisted.internet import defer
 from twisted.internet import threads
 from twisted.logger import Logger
+from twisted.web.error import Error
 
 import buildbot
 from buildbot import config
@@ -125,6 +126,11 @@ class OAuth2Auth(auth.AuthBase):
 
     def createSessionFromToken(self, token):
         s = requests.Session()
+        error = token.get("error")
+        if error:
+            error_description = token.get("error_description") or error
+            msg = f"OAuth2 session: creation failed: {error_description}"
+            raise Error(503, msg)
         s.params = {'access_token': token['access_token']}
         s.verify = self.sslVerify
         return s

--- a/newsfragments/oauth2-improve-error.bugfix
+++ b/newsfragments/oauth2-improve-error.bugfix
@@ -1,0 +1,1 @@
+Improved error message in case of OAuth2 failures.


### PR DESCRIPTION
Instead of trying to access a non-existing token it's better to show the error to the user:
https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
