### PR TITLE
docs:fix typo in cppcheck example

### DIFF
--- a/master/docs/manual/configuration/steps/cppcheck.rst
+++ b/master/docs/manual/configuration/steps/cppcheck.rst
@@ -11,7 +11,7 @@ This step runs ``cppcheck``, analyse its output, and set the outcome in :ref:`Pr
 
     from buildbot.plugins import steps
 
-    f.addStep(steps.Cppcheck(enable=['all'], inconclusive=True]))
+    f.addStep(steps.Cppcheck(enable=['all'], inconclusive=True))
 
 This class adds the following arguments:
 


### PR DESCRIPTION
This is a minor documentation fix that eliminates the unpaired ']' symbol in the cppcheck example.

## Contributor Checklist:

* [n/a ] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
