### PR TITLE
Drop future dependency

### DIFF
--- a/newsfragments/drop-future.misc
+++ b/newsfragments/drop-future.misc
@@ -1,0 +1,1 @@
+Drop future dependency as usage of the future library was already dropped in https://github.com/buildbot/buildbot/pull/6997.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -50,7 +50,6 @@ docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
 extras==1.0.0
 fixtures==4.1.0
 funcsigs==1.0.2
-future==1.0.0
 graphql-core==3.3.0a4; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
 graphql-core==3.2.3; python_version < "3.12"
 greenlet==3.0.3

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -10,7 +10,6 @@ constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
 cryptography==42.0.8;  python_version >= "3.6"
 funcsigs==1.0.2
-future==1.0.0
 hyperlink==21.0.0
 idna==3.7
 incremental==22.10.0;  python_version >= "3.6"

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -139,7 +139,6 @@ twisted_ver = ">= 19.2.0"
 
 setup_args['install_requires'] = [
     'twisted ' + twisted_ver,
-    'future',
 ]
 
 if sys.version_info >= (3, 6):


### PR DESCRIPTION
Usage of the future library was already dropped in https://github.com/buildbot/buildbot/pull/6997

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
