### PR TITLE
3.11 backports: GitPoller: Fix _tracker_ref when repourl port is specified

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -289,7 +289,8 @@ class GitPoller(base.ReconfigurablePollingChangeSource, StateMixin, GitMixin):
         else:
             url_identifier = f"{git_url.proto}/{_sanitize(git_url.domain)}"
             if git_url.port is not None:
-                url_identifier += f":{git_url.port}"
+                # replace `:` with url encode `%3A`
+                url_identifier += f"%3A{git_url.port}"
 
             if git_url.owner is not None:
                 url_identifier += f"/{_sanitize(git_url.owner)}"

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -2253,7 +2253,7 @@ class TestGitPollerUtils(unittest.TestCase):
             gitpoller.GitPoller._tracker_ref(
                 "https://example.org:1234/owner/repo.git", "refs/heads/branch_name"
             ),
-            "refs/buildbot/https/example.org:1234/owner/repo/heads/branch_name",
+            "refs/buildbot/https/example.org%3A1234/owner/repo/heads/branch_name",
         )
 
     def test_tracker_ref_tag(self):
@@ -2261,7 +2261,7 @@ class TestGitPollerUtils(unittest.TestCase):
             gitpoller.GitPoller._tracker_ref(
                 "https://example.org:1234/owner/repo.git", "refs/tags/v1"
             ),
-            "refs/buildbot/https/example.org:1234/owner/repo/tags/v1",
+            "refs/buildbot/https/example.org%3A1234/owner/repo/tags/v1",
         )
 
     def test_tracker_ref_with_credentials(self):
@@ -2269,7 +2269,7 @@ class TestGitPollerUtils(unittest.TestCase):
             gitpoller.GitPoller._tracker_ref(
                 "https://user:password@example.org:1234/owner/repo.git", "refs/heads/branch_name"
             ),
-            "refs/buildbot/https/example.org:1234/owner/repo/heads/branch_name",
+            "refs/buildbot/https/example.org%3A1234/owner/repo/heads/branch_name",
         )
 
     def test_tracker_ref_sub_branch(self):
@@ -2277,7 +2277,7 @@ class TestGitPollerUtils(unittest.TestCase):
             gitpoller.GitPoller._tracker_ref(
                 "https://user:password@example.org:1234/owner/repo.git", "refs/heads/branch_name"
             ),
-            "refs/buildbot/https/example.org:1234/owner/repo/heads/branch_name",
+            "refs/buildbot/https/example.org%3A1234/owner/repo/heads/branch_name",
         )
 
     def test_tracker_ref_not_ref_collision(self):

--- a/newsfragments/fix-gitpoller-refspec-url-with-port.bugfix
+++ b/newsfragments/fix-gitpoller-refspec-url-with-port.bugfix
@@ -1,0 +1,1 @@
+Fix ``GitPoller`` when repourl has the port specified (:issue:`7822`)


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7823.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7803.