### PR TITLE
3.11 backports: www: Bump Javascript compile target to ES2020

### DIFF
--- a/newsfragments/www-supported-browsers.change
+++ b/newsfragments/www-supported-browsers.change
@@ -1,0 +1,2 @@
+The list of supported browsers has been updated to Chrome >=80, Firefox >= 80, Edge >=80,
+Safari >= 14, Opera >=67.

--- a/www/plugin_support/vite.config.mts
+++ b/www/plugin_support/vite.config.mts
@@ -14,7 +14,7 @@ export default defineConfig({
       name: "buildbot-plugin-support",
       fileName: "buildbot-plugin-support",
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },

--- a/www/react-base/public/browser-warning-list.js
+++ b/www/react-base/public/browser-warning-list.js
@@ -1,16 +1,16 @@
-// this file is not transpiled and included direcly to index.html because we must show the browser
-// warning even on ancient browsers. The browser list here must correspond to the browser list in
-// babel config which is located at TODO
+// this file is not transpiled and included directly to index.html because we must show the browser
+// warning even on ancient browsers. The browser list should correspond to the list of browsers
+// supporting ES2020 target in https://caniuse.com.
 outdatedBrowserRework({
     browserSupport: {
-        'Chrome': 56, // Includes Chrome for mobile devices
-        'Chromium': 56, // same as Chrome, but needs to be listed explicitly
+        'Chrome': 80, // Includes Chrome for mobile devices
+        'Chromium': 80, // same as Chrome, but needs to be listed explicitly
                         // (https://github.com/mikemaccana/outdated-browser-rework/issues/49)
-        'Edge': 13,
-        'Safari': 10,
-        'Mobile Safari': 10,
-        'Firefox': 52,
-        'Opera': 43, // uses Chrome 56 internally
+        'Edge': 80,
+        'Safari': 14,
+        'Mobile Safari': 14,
+        'Firefox': 80,
+        'Opera': 67,
         'IE': false
     },
     requireChromeOnAndroid: false,

--- a/www/react-base/vite.config.mts
+++ b/www/react-base/vite.config.mts
@@ -93,7 +93,7 @@ export default defineConfig({
   // path prefix, like my-domain.com/custom-buildbot-path/
   base: './',
   build: {
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },

--- a/www/react-console_view/vite.config.mts
+++ b/www/react-console_view/vite.config.mts
@@ -54,7 +54,7 @@ export default defineConfig({
         },
       },
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },

--- a/www/react-data-module/vite.config.mts
+++ b/www/react-data-module/vite.config.mts
@@ -33,7 +33,7 @@ export default defineConfig({
         },
       },
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
     minify: false,

--- a/www/react-grid_view/vite.config.mts
+++ b/www/react-grid_view/vite.config.mts
@@ -55,7 +55,7 @@ export default defineConfig({
         },
       },
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },

--- a/www/react-ui/vite.config.mts
+++ b/www/react-ui/vite.config.mts
@@ -55,7 +55,7 @@ export default defineConfig({
         },
       },
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },

--- a/www/react-waterfall_view/vite.config.mts
+++ b/www/react-waterfall_view/vite.config.mts
@@ -54,7 +54,7 @@ export default defineConfig({
         },
       },
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },

--- a/www/react-wsgi_dashboards/vite.config.mts
+++ b/www/react-wsgi_dashboards/vite.config.mts
@@ -55,7 +55,7 @@ export default defineConfig({
         },
       },
     },
-    target: ['es2015'],
+    target: ['es2020'],
     outDir: outDir,
     emptyOutDir: true,
   },


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7727.