### PR TITLE
3.11 backports: Makefile: Don't gpg sign files released to Pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ finishrelease:
 	rm -rf dist
 	python3 ./common/download_release.py
 	rm -rf ./dist/v*
-	twine upload --sign dist/*
+	twine upload dist/*
 
 pyinstaller: virtualenv
 	$(PIP) install pyinstaller


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7758.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7770.