### PR TITLE
docker: Use explicit image registry names

### DIFF
--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -14,7 +14,7 @@
 # which get installed in the final image.
 # This allows us to avoid installing build tools like gcc in the final image.
 
-FROM        debian:11 AS buildbot-build
+FROM docker.io/library/debian:11 AS buildbot-build
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
@@ -91,7 +91,7 @@ RUN mkdir -p /wheels && \
 # Note that the UI and worker packages are the latest version published on pypi
 # This is to avoid pulling node inside this container
 
-FROM        debian:11-slim
+FROM docker.io/library/debian:11-slim
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -5,7 +5,7 @@
 
 # Provides a base Debian image with latest buildbot worker installed
 
-FROM debian:12
+FROM docker.io/library/debian:12
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so


### PR DESCRIPTION
There are more than one Docker registry so be explicit.

Additionally, on container runtimes that are not docker (e.g. podman) the docker.io registry may not have the highest priority.