### PR TITLE
waterfall_view: Allow float scaling_waterfall setting

### DIFF
--- a/newsfragments/www-waterfall-scaling.change
+++ b/newsfragments/www-waterfall-scaling.change
@@ -1,0 +1,1 @@
+waterfall_view: Allow floating scaling_waterfall setting (for a more condensed view)

--- a/www/waterfall_view/src/views/WaterfallView/WaterfallView.tsx
+++ b/www/waterfall_view/src/views/WaterfallView/WaterfallView.tsx
@@ -100,7 +100,7 @@ export const WaterfallView = observer(() => {
 
   const settings = buildbotGetSettings();
   const [scalingFactor, setScalingFactor] =
-    useState(() => settings.getIntegerSetting("Waterfall.scaling_waterfall"));
+    useState(() => settings.getFloatSetting("Waterfall.scaling_waterfall"));
   const lazyLoadingLimit = settings.getIntegerSetting("Waterfall.lazy_limit_waterfall");
   const showBuildersWithoutBuilds =
     settings.getBooleanSetting("Waterfall.show_builders_without_builds");
@@ -254,7 +254,7 @@ buildbotSetupPlugin(reg => {
     name: 'Waterfall',
     caption: 'Waterfall related settings',
     items: [{
-        type: 'integer',
+        type: 'float',
         name: 'scaling_waterfall',
         caption: 'Scaling factor',
         defaultValue: 1


### PR DESCRIPTION
A float instead of integer for scaling_waterfall setting can allow for a more condensed view by allowing values below 1.

This also fixes a bug where one would hit the "zoom out" button, causing a below-1 scaling factor, then move to the setting page and back to the waterfall page, causing a squashed waterfall with a scaling factor of 0.

As an example, our buildbot install uses a waterfall view with a default scaling_waterfall factor of 0.05, showing a couple days build history among 50 or so builders.

## Contributor Checklist:

* I have *not* updated the unit tests. Nothing relevant.
* I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* I have *not* updated the appropriate documentation. Nothing relevant
