### PR TITLE
config: ensure buildbotURL and titleURL have a trailing '/'

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -134,7 +134,7 @@ class MasterConfig(util.ComparableMixin):
         # default values for all attributes
         # global
         self.title = 'Buildbot'
-        self.titleURL = 'http://buildbot.net'
+        self.titleURL = 'http://buildbot.net/'
         self.buildbotURL = 'http://localhost:8080/'
         self.changeHorizon = None
         self.logCompressionLimit = 4 * 1024
@@ -312,6 +312,12 @@ class MasterConfig(util.ComparableMixin):
         def copy_str_param(name):
             copy_param(name, check_type=(str,), check_type_name='a string')
 
+        def copy_str_url_param_with_trailing_slash(name):
+            copy_str_param(name)
+            url = getattr(self, name, None)
+            if url is not None and not url.endswith('/'):
+                setattr(self, name, url + '/')
+
         copy_str_param('title')
 
         max_title_len = 18
@@ -323,8 +329,8 @@ class MasterConfig(util.ComparableMixin):
                 category=ConfigWarning,
             )
 
-        copy_str_param('titleURL')
-        copy_str_param('buildbotURL')
+        copy_str_url_param_with_trailing_slash('titleURL')
+        copy_str_url_param_with_trailing_slash('buildbotURL')
 
         def copy_str_or_callable_param(name):
             copy_param(

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -47,7 +47,7 @@ from buildbot.warnings import DeprecatedApiWarning
 
 global_defaults = {
     "title": 'Buildbot',
-    "titleURL": 'http://buildbot.net',
+    "titleURL": 'http://buildbot.net/',
     "buildbotURL": 'http://localhost:8080/',
     "logCompressionLimit": 4096,
     "logCompressionMethod": 'gz',
@@ -423,10 +423,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
             self.do_test_load_global({"title": "Very very very very very long title"})
 
     def test_load_global_titleURL(self):
-        self.do_test_load_global({"titleURL": 'hi'}, titleURL='hi')
+        self.do_test_load_global({"titleURL": 'hi'}, titleURL='hi/')
 
     def test_load_global_buildbotURL(self):
-        self.do_test_load_global({"buildbotURL": 'hey'}, buildbotURL='hey')
+        self.do_test_load_global({"buildbotURL": 'hey'}, buildbotURL='hey/')
 
     def test_load_global_changeHorizon(self):
         self.do_test_load_global({"changeHorizon": 10}, changeHorizon=10)

--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -71,7 +71,7 @@ class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         res = json.loads(bytes2unicode(res))
         exp = {
             "authz": {},
-            "titleURL": "http://buildbot.net",
+            "titleURL": "http://buildbot.net/",
             "versions": vjson,
             "title": "Buildbot",
             "auth": {"name": "NoAuth"},
@@ -149,7 +149,7 @@ class IndexResourceTest(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         _auth.maybeAutoLogin.assert_called_with(mock.ANY)
         exp = {
             "authz": {},
-            "titleURL": "http://buildbot.net",
+            "titleURL": "http://buildbot.net/",
             "versions": vjson,
             "title": "Buildbot",
             "auth": {"name": "NoAuth"},

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -306,12 +306,11 @@ Three basic settings describe the buildmaster in status reports:
 
 :bb:cfg:`title` is a short string that will appear at the top of this buildbot installation's home page (linked to the :bb:cfg:`titleURL`).
 
-:bb:cfg:`titleURL` is a URL string that must end with a slash (``/``).
+:bb:cfg:`titleURL` is a URL string.
 HTML status displays will show ``title`` as a link to :bb:cfg:`titleURL`.
 This URL is often used to provide a link from buildbot HTML pages to your project's home page.
 
 The :bb:cfg:`buildbotURL` string should point to the location where the buildbot's internal web server is visible.
-This URL must end with a slash (``/``).
 
 When status notices are sent to users (e.g., by email or over IRC), :bb:cfg:`buildbotURL` will be used to create a URL to the specific build or problem that they are being notified about.
 

--- a/newsfragments/config-urls-trailing-slash.change
+++ b/newsfragments/config-urls-trailing-slash.change
@@ -1,0 +1,1 @@
+Buildbot will now add a trailing '/' to the `buildbotURL` and `titleURL` configured values if it does not have one.


### PR DESCRIPTION
Since it was required in the doc but without config checks, I found it easier to ensure it there.


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
