### PR TITLE
4.0 backports: www: sort builds in the home page to show the latest one first

### DIFF
--- a/newsfragments/www-fix-build-order.bugfix
+++ b/newsfragments/www-fix-build-order.bugfix
@@ -1,0 +1,1 @@
+Sort builds in the home page to show the latest one first.

--- a/www/base/src/views/HomeView/HomeView.tsx
+++ b/www/base/src/views/HomeView/HomeView.tsx
@@ -142,7 +142,7 @@ export const HomeView = observer(() => {
                           <Card.Body>
                             {
                               Object.values(b.builds)
-                                .sort((a, b) => a.number - b.number)
+                                .sort((a, b) => b.number - a.number)
                                 .map(build => {
                                   return (
                                     <span key={build.id}>

--- a/www/react-base/src/views/HomeView/HomeView.tsx
+++ b/www/react-base/src/views/HomeView/HomeView.tsx
@@ -142,7 +142,7 @@ export const HomeView = observer(() => {
                           <Card.Body>
                             {
                               Object.values(b.builds)
-                                .sort((a, b) => a.number - b.number)
+                                .sort((a, b) => b.number - a.number)
                                 .map(build => {
                                   return (
                                     <span key={build.id}>


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7916.
PR is a partial fix for https://github.com/buildbot/buildbot/issues/7871.