### PR TITLE
test: Fix integration tests on certain setups with unclean repository

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1233,6 +1233,7 @@ rmdirrecursive
 rmfile
 rmtree
 robocopy
+ropeproject
 routingkey
 rp
 rpc

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -51,7 +51,9 @@ def get_python_module_contents(package_name):
             if dir_entry.is_file() and filename.endswith('.py'):
                 result.add(next_package_name)
 
-            if dir_entry.is_dir():
+            if dir_entry.is_dir() and not filename.startswith('.'):
+                # Ignore hidden directories added by various tooling an user may have, e.g.
+                # .ropeproject
                 result.add(next_package_name)
                 result |= get_python_module_contents(next_package_name)
 


### PR DESCRIPTION
Creating directories that have dots in their names currently will break entrypoints integration test.
