### PR TITLE
3.11 backports: waterfall_view: builds are now clickable links to their build page

### DIFF
--- a/newsfragments/www-waterfall-build-links.feature
+++ b/newsfragments/www-waterfall-build-links.feature
@@ -1,0 +1,1 @@
+waterfall_view: builds in waterfall view now link to their build page


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7791.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7803.