### PR TITLE
www: fix ansi color reset in log view

### DIFF
--- a/www/base/src/util/AnsiEscapeCodes.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.tsx
@@ -75,7 +75,7 @@ export function stripAnsiSgrEntry(ansiEntry: string): string {
 
 export function ansiSgrClassesToCss(ansiClasses: string[], cssClasses: {[key: string]: boolean}) {
   if (ansiClasses.length === 0) {
-    return cssClasses;
+    return {};
   }
 
   const fgbg: {[key: string]: string} = {'38': 'fg', '48': 'bg'};


### PR DESCRIPTION
If we just return cssClasses, we are returning the previous instance which may be filled with existing colors. That means a reset sequence `CSI_PREFIX[m`, which has zero ansi classes, will result in the previous class set being used, rather than resetting the colors. This is in contrast to `CSI_PREFIX[0m`, which correctly empties the class set.

That said, in full log view, the escaper still gives up after 500something lines and starts printing unescaped sequences, e.g. like https://build.chimera-linux.org/#/builders/2/builds/1148/steps/5/logs/pkg_main_glycin-loaders_1_1_1-r0 - this is issue https://github.com/buildbot/buildbot/issues/7852 and appears to be unrelated.