### PR TITLE
4.0 backports: waterfall_view: Allow float scaling_waterfall setting

### DIFF
--- a/newsfragments/www-waterfall-scaling.change
+++ b/newsfragments/www-waterfall-scaling.change
@@ -1,0 +1,1 @@
+waterfall_view: Allow floating scaling_waterfall setting (for a more condensed view)

--- a/www/react-waterfall_view/src/views/WaterfallView/WaterfallView.tsx
+++ b/www/react-waterfall_view/src/views/WaterfallView/WaterfallView.tsx
@@ -100,7 +100,7 @@ export const WaterfallView = observer(() => {
 
   const settings = buildbotGetSettings();
   const [scalingFactor, setScalingFactor] =
-    useState(() => settings.getIntegerSetting("Waterfall.scaling_waterfall"));
+    useState(() => settings.getFloatSetting("Waterfall.scaling_waterfall"));
   const lazyLoadingLimit = settings.getIntegerSetting("Waterfall.lazy_limit_waterfall");
   const showBuildersWithoutBuilds =
     settings.getBooleanSetting("Waterfall.show_builders_without_builds");
@@ -254,7 +254,7 @@ buildbotSetupPlugin(reg => {
     name: 'Waterfall',
     caption: 'Waterfall related settings',
     items: [{
-        type: 'integer',
+        type: 'float',
         name: 'scaling_waterfall',
         caption: 'Scaling factor',
         defaultValue: 1

--- a/www/waterfall_view/src/views/WaterfallView/WaterfallView.tsx
+++ b/www/waterfall_view/src/views/WaterfallView/WaterfallView.tsx
@@ -100,7 +100,7 @@ export const WaterfallView = observer(() => {
 
   const settings = buildbotGetSettings();
   const [scalingFactor, setScalingFactor] =
-    useState(() => settings.getIntegerSetting("Waterfall.scaling_waterfall"));
+    useState(() => settings.getFloatSetting("Waterfall.scaling_waterfall"));
   const lazyLoadingLimit = settings.getIntegerSetting("Waterfall.lazy_limit_waterfall");
   const showBuildersWithoutBuilds =
     settings.getBooleanSetting("Waterfall.show_builders_without_builds");
@@ -254,7 +254,7 @@ buildbotSetupPlugin(reg => {
     name: 'Waterfall',
     caption: 'Waterfall related settings',
     items: [{
-        type: 'integer',
+        type: 'float',
         name: 'scaling_waterfall',
         caption: 'Scaling factor',
         defaultValue: 1


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7766.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7759.