### PR TITLE
buildbot_worker/runprocess.py: Use windows Job API

### DIFF
--- a/master/docs/manual/configuration/steps/shell_command.rst
+++ b/master/docs/manual/configuration/steps/shell_command.rst
@@ -26,6 +26,13 @@ You can also specify the command with a single string, in which case the string 
 On Windows, commands are run via ``cmd.exe /c`` which works well.
 However, if you're running a batch file, the error level does not get propagated correctly unless you add 'call' before your batch file's name: ``cmd=['call', 'myfile.bat', ...]``.
 
+``ShellCommand`` includes all sub-processes created by the command in ``JobObject``. This ensures
+that all child processes are managed together with the parent process. When the main command is
+terminated, all sub-processes are also terminated automatically, preventing any orphaned processes.
+This enhancement aligns the behavior of Windows systems with POSIX systems, where similar process
+management has been in place.
+
+
 The :bb:step:`ShellCommand` arguments are:
 
 ``command``

--- a/newsfragments/windows-job-api.change
+++ b/newsfragments/windows-job-api.change
@@ -1,0 +1,1 @@
+Buildbot worker will now run process in `JobObject`, so child processes can be killed if main process dies itself either intentionally or accidentally.


### PR DESCRIPTION
If process dies, there can still be sub-processes which can not be killed (on windows platform). This can cause problems with tests running on buildbot.

Attach spawned process to `JobObject` so if process dies, we can still kill all its child processes. Now we do not have to kill process (which does not have to exists) but we terminate whole JobObject, where are all processes of the main process (included).

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
