### PR TITLE
Fix: 4.0 backports: Use less space for Tags column in Builders page when there are n…

### DIFF
--- a/www/react-base/src/components/BuildersTable/BuildersTable.tsx
+++ b/www/react-base/src/components/BuildersTable/BuildersTable.tsx
@@ -129,10 +129,10 @@ export const BuildersTable = observer(
           <td>
             {buildElements}
           </td>
-          <td style={{width: "20%"}}>
+          <td>
             {filterManager.getElementsForTags(builder.tags)}
           </td>
-          <td style={{width: "20%"}}>
+          <td>
             {workerElements}
           </td>
         </tr>
@@ -154,11 +154,11 @@ export const BuildersTable = observer(
       <tr>
         <th>Builder Name</th>
         <th>Builds</th>
-        <th>
+        <th style={{maxWidth: "20%", minWidth: "70px"}}>
           {filterManager.getFiltersHelpElement()}
           {filterManager.getEnabledFiltersElements()}
         </th>
-        <th style={{width: "20%px"}}>Workers</th>
+        <th style={{width: "20%"}}>Workers</th>
       </tr>
       {builderRowElements}
       </tbody>


### PR DESCRIPTION
This PR fixes https://github.com/buildbot/buildbot/pull/7877 as changes were not copied to `www/react-base` part.