### PR TITLE
steps: Add steps that support creating steps according to file in repo

### DIFF
--- a/master/buildbot/steps/configurable.py
+++ b/master/buildbot/steps/configurable.py
@@ -1,0 +1,384 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import traceback
+import warnings
+from shlex import shlex
+
+import yaml
+from evalidate import Expr
+from evalidate import base_eval_model
+from twisted.internet import defer
+
+from buildbot.db.model import Model
+from buildbot.plugins import util
+from buildbot.plugins.db import get_plugins
+from buildbot.process import buildstep
+from buildbot.process.properties import Properties
+from buildbot.process.results import SUCCESS
+from buildbot.steps.shell import ShellCommand
+from buildbot.steps.trigger import Trigger
+from buildbot.steps.worker import CompositeStepMixin
+
+
+class BuildbotCiYmlInvalid(Exception):
+    pass
+
+
+def parse_env_string(env_str, parent_env=None):
+    env_str = env_str.strip()
+
+    props = {}
+    if parent_env:
+        props.update(parent_env)
+    if not env_str:
+        return props
+
+    lexer = shlex(env_str, posix=True)  # posix=True is needed to properly handle escaping
+    lexer.whitespace = ' '
+    lexer.wordchars += '=.,'
+
+    for word in lexer:
+        k, v = word.split('=', maxsplit=1)
+        props[k] = v
+
+    return props
+
+
+def interpolate_constructor(loader, node):
+    value = loader.construct_scalar(node)
+    return util.Interpolate(value)
+
+
+class BuildbotCiLoader(yaml.SafeLoader):
+    constructors_loaded = False
+
+    @classmethod
+    def ensure_constructors_loaded(cls):
+        if cls.constructors_loaded:
+            return
+        cls.load_constructors()
+
+    @classmethod
+    def load_constructors(cls):
+        cls.add_constructor('!Interpolate', interpolate_constructor)
+        cls.add_constructor('!i', interpolate_constructor)
+
+        steps = get_plugins('steps', None, load_now=True)
+        for step_name in steps.names:
+            # Accessing a step from the plugin DB may raise warrings (e.g. deprecation).
+            # We don't want them logged until the step is actually used.
+            with warnings.catch_warnings(record=True) as all_warnings:
+                warnings.simplefilter("always")
+                step_class = steps.get(step_name)
+                step_warnings = list(all_warnings)
+            cls.register_step_class(step_name, step_class, step_warnings)
+
+    @classmethod
+    def register_step_class(cls, name, step_class, step_warnings):
+        def step_constructor(loader, node):
+            try:
+                if isinstance(node, yaml.ScalarNode):
+                    args = [loader.construct_scalar(node)]
+                    kwargs = {}
+                elif isinstance(node, yaml.SequenceNode):
+                    args = loader.construct_sequence(node)
+                    kwargs = {}
+                elif isinstance(node, yaml.MappingNode):
+                    args = []
+                    kwargs = loader.construct_mapping(node)
+                else:
+                    raise Exception('Unsupported node type')
+            except Exception as e:
+                raise Exception(f"Could not parse steps arguments: {e}") from e
+
+            # Re-raise all warnings that occurred when accessing step class. We only want them to be
+            # logged if the configuration actually uses the step class.
+            for w in step_warnings:
+                warnings.warn_explicit(w.message, w.category, w.filename, w.lineno)
+
+            return step_class(*args, **kwargs)
+
+        cls.add_constructor('!' + name, step_constructor)
+
+
+class BuildbotCiYml:
+    SCRIPTS = (
+        "before_install",
+        "install",
+        "after_install",
+        "before_script",
+        "script",
+        "after_script",
+    )
+
+    steps_loaded = False
+
+    def __init__(self):
+        self.config_dict = None
+        self.label_mapping = {}
+        self.global_env = {}
+        self.script_commands = {}
+        for script in self.SCRIPTS:
+            self.script_commands[script] = []
+        self.matrix = []
+
+    @classmethod
+    def load_from_str(cls, config_input):
+        BuildbotCiLoader.ensure_constructors_loaded()
+
+        try:
+            config_dict = yaml.load(config_input, Loader=BuildbotCiLoader)
+        except Exception as e:
+            raise BuildbotCiYmlInvalid(f"Invalid YAML data\n{e}")
+
+        return cls.load_from_dict(config_dict)
+
+    @classmethod
+    def load_from_dict(cls, config):
+        yml = cls()
+        yml.load_from_dict_internal(config)
+        return yml
+
+    def load_from_dict_internal(self, config):
+        self.config = config
+        self.label_mapping = self.config.get('label_mapping', {})
+        self.global_env = BuildbotCiYml.load_global_env(config)
+        self.script_commands = BuildbotCiYml.load_scripts(config)
+        self.matrix = BuildbotCiYml.load_matrix(config, self.global_env)
+
+    @classmethod
+    def load_global_env(cls, config):
+        env = config.get("env", None)
+
+        if env is None:
+            return {}
+
+        if isinstance(env, list):
+            return {}
+
+        if isinstance(env, dict):
+            env = env.get('global')
+            if isinstance(env, str):
+                return parse_env_string(env)
+            if isinstance(env, list):
+                global_env = {}
+                for e in env:
+                    global_env.update(parse_env_string(e))
+                return global_env
+            raise BuildbotCiYmlInvalid("'env.global' configuration parameter is invalid")
+
+        raise BuildbotCiYmlInvalid("'env' parameter is invalid")
+
+    @classmethod
+    def load_scripts(cls, config):
+        script_commands = {}
+        for script in cls.SCRIPTS:
+            commands = config.get(script, [])
+            if isinstance(commands, str):
+                commands = [commands]
+            if not isinstance(commands, list):
+                raise BuildbotCiYmlInvalid(f"'{script}' parameter is invalid")
+            script_commands[script] = commands
+        return script_commands
+
+    @staticmethod
+    def adjust_matrix_config(c, global_env):
+        c = c.copy()
+        c['env'] = parse_env_string(c.get('env', ''), global_env)
+        return c
+
+    @classmethod
+    def load_matrix(cls, config, global_env):
+        return [
+            cls.adjust_matrix_config(matrix_config, global_env)
+            for matrix_config in config.get('matrix', {}).get('include') or []
+        ]
+
+
+class BuildbotTestCiReadConfigMixin:
+    config_filenames = ['.bbtravis.yml', '.buildbot-ci.yml']
+    config = None
+
+    @defer.inlineCallbacks
+    def get_config_yml_from_worker(self):
+        exceptions = []
+        for filename in self.config_filenames:
+            try:
+                config_yml = yield self.getFileContentFromWorker(filename, abandonOnFailure=True)
+                return filename, config_yml
+            except buildstep.BuildStepFailed as e:
+                exceptions.append(e)
+
+        return None, exceptions
+
+    @defer.inlineCallbacks
+    def get_ci_config(self):
+        filename, result = yield self.get_config_yml_from_worker()
+        if not filename:
+            exceptions = result
+            msg = ' '.join(str(exceptions))
+
+            self.descriptionDone = "failed to read configuration"
+            self.addCompleteLog(
+                'error',
+                f'Failed to read configuration from files {self.config_filenames}: got {msg}',
+            )
+            raise buildstep.BuildStepFailed("failed to read configuration")
+
+        config_yml = result
+
+        self.addCompleteLog(filename, config_yml)
+
+        try:
+            config = BuildbotCiYml.load_from_str(config_yml)
+        except BuildbotCiYmlInvalid as e:
+            self.descriptionDone = f'bad configuration file {filename}'
+            self.addCompleteLog('error', f'Bad configuration file:\n{e}')
+            raise buildstep.BuildStepFailed(f'bad configuration file {filename}')
+
+        return config
+
+
+class BuildbotTestCiTrigger(BuildbotTestCiReadConfigMixin, CompositeStepMixin, Trigger):
+    def __init__(self, scheduler, **kwargs):
+        super().__init__(
+            name='buildbot-test-ci trigger',
+            waitForFinish=True,
+            schedulerNames=[scheduler],
+            haltOnFailure=True,
+            flunkOnFailure=True,
+            sourceStamps=[],
+            alwaysUseLatest=False,
+            updateSourceStamp=False,
+            **kwargs,
+        )
+
+    @defer.inlineCallbacks
+    def run(self):
+        self.config = yield self.get_ci_config()
+
+        rv = yield super().run()
+        return rv
+
+    def _replace_label(self, v):
+        return str(self.config.label_mapping.get(v, v))
+
+    def build_scheduler_for_env(self, scheduler_name, env):
+        new_build_props = Properties()
+        new_build_props.setProperty(
+            "BUILDBOT_PULL_REQUEST", self.getProperty("BUILDBOT_PULL_REQUEST"), "inherit"
+        )
+        for k, v in env.items():
+            if k == "env":
+                # v is dictionary
+                new_build_props.update(v, "BuildbotTestCiTrigger")
+            else:
+                new_build_props.setProperty(k, v, "BuildbotTestCiTrigger")
+
+        tags_from_props = sorted(
+            f'{self._replace_label(k)}:{self._replace_label(v)}'
+            for k, (v, _) in new_build_props.asDict().items()
+            if k not in self.config.global_env.keys() and k != 'BUILDBOT_PULL_REQUEST'
+        )
+
+        tags = [t for t in self.build.builder.config.tags if t not in ('try', 'spawner')]
+
+        new_build_props.setProperty(
+            "virtual_builder_name", " ".join(tags + tags_from_props), "BuildbotTestCiTrigger"
+        )
+        new_build_props.setProperty(
+            "virtual_builder_tags", tags + tags_from_props, "BuildbotTestCiTrigger"
+        )
+        new_build_props.setProperty(
+            "matrix_label", "/".join(tags_from_props), "BuildbotTestCiTrigger"
+        )
+
+        return (scheduler_name, new_build_props)
+
+    def createTriggerProperties(self, props):
+        return props
+
+    def getSchedulersAndProperties(self):
+        scheduler_name = self.schedulerNames[0]
+        return [self.build_scheduler_for_env(scheduler_name, env) for env in self.config.matrix]
+
+
+class BuildbotCiSetupSteps(BuildbotTestCiReadConfigMixin, CompositeStepMixin, buildstep.BuildStep):
+    name = "setup-steps"
+    haltOnFailure = True
+    flunkOnFailure = True
+    MAX_NAME_LENGTH = 47
+    disable = False
+
+    def _add_step(self, command):
+        name = None
+        condition = None
+        step = None
+        original_command = command
+        if isinstance(command, dict):
+            name = command.get("title")
+            condition = command.get("condition")
+            step = command.get("step")
+            command = command.get("cmd")
+
+        if isinstance(command, buildstep.BuildStep):
+            step = command
+
+        if condition is not None:
+            try:
+                if not self.test_condition(condition):
+                    return
+            except Exception:
+                self.descriptionDone = "Problem parsing condition"
+                self.addCompleteLog("condition error", traceback.format_exc())
+                return
+
+        if step is None:
+            if command is None:
+                self.addCompleteLog(
+                    "BuildbotCiSetupSteps error",
+                    f"Neither step nor cmd is defined: {original_command}",
+                )
+                return
+            if name is None:
+                name = self._name_from_command(command)
+
+            step = ShellCommand(
+                name=name, description=command, command=command, doStepIf=not self.disable
+            )
+        self.build.addStepsAfterLastStep([step])
+
+    def test_condition(self, condition):
+        local_dict = {k: v for k, (v, s) in self.build.getProperties().properties.items()}
+        expr = Expr(condition, base_eval_model)
+        return expr.eval(condition, local_dict)
+
+    def _name_from_command(self, name):
+        name = name.lstrip("#").lstrip(" ").split("\n")[0]
+        max_length = Model.steps.c.name.type.length
+        if len(name) > max_length:
+            name = name[: max_length - 3] + "..."
+        return name
+
+    @defer.inlineCallbacks
+    def run(self):
+        config = yield self.get_ci_config()
+        for k in BuildbotCiYml.SCRIPTS:
+            for command in config.script_commands[k]:
+                self._add_step(command=command)
+
+        return SUCCESS

--- a/master/buildbot/test/integration/test_steps_configurable.py
+++ b/master/buildbot/test/integration/test_steps_configurable.py
@@ -1,0 +1,314 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import os
+import tempfile
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.config import BuilderConfig
+from buildbot.plugins import changes
+from buildbot.plugins import schedulers
+from buildbot.process import factory
+from buildbot.steps.configurable import BuildbotCiSetupSteps
+from buildbot.steps.configurable import BuildbotTestCiTrigger
+from buildbot.steps.source.git import Git
+from buildbot.test.util.git_repository import TestGitRepository
+from buildbot.test.util.integration import RunMasterBase
+from buildbot.worker import Worker
+
+buildbot_ci_yml = """\
+language: python
+
+label_mapping:
+  TWISTED: tw
+  SQLALCHEMY: sqla
+  SQLALCHEMY_MIGRATE: sqlam
+  latest: l
+  python: py
+
+python:
+  - "3.8"
+env:
+  global:
+      - CI=true
+matrix:
+  include:
+    # Test different versions of SQLAlchemy
+    - python: "3.8"
+      env: TWISTED=12.0.0 SQLALCHEMY=0.6.0 SQLALCHEMY_MIGRATE=0.7.1
+    - python: "3.8"
+      env: TWISTED=13.0.0 SQLALCHEMY=0.6.8 SQLALCHEMY_MIGRATE=0.7.1
+    - python: "3.8"
+      env: TWISTED=14.0.0 SQLALCHEMY=0.6.8 SQLALCHEMY_MIGRATE=0.7.1
+    - python: "3.8"
+      env: TWISTED=15.0.0 SQLALCHEMY=0.6.8 SQLALCHEMY_MIGRATE=0.7.1
+
+before_install:
+  - echo doing before install
+  - echo doing before install 2nd command
+install:
+  - echo doing install
+script:
+  - echo doing scripts
+  - echo Ran 10 tests with 0 failures and 0 errors
+after_success:
+  - echo doing after success
+notifications:
+  email: false
+
+"""
+
+
+class BuildbotTestCiTest(RunMasterBase):
+    timeout = 300
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield super().setUp()
+        try:
+            self.repo = TestGitRepository(
+                repository_path=tempfile.mkdtemp(
+                    prefix="TestRepository_",
+                    dir=os.getcwd(),
+                )
+            )
+        except FileNotFoundError as e:
+            raise unittest.SkipTest("Can't find git binary") from e
+
+        self.prepare_repository()
+
+    def prepare_repository(self):
+        self.repo.create_file_text('.bbtravis.yml', buildbot_ci_yml)
+        self.repo.exec_git(['add', '.bbtravis.yml'])
+        self.repo.commit(message='Initial commit', files=['.bbtravis.yml'])
+
+    @defer.inlineCallbacks
+    def setup_config(self):
+        c = {
+            'workers': [Worker("local1", "p")],
+            'services': [
+                changes.GitPoller(
+                    repourl=str(self.repo.repository_path), project='buildbot', branch='main'
+                )
+            ],
+            'builders': [],
+            'schedulers': [],
+            'multiMaster': True,
+        }
+
+        repository = str(self.repo.repository_path)
+        job_name = "buildbot-job"
+        try_name = "buildbot-try"
+        spawner_name = "buildbot"
+
+        codebases = {spawner_name: {'repository': repository}}
+
+        # main job
+        f = factory.BuildFactory()
+        f.addStep(Git(repourl=repository, codebase=spawner_name, mode='incremental'))
+        f.addStep(BuildbotCiSetupSteps())
+
+        c['builders'].append(
+            BuilderConfig(
+                name=job_name,
+                workernames=['local1'],
+                collapseRequests=False,
+                tags=["job", 'buildbot'],
+                factory=f,
+            )
+        )
+
+        c['schedulers'].append(
+            schedulers.Triggerable(name=job_name, builderNames=[job_name], codebases=codebases)
+        )
+
+        # spawner
+        f = factory.BuildFactory()
+        f.addStep(Git(repourl=repository, codebase=spawner_name, mode='incremental'))
+        f.addStep(BuildbotTestCiTrigger(scheduler=job_name))
+        c['builders'].append(
+            BuilderConfig(
+                name=spawner_name,
+                workernames=['local1'],
+                properties={'BUILDBOT_PULL_REQUEST': True},
+                tags=["spawner", 'buildbot'],
+                factory=f,
+            )
+        )
+
+        c['schedulers'].append(
+            schedulers.AnyBranchScheduler(
+                name=spawner_name, builderNames=[spawner_name], codebases=codebases
+            )
+        )
+
+        # try job
+        f = factory.BuildFactory()
+        f.addStep(Git(repourl=repository, codebase=spawner_name, mode='incremental'))
+        f.addStep(BuildbotTestCiTrigger(scheduler=job_name))
+
+        c['builders'].append(
+            BuilderConfig(
+                name=try_name,
+                workernames=['local1'],
+                properties={'BUILDBOT_PULL_REQUEST': True},
+                tags=["try", 'buildbot'],
+                factory=f,
+            )
+        )
+
+        yield self.setup_master(c)
+
+    @defer.inlineCallbacks
+    def test_buildbot_ci(self):
+        yield self.setup_config()
+        change = dict(
+            branch="main",
+            files=["foo.c"],
+            author="me@foo.com",
+            comments="good stuff",
+            revision="HEAD",
+            repository=str(self.repo.repository_path),
+            codebase='buildbot',
+            project="buildbot",
+        )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        if 'worker local1 ready' in build['steps'][0]['state_string']:
+            build['steps'] = build['steps'][1:]
+        self.assertEqual(build['steps'][0]['state_string'], 'update buildbot')
+        self.assertEqual(build['steps'][0]['name'], 'git-buildbot')
+        self.assertEqual(
+            build['steps'][1]['state_string'],
+            'triggered ' + ", ".join(["buildbot-job"] * 4) + ', 4 successes',
+        )
+        url_names = [url['name'] for url in build['steps'][1]['urls']]
+        url_urls = [url['url'] for url in build['steps'][1]['urls']]
+        self.assertIn('http://localhost:8080/#/builders/4/builds/1', url_urls)
+        self.assertIn('success: buildbot py:3.8 sqla:0.6.0 sqlam:0.7.1 tw:12.0.0 #1', url_names)
+        self.assertEqual(build['steps'][1]['logs'][0]['contents']['content'], buildbot_ci_yml)
+
+        builds = yield self.master.data.get(("builds",))
+        self.assertEqual(len(builds), 5)
+        props = {}
+        buildernames = {}
+        labels = {}
+        for build in builds:
+            build['properties'] = yield self.master.data.get((
+                "builds",
+                build['buildid'],
+                'properties',
+            ))
+            props[build['buildid']] = {
+                k: v[0] for k, v in build['properties'].items() if v[1] == 'BuildbotTestCiTrigger'
+            }
+            buildernames[build['buildid']] = build['properties'].get('virtual_builder_name')
+            labels[build['buildid']] = build['properties'].get('matrix_label')
+        self.assertEqual(
+            props,
+            {
+                1: {},
+                2: {
+                    'python': '3.8',
+                    'CI': 'true',
+                    'TWISTED': '12.0.0',
+                    'SQLALCHEMY': '0.6.0',
+                    'SQLALCHEMY_MIGRATE': '0.7.1',
+                    'virtual_builder_name': 'buildbot py:3.8 sqla:0.6.0 sqlam:0.7.1 tw:12.0.0',
+                    'virtual_builder_tags': [
+                        'buildbot',
+                        'py:3.8',
+                        'sqla:0.6.0',
+                        'sqlam:0.7.1',
+                        'tw:12.0.0',
+                        '_virtual_',
+                    ],
+                    'matrix_label': 'py:3.8/sqla:0.6.0/sqlam:0.7.1/tw:12.0.0',
+                },
+                3: {
+                    'python': '3.8',
+                    'CI': 'true',
+                    'TWISTED': '13.0.0',
+                    'SQLALCHEMY': '0.6.8',
+                    'SQLALCHEMY_MIGRATE': '0.7.1',
+                    'virtual_builder_name': 'buildbot py:3.8 sqla:0.6.8 sqlam:0.7.1 tw:13.0.0',
+                    'virtual_builder_tags': [
+                        'buildbot',
+                        'py:3.8',
+                        'sqla:0.6.8',
+                        'sqlam:0.7.1',
+                        'tw:13.0.0',
+                        '_virtual_',
+                    ],
+                    'matrix_label': 'py:3.8/sqla:0.6.8/sqlam:0.7.1/tw:13.0.0',
+                },
+                4: {
+                    'python': '3.8',
+                    'CI': 'true',
+                    'TWISTED': '14.0.0',
+                    'SQLALCHEMY': '0.6.8',
+                    'SQLALCHEMY_MIGRATE': '0.7.1',
+                    'virtual_builder_name': 'buildbot py:3.8 sqla:0.6.8 sqlam:0.7.1 tw:14.0.0',
+                    'virtual_builder_tags': [
+                        'buildbot',
+                        'py:3.8',
+                        'sqla:0.6.8',
+                        'sqlam:0.7.1',
+                        'tw:14.0.0',
+                        '_virtual_',
+                    ],
+                    'matrix_label': 'py:3.8/sqla:0.6.8/sqlam:0.7.1/tw:14.0.0',
+                },
+                5: {
+                    'python': '3.8',
+                    'CI': 'true',
+                    'TWISTED': '15.0.0',
+                    'SQLALCHEMY': '0.6.8',
+                    'SQLALCHEMY_MIGRATE': '0.7.1',
+                    'virtual_builder_name': 'buildbot py:3.8 sqla:0.6.8 sqlam:0.7.1 tw:15.0.0',
+                    'virtual_builder_tags': [
+                        'buildbot',
+                        'py:3.8',
+                        'sqla:0.6.8',
+                        'sqlam:0.7.1',
+                        'tw:15.0.0',
+                        '_virtual_',
+                    ],
+                    'matrix_label': 'py:3.8/sqla:0.6.8/sqlam:0.7.1/tw:15.0.0',
+                },
+            },
+        )
+        # global env CI should not be there
+        self.assertEqual(
+            buildernames,
+            {
+                1: None,
+                2: ('buildbot py:3.8 sqla:0.6.0 sqlam:0.7.1 tw:12.0.0', 'BuildbotTestCiTrigger'),
+                3: ('buildbot py:3.8 sqla:0.6.8 sqlam:0.7.1 tw:13.0.0', 'BuildbotTestCiTrigger'),
+                4: ('buildbot py:3.8 sqla:0.6.8 sqlam:0.7.1 tw:14.0.0', 'BuildbotTestCiTrigger'),
+                5: ('buildbot py:3.8 sqla:0.6.8 sqlam:0.7.1 tw:15.0.0', 'BuildbotTestCiTrigger'),
+            },
+        )
+        self.assertEqual(
+            labels,
+            {
+                1: None,
+                2: ('py:3.8/sqla:0.6.0/sqlam:0.7.1/tw:12.0.0', 'BuildbotTestCiTrigger'),
+                3: ('py:3.8/sqla:0.6.8/sqlam:0.7.1/tw:13.0.0', 'BuildbotTestCiTrigger'),
+                4: ('py:3.8/sqla:0.6.8/sqlam:0.7.1/tw:14.0.0', 'BuildbotTestCiTrigger'),
+                5: ('py:3.8/sqla:0.6.8/sqlam:0.7.1/tw:15.0.0', 'BuildbotTestCiTrigger'),
+            },
+        )

--- a/master/buildbot/test/unit/steps/test_configurable.py
+++ b/master/buildbot/test/unit/steps/test_configurable.py
@@ -1,0 +1,206 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from parameterized import parameterized
+from twisted.trial import unittest
+
+from buildbot.process.properties import Interpolate
+from buildbot.steps.configurable import BuildbotCiYml
+from buildbot.steps.configurable import parse_env_string
+from buildbot.steps.shell import ShellCommand
+
+
+class TestParseEnvString(unittest.TestCase):
+    @parameterized.expand([
+        ('single', 'ABC=1', {'ABC': '1'}),
+        ('single_with_dot', 'ABC=1.0', {'ABC': '1.0'}),
+        ('single_with_comma', 'ABC=1,0', {'ABC': '1,0'}),
+        ('multiple', 'ABC=1 EFG=2', {'ABC': '1', 'EFG': '2'}),
+        ('multiple_single_quotes', 'ABC=\'1\' EFG=2', {'ABC': '1', 'EFG': '2'}),
+        ('multiple_double_quotes', 'ABC="1" EFG=2', {'ABC': '1', 'EFG': '2'}),
+        ('multiple_with_equals_in_value', 'ABC=1=2 EFG=2', {'ABC': '1=2', 'EFG': '2'}),
+        (
+            'multiple_with_equals_in_value_single_quotes',
+            'ABC=\'1=2\' EFG=2',
+            {'ABC': '1=2', 'EFG': '2'},
+        ),
+        (
+            'multiple_with_equals_in_value_double_quotes',
+            'ABC="1=2" EFG=2',
+            {'ABC': '1=2', 'EFG': '2'},
+        ),
+        (
+            'multiple_with_space_in_value_single_quotes',
+            'ABC=\'1 2\' EFG=2',
+            {'ABC': '1 2', 'EFG': '2'},
+        ),
+        (
+            'multiple_with_space_in_value_double_quotes',
+            'ABC="1 2" EFG=2',
+            {'ABC': '1 2', 'EFG': '2'},
+        ),
+    ])
+    def test_one(self, name, value, expected):
+        self.assertEqual(parse_env_string(value), expected)
+
+    def test_global_overridden(self):
+        self.assertEqual(
+            parse_env_string('K1=VE1 K2=VE2', {'K2': 'VG1', 'K3': 'VG3'}),
+            {'K1': 'VE1', 'K2': 'VE2', 'K3': 'VG3'},
+        )
+
+
+class TestLoading(unittest.TestCase):
+    def test_single_script(self):
+        c = BuildbotCiYml.load_from_str("""
+        script:
+            - echo success
+        """)
+        self.assertEqual(
+            c.script_commands,
+            {
+                'before_install': [],
+                'install': [],
+                'after_install': [],
+                'before_script': [],
+                'script': ['echo success'],
+                'after_script': [],
+            },
+        )
+
+    def test_single_script_interpolated_no_replacement(self):
+        c = BuildbotCiYml.load_from_str("""
+        script:
+            - !i echo success
+        """)
+        self.assertEqual(
+            c.script_commands,
+            {
+                'before_install': [],
+                'install': [],
+                'after_install': [],
+                'before_script': [],
+                'script': [Interpolate("echo success")],
+                'after_script': [],
+            },
+        )
+
+    def test_single_script_interpolated_with_replacement(self):
+        c = BuildbotCiYml.load_from_str("""
+        script:
+            - !i echo "%(prop:name)s"
+        """)
+        self.assertEqual(
+            c.script_commands,
+            {
+                'before_install': [],
+                'install': [],
+                'after_install': [],
+                'before_script': [],
+                'script': [Interpolate("echo %(prop:name)s")],
+                'after_script': [],
+            },
+        )
+
+    def test_single_script_dict_interpolate_with_replacement(self):
+        c = BuildbotCiYml.load_from_str("""
+        script:
+            - title: mytitle
+            - cmd: [ "echo", !i "%(prop:name)s" ]
+        """)
+        self.assertEqual(
+            c.script_commands,
+            {
+                'before_install': [],
+                'install': [],
+                'after_install': [],
+                'before_script': [],
+                'script': [{'title': 'mytitle'}, {'cmd': ['echo', Interpolate('%(prop:name)s')]}],
+                'after_script': [],
+            },
+        )
+
+    def test_multiple_scripts(self):
+        c = BuildbotCiYml.load_from_str("""
+        script:
+            - echo success
+            - echo success2
+            - echo success3
+        """)
+        self.assertEqual(
+            c.script_commands,
+            {
+                'before_install': [],
+                'install': [],
+                'after_install': [],
+                'before_script': [],
+                'script': ['echo success', 'echo success2', 'echo success3'],
+                'after_script': [],
+            },
+        )
+
+    def test_script_with_step(self):
+        c = BuildbotCiYml.load_from_str("""
+        script:
+            - !ShellCommand
+              command: "echo success"
+        """)
+        self.assertEqual(
+            c.script_commands,
+            {
+                'before_install': [],
+                'install': [],
+                'after_install': [],
+                'before_script': [],
+                'script': [ShellCommand(command='echo success')],
+                'after_script': [],
+            },
+        )
+
+    def test_matrix_include_simple(self):
+        m = BuildbotCiYml.load_matrix(
+            {'matrix': {'include': [{'env': 'ABC=10'}, {'env': 'ABC=11'}, {'env': 'ABC=12'}]}}, {}
+        )
+        self.assertEqual(
+            m, [{'env': {'ABC': '10'}}, {'env': {'ABC': '11'}}, {'env': {'ABC': '12'}}]
+        )
+
+    def test_matrix_include_global(self):
+        m = BuildbotCiYml.load_matrix(
+            {'matrix': {'include': [{'env': 'ABC=10'}, {'env': 'ABC=11'}, {'env': 'ABC=12'}]}},
+            {'GLOBAL': 'GV'},
+        )
+        self.assertEqual(
+            m,
+            [
+                {'env': {'ABC': '10', 'GLOBAL': 'GV'}},
+                {'env': {'ABC': '11', 'GLOBAL': 'GV'}},
+                {'env': {'ABC': '12', 'GLOBAL': 'GV'}},
+            ],
+        )
+
+    def test_matrix_include_global_with_override(self):
+        m = BuildbotCiYml.load_matrix(
+            {'matrix': {'include': [{'env': 'ABC=10'}, {'env': 'ABC=11'}, {'env': 'ABC=12'}]}},
+            {'ABC': 'GV'},
+        )
+        self.assertEqual(
+            m,
+            [
+                {'env': {'ABC': '10'}},
+                {'env': {'ABC': '11'}},
+                {'env': {'ABC': '12'}},
+            ],
+        )

--- a/master/setup.py
+++ b/master/setup.py
@@ -295,6 +295,10 @@ setup_args = {
                 [
                     ('buildbot.process.buildstep', ['BuildStep']),
                     ('buildbot.steps.cmake', ['CMake']),
+                    (
+                        'buildbot.steps.configurable',
+                        ['BuildbotTestCiTrigger', 'BuildbotCiSetupSteps'],
+                    ),
                     ('buildbot.steps.cppcheck', ['Cppcheck']),
                     ('buildbot.steps.gitdiffinfo', ['GitDiffInfo']),
                     (

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -47,6 +47,7 @@ dicttoxml==1.7.16
 dill==0.3.8
 docker==7.1.0
 docutils==0.20.1  # pyup: ignore (sphinx-rtd-theme 2.0.0 requires docutils<0.21)
+evalidate==2.0.3
 extras==1.0.0
 fixtures==4.1.0
 funcsigs==1.0.2


### PR DESCRIPTION
This is experimental and not documented for now.

Currently the supports only the syntax used in .bbtravis.yml file in the Buildbot repository.