### PR TITLE
www: Fix auth when Buildbot is not hosted at the URL's root

### DIFF
--- a/newsfragments/fix-www-auth-reverseproxy-subpath.bugfix
+++ b/newsfragments/fix-www-auth-reverseproxy-subpath.bugfix
@@ -1,0 +1,1 @@
+Fix ReactUI authentication when Buildbot is hosted behind a reverse proxy not at url's root. (:issue:`7814`)

--- a/www/base/src/components/Loginbar/Loginbar.tsx
+++ b/www/base/src/components/Loginbar/Loginbar.tsx
@@ -24,6 +24,7 @@ import {
 import {useLocation} from "react-router-dom";
 import {Nav, NavDropdown} from "react-bootstrap";
 import {ConfigContext} from "buildbot-ui";
+import { getBaseUrl } from 'buildbot-data-js';
 
 function getAuthIcon(faIcon: string) {
   switch (faIcon) {
@@ -56,7 +57,7 @@ export const Loginbar = () => {
     return (
       <Nav className="bb-loginbar-dropdown-nav">
         <NavDropdown title="Anonymous" id="bb-loginbar-dropdown">
-          <NavDropdown.Item href={"/auth/login?redirect=" + encodeURI(redirect)}>
+          <NavDropdown.Item href={getBaseUrl(window.location, "auth/login?redirect=" + encodeURI(redirect))}>
             {
               config.auth.oauth2
                 ? <span>
@@ -90,7 +91,7 @@ export const Loginbar = () => {
     <Nav className="bb-loginbar-dropdown-nav">
       <NavDropdown title={dropdownToggle} id="bb-loginbar-dropdown">
         {userDropdownHeader}
-        <NavDropdown.Item href={"auth/logout?redirect=" + encodeURI(redirect)}>
+        <NavDropdown.Item href={getBaseUrl(window.location, "auth/logout?redirect=" + encodeURI(redirect))}>
           <FaSignOutAlt/>
           Logout
         </NavDropdown.Item>


### PR DESCRIPTION
I looked over others `href` and did not see other that warranted patching.
Hopefully, that's the last bug regarding hosting Buildbot not at the root URL.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
