### PR TITLE
master: add self argument to CustomAuth.check_credentials

### DIFF
--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -207,7 +207,7 @@ class CustomAuth(TwistedICredAuthBase):
         return defer.fail(UnauthorizedLogin())
 
     @abstractmethod
-    def check_credentials(username, password):  # noqa pylint: disable=no-self-argument
+    def check_credentials(self, username, password):
         return False
 
 

--- a/newsfragments/fix-customauth-check_credentials-signature.bugfix
+++ b/newsfragments/fix-customauth-check_credentials-signature.bugfix
@@ -1,0 +1,1 @@
+Fix function signature for CustomAuth.check_credentials.


### PR DESCRIPTION
this function is [documented as having a self argument](https://docs.buildbot.net/current/manual/configuration/www.html#buildbot.www.auth.CustomAuth), but it does not exist in the code and was disabled by a linter ignore comment in #6400.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
