### PR TITLE
e2e: Emit full twistd.log in case worker fails to connect

### DIFF
--- a/smokes-react/run.sh
+++ b/smokes-react/run.sh
@@ -43,9 +43,9 @@ buildbot checkconfig workdir
 # on docker buildbot might be a little bit slower to start, so sleep another 20s in case of start to slow.
 buildbot start workdir || sleep 20
 
-trap finish EXIT
-
 buildbot-worker start workdir/worker
+
+trap finish EXIT
 cat workdir/twistd.log &
 
 yarn install --pure-lockfile


### PR DESCRIPTION
Currently in cases master fails to start for some reason the output of the test does not contain any clues as to why the test failed.