### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 28"

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==4.0.0
+buildbot-www==4.0.1
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -30,7 +30,7 @@ Automat==22.10.0
 Babel==2.15.0
 backports.functools-lru-cache==2.0.0
 boto==2.49.0
-botocore==1.34.136
+botocore==1.34.144
 certifi==2024.7.4
 cffi==1.16.0
 chardet==5.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -74,7 +74,7 @@ markdown2==2.5.0
 MarkupSafe==2.1.5
 mccabe==0.7.0
 more-itertools==10.3.0
-moto==5.0.10
+moto==5.0.11
 olefile==0.47
 packaging==24.1
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -70,7 +70,7 @@ lazy-object-proxy==1.9.0  # pyup: ignore (required by astroid)
 ldap3==2.9.1
 lz4==4.3.3
 Mako==1.3.5
-markdown2==2.4.13
+markdown2==2.5.0
 MarkupSafe==2.1.5
 mccabe==0.7.0
 more-itertools==10.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ buildbot-www==4.0.1
 
 autobahn==23.6.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-boto3==1.34.136
+boto3==1.34.144
 msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.5

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -24,7 +24,7 @@ alabaster==0.7.13; python_version < "3.9" # pyup: ignore 0.7.14 dropped support 
 alembic==1.13.2
 appdirs==1.4.4
 asn1crypto==1.5.1
-astroid==3.2.2
+astroid==3.2.3
 attrs==23.2.0
 Automat==22.10.0
 Babel==2.15.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -46,7 +46,7 @@ decorator==5.1.1
 dicttoxml==1.7.16
 dill==0.3.8
 docker==7.1.0
-docutils==0.18.1  # pyup: ignore (sphinx-rtd-theme 1.2.0 requires docutils<0.19)
+docutils==0.20.1  # pyup: ignore (sphinx-rtd-theme 2.0.0 requires docutils<0.21)
 extras==1.0.0
 fixtures==4.1.0
 funcsigs==1.0.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,7 +39,7 @@ click==8.1.7
 configparser==7.0.0
 constantly==23.10.4
 cookies==2.2.1
-coverage==7.5.4
+coverage==7.6.0
 croniter==2.0.5
 cryptography==42.0.8
 decorator==5.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,7 +10,7 @@ boto3==1.34.144
 msgpack==1.0.8
 Markdown==3.6
 pylint==3.2.5
-ruff==0.5.0
+ruff==0.5.2
 mypy==1.10.1
 mypy-zope==1.0.5
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -114,7 +114,7 @@ termcolor==2.4.0
 testtools==2.7.2
 toml==0.10.2
 tomli==2.0.1
-tomlkit==0.12.5
+tomlkit==0.13.0
 towncrier==23.11.0
 treq==23.11.0;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,5 +1,5 @@
 Sphinx==7.1.2;  python_version < "3.9" # pyup: ignore
-Sphinx==7.3.7;  python_version >= "3.9"
+Sphinx==7.4.3;  python_version >= "3.9"
 sphinx-jinja==2.0.2
 sphinx-rtd-theme==2.0.0
 sphinxcontrib-applehelp==1.0.4;  python_version < "3.9" # pyup: ignore


### PR DESCRIPTION
This PR is based on https://github.com/buildbot/buildbot/pull/7815 with following changes:
- updates docutils from 0.18.1 to 0.20.1

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
