### PR TITLE
4.0 backports: waterfall_view: Fix builder results color (in header)

### DIFF
--- a/newsfragments/www-waterfall-builderresults-class.bugfix
+++ b/newsfragments/www-waterfall-builderresults-class.bugfix
@@ -1,0 +1,1 @@
+waterfall_view: Fix results color shown on builder's header (should be same as its last build)

--- a/www/react-waterfall_view/src/views/WaterfallView/Visualizer.ts
+++ b/www/react-waterfall_view/src/views/WaterfallView/Visualizer.ts
@@ -150,7 +150,7 @@ export class Visualizer {
 
   getClassForBuilderResults(builder: Builder) {
     const builds = this.builderToBuilds.get(builder.builderid);
-    return results2class(builds === undefined ? null : builds[builds.length - 1], null);
+    return results2class(builds === undefined ? null : builds[0], null);
   }
 
   getHeaderHeight() {

--- a/www/waterfall_view/src/views/WaterfallView/Visualizer.ts
+++ b/www/waterfall_view/src/views/WaterfallView/Visualizer.ts
@@ -150,7 +150,7 @@ export class Visualizer {
 
   getClassForBuilderResults(builder: Builder) {
     const builds = this.builderToBuilds.get(builder.builderid);
-    return results2class(builds === undefined ? null : builds[builds.length - 1], null);
+    return results2class(builds === undefined ? null : builds[0], null);
   }
 
   getHeaderHeight() {


### PR DESCRIPTION
This PR backports  https://github.com/buildbot/buildbot/pull/7765.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7759.