### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 33"

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -59,7 +59,7 @@ pyOpenSSL==24.2.1
 pypugjs==5.11.0
 python-dateutil==2.9.0.post0
 pytz==2024.1
-PyYAML==6.0.1
+PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.3
 ruff==0.5.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -46,7 +46,7 @@ jmespath==1.0.1
 lz4==4.3.3
 Mako==1.3.5
 MarkupSafe==2.1.5
-moto==5.0.12
+moto==5.0.13
 msgpack==1.0.8
 mypy-extensions==1.0.0
 packaging==24.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -80,5 +80,5 @@ urllib3==1.26.19  # pyup: ignore
 Werkzeug==3.0.3
 xmltodict==0.13.0
 zope.event==5.0
-zope.interface==6.4.post2
+zope.interface==7.0.1
 zope.schema==7.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,7 +21,7 @@ psutil==6.0.0
 # while to remove no longer needed dependencies.
 
 alembic==1.13.2
-attrs==24.1.0
+attrs==24.2.0
 autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==22.10.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,7 @@
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
 buildbot-www==4.0.2
 
-Markdown==3.6
+Markdown==3.7
 coverage==7.6.1
 docker==7.1.0
 hvac==2.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -26,7 +26,7 @@ autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.0
 boto==2.49.0
-boto3==1.34.161
+boto3==1.35.0
 botocore==1.34.161
 certifi==2024.7.4
 cffi==1.16.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -24,7 +24,7 @@ alembic==1.13.2
 attrs==24.2.0
 autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-Automat==22.10.0
+Automat==24.8.0
 boto==2.49.0
 boto3==1.34.161
 botocore==1.34.161

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==4.0.1
+buildbot-www==4.0.2
 
 Markdown==3.6
 coverage==7.6.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -67,7 +67,7 @@ s3transfer==0.10.2
 service-identity==24.1.0
 setuptools-trial==0.6.0
 six==1.16.0
-SQLAlchemy==2.0.31
+SQLAlchemy==2.0.32
 treq==23.11.0;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore
 Twisted==24.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -29,7 +29,7 @@ boto==2.49.0
 boto3==1.35.0
 botocore==1.35.0
 certifi==2024.7.4
-cffi==1.16.0
+cffi==1.17.0
 charset-normalizer==3.3.2
 constantly==23.10.4
 croniter==3.0.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.0
 boto==2.49.0
 boto3==1.35.0
-botocore==1.34.161
+botocore==1.35.0
 certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -29,7 +29,7 @@ towncrier==24.7.1
 alabaster==1.0.0; python_version >= "3.10"
 alabaster==0.7.16; python_version == "3.9" # pyup: ignore 1.0.0 dropped support for Python 3.9 and earlier
 alabaster==0.7.13; python_version < "3.9" # pyup: ignore 0.7.14 dropped support for Python 3.8 and earlier
-Babel==2.15.0
+Babel==2.16.0
 click==8.1.7
 docutils==0.20.1  # pyup: ignore (sphinx-rtd-theme 2.0.0 requires docutils<0.21)
 imagesize==1.4.1

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -1,5 +1,5 @@
 attrs==21.4.0;  python_version < "3.6"  # pyup: ignore
-attrs==24.1.0;  python_version >= "3.6"
+attrs==24.2.0;  python_version >= "3.6"
 autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: ignore
 autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -31,5 +31,5 @@ txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.12.2;  python_version >= "3.7"
 typing-extensions==4.12.2;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
-zope.interface==6.4.post2;  python_version >= "3.6"
+zope.interface==7.0.1;  python_version >= "3.6"
 -e worker

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -4,7 +4,7 @@ autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: ignore
 autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
 Automat==20.2.0;  python_version < "3.6"  # pyup: ignore
-Automat==22.10.0;  python_version >= "3.6"
+Automat==24.8.0;  python_version >= "3.6"
 cffi==1.16.0;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -5,7 +5,7 @@ autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: i
 autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
 Automat==20.2.0;  python_version < "3.6"  # pyup: ignore
 Automat==24.8.0;  python_version >= "3.6"
-cffi==1.16.0;  python_version >= "3.6"
+cffi==1.17.0;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
 cryptography==43.0.0;  python_version >= "3.6"

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,3 +1,3 @@
 pip==24.2
-setuptools==70.3.0
+setuptools==72.2.0
 wheel==0.44.0


### PR DESCRIPTION
This PR is based on #7935 with these modification(s):

- removed mypy upgrade due to mypy-zope upgrade issue - see https://github.com/Shoobx/mypy-zope/pull/117
- removed Update twisted from 24.3.0 to 24.7.0 to address deprecation changes in separate PR
builtins.DeprecationWarning: twisted.web.resource._UnsafeNoResource.__init__ was deprecated in Twisted 22.10.0; please use Use twisted.web.pages.notFound instead, which properly escapes HTML. instead
- Removed update ruff from 0.5.2 to 0.6.1 due to it needs additional source chages in 
  * master/buildbot/test/unit/util/test_interfaces.py
  * master/buildbot/test/util/endpoint.py
  * worker/buildbot_worker/commands/fs.py
  * worker/buildbot_worker/commands/utils.py


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
