### PR TITLE
requirements: Upgrade buildbot-www to 4.0.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==3.11.3
+buildbot-www==4.0.0
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore


### PR DESCRIPTION
This is needed for the unit tests to use correct www format. 3.x was AnularJS, 4.0 is React.