### PR TITLE
www: fix links in the about page

### DIFF
--- a/newsfragments/www-fix-about-page-links.bugfix
+++ b/newsfragments/www-fix-about-page-links.bugfix
@@ -1,0 +1,1 @@
+Fix links to external URLs in the about pages.

--- a/www/base/src/views/AboutView/AboutView.tsx
+++ b/www/base/src/views/AboutView/AboutView.tsx
@@ -88,8 +88,8 @@ export const AboutView = observer(() => {
         <Card.Body>
           <h2>
             <img src="icon.svg" alt="" width="64px" className="nut-spin"/>&nbsp;About this&nbsp;
-            <Link to="http://buildbot.net">buildbot</Link>&nbsp;running for&nbsp;
-            <Link to={config.titleURL}>{config.title}</Link>
+            <a href="https://buildbot.net">buildbot</a>&nbsp;running for&nbsp;
+            <a href={config.titleURL}>{config.title}</a>
           </h2>
           <div className="col-sm-12">
             <ul>


### PR DESCRIPTION
Somehow `<Link>` forces relative links and breaks external URLs (ex: https://buildbot.buildbot.net/#/about/http://buildbot.net). It might be fixed with react-router 6.7.1 [1], while I prefer to just use basic `<a>`.

While I'm at it, I also updated the link to use HTTPS.

[1] https://github.com/remix-run/react-router/pull/9900

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
