### PR TITLE
GitPoller: implement auth by user/password

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -275,7 +275,7 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         return None
 
     @async_to_deferred
-    async def _get_refs(self, refs: list[str] | None = None) -> list[str]:
+    async def _list_remote_refs(self, refs: list[str] | None = None) -> list[str]:
         rows: str = await self._dovccmd(
             'ls-remote', ['--refs', self.repourl] + (refs if refs is not None else [])
         )
@@ -347,13 +347,13 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         trim_ref_head = False
         if callable(self.branches):
             # Get all refs and let callback filter them
-            remote_refs = yield self._get_refs()
+            remote_refs = yield self._list_remote_refs()
             refs = [b for b in remote_refs if self.branches(b)]
         elif self.branches is True:
             # Get all branch refs
-            refs = yield self._get_refs(["refs/heads/*"])
+            refs = yield self._list_remote_refs(["refs/heads/*"])
         elif self.branches:
-            refs = yield self._get_refs([f"refs/heads/{b}" for b in self.branches])
+            refs = yield self._list_remote_refs([f"refs/heads/{b}" for b in self.branches])
             trim_ref_head = True
         else:
             head_ref = yield self._resolve_head_ref()

--- a/master/buildbot/test/runprocess.py
+++ b/master/buildbot/test/runprocess.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
+
 from buildbot.test.steps import ExpectMasterShell
 from buildbot.test.steps import _check_env_is_expected
 from buildbot.util import runprocess
@@ -45,7 +47,7 @@ class MasterRunProcessMixin:
         sigterm_timeout=5,
         initial_stdin=None,
         use_pty=False,
-    ):
+    ) -> defer.Deferred:
         _check_env_is_expected(self, self._master_run_process_expect_env, env)
 
         if not self._expected_master_commands:
@@ -59,12 +61,12 @@ class MasterRunProcessMixin:
             rc = -1
 
         if collect_stdout and collect_stderr:
-            return (rc, stdout, stderr)
+            return defer.succeed((rc, stdout, stderr))
         if collect_stdout:
-            return (rc, stdout)
+            return defer.succeed((rc, stdout))
         if collect_stderr:
-            return (rc, stderr)
-        return rc
+            return defer.succeed((rc, stderr))
+        return defer.succeed(rc)
 
     def _patch_runprocess(self):
         if not self._master_run_process_patched:

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -2117,7 +2117,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         yield self.assert_last_rev({'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'})
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700)])
         write_local_file_mock.assert_called_with(key_path, 'ssh-key\n', mode=0o400)
 
     @mock.patch(
@@ -2165,7 +2165,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         yield self.assert_last_rev({'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'})
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700)])
         write_local_file_mock.assert_called_with(key_path, 'ssh-key\n', mode=0o400)
 
     @mock.patch(
@@ -2210,7 +2210,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
         self.assert_all_commands_ran()
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700)])
         write_local_file_mock.assert_called_with(key_path, 'ssh-key\n', mode=0o400)
 
 
@@ -2272,11 +2272,9 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
         yield self.assert_last_rev({'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'})
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700)])
 
         expected_file_writes = [
-            mock.call(key_path, 'ssh-key\n', mode=0o400),
-            mock.call(known_hosts_path, '* ssh-host-key', mode=0o400),
             mock.call(key_path, 'ssh-key\n', mode=0o400),
             mock.call(known_hosts_path, '* ssh-host-key', mode=0o400),
         ]
@@ -2345,11 +2343,9 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
         yield self.assert_last_rev({'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'})
 
         temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
-        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700), (temp_dir_path, 0o700)])
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700)])
 
         expected_file_writes = [
-            mock.call(key_path, 'ssh-key\n', mode=0o400),
-            mock.call(known_hosts_path, 'ssh-known-hosts', mode=0o400),
             mock.call(key_path, 'ssh-key\n', mode=0o400),
             mock.call(known_hosts_path, 'ssh-known-hosts', mode=0o400),
         ]

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -39,6 +39,7 @@ from buildbot.test.util import logging
 from buildbot.test.util.git_repository import TestGitRepository
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
+from buildbot.util.git_credential import GitCredentialOptions
 from buildbot.util.twisted import async_to_deferred
 
 # Test that environment variables get propagated to subprocesses (See #2116)
@@ -2351,6 +2352,78 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
         ]
 
         self.assertEqual(expected_file_writes, write_local_file_mock.call_args_list)
+
+
+class TestGitPollerWithAuthCredentials(TestGitPollerBase):
+    def createPoller(self):
+        return gitpoller.GitPoller(
+            self.REPOURL,
+            branches=['master'],
+            auth_credentials=('username', 'token'),
+            git_credentials=GitCredentialOptions(
+                credentials=[],
+            ),
+        )
+
+    @mock.patch(
+        'buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+        new_callable=MockPrivateTemporaryDirectory,
+    )
+    @defer.inlineCallbacks
+    def test_poll_initial_2_10(self, temp_dir_mock):
+        temp_dir_path = os.path.join('basedir', 'gitpoller-work', '.buildbot-ssh@@@')
+        credential_store_filepath = os.path.join(temp_dir_path, '.git-credentials')
+        self.expect_commands(
+            ExpectMasterShell(['git', '--version']).stdout(b'git version 2.10.0\n'),
+            ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                'credential.helper=',
+                '-c',
+                f'credential.helper=store "--file={credential_store_filepath}"',
+                'credential',
+                'approve',
+            ]).workdir(temp_dir_path),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                'credential.helper=',
+                '-c',
+                f'credential.helper=store "--file={credential_store_filepath}"',
+                'ls-remote',
+                '--refs',
+                self.REPOURL,
+                'refs/heads/master',
+            ]).stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\trefs/heads/master\n'),
+            ExpectMasterShell([
+                'git',
+                '-c',
+                'credential.helper=',
+                '-c',
+                f'credential.helper=store "--file={credential_store_filepath}"',
+                'fetch',
+                '--progress',
+                self.REPOURL,
+                f'+refs/heads/master:refs/buildbot/{self.REPOURL_QUOTED}/heads/master',
+                '--',
+            ]).workdir(self.POLLER_WORKDIR),
+            ExpectMasterShell([
+                'git',
+                'rev-parse',
+                f'refs/buildbot/{self.REPOURL_QUOTED}/heads/master',
+            ])
+            .workdir(self.POLLER_WORKDIR)
+            .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
+        )
+
+        self.poller.doPoll.running = True
+        yield self.poller.poll()
+
+        self.assert_all_commands_ran()
+        yield self.assert_last_rev({'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'})
+
+        self.assertEqual(temp_dir_mock.dirs, [(temp_dir_path, 0o700)])
 
 
 class TestGitPollerConstructor(

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -292,11 +292,15 @@ class AbstractGitAuth(ComparableMixin):
 
         check_ssh_config('Git', self.ssh_private_key, self.ssh_host_key, self.ssh_known_hosts)
 
+    @property
+    def is_auth_needed(self) -> bool:
+        return self.ssh_private_key is not None or self.git_credential_options is not None
+
     def is_auth_needed_for_git_command(self, git_command: str) -> bool:
         if not git_command:
             return False
 
-        if self.ssh_private_key is None and self.git_credential_options is None:
+        if not self.is_auth_needed:
             return False
 
         git_commands_that_need_auth = [

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -37,8 +37,8 @@ from buildbot.util.misc import writeLocalFile
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    from buildbot.changes.gitpoller import GitPoller
     from buildbot.interfaces import IRenderable
-    from buildbot.util.service import BuildbotService
 
 RC_SUCCESS = 0
 
@@ -669,14 +669,15 @@ class GitStepAuth(AbstractGitAuth):
 class GitServiceAuth(AbstractGitAuth):
     def __init__(
         self,
-        service: BuildbotService,
+        service: GitPoller,
         ssh_private_key: IRenderable | None = None,
         ssh_host_key: IRenderable | None = None,
         ssh_known_hosts: IRenderable | None = None,
+        git_credential_options: GitCredentialOptions | None = None,
     ) -> None:
         self._service = service
 
-        super().__init__(ssh_private_key, ssh_host_key, ssh_known_hosts)
+        super().__init__(ssh_private_key, ssh_host_key, ssh_known_hosts, git_credential_options)
 
     @property
     def _path_module(self):
@@ -686,6 +687,21 @@ class GitServiceAuth(AbstractGitAuth):
     def _master(self):
         assert self._service.master is not None
         return self._service.master
+
+    @async_to_deferred
+    async def _dovccmd(
+        self,
+        command: list[str],
+        initial_stdin: str | None = None,
+        workdir: str | None = None,
+    ) -> None:
+        await self._service._dovccmd(
+            command=command[0],
+            args=command[1:],
+            initial_stdin=initial_stdin,
+            path=workdir,
+            auth_files_path=workdir,  # this is ... not great
+        )
 
     @async_to_deferred
     async def _download_file(

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -967,6 +967,16 @@ It accepts the following arguments:
    `sshPrivateKey` must be specified in order to use this option.
    `sshHostKey` must not be specified in order to use this option.
 
+``auth_credentials``
+
+    (optional) An username/password tuple to use when running git for fetch operations.
+    The worker's git version needs to be at least 1.7.9.
+
+``git_credentials``
+
+    (optional) See :ref:`GitCredentialOptions`.
+    The worker's git version needs to be at least 1.7.9.
+
 A configuration for the Git poller might look like this:
 
 .. code-block:: python

--- a/newsfragments/gitpoller-credential-auth.feature
+++ b/newsfragments/gitpoller-credential-auth.feature
@@ -1,0 +1,1 @@
+:bb:chsrc:`GitPoller` now supports authentication with username/password. Credentials can be provided through the `auth_credentials` and/or `git_credentials` parameters.


### PR DESCRIPTION
Closes #7384 

As was implemented in #7543 for Git steps, this implement auth by user/password for GitPoller.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
