### PR TITLE
4.0 backports: Fix #7665: buildbot-badges doesn't work with the new react frontend

### DIFF
--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -305,8 +305,6 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             app.setConfiguration(plugin)
             plugin_root.putChild(unicode2bytes(key), app.resource)
 
-            if not app.ui:
-                del new_config.www['plugins'][key]
         for plugin_name in set(self.apps.names) - known_plugins:
             log.msg(f"NOTE: www plugin {repr(plugin_name)} is installed but not configured")
 

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -336,7 +336,7 @@ PNG generation is based on the CAIRO_ SVG engine, it requires a bit more CPU to 
           'plugins': {'badges': {}}
       }
 
-You can the access your builder's badges using urls like ``http://<buildbotURL>/badges/<buildername>.svg``.
+You can the access your builder's badges using urls like ``http://<buildbotURL>/plugins/badges/<buildername>.svg``.
 The default templates are very much configurable via the following options:
 
 .. code-block:: python
@@ -372,7 +372,7 @@ Those options can be configured either using the plugin configuration:
           'plugins': {'badges': {"left_color": "#222"}}
       }
 
-or via the URL arguments like ``http://<buildbotURL>/badges/<buildername>.svg?left_color=222``.
+or via the URL arguments like ``http://<buildbotURL>/plugins/badges/<buildername>.svg?left_color=222``.
 Custom templates can also be specified in a ``template`` directory nearby the ``master.cfg``.
 
 The badgeio template

--- a/newsfragments/fix-non-ui-www-plugins-reconfig.bugfix
+++ b/newsfragments/fix-non-ui-www-plugins-reconfig.bugfix
@@ -1,0 +1,1 @@
+Fix an issue that would cause non-ui www plugins to not be configured (such as buildbot-badges) (:issue:7665)


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7805.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7804.