### PR TITLE
www: fix path to browser-warning-list.js

### DIFF
--- a/newsfragments/www-fix-browser-warnings.bugfix
+++ b/newsfragments/www-fix-browser-warnings.bugfix
@@ -1,0 +1,1 @@
+Fix missing warnings on old browsers.

--- a/www/base/index.html
+++ b/www/base/index.html
@@ -38,7 +38,7 @@
   </body>
   <script src="browser-warning.js"></script>
   <link href="browser-warning.css" rel="stylesheet">
-  <script src="src/browser-warning-list.js"></script>
+  <script src="browser-warning-list.js"></script>
   <!-- BUILDBOT_CONFIG_PLACEHOLDER -->
   <script src="/src/index.tsx" type="module"></script>
 </html>


### PR DESCRIPTION
This is a partial fix for [1].

Testing: on IE 11, a red banner with a warning about the old browser is shown.

[1] https://github.com/buildbot/buildbot/issues/7439

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
