### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 37"

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -90,3 +90,27 @@ warnings.filterwarnings(
     r"and will be removed in or after August 2025\.",
     category=DeprecationWarning,
 )
+
+warnings.filterwarnings(
+    "ignore",
+    r"twisted.web.resource._UnsafeErrorPage.__init__ was deprecated in "
+    r"Twisted 22.10.0; please use Use twisted.web.pages.errorPage instead, "
+    r"which properly escapes HTML. instead",
+    category=DeprecationWarning,
+)
+
+warnings.filterwarnings(
+    "ignore",
+    r"twisted.web.resource._UnsafeNoResource.__init__ was deprecated in "
+    r"Twisted 22.10.0; please use Use twisted.web.pages.notFound instead, "
+    r"which properly escapes HTML. instead",
+    category=DeprecationWarning,
+)
+
+warnings.filterwarnings(
+    "ignore",
+    r"twisted.web.resource._UnsafeForbiddenResource.__init__ was deprecated in "
+    r"Twisted 22.10.0; please use Use twisted.web.pages.forbidden instead, "
+    r"which properly escapes HTML. instead",
+    category=DeprecationWarning,
+)

--- a/newsfragments/twisted-lim-24.7.0.removal
+++ b/newsfragments/twisted-lim-24.7.0.removal
@@ -1,0 +1,2 @@
+Master running with Twisted >= 24.7.0 does not work with buildbot-worker 0.8.
+Use Twisted 24.3.0 on master if you need to communicate with buildbot-worker 0.8.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -80,5 +80,5 @@ urllib3==1.26.19  # pyup: ignore
 Werkzeug==3.0.4
 xmltodict==0.13.0
 zope.event==5.0
-zope.interface==7.0.1
+zope.interface==7.0.3
 zope.schema==7.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -46,7 +46,7 @@ jmespath==1.0.1
 lz4==4.3.3
 Mako==1.3.5
 MarkupSafe==2.1.5
-moto==5.0.13
+moto==5.0.14
 msgpack==1.0.8
 mypy-extensions==1.0.0
 packaging==24.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -62,7 +62,7 @@ pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.3
-ruff==0.6.1
+ruff==0.6.5
 s3transfer==0.10.2
 service-identity==24.1.0
 setuptools-trial==0.6.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -33,7 +33,7 @@ cffi==1.17.1
 charset-normalizer==3.3.2
 constantly==23.10.4
 croniter==3.0.3
-cryptography==43.0.0
+cryptography==43.0.1
 dill==0.3.8
 evalidate==2.0.3
 greenlet==3.0.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -38,7 +38,7 @@ dill==0.3.8
 evalidate==2.0.3
 greenlet==3.1.0
 hyperlink==21.0.0
-idna==3.7
+idna==3.10
 incremental==24.7.2
 incremental==22.10.0;  python_version < "3.8" # pyup: ignore
 Jinja2==3.1.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -36,7 +36,7 @@ croniter==3.0.3
 cryptography==43.0.1
 dill==0.3.8
 evalidate==2.0.3
-greenlet==3.0.3
+greenlet==3.1.0
 hyperlink==21.0.0
 idna==3.7
 incremental==24.7.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -77,7 +77,7 @@ typing_extensions==4.12.2
 unidiff==0.7.5
 # botocore depends on urllib3<1.27
 urllib3==1.26.19  # pyup: ignore
-Werkzeug==3.0.3
+Werkzeug==3.0.4
 xmltodict==0.13.0
 zope.event==5.0
 zope.interface==7.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -58,7 +58,7 @@ PyJWT==2.9.0
 pyOpenSSL==24.2.1
 pypugjs==5.11.0
 python-dateutil==2.9.0.post0
-pytz==2024.1
+pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -70,7 +70,7 @@ six==1.16.0
 SQLAlchemy==2.0.34
 treq==23.11.0;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore
-Twisted==24.3.0
+Twisted==24.7.0
 txaio==23.1.1
 txrequests==0.9.6
 typing_extensions==4.12.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -26,7 +26,7 @@ autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
-boto3==1.35.0
+boto3==1.35.19
 botocore==1.35.0
 certifi==2024.7.4
 cffi==1.17.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
 boto3==1.35.19
-botocore==1.35.0
+botocore==1.35.19
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,7 +12,7 @@ ldap3==2.9.1
 mypy==1.10.1
 mypy-zope==1.0.5
 graphql-core==3.3.0a6; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
-graphql-core==3.2.3; python_version < "3.12"
+graphql-core==3.2.4; python_version < "3.12"
 psutil==6.0.0
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -24,7 +24,7 @@ alembic==1.13.2
 attrs==24.2.0
 autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
-Automat==24.8.0
+Automat==24.8.1
 boto==2.49.0
 boto3==1.35.0
 botocore==1.35.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -47,7 +47,7 @@ lz4==4.3.3
 Mako==1.3.5
 MarkupSafe==2.1.5
 moto==5.0.14
-msgpack==1.0.8
+msgpack==1.1.0
 mypy-extensions==1.0.0
 packaging==24.1
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -29,7 +29,7 @@ boto==2.49.0
 boto3==1.35.19
 botocore==1.35.19
 certifi==2024.8.30
-cffi==1.17.0
+cffi==1.17.1
 charset-normalizer==3.3.2
 constantly==23.10.4
 croniter==3.0.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -67,7 +67,7 @@ s3transfer==0.10.2
 service-identity==24.1.0
 setuptools-trial==0.6.0
 six==1.16.0
-SQLAlchemy==2.0.32
+SQLAlchemy==2.0.34
 treq==23.11.0;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore
 Twisted==24.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -28,7 +28,7 @@ Automat==24.8.1
 boto==2.49.0
 boto3==1.35.19
 botocore==1.35.19
-certifi==2024.7.4
+certifi==2024.8.30
 cffi==1.17.0
 charset-normalizer==3.3.2
 constantly==23.10.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -52,7 +52,7 @@ mypy-extensions==1.0.0
 packaging==24.1
 parameterized==0.9.0
 pyasn1==0.6.0
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
 pycparser==2.22
 PyJWT==2.9.0
 pyOpenSSL==24.2.1

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -20,7 +20,7 @@ sphinxcontrib-spelling==8.0.0
 sphinxcontrib-websupport==1.2.4;  python_version < "3.9" # pyup: ignore
 sphinxcontrib-websupport==2.0.0;  python_version >= "3.9"
 Pygments==2.18.0
-towncrier==24.7.1
+towncrier==24.8.0
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests
 # are reproducible. The versions should be upgraded whenever we see new versions to catch problems

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -5,7 +5,7 @@ autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: i
 autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
 Automat==20.2.0;  python_version < "3.6"  # pyup: ignore
 Automat==24.8.1;  python_version >= "3.6"
-cffi==1.17.0;  python_version >= "3.6"
+cffi==1.17.1;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
 cryptography==43.0.0;  python_version >= "3.6"

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -4,7 +4,7 @@ autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" and python_version >= "3.7"  # pyup: ignore
 autobahn==20.12.3;  python_version < "3.7" and python_version >= "3.6"  # pyup: ignore
 Automat==20.2.0;  python_version < "3.6"  # pyup: ignore
-Automat==24.8.0;  python_version >= "3.6"
+Automat==24.8.1;  python_version >= "3.6"
 cffi==1.17.0;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -25,7 +25,7 @@ PyHamcrest==1.9.0  # pyup: ignore
 psutil==6.0.0
 pycparser==2.22;  python_version >= "3.6"
 six==1.16.0
-Twisted==24.3.0;  python_version >= "3.6"
+Twisted==24.7.0;  python_version >= "3.6"
 Twisted==20.3.0;  python_version < "3.6"  # pyup: ignore
 txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.12.2;  python_version >= "3.7"

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -19,7 +19,7 @@ mock==3.0.5;  python_version < "3.6"  # pyup: ignore
 mock==5.1.0;  python_version >= "3.6"
 parameterized==0.8.1;  python_version < "3.6"  # pyup: ignore
 parameterized==0.9.0;  python_version >= "3.6"
-pbr==6.0.0
+pbr==6.1.0
 # pin PyHamcrest, because 2.x no longer supports Python 2.7
 PyHamcrest==1.9.0  # pyup: ignore
 psutil==6.0.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -31,5 +31,5 @@ txaio==23.1.1;  python_version >= "3.6"
 typing-extensions==4.12.2;  python_version >= "3.7"
 typing-extensions==4.12.2;  python_version < "3.7" and python_version >= "3.5"
 zope.interface==5.4.0;  python_version < "3.6"  # pyup: ignore
-zope.interface==7.0.1;  python_version >= "3.6"
+zope.interface==7.0.3;  python_version >= "3.6"
 -e worker

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -8,7 +8,7 @@ Automat==24.8.1;  python_version >= "3.6"
 cffi==1.17.1;  python_version >= "3.6"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==43.0.0;  python_version >= "3.6"
+cryptography==43.0.1;  python_version >= "3.6"
 funcsigs==1.0.2
 hyperlink==21.0.0
 idna==3.7

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -11,7 +11,7 @@ constantly==15.1.0; python_version < "3.8"  # pyup: ignore
 cryptography==43.0.1;  python_version >= "3.6"
 funcsigs==1.0.2
 hyperlink==21.0.0
-idna==3.7
+idna==3.10
 incremental==24.7.2
 incremental==22.10.0;  python_version < "3.8" # pyup: ignore
 incremental==17.5.0;  python_version < "3.0"  # pyup: ignore

--- a/requirements-master-docker-extras.txt
+++ b/requirements-master-docker-extras.txt
@@ -1,4 +1,4 @@
 requests==2.32.3
 psycopg2==2.9.9
 txrequests==0.9.6
-pycairo==1.26.1
+pycairo==1.27.0

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,3 +1,3 @@
 pip==24.2
-setuptools==72.2.0
+setuptools==75.1.0
 wheel==0.44.0


### PR DESCRIPTION
This PR is based on #7994 with these modification(s):

- removed mypy upgrade due to mypy-zope upgrade issue - see https://github.com/Shoobx/mypy-zope/pull/117
- suppresses some twisted warnings
- Drop update of pyasn1 because ladp3 depends on it and generates warning: "builtins.DeprecationWarning: tagMap is deprecated. Please use TAG_MAP instead."


## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
