### PR TITLE
start.py: add support for env timeout

### DIFF
--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -152,6 +152,8 @@ def start(config):
 
     # this is the parent
     timeout = config.get('start_timeout', None)
+    if timeout is None:
+        timeout = os.getenv('START_TIMEOUT', None)
     if timeout is not None:
         try:
             timeout = float(timeout)

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -94,6 +94,10 @@ The option `--nodaemon` option instructs Buildbot to skip daemonizing.
 The process will start in the foreground.
 It will only return to the command-line when it is stopped.
 
+Additionally, the user can set the environment variable `START_TIMEOUT`
+to specify the amount of time the script waits for the master to start
+until it declares the operation as failure.
+
 .. bb:cmdline:: restart (buildbot)
 
 restart

--- a/newsfragments/custom-timeout-env.feature
+++ b/newsfragments/custom-timeout-env.feature
@@ -1,0 +1,1 @@
+Added possibility to set `START_TIMEOUT` via environment variable.


### PR DESCRIPTION
Add support for env parameter `START_TIMEOUT` along with the config.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
