### PR TITLE
waterfall_view: builds are now clickable links to their build page

### DIFF
--- a/newsfragments/www-waterfall-build-links.feature
+++ b/newsfragments/www-waterfall-build-links.feature
@@ -1,0 +1,1 @@
+waterfall_view: builds in waterfall view now link to their build page


### PR DESCRIPTION
Builds in waterfall view now directly link to their own page. 

## Contributor Checklist:

* I have not updated the unit tests. Nothing relevant
* I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* I have not updated the appropriate documentation. Nothing relevant
