### PR TITLE
Makefile: Don't gpg sign files released to Pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ finishrelease:
 	rm -rf dist
 	python3 ./common/download_release.py
 	rm -rf ./dist/v*
-	twine upload --sign dist/*
+	twine upload dist/*
 
 pyinstaller: virtualenv
 	$(PIP) install pyinstaller


### PR DESCRIPTION
Pypi does not use GPG signatures since 2023, so it does not make sense to sign all release files being uploaded there.
