### PR TITLE
data: stream log lines to avoid loading the whole file in memory

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -28,8 +28,10 @@ from buildbot.data import exceptions
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    from typing import Any
     from typing import Literal
 
+    from buildbot.data.resultspec import ResultSpec
     from buildbot.db.builders import BuilderModel
     from buildbot.db.builds import BuildModel
     from buildbot.db.logs import LogModel
@@ -129,7 +131,15 @@ class Endpoint:
         self.rtype = rtype
         self.master = master
 
-    def get(self, resultSpec, kwargs):
+    def get(self, resultSpec: ResultSpec, kwargs: dict[str, Any]):
+        raise NotImplementedError
+
+    async def stream(self, resultSpec: ResultSpec, kwargs: dict[str, Any]):
+        """
+        This is a prototype interface method for internal use.
+        There could be breaking changes to it.
+        Use at your own risks.
+        """
         raise NotImplementedError
 
     def control(self, action, args, kwargs):

--- a/master/buildbot/test/unit/data/test_logchunks.py
+++ b/master/buildbot/test/unit/data/test_logchunks.py
@@ -223,7 +223,7 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
         self.validateData(logchunk)
         if logid == 60:
             expContent = 'Builder: some:builder\nBuild number: 3\nWorker name: wrk\n'
-            expContent += '\n'.join([line[1:] for line in expLines])
+            expContent += ''.join([f"{line[1:]}\n" for line in expLines])
             expFilename = "some:builder_build_3_step_make_log_stdio"
         else:
             expContent = '\n'.join(expLines) + '\n'

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -13,12 +13,15 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import cgi
 import datetime
 import fnmatch
 import json
 import re
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from twisted.internet import defer
@@ -32,6 +35,14 @@ from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 from buildbot.www import resource
 from buildbot.www.authz import Forbidden
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from twisted.web import server
+
+    from buildbot.data.base import Endpoint
+    from buildbot.data.resultspec import ResultSpec
 
 
 class BadJsonRpc2(Exception):
@@ -254,47 +265,67 @@ class V2RootResource(resource.Resource):
             args, entityType, endpoint.kind == EndpointKind.COLLECTION
         )
 
-    def encodeRaw(self, data, request, is_inline):
+    def _write_rest_error(self, request: server.Request, msg, errcode: int = 404):
+        if self.debug:
+            log.msg(f"REST error: {msg}")
+        request.setResponseCode(errcode)
+        request.setHeader(b'content-type', b'text/plain; charset=utf-8')
+        msg = bytes2unicode(msg)
+        data = json.dumps({"error": msg})
+        data = unicode2bytes(data)
+        request.write(data)
+
+    def _write_not_found_rest_error(
+        self,
+        request: server.Request,
+        ep: Endpoint,
+        rspec: ResultSpec,
+        kwargs: dict[str, Any],
+    ):
+        self._write_rest_error(
+            request=request,
+            msg=(
+                f"not found while getting from {repr(ep)} with "
+                f"arguments {repr(rspec)} and {str(kwargs)}"
+            ),
+        )
+
+    async def _render_raw(
+        self,
+        request: server.Request,
+        ep: Endpoint,
+        rspec: ResultSpec,
+        kwargs: dict[str, Any],
+    ):
+        assert ep.kind in (EndpointKind.RAW, EndpointKind.RAW_INLINE)
+        data = await ep.get(rspec, kwargs)
+        if data is None:
+            self._write_not_found_rest_error(request, ep, rspec=rspec, kwargs=kwargs)
+            return
+
         request.setHeader(b"content-type", unicode2bytes(data['mime-type']) + b'; charset=utf-8')
-        if not is_inline:
+        if ep.kind != EndpointKind.RAW_INLINE:
             request.setHeader(
                 b"content-disposition", b'attachment; filename=' + unicode2bytes(data['filename'])
             )
         request.write(unicode2bytes(data['raw']))
-        return
 
     @defer.inlineCallbacks
-    def renderRest(self, request):
+    def renderRest(self, request: server.Request):
         def writeError(msg, errcode=404, jsonrpccode=None):
-            if self.debug:
-                log.msg(f"REST error: {msg}")
-            request.setResponseCode(errcode)
-            request.setHeader(b'content-type', b'text/plain; charset=utf-8')
-            msg = bytes2unicode(msg)
-            data = json.dumps({"error": msg})
-            data = unicode2bytes(data)
-            request.write(data)
+            self._write_rest_error(request, msg=msg, errcode=errcode)
 
         with self.handleErrors(writeError):
             ep, kwargs = yield self.getEndpoint(request, bytes2unicode(request.method), {})
 
             rspec = self.decodeResultSpec(request, ep)
+            if ep.kind in (EndpointKind.RAW, EndpointKind.RAW_INLINE):
+                yield defer.Deferred.fromCoroutine(self._render_raw(request, ep, rspec, kwargs))
+                return
+
             data = yield ep.get(rspec, kwargs)
             if data is None:
-                msg = (
-                    f"not found while getting from {repr(ep)} with "
-                    f"arguments {repr(rspec)} and {str(kwargs)}"
-                )
-                msg = unicode2bytes(msg)
-                writeError(msg, errcode=404)
-                return
-
-            if ep.kind == EndpointKind.RAW:
-                self.encodeRaw(data, request, False)
-                return
-
-            if ep.kind == EndpointKind.RAW_INLINE:
-                self.encodeRaw(data, request, True)
+                self._write_not_found_rest_error(request, ep, rspec=rspec, kwargs=kwargs)
                 return
 
             # post-process any remaining parts of the resultspec

--- a/newsfragments/www-rest-log-download-memory-consumption.bugfix
+++ b/newsfragments/www-rest-log-download-memory-consumption.bugfix
@@ -1,0 +1,1 @@
+Fix logs ``/raw`` and ``/raw_inline`` endpoint requiring large memory on master (more than full log size) (:issue:`3011`)


### PR DESCRIPTION
Relates to #3011

We have some builders that generated huge logs (10+Go) due to an issue. Trying to download this log crashed the master with OOM.
This fixes the issue by streaming the log content to the HTTP response with an `AsyncGenerator`.

Here is a graph of memory usage downloading a logfile (first 2GB of a 11GB file):
![image](https://github.com/user-attachments/assets/b3acee58-33e3-47b0-b932-51a2228ff932)

Here is a comparison with master:
![image](https://github.com/user-attachments/assets/589c6c04-7229-4bd2-bed4-68850e9d239c)

Note that the process was killed before the file was downloaded.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
