### PR TITLE
e2e: Always use software rendering

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -50,4 +50,4 @@ cat workdir/twistd.log &
 
 yarn install --pure-lockfile
 yarn playwright install
-yarn playwright test
+LIBGL_ALWAYS_SOFTWARE=1 yarn playwright test


### PR DESCRIPTION
This ensures that tests pass on weird configuration where the browser may crash due to bugs in graphics drivers.

