### PR TITLE
www: Preserve navigation link as one line on narrow window

### DIFF
--- a/newsfragments/preserve-navigation-link-as-one-line-narrow-window.bugfix
+++ b/newsfragments/preserve-navigation-link-as-one-line-narrow-window.bugfix
@@ -1,0 +1,1 @@
+Preserve navigation link as one line on narrow window (:issue:7818)

--- a/www/base/src/components/Topbar/Topbar.scss
+++ b/www/base/src/components/Topbar/Topbar.scss
@@ -69,6 +69,11 @@ $gl-sidebar-small-threshold: 600px;
   }
 }
 
+div.bb-topbar-navbar-elements {
+  display: flex;
+  flex-direction: row;
+}
+
 // Align navbar with sidebar
 .navbar {
   padding-bottom: 0;


### PR DESCRIPTION
This PR preserves navigation link as one line on narrow window.
PR fixes issue https://github.com/buildbot/buildbot/issues/7818.

* [not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
