### PR TITLE
www: add worker bulk action modal

### DIFF
--- a/www/base/src/components/MultipleWorkersActionsModal/MultipleWorkersActionsModal.tsx
+++ b/www/base/src/components/MultipleWorkersActionsModal/MultipleWorkersActionsModal.tsx
@@ -1,0 +1,106 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {observer} from "mobx-react";
+import {useState} from "react";
+import {Button, Form, Modal} from "react-bootstrap";
+import {Worker} from "buildbot-data-js";
+
+type MultipleWorkersActionsModalProps = {
+  workers: Worker[];
+  preselectedWorkers: Worker[];
+  onClose: () => void;
+}
+
+export const MultipleWorkersActionsModal = observer(({workers, preselectedWorkers, onClose}: MultipleWorkersActionsModalProps) => {
+  if (workers.length === 1) {
+    preselectedWorkers = [...workers];
+  }
+
+  const [errors, setErrors] = useState<string|null>(null);
+  const [reasonText, setReasonText] = useState<string>("");
+  const [selectedWorkerNames, setSelectedWorkerNames] = useState<string[]>(preselectedWorkers.map(w => w.name));
+
+  const selectedWorkers = workers.filter(w => selectedWorkerNames.includes(w.name))
+  const stopDisabled = selectedWorkers.length <= 0 || selectedWorkers.every(w => w.connected_to.length === 0)
+  const pauseDisabled = selectedWorkers.length <= 0 || selectedWorkers.every(w => w.paused)
+  const unpauseDisabled = selectedWorkers.length <= 0 || selectedWorkers.every(w => !w.paused)
+
+  const doAction = async (method: string) => {
+    if (selectedWorkers.length <= 0) {
+      setErrors("No worker selected for action");
+      return
+    }
+    setErrors(null);
+    const results = await Promise.allSettled(selectedWorkers.map(w => w.control(method, {reason: reasonText})));
+    const rejectedActions = results.filter(r => r.status === "rejected")
+    if (rejectedActions.length > 0) {
+      setErrors(rejectedActions.map(r => (r as PromiseRejectedResult).reason).join("\n"));
+    }
+    else {
+      onClose();
+    }
+  }
+
+  return (
+    <Modal size="lg" show={true} onHide={() => onClose()}>
+      <Modal.Header closeButton>
+        <Modal.Title>Worker actions for {workers.length === 1 ? workers[0].name : "..."}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="form-horizontal">
+          {
+            errors === null
+              ? <></>
+              : <div ng-show="error" className="alert alert-danger">{errors}</div>
+          }
+          {workers.length !== 1 ?
+            <Form.Control
+                as="select" multiple value={selectedWorkerNames}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                  const selectedOptions: HTMLOptionElement[] = [].slice.call(event.target.selectedOptions ?? []);
+                  setSelectedWorkerNames(selectedOptions.map(e => e.value));
+                }}>
+              {workers.map(worker => (<option key={worker.name}>{worker.name}</option>))}
+            </Form.Control>
+            : <></>
+          }
+          <label htmlFor="reason" className="control-label col-sm-2">Reason</label>
+          <div className="col-sm-10">
+            <textarea rows={15} value={reasonText} onChange={e => setReasonText(e.target.value)}
+                      className="form-control"/>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="default" onClick={() => onClose()}>Cancel</Button>
+        <Button variant="primary" disabled={stopDisabled} onClick={async () => await doAction('stop')}>
+          Graceful Shutdown
+        </Button>
+        <Button variant="primary" disabled={stopDisabled} onClick={async () => await doAction('kill')}>
+          Force Shutdown
+        </Button>
+        <Button variant="primary" disabled={pauseDisabled} onClick={async () => await doAction('pause')}>
+          Pause
+        </Button>
+        <Button variant="primary" disabled={unpauseDisabled} onClick={async () => await doAction('unpause')}>
+          Unpause
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+});

--- a/www/base/src/components/WorkerActionsModal/WorkerActionsModal.tsx
+++ b/www/base/src/components/WorkerActionsModal/WorkerActionsModal.tsx
@@ -16,9 +16,8 @@
 */
 
 import {observer} from "mobx-react";
-import {useState} from "react";
-import {Button, Modal} from "react-bootstrap";
 import {Worker} from "buildbot-data-js";
+import {MultipleWorkersActionsModal} from "../MultipleWorkersActionsModal/MultipleWorkersActionsModal";
 
 type WorkerActionsModalProps = {
   worker: Worker;
@@ -26,58 +25,5 @@ type WorkerActionsModalProps = {
 }
 
 export const WorkerActionsModal = observer(({worker, onClose}: WorkerActionsModalProps) => {
-
-  const [errors, setErrors] = useState<string|null>(null);
-  const [reasonText, setReasonText] = useState<string>("");
-
-  const doAction = (method: string) => {
-    const doActionAsync = async () => {
-      try {
-        await worker.control(method, {reason: reasonText});
-        onClose();
-      } catch (err: any) {
-        setErrors(err.message);
-      }
-    }
-    doActionAsync();
-  }
-
-  const stopDisabled = worker.connected_to.length === 0;
-
-  return (
-    <Modal show={true} onHide={() => onClose()}>
-      <Modal.Header closeButton>
-        <Modal.Title>Worker actions for {worker.name}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <div className="form-horizontal">
-          {
-            errors === null
-              ? <></>
-              : <div ng-show="error" className="alert alert-danger">{errors}</div>
-          }
-          <label htmlFor="reason" className="control-label col-sm-2">Reason</label>
-          <div className="col-sm-10">
-            <textarea rows={15} value={reasonText} onChange={e => setReasonText(e.target.value)}
-                      className="form-control"/>
-          </div>
-        </div>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="default" onClick={() => onClose()}>Cancel</Button>
-        <Button variant="primary" disabled={stopDisabled} onClick={() => doAction('stop')}>
-          Graceful Shutdown
-        </Button>
-        <Button variant="primary" disabled={stopDisabled} onClick={() => doAction('kill')}>
-          Force Shutdown
-        </Button>
-        <Button variant="primary" disabled={worker.paused} onClick={() => doAction('pause')}>
-          Pause
-        </Button>
-        <Button variant="primary" disabled={!worker.paused} onClick={() => doAction('unpause')}>
-          Unpause
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  )
+  return <MultipleWorkersActionsModal workers={[worker]} preselectedWorkers={[worker]} onClose={onClose}/>
 });

--- a/www/base/src/views/WorkersView/WorkersView.tsx
+++ b/www/base/src/views/WorkersView/WorkersView.tsx
@@ -28,8 +28,12 @@ import {
   useDataApiQuery
 } from "buildbot-data-js";
 import {WorkerActionsModal} from "../../components/WorkerActionsModal/WorkerActionsModal";
+import {MultipleWorkersActionsModal} from "../../components/MultipleWorkersActionsModal/MultipleWorkersActionsModal";
 import {WorkersTable} from "../../components/WorkersTable/WorkersTable";
-import {getBuildLinkDisplayProperties} from "buildbot-ui";
+import {
+  getBuildLinkDisplayProperties,
+  useTopbarActions,
+} from "buildbot-ui";
 
 const isWorkerFiltered = (worker: Worker, showOldWorkers: boolean) => {
   if (showOldWorkers) {
@@ -91,6 +95,19 @@ export const WorkersView = observer(() => {
   }).sort((a, b) => a.name.localeCompare(b.name))
     .sort((a, b) => b.connected_to.length - a.connected_to.length);
 
+  const [showWorkersActions, setShowWorkersActions] =
+    useState<boolean>(false);
+
+  useTopbarActions([
+    {
+      caption: "Actions...",
+      variant: "primary",
+      action: () => {
+        setShowWorkersActions(true);
+      },
+    },
+  ]);
+
   return (
     <div className="container">
       <WorkersTable workers={filteredWorkers} buildersQuery={buildersQuery}
@@ -100,6 +117,13 @@ export const WorkersView = observer(() => {
       { workerForActions !== null
         ? <WorkerActionsModal worker={workerForActions}
                               onClose={() => setWorkerForActions(null)}/>
+        : <></>
+      }
+      { showWorkersActions
+        ? <MultipleWorkersActionsModal
+            workers={workersQuery.array}
+            preselectedWorkers={filteredWorkers}
+            onClose={() => setShowWorkersActions(false)}/>
         : <></>
       }
     </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/290ae15c-b5df-46b3-90d6-2edc498b9407)

Simple select component is pretty bare bone and does not provide features parity with Angular version ([un]select-all, search).

I looked at some existing components for multi select, but they all seem not maintained:
- [react-select](https://github.com/JedWatson/react-select): (last release close to one year ago)
- [react-multi-select-component](https://github.com/hc-oss/react-multi-select-component): (last release 2 years ago)
- [multiselect-react-dropdown](https://github.com/srigar/multiselect-react-dropdown): (last release 2 years ago)

I found that bigger component libraries that contain a widget that would help are kept up to date.
Candidates:
- https://primereact.org/multiselect/
- https://mui.com/material-ui/react-select/#multiple-select
- https://coreui.io/react/docs/forms/multi-select/

These libraries should provide other components that could be used elsewhere in the UI and plugins.

Leaving the decision whether to add one and which one to Buildbot's maintainer team.
Waiting on feedback to un-draft this PR. This could be merged as-is as a first step.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
