### PR TITLE
www: Make wsgi_dashboards routes backwards compatible with old plugin

### DIFF
--- a/newsfragments/www-fix-wsgi-url.bugfix
+++ b/newsfragments/www-fix-wsgi-url.bugfix
@@ -1,0 +1,1 @@
+Fix URL of WGSI dashboards to keep backward compatibility with the 3.x WSGI plugin.

--- a/www/wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
+++ b/www/wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
@@ -101,12 +101,12 @@ buildbotSetupPlugin((reg, config) => {
       caption: caption,
       icon: createElement(icon, {}),
       order: dashboard.order,
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       parentName: null,
     });
   
     reg.registerRoute({
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       group: name,
       element: () => <WSGIDashboardsView name={name}/>,
     });


### PR DESCRIPTION
Fix the WSGI dashboards plugin routes match the routes of the old WSGI plugin.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
