### PR TITLE
www: Do not trim spaces in logs

### DIFF
--- a/newsfragments/do-not-trim-spaces-in-logs.bugfix
+++ b/newsfragments/do-not-trim-spaces-in-logs.bugfix
@@ -1,0 +1,1 @@
+Do not trim spaces in logs (:issue:7774)

--- a/www/base/src/components/LogPreview/LogPreview.scss
+++ b/www/base/src/components/LogPreview/LogPreview.scss
@@ -12,5 +12,5 @@
 }
 
 .logline > span {
-  white-space: nowrap;
+  white-space: pre;
 }

--- a/www/base/src/components/LogViewer/LogViewerText.scss
+++ b/www/base/src/components/LogViewer/LogViewerText.scss
@@ -79,7 +79,7 @@
 }
 
 .bb-logviewer-text-row > span {
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .bb-logviewer-text-download-log {


### PR DESCRIPTION
This PR does not allow trimming spaces in logs as original log lines should be preserved.
PR fixes issue https://github.com/buildbot/buildbot/issues/7774.

* [not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
