### PR TITLE
deps: Add missing dependencies versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             pip install -r requirements-pip.txt
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
-            pip install pyinstaller
+            pip install pyinstaller==6.9.0
 
       - save_cache:
           paths:

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,7 @@ docker-buildbot-master:
 
 $(VENV_NAME):
 	$(VENV_CREATE) $(VENV_NAME)
-	$(VENV_PYTHON) -m pip install --upgrade pip
-	$(PIP) install -U setuptools wheel
+	$(PIP) install -r requirements-pip.txt
 
 # helper for virtualenv creation
 virtualenv: $(VENV_NAME)   # usage: make virtualenv VENV_PY_VERSION=python3.4

--- a/common/smokedist-react.sh
+++ b/common/smokedist-react.sh
@@ -16,8 +16,8 @@ do
         virtualenv --python python$python $VE
     fi
     . $VE/bin/activate
-    pip install -U pip
-    pip install requests flask
+    pip install pip==24.1.2
+    pip install requests==2.32.3 flask==3.0.3
     pip install dist/buildbot-[0-9]*.$suffix
     pip install dist/buildbot?pkg*.$suffix
     pip install dist/*.$suffix


### PR DESCRIPTION
This PR applies missing specific `pip install` packet versions and uses requirements-pip file in Makefile, so that automatic upgrades of packets do not affect tests results anymore.
This PR fixes https://github.com/buildbot/buildbot/issues/7836.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
