### PR TITLE
ruff: bugbear and breakpoint linter rules.

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -91,7 +91,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
         if bitbucket_property_whitelist is None:
             bitbucket_property_whitelist = []
 
-        if hasattr(pullrequest_filter, '__call__'):
+        if callable(pullrequest_filter):
             self.pullrequest_filter = pullrequest_filter
         else:
             self.pullrequest_filter = lambda _: pullrequest_filter

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -15,6 +15,7 @@
 
 import re
 import traceback
+from typing import Optional
 
 from twisted.internet import defer
 from twisted.python.reflect import accumulateClassList
@@ -651,14 +652,14 @@ class ForceScheduler(base.BaseScheduler):
         self,
         name,
         builderNames,
-        username=UserNameParameter(),
-        reason=StringParameter(name="reason", default="force build", size=20),
+        username: Optional[UserNameParameter] = None,
+        reason: Optional[StringParameter] = None,
         reasonString="A build was forced by '%(owner)s': %(reason)s",
         buttonName=None,
         codebases=None,
         label=None,
         properties=None,
-        priority=IntParameter(name="priority", default=0),
+        priority: Optional[IntParameter] = None,
     ):
         """
         Initialize a ForceScheduler.
@@ -710,6 +711,9 @@ class ForceScheduler(base.BaseScheduler):
                 f"{repr(builderNames)}"
             )
 
+        if reason is None:
+            reason = StringParameter(name="reason", default="force build", size=20)
+
         if self.checkIfType(reason, BaseParameter):
             self.reason = reason
         else:
@@ -724,6 +728,9 @@ class ForceScheduler(base.BaseScheduler):
                 f"ForceScheduler '{name}': properties must be "
                 f"a list of BaseParameters: {repr(properties)}"
             )
+
+        if username is None:
+            username = UserNameParameter()
 
         if self.checkIfType(username, BaseParameter):
             self.username = username
@@ -766,6 +773,9 @@ class ForceScheduler(base.BaseScheduler):
         super().__init__(
             name=name, builderNames=builderNames, properties={}, codebases=codebase_dict
         )
+
+        if priority is None:
+            priority = IntParameter(name="priority", default=0)
 
         if self.checkIfType(priority, IntParameter):
             self.priority = priority

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -15,6 +15,7 @@
 # Portions Copyright 2013 Bad Dog Consulting
 
 import re
+from typing import Optional
 
 from twisted.internet import defer
 from twisted.python import log
@@ -70,7 +71,7 @@ class P4(Source):
         p4line_end='local',
         p4viewspec=None,
         p4viewspec_suffix='...',
-        p4client=Interpolate('buildbot_%(prop:workername)s_%(prop:buildername)s'),
+        p4client: Optional[Interpolate] = None,
         p4client_spec_options='allwrite rmdir',
         p4client_type=None,
         p4extra_args=None,
@@ -92,6 +93,8 @@ class P4(Source):
         self.p4viewspec = p4viewspec
         self.p4viewspec_suffix = p4viewspec_suffix
         self.p4line_end = p4line_end
+        if p4client is None:
+            p4client = Interpolate('buildbot_%(prop:workername)s_%(prop:buildername)s')
         self.p4client = p4client
         self.p4client_spec_options = p4client_spec_options
         self.p4client_type = p4client_type

--- a/master/buildbot/test/unit/process/test_properties.py
+++ b/master/buildbot/test/unit/process/test_properties.py
@@ -1091,7 +1091,7 @@ class TestPropertiesMixin(unittest.TestCase):
     def test_has_key(self):
         self.mp.properties.hasProperty.return_value = True
         # getattr because pep8 doesn't like calls to has_key
-        self.assertTrue(getattr(self.mp, 'has_key')('abc'))
+        self.assertTrue(self.mp.has_key('abc'))
         self.mp.properties.hasProperty.assert_called_with('abc')
 
     def test_setProperty(self):

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import os
+from typing import Optional
 from unittest import SkipTest
 
 from twisted.internet import defer
@@ -39,7 +40,9 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
         return fakehttpclientservice.HTTPClientService.getService(self.master, self, base_url)
 
     @defer.inlineCallbacks
-    def setupPushjetNotifier(self, secret=Interpolate("1234"), **kwargs):
+    def setupPushjetNotifier(self, secret: Optional[Interpolate] = None, **kwargs):
+        if secret is None:
+            secret = Interpolate("1234")
         pn = PushjetNotifier(secret, **kwargs)
         yield pn.setServiceParent(self.master)
         yield pn.startService()

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -15,6 +15,7 @@
 
 
 import os
+from typing import Optional
 from unittest import SkipTest
 
 from twisted.internet import defer
@@ -42,7 +43,11 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
         )
 
     @defer.inlineCallbacks
-    def setupPushoverNotifier(self, user_key="1234", api_token=Interpolate("abcd"), **kwargs):
+    def setupPushoverNotifier(
+        self, user_key="1234", api_token: Optional[Interpolate] = None, **kwargs
+    ):
+        if api_token is None:
+            api_token = Interpolate("abcd")
         pn = PushoverNotifier(user_key, api_token, **kwargs)
         yield pn.setServiceParent(self.master)
         yield pn.startService()

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -446,7 +446,7 @@ class TestBuildbotPlugins(unittest.TestCase):
         plugins = db.get_plugins('interface', interface=ITestInterface)
 
         with self.assertRaises(AttributeError):
-            getattr(plugins, 'bad')
+            plugins.bad
         with self.assertRaises(PluginDBError):
             plugins.get('bad')
         with self.assertRaises(PluginDBError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 target-version = "py38"
 
 [tool.ruff.lint]
-    select = ["W", "E", "F", "I", "PL", "UP"]
+    select = ["W", "E", "F", "I", "PL", "UP", "T100"]
     ignore = [
         "E711", # comparison to None should be 'if cond is None:'
         "E712", # comparison to False should be 'if cond is False:' or 'if not cond:'

--- a/worker/buildbot_worker/test/unit/runprocess-scripts.py
+++ b/worker/buildbot_worker/test/unit/runprocess-scripts.py
@@ -124,7 +124,7 @@ def assert_stdin_closed():
         if r == [0]:
             return  # success!
         if time.time() > bail_at:
-            assert False  # failure :(
+            raise AssertionError()  # failure :(
 
 
 # make sure this process dies if necessary


### PR DESCRIPTION
Checks for "breakpoint()" in code:
https://docs.astral.sh/ruff/rules/#flake8-debugger-t10

Ruff [bugbear rules](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b): B002-B016 
Not enforced yet in CI. Those rules are quite useful at catching pitfalls in python, but they sometimes need custom adjustment, so I make pull requests smaller.