### PR TITLE
data: allow buildername path var to be a string

### DIFF
--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -40,7 +40,7 @@ class BuildDatasNoValueEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/data
-        /builders/i:buildername/builds/n:build_number/data
+        /builders/s:buildername/builds/n:build_number/data
         /builds/n:buildid/data
         """
 
@@ -60,7 +60,7 @@ class BuildDataNoValueEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/data/i:name
-        /builders/i:buildername/builds/n:build_number/data/i:name
+        /builders/s:buildername/builds/n:build_number/data/i:name
         /builds/n:buildid/data/i:name
     """
 
@@ -78,7 +78,7 @@ class BuildDataEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.RAW
     pathPatterns = """
         /builders/n:builderid/builds/n:build_number/data/i:name/value
-        /builders/i:buildername/builds/n:build_number/data/i:name/value
+        /builders/s:buildername/builds/n:build_number/data/i:name/value
         /builds/n:buildid/data/i:name/value
     """
 

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -43,7 +43,7 @@ class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /builders/n:builderid
-        /builders/i:buildername
+        /builders/s:buildername
         /masters/n:masterid/builders/n:builderid
     """
 
@@ -96,7 +96,7 @@ class Builder(base.ResourceType):
 
     class EntityType(types.Entity):
         builderid = types.Integer()
-        name = types.Identifier(70)
+        name = types.String()
         masterids = types.List(of=types.Integer())
         description = types.NoneOk(types.String())
         description_format = types.NoneOk(types.String())

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -87,7 +87,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     pathPatterns = """
         /builds/n:buildid
         /builders/n:builderid/builds/n:build_number
-        /builders/i:buildername/builds/n:build_number
+        /builders/s:buildername/builds/n:build_number
     """
 
     @defer.inlineCallbacks
@@ -144,7 +144,7 @@ class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     pathPatterns = """
         /builds
         /builders/n:builderid/builds
-        /builders/i:buildername/builds
+        /builders/s:buildername/builds
         /buildrequests/n:buildrequestid/builds
         /changes/n:changeid/builds
         /workers/n:workerid/builds

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -50,8 +50,8 @@ class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
         /builds/n:buildid/steps/n:step_number/logs/i:log_slug
         /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug
         /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug
-        /builders/i:buildername/builds/n:build_number/steps/i:step_name/logs/i:log_slug
-        /builders/i:buildername/builds/n:build_number/steps/n:step_number/logs/i:log_slug
+        /builders/s:buildername/builds/n:build_number/steps/i:step_name/logs/i:log_slug
+        /builders/s:buildername/builds/n:build_number/steps/n:step_number/logs/i:log_slug
     """
 
     @defer.inlineCallbacks
@@ -77,8 +77,8 @@ class LogsEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
         /builds/n:buildid/steps/n:step_number/logs
         /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs
         /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs
-        /builders/i:buildername/builds/n:build_number/steps/i:step_name/logs
-        /builders/i:buildername/builds/n:build_number/steps/n:step_number/logs
+        /builders/s:buildername/builds/n:build_number/steps/i:step_name/logs
+        /builders/s:buildername/builds/n:build_number/steps/n:step_number/logs
     """
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -52,8 +52,8 @@ class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         /builds/n:buildid/steps/n:step_number
         /builders/n:builderid/builds/n:build_number/steps/i:step_name
         /builders/n:builderid/builds/n:build_number/steps/n:step_number
-        /builders/i:buildername/builds/n:build_number/steps/i:step_name
-        /builders/i:buildername/builds/n:build_number/steps/n:step_number
+        /builders/s:buildername/builds/n:build_number/steps/i:step_name
+        /builders/s:buildername/builds/n:build_number/steps/n:step_number
         """
 
     @defer.inlineCallbacks
@@ -75,7 +75,7 @@ class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     pathPatterns = """
         /builds/n:buildid/steps
         /builders/n:builderid/builds/n:build_number/steps
-        /builders/i:buildername/builds/n:build_number/steps
+        /builders/s:buildername/builds/n:build_number/steps
     """
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -46,7 +46,7 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /builders/n:builderid/test_result_sets
-        /builders/i:buildername/test_result_sets
+        /builders/s:buildername/test_result_sets
         /builds/n:buildid/test_result_sets
         /steps/n:stepid/test_result_sets
         """

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -80,7 +80,7 @@ types:
     /{builderid_or_buildername}:
         uriParameters:
             builderid_or_buildername:
-                type: number|identifier
+                type: number|string
                 description: the ID or name of the builder
         description: This path selects a builder by builderid
         get:

--- a/master/buildbot/spec/types/builder.raml
+++ b/master/buildbot/spec/types/builder.raml
@@ -31,7 +31,7 @@ properties:
         type: integer
     name:
         description: builder name
-        type: identifier
+        type: string
     tags[]:
         description: list of tags for this builder
         type: string

--- a/master/buildbot/spec/types/forcescheduler.raml
+++ b/master/buildbot/spec/types/forcescheduler.raml
@@ -14,7 +14,7 @@ properties:
         type: object
     builder_names[]:
         description: names of the builders that this scheduler can trigger
-        type: identifier
+        type: string
     button_name:
         description: label of the button to use in the UI
         type: string

--- a/master/buildbot/test/unit/util/test_pathmatch.py
+++ b/master/buildbot/test/unit/util/test_pathmatch.py
@@ -60,6 +60,10 @@ class Matcher(unittest.TestCase):
         self.m[('A', 'i:a', 'B', 'i:b')] = 'AB'
         self.assertEqual(self.m[('A', 'abc', 'B', 'x-z-B')], ('AB', {"a": 'abc', "b": 'x-z-B'}))
 
+    def test_pattern_variables_string(self):
+        self.m[('A', 's:a')] = 'A'
+        self.assertEqual(self.m[('A', 'unicode \N{SNOWMAN}')], ('A', {"a": 'unicode \N{SNOWMAN}'}))
+
     def test_pattern_variables_num_invalid(self):
         self.m[('A', 'n:a')] = 'AB'
         with self.assertRaises(KeyError):

--- a/master/buildbot/util/pathmatch.py
+++ b/master/buildbot/util/pathmatch.py
@@ -38,7 +38,7 @@ class Matcher:
         return f'<Matcher {repr(self._patterns)}>'
 
     path_elt_re = re.compile('^(.?):([a-z0-9_.]+)$')
-    type_fns = {"n": int, "i": ident}
+    type_fns = {"n": int, "i": ident, "s": str}
 
     def __getitem__(self, path):
         if self._dirty:

--- a/master/docs/developer/database/builders.rst
+++ b/master/docs/developer/database/builders.rst
@@ -12,7 +12,7 @@ Builders connector
     Builders are represented by a :class:`BuilderModel` dataclass with the following fields:
 
     * ``id`` -- the ID of this builder
-    * ``name``  -- the builder name, a 20-character :ref:`identifier <type-identifier>`
+    * ``name``  -- the builder name
     * ``description`` -- the builder's description (optional)
     * ``description_format`` -- the format of builder's description (optional)
     * ``description_html`` -- the builder description rendered as html (optional, depends on ``description_format``)
@@ -23,7 +23,7 @@ Builders connector
     .. py:method:: findBuilderId(name, autoCreate=True)
 
         :param name: name of this builder
-        :type name: 20-character :ref:`identifier <type-identifier>`
+        :type name: string
         :param autoCreate: automatically create the builder if name not found
         :type autoCreate: bool
         :returns: builder id via Deferred

--- a/newsfragments/data-builder-name-string.bugfix
+++ b/newsfragments/data-builder-name-string.bugfix
@@ -1,0 +1,1 @@
+Fix data API query using buildername to correctly work with buildername containing spaces and unicode (:issue:7752)


### PR DESCRIPTION
This fixes the inconsistency of a builder's name being a string in multiple places, but typed as an Identifier in the Data-API.

[this comment](https://github.com/buildbot/buildbot/issues/3465#issuecomment-317241432) confirms that the builder name is intended to be a unicode string.

Closes #7552

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
