### PR TITLE
Give access to `full_name` in the GitHub hook properties

### DIFF
--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -237,6 +237,7 @@ class GitHubEventHandler(PullRequestMixin):
         if self._token:
             p = Properties()
             p.master = self.master
+            p.setProperty("full_name", repo, "change_hook")
             token = yield p.render(self._token)
             headers['Authorization'] = 'token ' + token
 
@@ -268,6 +269,7 @@ class GitHubEventHandler(PullRequestMixin):
         if self._token:
             p = Properties()
             p.master = self.master
+            p.setProperty("full_name", repo, "change_hook")
             token = yield p.render(self._token)
             headers["Authorization"] = "token " + token
 

--- a/master/docs/manual/configuration/wwwhooks.rst
+++ b/master/docs/manual/configuration/wwwhooks.rst
@@ -138,9 +138,11 @@ The GitHub hook has the following parameters:
 ``github_api_endpoint`` (default ``https://api.github.com``)
     If you have a self-host GitHub Enterprise installation, please set this URL properly.
 
-``token``
-    If your GitHub or GitHub Enterprise instance does not allow anonymous communication, you need to provide an access token.
-    Instructions can be found `here <https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>`_.
+``token`` If your GitHub or GitHub Enterprise instance does not allow anonymous communication, you
+    need to provide an access token.  Instructions can be found `here
+    <https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>`_. This
+    attribute is rendered using the :class:`~buildbot.interfaces.IRenderable` interface, the only
+    property available is ``full_name``, of the format ``{owner}/{full_name}``.
 
 ``pullrequest_ref`` (default ``merge``)
     Remote ref to test if a pull request is sent to the endpoint.

--- a/newsfragments/give-access-to-full_name-in-the-github-hook-properties.feature
+++ b/newsfragments/give-access-to-full_name-in-the-github-hook-properties.feature
@@ -1,0 +1,1 @@
+Give access to `full_name` of the repository when rendering GitHub tokens in the GitHub change hooks


### PR DESCRIPTION
## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
