### PR TITLE
copydb improvements: batched, faster, lower memory footprint 

### DIFF
--- a/newsfragments/copydb-improvements.feature
+++ b/newsfragments/copydb-improvements.feature
@@ -1,0 +1,1 @@
+copy-db script now reads/writes in parallel and in batches. Faster and much more contained memory footprint


### PR DESCRIPTION
copy-db would first fetch all data from a table in memory, and then insert everything in the new database in batches of 10000. It could easy get out-of-memory'ed or fail on full queues. 

This :
* makes it parallel (instead of read then write)
* makes it properly batched (instead of fetchall)
* limits the memory usage by using a smaller queue. Reader thread will block until writer thread frees slots

This was tested on a database copy from sqlite to mysql containing, among other large tables, a 50GB+ logchunks table. 

## Contributor Checklist:

* [❌  ] I have updated the unit tests _(I have not found any tests testing copy-db)_
* [ ✔️ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [❌  ] I have updated the appropriate documentation _(No behavorial change requiring documentation update in my opinion)_
