### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 26"

### DIFF
--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -66,6 +66,7 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         def collapseRequests_fn(master, builder, brdict1, brdict2):
             # Allow all requests
             self.fail("Should never be called")
+            # pylint: disable=unreachable
             return True
 
         self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -30,7 +30,7 @@ Automat==22.10.0
 Babel==2.15.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
-botocore==1.34.127
+botocore==1.34.136
 certifi==2024.7.4
 cffi==1.16.0
 chardet==5.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,7 +9,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 boto3==1.34.136
 msgpack==1.0.8
 Markdown==3.6
-pylint==3.2.3
+pylint==3.2.5
 ruff==0.4.9
 mypy==1.9.0
 mypy-zope==1.0.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,7 +12,7 @@ Markdown==3.6
 pylint==3.2.5
 ruff==0.5.0
 mypy==1.10.1
-mypy-zope==1.0.4
+mypy-zope==1.0.5
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests
 # are reproducible. The versions should be upgraded whenever we see new versions to catch problems

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -75,7 +75,7 @@ markdown2==2.4.13
 MarkupSafe==2.1.5
 mccabe==0.7.0
 more-itertools==10.3.0
-moto==5.0.9
+moto==5.0.10
 olefile==0.47
 packaging==24.1
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -54,7 +54,7 @@ future==1.0.0
 graphql-core==3.3.0a4; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
 graphql-core==3.2.3; python_version < "3.12"
 greenlet==3.0.3
-hvac==2.2.0
+hvac==2.3.0
 hyperlink==21.0.0
 idna==3.7
 imagesize==1.4.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,7 +21,7 @@ mypy-zope==1.0.4
 
 alabaster==0.7.16; python_version >= "3.9"
 alabaster==0.7.13; python_version < "3.9" # pyup: ignore 0.7.14 dropped support for Python 3.8 and earlier
-alembic==1.13.1
+alembic==1.13.2
 appdirs==1.4.4
 asn1crypto==1.5.1
 astroid==3.2.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,7 +11,7 @@ msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.5
 ruff==0.5.0
-mypy==1.9.0
+mypy==1.10.1
 mypy-zope==1.0.4
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -58,7 +58,7 @@ hvac==2.3.0
 hyperlink==21.0.0
 idna==3.7
 imagesize==1.4.1
-importlib-metadata==7.1.0
+importlib-metadata==8.0.0
 importlib-resources==6.4.0;  python_version < "3.9"
 incremental==22.10.0
 ipaddress==1.0.23

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -103,7 +103,7 @@ requests==2.32.3
 responses==0.25.3
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
-s3transfer==0.10.1
+s3transfer==0.10.2
 service-identity==24.1.0
 setuptools-trial==0.6.0
 singledispatch==4.1.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,7 +10,7 @@ boto3==1.34.136
 msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.5
-ruff==0.4.9
+ruff==0.5.0
 mypy==1.9.0
 mypy-zope==1.0.4
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,7 +39,7 @@ click==8.1.7
 configparser==7.0.0
 constantly==23.10.4
 cookies==2.2.1
-coverage==7.5.3
+coverage==7.5.4
 croniter==2.0.5
 cryptography==42.0.8
 decorator==5.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ buildbot-www==4.0.0
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-boto3==1.34.127
+boto3==1.34.136
 msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -109,7 +109,7 @@ setuptools-trial==0.6.0
 singledispatch==4.1.0
 six==1.16.0
 snowballstemmer==2.2.0
-SQLAlchemy==2.0.30
+SQLAlchemy==2.0.31
 sqlparse==0.5.0
 termcolor==2.4.0
 testtools==2.7.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -81,7 +81,7 @@ packaging==24.1
 parameterized==0.9.0
 pathlib2==2.3.7.post1
 pbr==6.0.0
-Pillow==10.3.0
+Pillow==10.4.0
 platformdirs==4.2.2
 psutil==5.9.8
 pyaml==24.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -83,7 +83,7 @@ pathlib2==2.3.7.post1
 pbr==6.0.0
 Pillow==10.4.0
 platformdirs==4.2.2
-psutil==5.9.8
+psutil==6.0.0
 pyaml==24.4.0
 pyasn1==0.6.0
 pyasn1-modules==0.4.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -22,7 +22,7 @@ parameterized==0.9.0;  python_version >= "3.6"
 pbr==6.0.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
-psutil==5.9.8
+psutil==6.0.0
 pycparser==2.22;  python_version >= "3.6"
 six==1.16.0
 Twisted==24.3.0;  python_version >= "3.6"

--- a/requirements-master-docker-extras.txt
+++ b/requirements-master-docker-extras.txt
@@ -1,4 +1,4 @@
 requests==2.32.3
 psycopg2==2.9.9
 txrequests==0.9.6
-pycairo==1.26.0
+pycairo==1.26.1

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -131,6 +131,7 @@ class RemoveDirectory(base.Command):
         assert isinstance(rc, int)
         if rc == 0:
             defer.returnValue(0)
+            # pylint: disable=unreachable
             return  # pragma: no cover
         # Attempt a recursive chmod and re-try the rm -rf after.
 


### PR DESCRIPTION
This PR is based on https://github.com/buildbot/buildbot/pull/7745 with these modification(s):
- updates `mypy-zope` from `1.0.4` to `1.0.5`
- fixes pylint issue about unreachable code

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
