### PR TITLE
www: Fix icon paths in two places

### DIFF
--- a/newsfragments/www-fix-the-icon-in-about-pages.bugfix
+++ b/newsfragments/www-fix-the-icon-in-about-pages.bugfix
@@ -1,0 +1,1 @@
+Favicon colors on build views (https://host/#/builders/xx/builds/yy) and the icon on the about page (https://host/#/about) are fixed.

--- a/www/base/src/views/AboutView/AboutView.tsx
+++ b/www/base/src/views/AboutView/AboutView.tsx
@@ -87,7 +87,7 @@ export const AboutView = observer(() => {
       <Card bg="light">
         <Card.Body>
           <h2>
-            <img src="img/icon.svg" alt="" width="64px" className="nut-spin"/>&nbsp;About this&nbsp;
+            <img src="icon.svg" alt="" width="64px" className="nut-spin"/>&nbsp;About this&nbsp;
             <Link to="http://buildbot.net">buildbot</Link>&nbsp;running for&nbsp;
             <Link to={config.titleURL}>{config.title}</Link>
           </h2>

--- a/www/ui/src/util/FavIcon.ts
+++ b/www/ui/src/util/FavIcon.ts
@@ -28,7 +28,7 @@ function setFavIconUrl(url: string) {
 }
 
 function setFavIconUrlOriginal(buildbotUrl: string) {
-  setFavIconUrl(buildbotUrl + "/img/icon.png");
+  setFavIconUrl(buildbotUrl + "/icon.png");
 }
 
 async function setFavIcon(buildbotUrl: string, result: number) {
@@ -37,7 +37,7 @@ async function setFavIcon(buildbotUrl: string, result: number) {
     return;
   }
 
-  const response = await axios.get(buildbotUrl + "/img/icon.svg");
+  const response = await axios.get(buildbotUrl + "/icon.svg");
   const iconSvg = response.data;
 
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
* Favicons in build views

Favicon colors on build views (https://host/#/builders/xx/builds/yy) now correctly changes with the build status

* The icon on about pages (https://host/#/about)

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
