### PR TITLE
e2e: Attempt to increase test reliability by ensuring page loaded state

### DIFF
--- a/e2e/tests/buildsnavigation.spec.ts
+++ b/e2e/tests/buildsnavigation.spec.ts
@@ -16,7 +16,6 @@
 */
 
 import {expect, test} from "@playwright/test";
-import {BasePage} from "./pages/base";
 import {BuilderPage} from './pages/builder';
 import {ForcePage} from "./pages/force";
 import {HomePage} from './pages/home';

--- a/e2e/tests/pages/about.ts
+++ b/e2e/tests/pages/about.ts
@@ -16,9 +16,11 @@
 */
 
 import {Page} from "@playwright/test";
+import {BasePage} from "./base";
 
 export class AboutPage {
   static async goto(page: Page) {
     await page.goto('/#/about');
+    await BasePage.waitUntilFinishedLoading(page);
   }
 }

--- a/e2e/tests/pages/base.ts
+++ b/e2e/tests/pages/base.ts
@@ -29,6 +29,7 @@ export class BasePage {
 
   static async loginUser(page: Page, user: string, password: string) {
     await page.goto(`http://${user}:${password}@localhost:8011/auth/login`);
+    await BasePage.waitUntilFinishedLoading(page);
     await expect(page.locator('.dropdown').first()).not.toContainText("Anonymous");
   }
 

--- a/e2e/tests/pages/builder.ts
+++ b/e2e/tests/pages/builder.ts
@@ -21,6 +21,7 @@ import {BasePage} from "./base";
 export class BuilderPage {
   static async gotoBuildersList(page: Page) {
     await page.goto('/#/builders');
+    await BasePage.waitUntilFinishedLoading(page);
   }
 
   static async goto(page: Page, builder: string) {

--- a/e2e/tests/pages/console.ts
+++ b/e2e/tests/pages/console.ts
@@ -17,10 +17,12 @@
 
 import './imports';
 import {Page} from "@playwright/test";
+import {BasePage} from "./base";
 
 export class ConsolePage {
   static async goto(page: Page) {
     await page.goto("/#/console");
+    await BasePage.waitUntilFinishedLoading(page);
   }
 
   static async countSuccess(page: Page) {

--- a/e2e/tests/pages/worker.ts
+++ b/e2e/tests/pages/worker.ts
@@ -21,6 +21,7 @@ import {BasePage} from "./base";
 export class WorkerPage {
   static async gotoWorkerList(page: Page) {
     await page.goto('/#/workers');
+    await BasePage.waitUntilFinishedLoading(page);
   }
 
   static async gotoWorker(page: Page, workerName: string) {


### PR DESCRIPTION
Most pages call BasePage.waitUntilFinishedLoading() but this has been missed in a few places.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
