### PR TITLE
4.0 backports: Removed useless logs fatal Exception on DB: log with slug ... already exists in this step

### DIFF
--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -18,6 +18,7 @@ from twisted.internet import defer
 
 from buildbot.data import base
 from buildbot.data import types
+from buildbot.db.logs import LogSlugExistsError
 from buildbot.util import identifiers
 
 
@@ -125,7 +126,7 @@ class Log(base.ResourceType):
                 logid = yield self.master.db.logs.addLog(
                     stepid=stepid, name=name, slug=slug, type=type
                 )
-            except KeyError:
+            except LogSlugExistsError:
                 slug = identifiers.incrementIdentifier(50, slug)
                 continue
             self.generateEvent(logid, "new")

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -28,6 +28,7 @@ from twisted.python import threadpool
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.db.buildsets import AlreadyCompleteError
 from buildbot.db.changesources import ChangeSourceAlreadyClaimedError
+from buildbot.db.logs import LogSlugExistsError
 from buildbot.db.schedulers import SchedulerAlreadyClaimedError
 from buildbot.process import metrics
 
@@ -245,6 +246,7 @@ class DBThreadPool:
                             ChangeSourceAlreadyClaimedError,
                             SchedulerAlreadyClaimedError,
                             AlreadyCompleteError,
+                            LogSlugExistsError,
                         ),
                     ):
                         log.err(e, 'Got fatal Exception on DB')

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -19,6 +19,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.data import logs
+from buildbot.db.logs import LogSlugExistsError
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
@@ -227,7 +228,7 @@ class Log(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
         def addLog(stepid, name, slug, type):
             tries.append((stepid, name, slug, type))
             if len(tries) < 3:
-                return defer.fail(KeyError())
+                return defer.fail(LogSlugExistsError())
             return defer.succeed(23)
 
         self.patch(self.master.db.logs, 'addLog', addLog)

--- a/newsfragments/fix-log-slug-exists.misc
+++ b/newsfragments/fix-log-slug-exists.misc
@@ -1,0 +1,1 @@
+Removed useless logs `fatal Exception on DB: log with slug ... already exists in this step`.


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7777.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7759.