### PR TITLE
Fix #2860: Failed FileUpload step generates a 0-sized file

### DIFF
--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -18,6 +18,7 @@ module for regrouping all FileWriterImpl and FileReaderImpl away from steps
 """
 
 import os
+import shutil
 import tarfile
 import tempfile
 from io import BytesIO
@@ -86,10 +87,13 @@ class FileWriter(base.FileWriterImpl):
         fp = getattr(self, "fp", None)
         if fp:
             fp.close()
-            if self.destfile and os.path.exists(self.destfile):
-                os.unlink(self.destfile)
-            if self.tmpname and os.path.exists(self.tmpname):
-                os.unlink(self.tmpname)
+            self.purge()
+
+    def purge(self):
+        if self.destfile and os.path.exists(self.destfile):
+            os.unlink(self.destfile)
+        if self.tmpname and os.path.exists(self.tmpname):
+            os.unlink(self.tmpname)
 
 
 class DirectoryWriter(FileWriter):
@@ -129,6 +133,11 @@ class DirectoryWriter(FileWriter):
             else:
                 archive.extractall(path=self.destroot)
         os.remove(self.tarname)
+
+    def purge(self):
+        super().purge()
+        if os.path.isdir(self.destroot):
+            shutil.rmtree(self.destroot)
 
 
 class FileReader(base.FileReaderImpl):

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -110,7 +110,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
         f = BuildFactory()
 
-        f.addStep(FileUpload(workersrc="dir/noexist_path", masterdest="master_dest"))
+        f.addStep(step)
         c['builders'] = [BuilderConfig(name="testy", workernames=["local1"], factory=f)]
         yield self.setup_master(c)
 
@@ -179,7 +179,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
-        res = yield self.checkBuildStepLogExist(build, "Cannot open file")
+        res = yield self.checkBuildStepLogExist(build, "Cannot read directory")
         self.assertTrue(res)
 
     @defer.inlineCallbacks
@@ -189,7 +189,7 @@ class TransferStepsMasterPb(RunMasterBase):
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
-        res = yield self.checkBuildStepLogExist(build, "Cannot open file")
+        res = yield self.checkBuildStepLogExist(build, "No such file or directory")
         self.assertTrue(res)
 
 

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -171,6 +171,7 @@ class TransferStepsMasterPb(RunMasterBase):
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
         self.assertTrue(res)
+        self.assertFalse(os.path.exists("master_dest"))
 
     @defer.inlineCallbacks
     def test_no_exist_directory_upload(self):
@@ -181,6 +182,7 @@ class TransferStepsMasterPb(RunMasterBase):
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot read directory")
         self.assertTrue(res)
+        self.assertFalse(os.path.exists("master_dest"))
 
     @defer.inlineCallbacks
     def test_no_exist_multiple_file_upload(self):
@@ -189,8 +191,9 @@ class TransferStepsMasterPb(RunMasterBase):
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
-        res = yield self.checkBuildStepLogExist(build, "No such file or directory")
+        res = yield self.checkBuildStepLogExist(build, "not available at worker")
         self.assertTrue(res)
+        self.assertEqual(self.readMasterDirContents("master_dest"), {})
 
 
 class TransferStepsMasterNull(TransferStepsMasterPb):

--- a/newsfragments/upload-steps-clean-on-failure.bugfix
+++ b/newsfragments/upload-steps-clean-on-failure.bugfix
@@ -1,0 +1,1 @@
+Transfer build steps (:bb:step:`FileUpload`, :bb:step:`DirectoryUpload`, :bb:step:`MultipleFileUpload`, :bb:step:`FileDownload`, and :bb:step:`StringDownload`) now correctly remove destination on failure, no longer leaving partial content (:issue:`2860`)


### PR DESCRIPTION
Cleanup was left to `FileWrite.cancel` which would only remove destination if `remote_close` was not called.
Worker would call `remote_close`, even on failure. This lead to `cancel` not cleaning the destination file as it assumed process ended without issue.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
