### PR TITLE
Fix #7833: Secrets are not obfuscated in "Status" in case of failure

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -409,6 +409,8 @@ class BuildStep(
             elif self.max_lines_reached:
                 stepsumm += " (max lines reached)"
 
+        if self.build is not None:
+            stepsumm = self.build.properties.cleanupTextFromSecrets(stepsumm)
         return {'step': stepsumm}
 
     @defer.inlineCallbacks
@@ -1039,6 +1041,9 @@ class ShellMixin:
                     summary += " (timed out)"
                 elif self.max_lines_reached:
                     summary += " (max lines)"
+
+            if self.build is not None:
+                summary = self.build.properties.cleanupTextFromSecrets(summary)
             return {'step': summary}
         return super().getResultSummary()
 

--- a/master/buildbot/test/fake/secrets.py
+++ b/master/buildbot/test/fake/secrets.py
@@ -1,10 +1,19 @@
+from __future__ import annotations
+
 from buildbot.secrets.providers.base import SecretProviderBase
 
 
 class FakeSecretStorage(SecretProviderBase):
     name = "SecretsInFake"
 
+    def __init__(self, *args, secretdict: dict | None = None, **kwargs):
+        super().__init__(*args, **kwargs, secretdict=secretdict)
+        self._setup_secrets(secretdict=secretdict)
+
     def reconfigService(self, secretdict=None):
+        self._setup_secrets(secretdict=secretdict)
+
+    def _setup_secrets(self, secretdict: dict | None = None):
         if secretdict is None:
             secretdict = {}
         self.allsecrets = secretdict

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import stat
 import tarfile
 from io import BytesIO
@@ -656,7 +658,13 @@ class TestBuildStepMixin:
     @ivar properties: build properties (L{Properties} instance)
     """
 
-    def setup_test_build_step(self, want_data=True, want_db=False, want_mq=False):
+    def setup_test_build_step(
+        self,
+        want_data=True,
+        want_db=False,
+        want_mq=False,
+        with_secrets: dict | None = None,
+    ):
         if not hasattr(self, 'reactor'):
             raise RuntimeError('Reactor has not yet been setup for step')
 
@@ -666,7 +674,11 @@ class TestBuildStepMixin:
         self._expected_commands_popped = 0
 
         self.master = fakemaster.make_master(
-            self, wantData=want_data, wantDb=want_db, wantMq=want_mq
+            self,
+            wantData=want_data,
+            wantDb=want_db,
+            wantMq=want_mq,
+            with_secrets=with_secrets,
         )
 
         self.patch(runprocess, "create_process", self._patched_create_process)

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -454,8 +454,6 @@ def command_to_string(command):
     # flatten any nested lists
     words = flatten(words, (list, tuple))
 
-    # strip instances and other detritus (which can happen if a
-    # description is requested before rendering)
     stringWords = []
     for w in words:
         if isinstance(w, (bytes, str)):
@@ -463,6 +461,8 @@ def command_to_string(command):
             # trying to covert it.
             w = bytes2unicode(w, errors="replace")
             stringWords.append(w)
+        else:
+            stringWords.append(repr(w))
     words = stringWords
 
     if not words:

--- a/newsfragments/buildstep-summary-secret-leak.bugfix
+++ b/newsfragments/buildstep-summary-secret-leak.bugfix
@@ -1,0 +1,1 @@
+Fix ``Build`` summary containing non obfuscated ``Secret`` values present in a failed ``BuildStep`` summary (:issue:`7833`)

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -308,8 +308,6 @@ class RunProcess:
         @param useProcGroup: (default True) use a process group for non-PTY
             process invocations
         """
-        self.command_id = command
-
         if logfiles is None:
             logfiles = {}
 
@@ -321,6 +319,9 @@ class RunProcess:
                 return w
 
             command = [obfus(w) for w in command]
+
+        self.command_id = command
+
         # We need to take unicode commands and arguments and encode them using
         # the appropriate encoding for the worker.  This is mostly platform
         # specific, but can be overridden in the worker's buildbot.tac file.


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
