### PR TITLE
Use less space for Tags column in Builders page when there are no tags

### DIFF
--- a/newsfragments/reduce-tags-column-width-when-no-tags.bugfix
+++ b/newsfragments/reduce-tags-column-width-when-no-tags.bugfix
@@ -1,0 +1,1 @@
+Make Tags column in Builders page take less space when there are no tags

--- a/www/base/src/components/BuildersTable/BuildersTable.tsx
+++ b/www/base/src/components/BuildersTable/BuildersTable.tsx
@@ -130,10 +130,10 @@ export const BuildersTable = observer(
           <td>
             {buildElements}
           </td>
-          <td style={{width: "20%"}}>
+          <td>
             {filterManager.getElementsForTags(builder.tags)}
           </td>
-          <td style={{width: "20%"}}>
+          <td>
             {workerElements}
           </td>
         </tr>
@@ -155,11 +155,11 @@ export const BuildersTable = observer(
       <tr>
         <th>Builder Name</th>
         <th>Builds</th>
-        <th>
+        <th style={{maxWidth: "20%", minWidth: "70px"}}>
           {filterManager.getFiltersHelpElement()}
           {filterManager.getEnabledFiltersElements()}
         </th>
-        <th style={{width: "20%px"}}>Workers</th>
+        <th style={{width: "20%"}}>Workers</th>
       </tr>
       {builderRowElements}
       </tbody>


### PR DESCRIPTION
Taken from https://github.com/buildbot/buildbot/pull/7458.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
