### PR TITLE
www: Some improvements to V2RootResource.renderRest

### DIFF
--- a/newsfragments/www-rest-api-content-length.misc
+++ b/newsfragments/www-rest-api-content-length.misc
@@ -1,0 +1,1 @@
+REST API json response now correctly provide the Content-Length header for non-HEAD requests


### PR DESCRIPTION
Content-Length header was not correctly calculated (based on unicode str length rather than bytes, cf. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length).

Made some other chances while at it:
- Include Content-Length on non-HEAD requests
- Use JSONEncoder to chunk write the response

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
