### PR TITLE
4.0 backports: www: Fix login/logout href when instance is not at url's root

### DIFF
--- a/newsfragments/fix-www-auth-reverseproxy-subpath.bugfix
+++ b/newsfragments/fix-www-auth-reverseproxy-subpath.bugfix
@@ -1,0 +1,1 @@
+Fix ReactUI authentication when Buildbot is hosted behind a reverse proxy not at url's root. (:issue:`7814`)

--- a/www/base/src/components/Loginbar/Loginbar.tsx
+++ b/www/base/src/components/Loginbar/Loginbar.tsx
@@ -24,6 +24,7 @@ import {
 import {useLocation} from "react-router-dom";
 import {Nav, NavDropdown} from "react-bootstrap";
 import {ConfigContext} from "buildbot-ui";
+import { getBaseUrl } from 'buildbot-data-js';
 
 function getAuthIcon(faIcon: string) {
   switch (faIcon) {
@@ -56,7 +57,7 @@ export const Loginbar = () => {
     return (
       <Nav className="bb-loginbar-dropdown-nav">
         <NavDropdown title="Anonymous" id="bb-loginbar-dropdown">
-          <NavDropdown.Item href={"/auth/login?redirect=" + encodeURI(redirect)}>
+          <NavDropdown.Item href={getBaseUrl(window.location, "auth/login?redirect=" + encodeURI(redirect))}>
             {
               config.auth.oauth2
                 ? <span>
@@ -90,7 +91,7 @@ export const Loginbar = () => {
     <Nav className="bb-loginbar-dropdown-nav">
       <NavDropdown title={dropdownToggle} id="bb-loginbar-dropdown">
         {userDropdownHeader}
-        <NavDropdown.Item href={"auth/logout?redirect=" + encodeURI(redirect)}>
+        <NavDropdown.Item href={getBaseUrl(window.location, "auth/logout?redirect=" + encodeURI(redirect))}>
           <FaSignOutAlt/>
           Logout
         </NavDropdown.Item>

--- a/www/react-base/src/components/Loginbar/Loginbar.tsx
+++ b/www/react-base/src/components/Loginbar/Loginbar.tsx
@@ -24,6 +24,7 @@ import {
 import {useLocation} from "react-router-dom";
 import {Nav, NavDropdown} from "react-bootstrap";
 import {ConfigContext} from "buildbot-ui";
+import { getBaseUrl } from 'buildbot-data-js';
 
 function getAuthIcon(faIcon: string) {
   switch (faIcon) {
@@ -56,7 +57,7 @@ export const Loginbar = () => {
     return (
       <Nav className="bb-loginbar-dropdown-nav">
         <NavDropdown title="Anonymous" id="bb-loginbar-dropdown">
-          <NavDropdown.Item href={"/auth/login?redirect=" + encodeURI(redirect)}>
+          <NavDropdown.Item href={getBaseUrl(window.location, "auth/login?redirect=" + encodeURI(redirect))}>
             {
               config.auth.oauth2
                 ? <span>
@@ -90,7 +91,7 @@ export const Loginbar = () => {
     <Nav className="bb-loginbar-dropdown-nav">
       <NavDropdown title={dropdownToggle} id="bb-loginbar-dropdown">
         {userDropdownHeader}
-        <NavDropdown.Item href={"auth/logout?redirect=" + encodeURI(redirect)}>
+        <NavDropdown.Item href={getBaseUrl(window.location, "auth/logout?redirect=" + encodeURI(redirect))}>
           <FaSignOutAlt/>
           Logout
         </NavDropdown.Item>


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7824.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7871.