### PR TITLE
4.0 backports: waterfall_view: Fix waterfall squashed to a pixel high

### DIFF
--- a/newsfragments/www-waterfall-zero-height.bugfix
+++ b/newsfragments/www-waterfall-zero-height.bugfix
@@ -1,0 +1,1 @@
+Fix cases where waterfall could be squashed to a pixel high

--- a/www/react-waterfall_view/src/views/WaterfallView/WaterfallView.tsx
+++ b/www/react-waterfall_view/src/views/WaterfallView/WaterfallView.tsx
@@ -176,7 +176,7 @@ export const WaterfallView = observer(() => {
       const buildersToShow = buildersQuery.array.filter(b =>
         isBuilderFiltered(b, filterManager, mastersQuery, builderToBuilds, showBuildersWithoutBuilds,
           showOldBuilders));
-      const builderIds = new Set<number>(buildersToShow.keys());
+      const builderIds = new Set(buildersToShow.map(b => b.builderid));
       const buildGroups = groupBuildsByTime(builderIds, buildsQuery.array,
         settings.getIntegerSetting("Waterfall.idle_threshold_waterfall"), Date.now() / 1000);
 

--- a/www/waterfall_view/src/views/WaterfallView/WaterfallView.tsx
+++ b/www/waterfall_view/src/views/WaterfallView/WaterfallView.tsx
@@ -176,7 +176,7 @@ export const WaterfallView = observer(() => {
       const buildersToShow = buildersQuery.array.filter(b =>
         isBuilderFiltered(b, filterManager, mastersQuery, builderToBuilds, showBuildersWithoutBuilds,
           showOldBuilders));
-      const builderIds = new Set<number>(buildersToShow.keys());
+      const builderIds = new Set(buildersToShow.map(b => b.builderid));
       const buildGroups = groupBuildsByTime(builderIds, buildsQuery.array,
         settings.getIntegerSetting("Waterfall.idle_threshold_waterfall"), Date.now() / 1000);
 


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7764.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7759.