### PR TITLE
smokes-react: Add an e2e test to prevent regression on #7790

### DIFF
--- a/smokes-react/master.cfg
+++ b/smokes-react/master.cfg
@@ -124,7 +124,10 @@ c['www'] = {
         "console_view": {},
         "grid_view": {},
     },
-    "ui_default_config": {'Builders.buildFetchLimit': 201}
+    "ui_default_config": {
+        'Builders.buildFetchLimit': 201,
+        'Waterfall.scaling_waterfall': 1.234
+    }
 }
 
 c['buildbotNetUsageData'] = None

--- a/smokes-react/tests/settings.spec.ts
+++ b/smokes-react/tests/settings.spec.ts
@@ -68,6 +68,12 @@ test.describe('manage settings', function() {
       await SettingsPage.goto(page);
       await SettingsPage.checkIdleTime(page, idleTimeThreshold);
     })
+
+    test('check that custom ui_default_config from master.cfg is loaded', async ({page}) => {
+      await BuilderPage.gotoBuildersList(page);
+      await SettingsPage.goto(page);
+      await SettingsPage.checkScallingFactor(page, '1.234');
+    })
   });
 
   test.describe('console', () => {


### PR DESCRIPTION
As suggested by @p12tic in #7790 , this adds an end-to-end test to prevent regression on the loading of ui_default_config settings for plugins such as Waterfall.

## Contributor Checklist:

* I have added an e2e test.
* [ ] _I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)_
* [ ] _I have updated the appropriate documentation_
