### PR TITLE
www: Fix loading of plugin settings from master

### DIFF
--- a/newsfragments/www-plugin-settings-load.bugfix
+++ b/newsfragments/www-plugin-settings-load.bugfix
@@ -1,0 +1,1 @@
+Fix loading of plugins settings (e.g. from master's ui_default_config)

--- a/www/base/src/index.tsx
+++ b/www/base/src/index.tsx
@@ -48,8 +48,6 @@ const doRender = (buildbotFrontendConfig: Config) => {
   const sidebarStore = new SidebarStore();
   const topbarStore = new TopbarStore();
   initializeGlobalSetup(buildbotFrontendConfig);
-  globalSettings.applyBuildbotConfig(buildbotFrontendConfig);
-  globalSettings.load();
 
   for (const pluginKey in buildbotFrontendConfig.plugins) {
     // TODO: in production this could be added to the document by buildbot backend

--- a/www/base/src/plugins/GlobalSettings.test.ts
+++ b/www/base/src/plugins/GlobalSettings.test.ts
@@ -374,4 +374,57 @@ describe('GlobalSettings', () => {
     );
     localStorage.clear();
   });
+
+  it('setting loading late group addition', () => {
+    localStorage.clear();
+
+    localStorage.setItem("settings",
+      "{\"Group\":{\"setting_string\":\"value1\",\"setting_integer\":345,\"setting_boolean\":false}}");
+
+    const frontendConfig = {
+      "Group.setting_string" : "value456",
+      "Group.setting_integer": "789",
+      "Group.setting_integer_2": "234",
+      "Group.setting_boolean": "true"
+    };
+
+    const settings = new GlobalSettings();
+    // early load before Group is added
+    settings.fillDefaults(frontendConfig);
+    settings.load();
+
+    settings.addGroup({
+      name: 'Group',
+      caption: 'group caption',
+      items: [{
+        type: 'string',
+        name: 'setting_string',
+        caption: 'caption1',
+        defaultValue: "default1"
+      }, {
+        type: 'integer',
+        name: 'setting_integer',
+        caption: 'caption2',
+        defaultValue: 123
+      }, {
+        type: 'boolean',
+        name: 'setting_boolean',
+        caption: 'caption3',
+        defaultValue: true
+      }, {
+        type: 'integer',
+        name: 'setting_integer_2',
+        caption: 'caption4',
+        defaultValue: 123
+      }]
+    });
+    settings.fillDefaults(frontendConfig, 'Group');
+    settings.load('Group');
+
+    expect(settings.getSetting("Group.setting_string")).toEqual("value1");
+    expect(settings.getSetting("Group.setting_integer")).toEqual(345);
+    expect(settings.getSetting("Group.setting_boolean")).toEqual(false);
+    expect(settings.getSetting("Group.setting_integer_2")).toEqual(234);
+    localStorage.clear();
+  });
 });

--- a/www/base/src/plugins/GlobalSettings.ts
+++ b/www/base/src/plugins/GlobalSettings.ts
@@ -64,14 +64,19 @@ export class GlobalSettings implements ISettings {
     makeObservable(this);
   }
 
-  @action applyBuildbotConfig(config: Config) {
+  @action applyBuildbotConfig(config: Config, filterGroup?: string) {
     if (config.ui_default_config !== undefined) {
-      this.fillDefaults(config.ui_default_config);
+      this.fillDefaults(config.ui_default_config, filterGroup);
     }
   }
 
-  @action fillDefaults(uiConfig: {[key: string]: any}) {
+  @action fillDefaults(uiConfig: {[key: string]: any}, filterGroup?: string) {
     for (const [selector, value] of Object.entries(uiConfig)) {
+      if (filterGroup !== undefined) {
+        const groupAndSetting = this.splitSelector(selector);
+        if (groupAndSetting === null || groupAndSetting[0] != filterGroup)
+          continue;
+      }
       this.setSettingDefaultValue(selector, value);
     }
   }
@@ -101,7 +106,7 @@ export class GlobalSettings implements ISettings {
     }
   }
 
-  @action load() {
+  @action load(filterGroup?: string) {
     const settings = localStorage.getItem('settings');
     if (settings === null) {
       return;
@@ -109,6 +114,8 @@ export class GlobalSettings implements ISettings {
     try {
       const storedGroups = JSON.parse(settings) as StoredSettingGroups;
       for (const [groupName, storedGroup] of Object.entries(storedGroups)) {
+        if (filterGroup !== undefined && groupName != filterGroup)
+           continue;
         if (!(groupName in this.groups)) {
           console.log(`Ignoring unknown loaded setting group ${groupName}`);
           continue;

--- a/www/base/src/plugins/GlobalSetup.ts
+++ b/www/base/src/plugins/GlobalSetup.ts
@@ -32,7 +32,11 @@ export function initializeGlobalSetup(config: Config) {
     callback({
       registerMenuGroup: (group: GroupSettings) => { globalMenuSettings.addGroup(group); },
       registerRoute: (route: RouteConfig) => { globalRoutes.addRoute(route); },
-      registerSettingGroup: (group: SettingGroupConfig) => { globalSettings.addGroup(group); },
+      registerSettingGroup: (group: SettingGroupConfig) => {
+        globalSettings.addGroup(group);
+        globalSettings.applyBuildbotConfig(config, group.name);
+        globalSettings.load(group.name);
+      },
     }, config);
   }
   registerPluginRegistrationConsumer(onBuildbotSetupPlugin);


### PR DESCRIPTION
Settings that are set via ui_default_config currently fail to be applied because `applyBuildbotConfig` is called before the plugin's javascript is added, and therefore before the plugin registers its settings group.

This results in errors such as :
`bad setting name Waterfall.show_old_builders: group does not exist`

In this PR, I fixed this issue by deferring the load of global and local settings for a specific group to the moment the group is added to GlobalSettings (i.e. when each plugin registers itself). 

I suppose there could be other ways to fix this. For example :
* by waiting for all plugins to be registered before global and local settings are applied once. (`pluginScript.onload` ?)
* by applying ALL global and local settings on every single plugin registration

Please let me know if the solution I implemented is unsatisfactory.

## Contributor Checklist:

* I have updated the unit tests and added a new one to test the group-specific load.
* I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* I have not updated the appropriate documentation. Nothing relevant
