### PR TITLE
requirements: fix cidocs version conflicts

### DIFF
--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -2,7 +2,8 @@ Sphinx==7.1.2;  python_version < "3.9" # pyup: ignore
 Sphinx==7.4.7;  python_version == "3.9" # pyup: ignore
 Sphinx==8.0.2;  python_version >= "3.10"
 sphinx-jinja==2.0.2
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==2.0.0;  python_version < "3.10" # pyup: ignore
+sphinx-rtd-theme==3.0.0rc2;  python_version >= "3.10"
 sphinxcontrib-applehelp==1.0.4;  python_version < "3.9" # pyup: ignore
 sphinxcontrib-applehelp==2.0.0;  python_version >= "3.9"
 sphinxcontrib-devhelp==1.0.2;  python_version < "3.9" # pyup: ignore


### PR DESCRIPTION
Fixes
```
The conflict is caused by:
    The user requested Sphinx==8.0.2
    sphinx-jinja 2.0.2 depends on sphinx>4.2.0
    sphinx-rtd-theme 2.0.0 depends on sphinx<8 and >=5
```

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
