### PR TITLE
requirements: Add requirements-pip file with dependencies

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -78,7 +78,7 @@ install:
     cmd: |
       rm -rf /tmp/bbvenv
       python$PYTHON -m venv /tmp/bbvenv
-  - /tmp/bbvenv/bin/pip install -U pip wheel
+  - /tmp/bbvenv/bin/pip install -r requirements-pip.txt
   - condition: TESTS not in ("dev_virtualenv", "smokes", "e2e_react_whl", "e2e_react_tgz", "trial_worker")
     cmd: /tmp/bbvenv/bin/pip install -r requirements-ci.txt
   # On python 3.12 workaround done in dcbc28d1431e1aae892f7fdc0e266253365bc11e is no longer enough.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - 37-dependencies-{{ checksum "requirements-ci.txt" }}-{{ checksum "requirements-cidocs.txt" }}
+            - 37-dependencies-{{ checksum "requirements-ci.txt" }}-{{ checksum "requirements-cidocs.txt" }}-{{ checksum "requirements-pip.txt" }}
             # fallback to using the latest cache if no exact match is found
             - 37-dependencies-
 
@@ -29,7 +29,7 @@ jobs:
             env
             python3.8 -m venv .venv
             . .venv/bin/activate
-            pip install -U pip setuptools wheel
+            pip install -r requirements-pip.txt
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
             pip install pyinstaller
@@ -37,7 +37,7 @@ jobs:
       - save_cache:
           paths:
             - .venv
-          key: 3-dependencies-{{ checksum "requirements-ci.txt" }}-{{ checksum "requirements-cidocs.txt" }}
+          key: 3-dependencies-{{ checksum "requirements-ci.txt" }}-{{ checksum "requirements-cidocs.txt" }}-{{ checksum "requirements-pip.txt" }}
       - run:
           name: run tests
           command: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           python -c "import sys; print(sys.exec_prefix)"
           python -c "import sys; print(sys.executable)"
           python -V -V
-          python -m pip install -U pip setuptools wheel
+          python -m pip install -r requirements-pip.txt
           python -m pip install -r requirements-ci.txt
           python -m pip list
           # Check that pywin32 is properly installed

--- a/.github/workflows/cidb.yml
+++ b/.github/workflows/cidb.yml
@@ -85,6 +85,6 @@ jobs:
             worker/setup.py
             pkg/setup.py
 
-      - run: pip install -U pip wheel
+      - run: pip install -r requirements-pip.txt
       - run: pip install -r requirements-ci.txt -r requirements-cidb.txt
       - run: $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - "python -c \"import sys; print(sys.exec_prefix)\""
   - "python -c \"import sys; print(sys.executable)\""
   - "python -V -V"
-  - "python -m pip install -U pip setuptools wheel"
+  - "python -m pip install -r requirements-pip.txt"
   - "python -m pip install -r requirements-ci.txt"
   - "python -m pip list"
   # Check that pywin32 is properly installed

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,0 +1,3 @@
+pip==24.1.2
+setuptools==70.3.0
+wheel==0.43.0


### PR DESCRIPTION
This PR adds requirements-pip.txt file with relevant `pip`, `wheel` and `setuptools`  dependecies in order to preserve their relevant versions and prevent breaking code after these dependencies are upgraded.
This file is now used instead of `pip install -U <package(s)>`
PR fixes issue https://github.com/buildbot/buildbot/issues/7834.