### PR TITLE
3.11 backports: e2e: Emit full twistd.log in case worker fails to connect

### DIFF
--- a/smokes-react/run.sh
+++ b/smokes-react/run.sh
@@ -33,6 +33,8 @@ buildbot checkconfig workdir
 # on docker buildbot might be a little bit slower to start, so sleep another 20s in case of start to slow.
 buildbot start workdir || sleep 20
 buildbot-worker start workdir/worker
+
+trap finish EXIT
 cat workdir/twistd.log &
 
 yarn install --pure-lockfile


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7859.