### PR TITLE
steps: Rewrite parse_env_string() to use regex

### DIFF
--- a/master/buildbot/test/unit/steps/test_configurable.py
+++ b/master/buildbot/test/unit/steps/test_configurable.py
@@ -26,6 +26,8 @@ class TestParseEnvString(unittest.TestCase):
     @parameterized.expand([
         ('single', 'ABC=1', {'ABC': '1'}),
         ('multiple', 'ABC=1 EFG=2', {'ABC': '1', 'EFG': '2'}),
+        ('multiple_empty_quotes', 'ABC=\'\' EFG=2', {'ABC': '', 'EFG': '2'}),
+        ('multiple_empty_double_quotes', 'ABC="" EFG=2', {'ABC': '', 'EFG': '2'}),
         ('multiple_single_quotes', 'ABC=\'1\' EFG=2', {'ABC': '1', 'EFG': '2'}),
         ('multiple_double_quotes', 'ABC="1" EFG=2', {'ABC': '1', 'EFG': '2'}),
         ('multiple_with_equals_in_value', 'ABC=1=2 EFG=2', {'ABC': '1=2', 'EFG': '2'}),


### PR DESCRIPTION
shlex is limited by only supporting ASCII characters. Environment values may contain any UTF word characters. Accordingly more flexible approach is warranted.

Originally regexes were not selected because they do not support nested quotes. However, it is possible to support escaped characters and this should be enough.
