### PR TITLE
waterfall_view: Fix builder results color (in header)

### DIFF
--- a/newsfragments/www-waterfall-builderresults-class.bugfix
+++ b/newsfragments/www-waterfall-builderresults-class.bugfix
@@ -1,0 +1,1 @@
+waterfall_view: Fix results color shown on builder's header (should be same as its last build)

--- a/www/waterfall_view/src/views/WaterfallView/Visualizer.ts
+++ b/www/waterfall_view/src/views/WaterfallView/Visualizer.ts
@@ -150,7 +150,7 @@ export class Visualizer {
 
   getClassForBuilderResults(builder: Builder) {
     const builds = this.builderToBuilds.get(builder.builderid);
-    return results2class(builds === undefined ? null : builds[builds.length - 1], null);
+    return results2class(builds === undefined ? null : builds[0], null);
   }
 
   getHeaderHeight() {


### PR DESCRIPTION
builderToBuilds is filled with the results of the builder query, which is sorted in descending order of start time.
The first entry is the last build and should be the one picked for the overall builder results.

Before:
<img width="418" alt="Capture d’écran 2024-07-09 à 01 24 00" src="https://github.com/buildbot/buildbot/assets/1238961/c8de7873-3616-43c3-b78c-8f31aeb38b78">
After:
<img width="424" alt="Capture d’écran 2024-07-09 à 01 37 59" src="https://github.com/buildbot/buildbot/assets/1238961/91de9081-c065-4227-9bd0-8846ffb91d3a">

## Contributor Checklist:

*  I have *not* updated the unit tests. Nothing relevant
*  I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
*  I have *not* updated the appropriate documentation. Nothing relevant
