### PR TITLE
www: Add a way to fetch more builds or changes via a button

### DIFF
--- a/newsfragments/www-load-more-items.feature
+++ b/newsfragments/www-load-more-items.feature
@@ -1,0 +1,1 @@
+Changes tables in various places in the web UI now have a button to load more items.

--- a/newsfragments/www-load-more-items.feature
+++ b/newsfragments/www-load-more-items.feature
@@ -1,1 +1,1 @@
-Changes tables in various places in the web UI now have a button to load more items.
+Changes and builds tables in various places in the web UI now have a button to load more items.

--- a/www/base/src/components/BuildsTable/BuildsTable.tsx
+++ b/www/base/src/components/BuildsTable/BuildsTable.tsx
@@ -17,7 +17,7 @@
 
 import './BuildsTable.scss';
 import {observer} from "mobx-react";
-import {Table} from "react-bootstrap";
+import {Button, Table} from "react-bootstrap";
 import {
   Build,
   Builder,
@@ -39,10 +39,13 @@ import {durationFormat} from "buildbot-ui";
 import {buildbotGetSettings, buildbotSetupPlugin} from "../../../../plugin_support";
 import {FaHome} from "react-icons/fa";
 import {HomeView} from "../../views/HomeView/HomeView";
+import {LoadMoreListItem} from "../LoadMoreListItem/LoadMoreListItem";
 
 type BuildsTableProps = {
   builds: DataCollection<Build>;
   builders: DataCollection<Builder> | null;
+  fetchLimit: number;
+  onLoadMore: (() => void)|null;
 }
 
 const BUILD_TIME_BASE_START_TIME = 'Start time and duration';
@@ -68,7 +71,7 @@ const getBuildTimeElement = (build: Build, buildTimeBase: string, now: number) =
   )
 }
 
-export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
+export const BuildsTable = observer(({builds, builders, fetchLimit, onLoadMore}: BuildsTableProps) => {
   const now = useCurrentTime();
   const sortedBuilds = builds.array.slice().sort((a, b) => b.started_at - a.started_at);
 
@@ -118,6 +121,13 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
     );
   });
 
+  const maybeRenderLoadMore = () => {
+    if (!builds.isResolved() || onLoadMore === null || fetchLimit >= builds.array.length) {
+      return <></>;
+    }
+    return <LoadMoreListItem onLoadMore={onLoadMore}/>;
+  };
+
   const tableElement = () => {
     return (
       <Table hover striped size="sm">
@@ -133,6 +143,7 @@ export const BuildsTable = observer(({builds, builders}: BuildsTableProps) => {
             <td>Status</td>
           </tr>
           {rowElements}
+          {maybeRenderLoadMore()}
         </tbody>
       </Table>
     );

--- a/www/base/src/components/ChangesTable/ChangesTable.tsx
+++ b/www/base/src/components/ChangesTable/ChangesTable.tsx
@@ -24,6 +24,8 @@ import {ChangeDetails} from "buildbot-ui";
 import {observer, useLocalObservable} from "mobx-react";
 import {resizeArray} from "../../util/Array";
 import {LoadingSpan} from "../LoadingSpan/LoadingSpan";
+import {Button} from "react-bootstrap";
+import {LoadMoreListItem} from "../LoadMoreListItem/LoadMoreListItem";
 
 class ChangesTableState {
   showDetails = observable.array<boolean>();
@@ -46,10 +48,12 @@ class ChangesTableState {
 }
 
 type ChangesTableProps = {
-  changes: DataCollection<Change>
+  changes: DataCollection<Change>;
+  fetchLimit: number;
+  onLoadMore: (() => void)|null;
 }
 
-export const ChangesTable = observer(({changes}: ChangesTableProps) => {
+export const ChangesTable = observer(({changes, fetchLimit, onLoadMore}: ChangesTableProps) => {
   const tableState = useLocalObservable(() => new ChangesTableState());
   tableState.resizeTable(changes.array.length, false);
 
@@ -69,6 +73,13 @@ export const ChangesTable = observer(({changes}: ChangesTableProps) => {
     }
     return <LoadingSpan/>
   }
+
+  const maybeRenderLoadMore = () => {
+    if (!changes.isResolved() || onLoadMore === null || changes.array.length >= fetchLimit) {
+      return <></>;
+    }
+    return <LoadMoreListItem onLoadMore={onLoadMore}/>;
+  };
 
   return (
     <div className="container-fluid">
@@ -93,6 +104,7 @@ export const ChangesTable = observer(({changes}: ChangesTableProps) => {
       </div>
       <ul className="bb-changes-table-list list-group">
         {changeElements}
+        {maybeRenderLoadMore()}
       </ul>
     </div>
   );

--- a/www/base/src/components/LoadMoreListItem/LoadMoreListItem.tsx
+++ b/www/base/src/components/LoadMoreListItem/LoadMoreListItem.tsx
@@ -1,0 +1,31 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {Button} from "react-bootstrap";
+
+type LoadMoreListItemProps = {
+  onLoadMore: () => void;
+}
+
+export const LoadMoreListItem = ({onLoadMore}: LoadMoreListItemProps) => {
+
+  return (
+      <li key={'load-more'} className="list-group-item">
+        <Button variant="outline-secondary" onClick={onLoadMore}>Load more</Button>
+      </li>
+  );
+};

--- a/www/base/src/views/BuildView/BuildView.tsx
+++ b/www/base/src/views/BuildView/BuildView.tsx
@@ -400,7 +400,7 @@ const BuildView = observer(() => {
         </Tab>
         <Tab eventKey="changes" title="Changes">
           {build !== null
-            ? <ChangesTable changes={changesQuery}/>
+            ? <ChangesTable changes={changesQuery} fetchLimit={0} onLoadMore={null}/>
             : <></>
           }
         </Tab>

--- a/www/base/src/views/BuildView/BuildViewDebugTab.tsx
+++ b/www/base/src/views/BuildView/BuildViewDebugTab.tsx
@@ -24,7 +24,7 @@ import {
   useDataAccessor,
   useDataApiDynamicQuery,
 } from "buildbot-data-js";
-import {BuildLinkWithSummaryTooltip} from "../../../../ui";
+import {BuildLinkWithSummaryTooltip} from "buildbot-ui";
 import {LoadingDiv} from "../../components/LoadingDiv/LoadingDiv";
 import {RawData} from "../../components/RawData/RawData";
 import {TableHeading} from "../../components/TableHeading/TableHeading";

--- a/www/ui/src/util/React.ts
+++ b/www/ui/src/util/React.ts
@@ -62,3 +62,12 @@ export function useWindowSize() {
 
   return size;
 }
+
+export function useLoadMoreItemsState(defaultCount: number, increment: number) : [number, () => void] {
+  const [count, setCount] = useState<number>(defaultCount);
+
+  const onLoadMore = () => {
+    setCount(c => c + increment);
+  }
+  return [count, onLoadMore];
+}


### PR DESCRIPTION
This adds a button at the end of tables to fetch more builds or changes.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
