### PR TITLE
configurable: Allow Slice node in configuration

### DIFF
--- a/master/buildbot/steps/configurable.py
+++ b/master/buildbot/steps/configurable.py
@@ -334,6 +334,7 @@ class BuildbotTestCiTrigger(BuildbotTestCiReadConfigMixin, CompositeStepMixin, T
 
 eval_model = base_eval_model.clone()
 eval_model.nodes.append('Mul')
+eval_model.nodes.append('Slice')
 eval_model.nodes.append('Tuple')
 
 


### PR DESCRIPTION
This will allow to do checks like param[0:4] == 'test' in the configuration.