### PR TITLE
4.0 backports: Fix backport #7847

### DIFF
--- a/www/react-base/src/components/LogPreview/LogPreview.scss
+++ b/www/react-base/src/components/LogPreview/LogPreview.scss
@@ -12,5 +12,5 @@
 }
 
 .logline > span {
-  white-space: nowrap;
+  white-space: pre;
 }

--- a/www/react-base/src/components/LogViewer/LogViewerText.scss
+++ b/www/react-base/src/components/LogViewer/LogViewerText.scss
@@ -79,7 +79,7 @@
 }
 
 .bb-logviewer-text-row > span {
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .bb-logviewer-text-download-log {


### PR DESCRIPTION
This PR completes backporting of https://github.com/buildbot/buildbot/pull/7816 as changes in `www/react-base` were missing in https://github.com/buildbot/buildbot/pull/7847.