### PR TITLE
master/reporters/github: render token for each request

### DIFF
--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -48,7 +48,7 @@ class TestGitHubStatusPush(
             self.master,
             self,
             HOSTED_BASE_URL,
-            headers={'Authorization': 'token XXYYZZ', 'User-Agent': 'Buildbot'},
+            headers={'User-Agent': 'Buildbot'},
             debug=None,
             verify=None,
         )
@@ -74,6 +74,7 @@ class TestGitHubStatusPush(
                 'description': 'Build started.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -84,6 +85,7 @@ class TestGitHubStatusPush(
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -94,6 +96,7 @@ class TestGitHubStatusPush(
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         build['complete'] = False
@@ -177,6 +180,7 @@ class TestGitHubStatusPush(
                 'description': 'Build started.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -187,6 +191,7 @@ class TestGitHubStatusPush(
                 'description': 'Build started.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -197,6 +202,7 @@ class TestGitHubStatusPush(
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -207,6 +213,7 @@ class TestGitHubStatusPush(
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -217,6 +224,7 @@ class TestGitHubStatusPush(
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -227,6 +235,7 @@ class TestGitHubStatusPush(
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         # note that the first sourcestamp only has revision, second only branch and only the third
@@ -306,7 +315,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
             self.master,
             self,
             HOSTED_BASE_URL,
-            headers={'Authorization': 'token XXYYZZ', 'User-Agent': 'Buildbot'},
+            headers={'User-Agent': 'Buildbot'},
             debug=None,
             verify=None,
         )
@@ -334,6 +343,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
                 'description': 'Build started.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -344,6 +354,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -354,6 +365,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         yield self.sp._got_event(('builds', 20, 'new'), build)
@@ -376,6 +388,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
                 'description': 'Build started.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -386,6 +399,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
@@ -396,6 +410,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
                 'description': 'Build done.',
                 'context': 'buildbot/Builder0',
             },
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         yield self.sp._got_event(('builds', 20, 'new'), build)
@@ -415,10 +430,16 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
         build = yield self.insert_build_new()
         # we make sure proper calls to txrequests have been made
         self._http.expect(
-            'post', '/repos/buildbot/buildbot/issues/34/comments', json={'body': 'Build done.'}
+            'post',
+            '/repos/buildbot/buildbot/issues/34/comments',
+            json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
-            'post', '/repos/buildbot/buildbot/issues/34/comments', json={'body': 'Build done.'}
+            'post',
+            '/repos/buildbot/buildbot/issues/34/comments',
+            json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         build['complete'] = False
@@ -445,10 +466,16 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
         build = yield self.insert_build_new()
         # we make sure proper calls to txrequests have been made
         self._http.expect(
-            'post', '/repos/buildbot/buildbot/issues/13/comments', json={'body': 'Build done.'}
+            'post',
+            '/repos/buildbot/buildbot/issues/13/comments',
+            json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
-            'post', '/repos/buildbot/buildbot/issues/13/comments', json={'body': 'Build done.'}
+            'post',
+            '/repos/buildbot/buildbot/issues/13/comments',
+            json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         build['complete'] = False
@@ -473,21 +500,25 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
             'post',
             '/repos/test_user/test_project/issues/4192/comments',
             json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
             '/repos/test_user/test_project/issues/4192/comments',
             json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
             '/repos/test_user/test_project/issues/4192/comments',
             json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
         self._http.expect(
             'post',
             '/repos/test_user/test_project/issues/4192/comments',
             json={'body': 'Build done.'},
+            headers={'Authorization': 'token XXYYZZ'},
         )
 
         # note that the first sourcestamp only has revision, second only branch and only the third

--- a/newsfragments/github-reporter-secret-handling.change
+++ b/newsfragments/github-reporter-secret-handling.change
@@ -1,0 +1,3 @@
+GitHubStatusPush will now render github tokens right before the request.
+This allow to update the token in the configuration file without restarting the server,
+which is useful for Github App installations where tokens are rotated every hour.


### PR DESCRIPTION
Github token can expire i.e. if an GitHub apps are used the token needs to be renewed every hour from the installation token. By moving the renderSecrets just when the requests happens, we provide an interface for users to provide a new refresh GITHUB_TOKEN.


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
