### PR TITLE
e2e: Disable WebKit runner due to internal bug in WebKit

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -40,10 +40,14 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
 
-    {
+    // Webkit is disabled due to an internal bug that occurs when tests are run under gvisor.
+    // https://bugs.webkit.org/show_bug.cgi?id=280366.
+    // https://github.com/WebKit/WebKit/pull/34268 should fix it, once it's in WebKit version
+    // used by playwright, webkit can be re-enabled.
+    /*{
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
-    },
+    },*/
 
     /* Test against mobile viewports. */
     // {


### PR DESCRIPTION
WebKit contains a race condition that occurs under certain conditions.

https://bugs.webkit.org/show_bug.cgi?id=280366

It so happens that Buildbot internal CI which runs under gvisor manages to reproduce the issue quite often.

There exists a pull request that should address the issue.

https://github.com/WebKit/WebKit/pull/34268

For the time being the browser is disabled. It can be re-enabled once the fix lands into a version of WebKit distributed by Playwright.
