### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/common/validate.sh
+++ b/common/validate.sh
@@ -81,14 +81,6 @@ check_long_lines() {
 }
 
 
-check_yield_defer_returnValue() {
-    local yields=false
-    if git diff "$REVRANGE" | grep '+.*yield defer.returnValue'; then
-        yields=true
-    fi
-    $yields
-}
-
 check_relnotes() {
     if git diff --exit-code "$REVRANGE" master/docs/relnotes/index.rst >/dev/null 2>&1; then
         return 1
@@ -168,7 +160,6 @@ fi
 status "checking formatting"
 check_tabs && not_ok "$REVRANGE adds tabs"
 check_long_lines && warning "$REVRANGE adds long lines"
-check_yield_defer_returnValue && not_ok "$REVRANGE yields defer.returnValue"
 
 status "checking for use of sa.Table"
 check_sa_Table || warning "use (buildbot.util.)sautils.Table instead of sa.Table"

--- a/master/docs/developer/style.rst
+++ b/master/docs/developer/style.rst
@@ -179,9 +179,6 @@ The key points to notice here:
 * Use the decorator form of ``inlineCallbacks``.
 * In most cases, the result of a ``yield`` expression should be assigned to a variable.
   It can be used in a larger expression, but remember that Python requires that you enclose the expression in its own set of parentheses.
-* Python does not permit returning a value from a generator, so statements like ``return xval + y`` are invalid.
-  Instead, yield the result of ``defer.returnValue``.
-  For clarity, follow it with a bare ``return``, unless it is the last statement in the function.
 
 The great advantage of ``inlineCallbacks`` is that it allows you to use all of the usual Pythonic control structures in their natural form.
 In particular, it is easy to represent a loop or even nested loops in this style without losing any readability.

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -124,15 +124,13 @@ class RemoveDirectory(base.Command):
         # permissions and re-try the rm -rf.
         if not chmodDone:
             rc = yield self._tryChmod(rc, path)
-        defer.returnValue(rc)
+        return rc
 
     @defer.inlineCallbacks
     def _tryChmod(self, rc, path):
         assert isinstance(rc, int)
         if rc == 0:
-            defer.returnValue(0)
-            # pylint: disable=unreachable
-            return  # pragma: no cover
+            return 0
         # Attempt a recursive chmod and re-try the rm -rf after.
 
         command = ["chmod", "-Rf", "u+rwx", path]
@@ -158,7 +156,7 @@ class RemoveDirectory(base.Command):
         self.command = c
         rc = yield c.start()
         rc = yield self._clobber(rc, path, True)
-        defer.returnValue(rc)
+        return rc
 
 
 class CopyDirectory(base.Command):

--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -384,7 +384,7 @@ class BuildbotWebSocketClientProtocol(WebSocketClientProtocol):
         self.seq_number = self.seq_number + 1
         self.sendMessage(msg, isBinary=True)
         res1 = yield d
-        defer.returnValue(res1)
+        return res1
 
     def onClose(self, wasClean, code, reason):
         if self.debug:

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -411,7 +411,7 @@ class BotPbLike(BotBase):
                             "it now"
                         )
 
-        defer.returnValue(retval)
+        return retval
 
 
 class BotPb(BotPbLike, pb.Referenceable):

--- a/worker/buildbot_worker/pbutil.py
+++ b/worker/buildbot_worker/pbutil.py
@@ -116,7 +116,7 @@ class AutoLoginPBFactory(PBClientFactory):
         else:
             log.err(why, 'While trying to connect:')
             reactor.stop()
-            defer.returnValue(None)
+            return
 
         self._failedAttempts += 1
         delay = self._timeoutForAttempt(self._failedAttempts)

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -65,7 +65,7 @@ class MasterRealm:
         if self.on_attachment:
             yield self.on_attachment(mind)
 
-        defer.returnValue((pb.IPerspective, self.perspective, lambda: None))
+        return pb.IPerspective, self.perspective, lambda: None
 
     def shutdown(self):
         return self.mind.broker.transport.loseConnection()


### PR DESCRIPTION
Python 2 support was removed from the worker in buildbot 4.0.0, and `defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.

## Contributor Checklist:

* [x] I have updated the unit tests
* [N/A] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation