### PR TITLE
BuildbotServiceManager raise a config error if two services share the same name

### DIFF
--- a/newsfragments/config-error-on-multiple-service-with-same-name.change
+++ b/newsfragments/config-error-on-multiple-service-with-same-name.change
@@ -1,0 +1,1 @@
+Buildbot will now error when configured with multiple services of the same type are configured with the same name (:issue:6987)


### PR DESCRIPTION
Fixes #6987 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
