### PR TITLE
Data: fix BuildPropertiesEndpoint

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -249,14 +249,14 @@ class NestedBuildDataRetriever:
             return self.build_dict
 
         if 'build_number' in self.args:
-            builder_dict = await self.get_builder_dict()
+            builder_id = await self.get_builder_id()
 
-            if builder_dict is None:
+            if builder_id is None:
                 self.build_dict = None
                 return None
 
             self.build_dict = await self.master.db.builds.getBuildByNumber(
-                builderid=builder_dict.id, number=self.args['build_number']
+                builderid=builder_id, number=self.args['build_number']
             )
             return self.build_dict
 

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -38,12 +38,12 @@ class BuildPropertiesEndpoint(base.Endpoint):
         /builds/n:buildid/properties
     """
 
+    @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
-        buildid = kwargs.get("buildid", None)
-        if buildid is None:
-            # fixme: this cannot work...
-            buildid = kwargs.get("build_number")
-        return self.master.db.builds.getBuildProperties(buildid)
+        retriever = base.NestedBuildDataRetriever(self.master, kwargs)
+        buildid = yield retriever.get_build_id()
+        build_properties = yield self.master.db.builds.getBuildProperties(buildid)
+        return build_properties
 
 
 class PropertiesListEndpoint(base.Endpoint):

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -61,11 +61,12 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         self.setUpEndpoint()
         self.db.insert_test_data([
+            fakedb.Builder(id=1),
             fakedb.Buildset(id=28),
-            fakedb.BuildRequest(id=5, buildsetid=28),
+            fakedb.BuildRequest(id=5, buildsetid=28, builderid=1),
             fakedb.Master(id=3),
             fakedb.Worker(id=42, name="Friday"),
-            fakedb.Build(id=786, buildrequestid=5, masterid=3, workerid=42),
+            fakedb.Build(id=786, buildrequestid=5, masterid=3, workerid=42, builderid=1, number=5),
             fakedb.BuildProperty(buildid=786, name="year", value=1651, source="Wikipedia"),
             fakedb.BuildProperty(buildid=786, name="island_name", value="despair", source="Book"),
         ])
@@ -81,7 +82,7 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_properties_from_builder(self):
-        props = yield self.callGet(('builders', 1, 'builds', 786, 'properties'))
+        props = yield self.callGet(('builders', 1, 'builds', 5, 'properties'))
         self.assertEqual(props, {'year': (1651, 'Wikipedia'), 'island_name': ("despair", 'Book')})
 
 

--- a/newsfragments/data-BuildPropertiesEndpoint.bugfix
+++ b/newsfragments/data-BuildPropertiesEndpoint.bugfix
@@ -1,0 +1,1 @@
+``/builders/n:builderid/builds/n:build_number/properties`` endpoint would use ``build_number`` as ``buildid``


### PR DESCRIPTION
`BuildPropertiesEndpoint` would use `build_number` as `buildid`, which would result in properties from an entirely unexpected build to be returned.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
