### PR TITLE
db: add support for zstd/brotli for log compression

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -32,6 +32,7 @@ from buildbot.config.builder import BuilderConfig
 from buildbot.config.errors import ConfigErrors
 from buildbot.config.errors import capture_config_errors
 from buildbot.config.errors import error
+from buildbot.db.compression import ZStdCompressor
 from buildbot.interfaces import IRenderable
 from buildbot.process.project import Project
 from buildbot.revlinks import default_revlink_matcher
@@ -55,6 +56,12 @@ def set_is_in_unit_tests(in_tests):
 
 def get_is_in_unit_tests():
     return _in_unit_tests
+
+
+def _default_log_compression_method():
+    if ZStdCompressor.available:
+        return ZStdCompressor.name
+    return 'gz'
 
 
 def loadConfigDict(basedir, configFileName):
@@ -138,7 +145,7 @@ class MasterConfig(util.ComparableMixin):
         self.buildbotURL = 'http://localhost:8080/'
         self.changeHorizon = None
         self.logCompressionLimit = 4 * 1024
-        self.logCompressionMethod = 'gz'
+        self.logCompressionMethod = _default_log_compression_method()
         self.logEncoding = 'utf-8'
         self.logMaxSize = None
         self.logMaxTailSize = None
@@ -359,7 +366,10 @@ class MasterConfig(util.ComparableMixin):
         copy_int_param('changeHorizon')
         copy_int_param('logCompressionLimit')
 
-        self.logCompressionMethod = config_dict.get('logCompressionMethod', 'gz')
+        self.logCompressionMethod = config_dict.get(
+            'logCompressionMethod',
+            _default_log_compression_method(),
+        )
         if self.logCompressionMethod not in ('raw', 'bz2', 'gz', 'lz4', 'zstd', 'br'):
             error("c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4', 'br' or 'zstd'")
 

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -360,8 +360,8 @@ class MasterConfig(util.ComparableMixin):
         copy_int_param('logCompressionLimit')
 
         self.logCompressionMethod = config_dict.get('logCompressionMethod', 'gz')
-        if self.logCompressionMethod not in ('raw', 'bz2', 'gz', 'lz4'):
-            error("c['logCompressionMethod'] must be 'raw', 'bz2', 'gz' or 'lz4'")
+        if self.logCompressionMethod not in ('raw', 'bz2', 'gz', 'lz4', 'zstd'):
+            error("c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4' or 'zstd'")
 
         if self.logCompressionMethod == "lz4":
             try:
@@ -372,6 +372,16 @@ class MasterConfig(util.ComparableMixin):
                 error(
                     "To set c['logCompressionMethod'] to 'lz4' "
                     "you must install the lz4 library ('pip install lz4')"
+                )
+        elif self.logCompressionMethod == "zstd":
+            try:
+                import zstandard  # pylint: disable=import-outside-toplevel
+
+                [zstandard]
+            except ImportError:
+                error(
+                    "To set c['logCompressionMethod'] to 'zstd' "
+                    "you must install the zstandard Buildbot extra ('pip install buildbot[zstd]')"
                 )
 
         copy_int_param('logMaxSize')

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -360,8 +360,8 @@ class MasterConfig(util.ComparableMixin):
         copy_int_param('logCompressionLimit')
 
         self.logCompressionMethod = config_dict.get('logCompressionMethod', 'gz')
-        if self.logCompressionMethod not in ('raw', 'bz2', 'gz', 'lz4', 'zstd'):
-            error("c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4' or 'zstd'")
+        if self.logCompressionMethod not in ('raw', 'bz2', 'gz', 'lz4', 'zstd', 'br'):
+            error("c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4', 'br' or 'zstd'")
 
         if self.logCompressionMethod == "lz4":
             try:
@@ -382,6 +382,16 @@ class MasterConfig(util.ComparableMixin):
                 error(
                     "To set c['logCompressionMethod'] to 'zstd' "
                     "you must install the zstandard Buildbot extra ('pip install buildbot[zstd]')"
+                )
+        elif self.logCompressionMethod == "br":
+            try:
+                import brotli  # pylint: disable=import-outside-toplevel
+
+                [brotli]
+            except ImportError:
+                error(
+                    "To set c['logCompressionMethod'] to 'br' "
+                    "you must install the brotli Buildbot extra ('pip install buildbot[brotli]')"
                 )
 
         copy_int_param('logMaxSize')

--- a/master/buildbot/db/compression/__init__.py
+++ b/master/buildbot/db/compression/__init__.py
@@ -1,0 +1,26 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.db.compression.lz4 import LZ4Compressor
+from buildbot.db.compression.native import BZipCompressor
+from buildbot.db.compression.native import GZipCompressor
+from buildbot.db.compression.protocol import CompressorInterface
+
+__all__ = [
+    'BZipCompressor',
+    'CompressorInterface',
+    'GZipCompressor',
+    'LZ4Compressor',
+]

--- a/master/buildbot/db/compression/brotli.py
+++ b/master/buildbot/db/compression/brotli.py
@@ -13,18 +13,26 @@
 #
 # Copyright Buildbot Team Members
 
-from buildbot.db.compression.brotli import BrotliCompressor
-from buildbot.db.compression.lz4 import LZ4Compressor
-from buildbot.db.compression.native import BZipCompressor
-from buildbot.db.compression.native import GZipCompressor
-from buildbot.db.compression.protocol import CompressorInterface
-from buildbot.db.compression.zstd import ZStdCompressor
+from __future__ import annotations
 
-__all__ = [
-    'BrotliCompressor',
-    'BZipCompressor',
-    'CompressorInterface',
-    'GZipCompressor',
-    'LZ4Compressor',
-    'ZStdCompressor',
-]
+from buildbot.db.compression.protocol import CompressorInterface
+
+try:
+    import brotli
+
+    HAS_BROTLI = True
+except ImportError:
+    HAS_BROTLI = False
+
+
+class BrotliCompressor(CompressorInterface):
+    name = "br"
+    available = HAS_BROTLI
+
+    @staticmethod
+    def dumps(data: bytes) -> bytes:
+        return brotli.compress(data, mode=brotli.MODE_TEXT, quality=11)
+
+    @staticmethod
+    def read(data: bytes) -> bytes:
+        return brotli.decompress(data)

--- a/master/buildbot/db/compression/lz4.py
+++ b/master/buildbot/db/compression/lz4.py
@@ -1,0 +1,38 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from buildbot.db.compression.protocol import CompressorInterface
+
+try:
+    import lz4.block
+
+    HAS_LZ4 = True
+except ImportError:
+    HAS_LZ4 = False
+
+
+class LZ4Compressor(CompressorInterface):
+    name = "lz4"
+    available = HAS_LZ4
+
+    @staticmethod
+    def dumps(data: bytes) -> bytes:
+        return lz4.block.compress(data)
+
+    @staticmethod
+    def read(data: bytes) -> bytes:
+        return lz4.block.decompress(data)

--- a/master/buildbot/db/compression/native.py
+++ b/master/buildbot/db/compression/native.py
@@ -1,0 +1,45 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+import bz2
+import zlib
+
+from buildbot.db.compression.protocol import CompressorInterface
+
+
+class GZipCompressor(CompressorInterface):
+    name = "gz"
+
+    @staticmethod
+    def dumps(data: bytes) -> bytes:
+        return zlib.compress(data, 9)
+
+    @staticmethod
+    def read(data: bytes) -> bytes:
+        return zlib.decompress(data)
+
+
+class BZipCompressor(CompressorInterface):
+    name = "bz2"
+
+    @staticmethod
+    def dumps(data: bytes) -> bytes:
+        return bz2.compress(data, 9)
+
+    @staticmethod
+    def read(data: bytes) -> bytes:
+        return bz2.decompress(data)

--- a/master/buildbot/db/compression/protocol.py
+++ b/master/buildbot/db/compression/protocol.py
@@ -1,0 +1,38 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+from typing import Protocol
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+
+
+class CompressorInterface(Protocol):
+    name: ClassVar[str]
+    available: ClassVar[bool] = True
+
+    @staticmethod
+    @abstractmethod
+    def dumps(data: bytes) -> bytes:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def read(data: bytes) -> bytes:
+        raise NotImplementedError

--- a/master/buildbot/db/compression/zstd.py
+++ b/master/buildbot/db/compression/zstd.py
@@ -13,16 +13,26 @@
 #
 # Copyright Buildbot Team Members
 
-from buildbot.db.compression.lz4 import LZ4Compressor
-from buildbot.db.compression.native import BZipCompressor
-from buildbot.db.compression.native import GZipCompressor
-from buildbot.db.compression.protocol import CompressorInterface
-from buildbot.db.compression.zstd import ZStdCompressor
+from __future__ import annotations
 
-__all__ = [
-    'BZipCompressor',
-    'CompressorInterface',
-    'GZipCompressor',
-    'LZ4Compressor',
-    'ZStdCompressor',
-]
+from buildbot.db.compression.protocol import CompressorInterface
+
+try:
+    import zstandard
+
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+
+class ZStdCompressor(CompressorInterface):
+    name = "zstd"
+    available = HAS_ZSTD
+
+    @staticmethod
+    def dumps(data: bytes) -> bytes:
+        return zstandard.compress(data, level=9)
+
+    @staticmethod
+    def read(data: bytes) -> bytes:
+        return zstandard.decompress(data)

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -24,6 +24,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot.db import base
+from buildbot.db.compression import BrotliCompressor
 from buildbot.db.compression import BZipCompressor
 from buildbot.db.compression import CompressorInterface
 from buildbot.db.compression import GZipCompressor
@@ -98,6 +99,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
         COMPRESSION_BYID[3] = LZ4Compressor
     if ZStdCompressor.available:
         COMPRESSION_BYID[4] = ZStdCompressor
+    if BrotliCompressor.available:
+        COMPRESSION_BYID[5] = BrotliCompressor
 
     COMPRESSION_MODE = {
         compressor.name: (compressor_id, compressor)

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -28,6 +28,7 @@ from buildbot.db.compression import BZipCompressor
 from buildbot.db.compression import CompressorInterface
 from buildbot.db.compression import GZipCompressor
 from buildbot.db.compression import LZ4Compressor
+from buildbot.db.compression import ZStdCompressor
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
@@ -95,6 +96,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
     }
     if LZ4Compressor.available:
         COMPRESSION_BYID[3] = LZ4Compressor
+    if ZStdCompressor.available:
+        COMPRESSION_BYID[4] = ZStdCompressor
 
     COMPRESSION_MODE = {
         compressor.name: (compressor_id, compressor)

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -16,9 +16,7 @@
 
 from __future__ import annotations
 
-import bz2
 import dataclasses
-import zlib
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
@@ -26,23 +24,16 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot.db import base
+from buildbot.db.compression import BZipCompressor
+from buildbot.db.compression import CompressorInterface
+from buildbot.db.compression import GZipCompressor
+from buildbot.db.compression import LZ4Compressor
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     from typing import Literal
 
     LogType = Literal['s', 't', 'h', 'd']
-
-try:
-    from lz4.block import compress as dumps_lz4
-    from lz4.block import decompress as read_lz4
-except ImportError:
-    # config.py actually forbid this code path
-    def dumps_lz4(data):
-        return data
-
-    def read_lz4(data):
-        return data
 
 
 class LogSlugExistsError(KeyError):
@@ -77,20 +68,16 @@ class LogModel:
         raise KeyError(key)
 
 
-def dumps_gzip(data):
-    return zlib.compress(data, 9)
+class RawCompressor(CompressorInterface):
+    name = "raw"
 
+    @staticmethod
+    def dumps(data: bytes) -> bytes:
+        return data
 
-def read_gzip(data):
-    return zlib.decompress(data)
-
-
-def dumps_bz2(data):
-    return bz2.compress(data, 9)
-
-
-def read_bz2(data):
-    return bz2.decompress(data)
+    @staticmethod
+    def read(data: bytes) -> bytes:
+        return data
 
 
 class LogsConnectorComponent(base.DBConnectorComponent):
@@ -99,13 +86,20 @@ class LogsConnectorComponent(base.DBConnectorComponent):
     # note that MAX_CHUNK_SIZE is equal to BUFFER_SIZE in buildbot_worker.runprocess
     MAX_CHUNK_SIZE = 65536  # a chunk may not be bigger than this
     MAX_CHUNK_LINES = 1000  # a chunk may not have more lines than this
-    COMPRESSION_MODE = {
-        "raw": {"id": 0, "dumps": lambda x: x, "read": lambda x: x},
-        "gz": {"id": 1, "dumps": dumps_gzip, "read": read_gzip},
-        "bz2": {"id": 2, "dumps": dumps_bz2, "read": read_bz2},
-        "lz4": {"id": 3, "dumps": dumps_lz4, "read": read_lz4},
+
+    NO_COMPRESSION_ID = 0
+    COMPRESSION_BYID: dict[int, type[CompressorInterface]] = {
+        NO_COMPRESSION_ID: RawCompressor,
+        1: GZipCompressor,
+        2: BZipCompressor,
     }
-    COMPRESSION_BYID = dict((x["id"], x) for x in COMPRESSION_MODE.values())
+    if LZ4Compressor.available:
+        COMPRESSION_BYID[3] = LZ4Compressor
+
+    COMPRESSION_MODE = {
+        compressor.name: (compressor_id, compressor)
+        for compressor_id, compressor in COMPRESSION_BYID.items()
+    }
 
     def _getLog(self, whereclause) -> defer.Deferred[LogModel | None]:
         def thd_getLog(conn) -> LogModel | None:
@@ -155,7 +149,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             for row in conn.execute(q):
                 # Retrieve associated "reader" and extract the data
                 # Note that row.content is stored as bytes, and our caller expects unicode
-                data = self.COMPRESSION_BYID[row.compressed]["read"](row.content)
+                data = self.COMPRESSION_BYID.get(row.compressed, RawCompressor).read(row.content)
                 content = data.decode('utf-8')
 
                 if row.first_line < first_line:
@@ -202,17 +196,20 @@ class LogsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thdAddLog)
 
     def thdCompressChunk(self, chunk: bytes) -> tuple[bytes, int]:
-        # Set the default compressed mode to "raw" id
-        compressed_id = self.COMPRESSION_MODE["raw"]["id"]
+        compress_method: str = self.master.config.logCompressionMethod
+        compressed_id, compressor = self.COMPRESSION_MODE.get(
+            compress_method,
+            # if compression method is not available, default to no compression
+            (self.NO_COMPRESSION_ID, RawCompressor),
+        )
         # Do we have to compress the chunk?
-        if self.master.config.logCompressionMethod != "raw":
-            compressed_mode = self.COMPRESSION_MODE[self.master.config.logCompressionMethod]
-            compressed_chunk = compressed_mode["dumps"](chunk)
+        if compressed_id != self.NO_COMPRESSION_ID:
+            compressed_chunk = compressor.dumps(chunk)
             # Is it useful to compress the chunk?
             if len(chunk) > len(compressed_chunk):
-                compressed_id = compressed_mode["id"]
-                chunk = compressed_chunk
-        return chunk, compressed_id
+                return compressed_chunk, compressed_id
+
+        return chunk, self.NO_COMPRESSION_ID
 
     def thdSplitAndAppendChunk(
         self, conn, logid: int, content: bytes, first_line: int
@@ -370,11 +367,14 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 q = q.where(tbl.c.last_line <= todo_last_line)
                 q = q.order_by(tbl.c.first_line)
                 rows = conn.execute(q)
-                chunk = b""
+                chunks: list[bytes] = []
                 for row in rows:
-                    if chunk:
-                        chunk += b"\n"
-                    chunk += self.COMPRESSION_BYID[row.compressed]["read"](row.content)
+                    compressed_chunk = self.COMPRESSION_BYID.get(
+                        row.compressed,
+                        RawCompressor,
+                    ).read(row.content)
+                    if compressed_chunk:
+                        chunks.append(compressed_chunk)
                 rows.close()
 
                 # we remove the chunks that we are compressing
@@ -388,7 +388,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                     conn.execute(d).close()
 
                     # and we recompress them in one big chunk
-                    chunk, compressed_id = self.thdCompressChunk(chunk)
+                    chunk, compressed_id = self.thdCompressChunk(b'\n'.join(chunks))
                     conn.execute(
                         tbl.insert(),
                         {

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -265,7 +265,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('first_line', sa.Integer, nullable=False),
         sa.Column('last_line', sa.Integer, nullable=False),
         # log contents, including a terminating newline, encoded in utf-8 or,
-        # if 'compressed' is not 0, compressed with gzip, bzip2, lz4 or zstd
+        # if 'compressed' is not 0, compressed with gzip, bzip2, lz4, br or zstd
         sa.Column('content', sa.LargeBinary(65536)),
         sa.Column('compressed', sa.SmallInteger, nullable=False),
     )

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -265,7 +265,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('first_line', sa.Integer, nullable=False),
         sa.Column('last_line', sa.Integer, nullable=False),
         # log contents, including a terminating newline, encoded in utf-8 or,
-        # if 'compressed' is not 0, compressed with gzip, bzip2 or lz4
+        # if 'compressed' is not 0, compressed with gzip, bzip2, lz4 or zstd
         sa.Column('content', sa.LargeBinary(65536)),
         sa.Column('compressed', sa.SmallInteger, nullable=False),
     )

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -50,7 +50,7 @@ global_defaults = {
     "titleURL": 'http://buildbot.net/',
     "buildbotURL": 'http://localhost:8080/',
     "logCompressionLimit": 4096,
-    "logCompressionMethod": 'gz',
+    "logCompressionMethod": 'zstd',
     "logEncoding": 'utf-8',
     "logMaxTailSize": None,
     "logMaxSize": None,

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -453,7 +453,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
             self.cfg.load_global(self.filename, {'logCompressionMethod': 'foo'})
 
         self.assertConfigError(
-            errors, "c['logCompressionMethod'] must be 'raw', 'bz2', 'gz' or 'lz4'"
+            errors, "c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4' or 'zstd'"
         )
 
     def test_load_global_codebaseGenerator(self):

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -453,7 +453,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
             self.cfg.load_global(self.filename, {'logCompressionMethod': 'foo'})
 
         self.assertConfigError(
-            errors, "c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4' or 'zstd'"
+            errors, "c['logCompressionMethod'] must be 'raw', 'bz2', 'gz', 'lz4', 'br' or 'zstd'"
         )
 
     def test_load_global_codebaseGenerator(self):

--- a/master/buildbot/test/unit/db/test_logs.py
+++ b/master/buildbot/test/unit/db/test_logs.py
@@ -541,6 +541,16 @@ class RealTests(Tests):
         self.db.master.config.logCompressionMethod = "zstd"
         await self._test_compress_big_chunk(compression.ZStdCompressor.dumps, 4)
 
+    @async_to_deferred
+    async def test_br_compress_big_chunk(self):
+        try:
+            import brotli  # noqa pylint: disable=unused-import,import-outside-toplevel
+        except ImportError as e:
+            raise unittest.SkipTest("brotli not installed, skip the test") from e
+
+        self.db.master.config.logCompressionMethod = "br"
+        await self._test_compress_big_chunk(compression.BrotliCompressor.dumps, 5)
+
     @defer.inlineCallbacks
     def do_addLogLines_huge_log(self, NUM_CHUNKS=3000, chunk=('xy' * 70 + '\n') * 3):
         if chunk.endswith("\n"):

--- a/master/buildbot/test/unit/db/test_logs.py
+++ b/master/buildbot/test/unit/db/test_logs.py
@@ -531,6 +531,16 @@ class RealTests(Tests):
         self.db.master.config.logCompressionMethod = "lz4"
         await self._test_compress_big_chunk(compression.LZ4Compressor.dumps, 3)
 
+    @async_to_deferred
+    async def test_zstd_compress_big_chunk(self):
+        try:
+            import zstandard  # noqa pylint: disable=unused-import,import-outside-toplevel
+        except ImportError as e:
+            raise unittest.SkipTest("zstandard not installed, skip the test") from e
+
+        self.db.master.config.logCompressionMethod = "zstd"
+        await self._test_compress_big_chunk(compression.ZStdCompressor.dumps, 4)
+
     @defer.inlineCallbacks
     def do_addLogLines_huge_log(self, NUM_CHUNKS=3000, chunk=('xy' * 70 + '\n') * 3):
         if chunk.endswith("\n"):

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -44,6 +44,14 @@ try:
 except ImportError:
     HAS_ZSTD = False
 
+try:
+    import brotli
+
+    [brotli]
+    HAS_BROTLI = True
+except ImportError:
+    HAS_BROTLI = False
+
 
 def mkconfig(**kwargs):
     config = {"quiet": False, "basedir": os.path.abspath('basedir'), "force": True}
@@ -186,6 +194,10 @@ class TestCleanupDbRealDb(db.RealDatabaseWithConnectorMixin, TestCleanupDb):
                 # zstandard is not installed, don't fail
                 lengths["zstd"] = 20
                 continue
+            if mode == "br" and not HAS_BROTLI:
+                # brotli is not installed, don't fail
+                lengths["br"] = 14
+                continue
             # create a master.cfg with different compression method
             self.createMasterCfg(f"c['logCompressionMethod'] = '{mode}'")
             res = yield cleanupdb._cleanupDatabase(mkconfig(basedir='basedir'))
@@ -213,5 +225,6 @@ class TestCleanupDbRealDb(db.RealDatabaseWithConnectorMixin, TestCleanupDb):
                 'lz4': 40,
                 'gz': 31,
                 'zstd': 20,
+                'br': 14,
             },
         )

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -337,7 +337,7 @@ The default value is 4096, which should be a reasonable default on most file sys
 This setting has no impact on status plugins, and merely affects the required disk space on the master for build logs.
 
 The :bb:cfg:`logCompressionMethod` controls what type of compression is used for build logs.
-The default is 'gz', and the other valid option are 'raw' (no compression), 'gz' or 'lz4' (required lz4 package).
+The default is 'gz', and the other valid option are 'raw' (no compression), 'gz', 'lz4' (required lz4 package) or 'zstd' (requires buildbot[zstd] extra).
 
 Please find below some stats extracted from 50x "trial Pyflakes" runs (results may differ according to log type).
 

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -337,7 +337,8 @@ The default value is 4096, which should be a reasonable default on most file sys
 This setting has no impact on status plugins, and merely affects the required disk space on the master for build logs.
 
 The :bb:cfg:`logCompressionMethod` controls what type of compression is used for build logs.
-The default is 'gz', and the other valid option are 'raw' (no compression), 'gz', 'lz4' (required lz4 package), 'br' (requires buildbot[brotli] extra) or 'zstd' (requires buildbot[zstd] extra).
+Valid option are 'raw' (no compression), 'gz', 'lz4' (required lz4 package), 'br' (requires buildbot[brotli] extra) or 'zstd' (requires buildbot[zstd] extra).
+The default is 'zstd' if the ``buildbot[zstd]`` is installed, otherwise defaults to 'gz'.
 
 Please find below some stats extracted from 50x "trial Pyflakes" runs (results may differ according to log type).
 

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -337,7 +337,7 @@ The default value is 4096, which should be a reasonable default on most file sys
 This setting has no impact on status plugins, and merely affects the required disk space on the master for build logs.
 
 The :bb:cfg:`logCompressionMethod` controls what type of compression is used for build logs.
-The default is 'gz', and the other valid option are 'raw' (no compression), 'gz', 'lz4' (required lz4 package) or 'zstd' (requires buildbot[zstd] extra).
+The default is 'gz', and the other valid option are 'raw' (no compression), 'gz', 'lz4' (required lz4 package), 'br' (requires buildbot[brotli] extra) or 'zstd' (requires buildbot[zstd] extra).
 
 Please find below some stats extracted from 50x "trial Pyflakes" runs (results may differ according to log type).
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -147,6 +147,7 @@ setup_args = {
         "buildbot.config",
         "buildbot.data",
         "buildbot.db",
+        "buildbot.db.compression",
         "buildbot.db.migrations",
         "buildbot.db.migrations.versions",
         "buildbot.db.types",

--- a/newsfragments/log-compression-brotli.feature
+++ b/newsfragments/log-compression-brotli.feature
@@ -1,0 +1,1 @@
+``logCompressionMethod`` can now be set to ``br`` (using brotli, requires the buildbot[brotli] extra)

--- a/newsfragments/log-compression-default-zstd.change
+++ b/newsfragments/log-compression-default-zstd.change
@@ -1,0 +1,1 @@
+``logCompressionMethod`` will default to ``zstd`` if the buildbot[zstd] extra was installed (otherwise, default to ``gzip``)

--- a/newsfragments/log-compression-zstd.feature
+++ b/newsfragments/log-compression-zstd.feature
@@ -1,0 +1,1 @@
+``logCompressionMethod`` can now be set to ``zstd`` (using zstandard, requires the buildbot[zstd] extra)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -44,6 +44,7 @@ incremental==22.10.0;  python_version < "3.8" # pyup: ignore
 Jinja2==3.1.4
 jmespath==1.0.1
 lz4==4.3.3
+zstandard==0.23.0
 Mako==1.3.5
 MarkupSafe==2.1.5
 moto==5.0.14

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -45,6 +45,7 @@ Jinja2==3.1.4
 jmespath==1.0.1
 lz4==4.3.3
 zstandard==0.23.0
+Brotli==1.1.0
 Mako==1.3.5
 MarkupSafe==2.1.5
 moto==5.0.14


### PR DESCRIPTION
Changing the default compression to zstd if it's available before falling back to gzip is not really necessary, the commit can be dropped.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
