### PR TITLE
botmaster: fix access to builder with no config

### DIFF
--- a/newsfragments/fix-build-never-finishing.bugfix
+++ b/newsfragments/fix-build-never-finishing.bugfix
@@ -1,0 +1,1 @@
+Fix a rare exception when master is reconfigured with new builders and a build finishing at this time, causing the build to never finish.


### PR DESCRIPTION
`AttributeError: 'NoneType' object has no attribute 'workernames'`

On reconfig with new builder(s),
between `BotMaster.reconfigServiceBuilders` and `Builder.reconfigServiceWithBuildbotConfig`, a builder has it's `config` to `None`.

If a Build finish in this interval, it will eventually call `BotMaster.getBuildersForWorker` from `Build.buildFinished`, which will throw this exception, preventing the build to be marked as finished.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
