### PR TITLE
3.11 backports: www: Do not trim spaces in logs

### DIFF
--- a/newsfragments/do-not-trim-spaces-in-logs.bugfix
+++ b/newsfragments/do-not-trim-spaces-in-logs.bugfix
@@ -1,0 +1,1 @@
+Do not trim spaces in logs (:issue:7774)

--- a/www/react-base/src/components/LogPreview/LogPreview.scss
+++ b/www/react-base/src/components/LogPreview/LogPreview.scss
@@ -12,5 +12,5 @@
 }
 
 .logline > span {
-  white-space: nowrap;
+  white-space: pre;
 }

--- a/www/react-base/src/components/LogViewer/LogViewerText.scss
+++ b/www/react-base/src/components/LogViewer/LogViewerText.scss
@@ -79,7 +79,7 @@
 }
 
 .bb-logviewer-text-row > span {
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .bb-logviewer-text-download-log {


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7816.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7803.