### PR TITLE
deps: bump twisted min version to 21.2.0

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -36,7 +36,7 @@ matrix:
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=19.2.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=21.2.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=1.4.52 NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
@@ -55,7 +55,7 @@ matrix:
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
 
     # Worker tests on python and twisted package combinations.
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=19.2.0 SQLALCHEMY=latest TESTS=trial_worker
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=21.2.0 SQLALCHEMY=latest TESTS=trial_worker
 
     # Configuration when SQLite database is persistent between running tests
     # (by default in other tests in-memory SQLite database is used which is

--- a/master/setup.py
+++ b/master/setup.py
@@ -646,7 +646,7 @@ py_38 = sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_inf
 if not py_38:
     raise RuntimeError("Buildbot master requires at least Python-3.8")
 
-twisted_ver = ">= 19.2.0"
+twisted_ver = ">= 21.2.0"
 
 bundle_version = version.split("-")[0]
 

--- a/newsfragments/twisted-min-21.2.0.removal
+++ b/newsfragments/twisted-min-21.2.0.removal
@@ -1,0 +1,1 @@
+Buildbot now requires Twisted 21.2.0 or newer.

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -135,7 +135,7 @@ setup_args = {
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
-twisted_ver = ">= 19.2.0"
+twisted_ver = ">= 21.2.0"
 
 setup_args['install_requires'] = [
     'twisted ' + twisted_ver,


### PR DESCRIPTION
Since Buildbot requires Python3.8 at least,
it makes sense to require the first version of twisted that supports it.

ref: https://github.com/twisted/twisted/blob/twisted-21.2.0/NEWS.rst "Python 3.8 is now tested and supported. (#9955)"

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
