### PR TITLE
www: sort builds in the home page to show the latest one first

### DIFF
--- a/newsfragments/www-fix-build-order.bugfix
+++ b/newsfragments/www-fix-build-order.bugfix
@@ -1,0 +1,1 @@
+Sort builds in the home page to show the latest one first.

--- a/www/base/src/views/HomeView/HomeView.tsx
+++ b/www/base/src/views/HomeView/HomeView.tsx
@@ -142,7 +142,7 @@ export const HomeView = observer(() => {
                           <Card.Body>
                             {
                               Object.values(b.builds)
-                                .sort((a, b) => a.number - b.number)
+                                .sort((a, b) => b.number - a.number)
                                 .map(build => {
                                   return (
                                     <span key={build.id}>


### PR DESCRIPTION
Builds for the same builder are now sorted from newer to order on the home page (e.g., https://buildbot.host/#/). This matches the behavior of the Angular-based frontend, and it is more useful - usually I want to check recent builds rather than earlier ones.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
