### PR TITLE
3.11 backport: Migrate to quay.io as the location for official Buildbot docker images

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -10,9 +10,9 @@ Step 1: Verify that external dependants can be built
 Verify that the following resources can be built from the latest master.
 This can be checked by looking into the dashboards (maintainer access may be needed).
 
- - Docker Hub (buildbot-master) (https://hub.docker.com/repository/docker/buildbot/buildbot-master/general)
+ - quay.io (buildbot-master) (https://quay.io/repository/buildbot/buildbot-master?tab=builds)
 
- - Docker Hub (buildbot-worker) (https://hub.docker.com/repository/docker/buildbot/buildbot-worker/general)
+ - quay.io (buildbot-worker) (https://quay.io/repository/buildbot/buildbot-worker?tab=builds)
 
  - Read the Docs (https://readthedocs.org/projects/buildbot/builds/)
 

--- a/master/README.rst
+++ b/master/README.rst
@@ -26,7 +26,9 @@ See https://docs.buildbot.net/current/ for documentation of the current version 
 
 Docker container
 ----------------
-Buildbot comes with a ready to use docker container available at buildbot/buildbot-master
+Buildbot comes with a ready to use docker container available at
+`quay.io/buildbot/buildbot-master <https://quay.io/buildbot/buildbot-master>`_ container repository.
+
 Following environment variables are supported for configuration:
 
 * ``BUILDBOT_CONFIG_URL``: http url to a config tarball.

--- a/newsfragments/buildbot-docker-quay.change
+++ b/newsfragments/buildbot-docker-quay.change
@@ -1,0 +1,3 @@
+Buildbot has migrated to `quay.io` container registry for storing released container images.
+In order to migrate to the new registry container image name in `FROM` instruction in Dockerfiles
+needs to be adjusted to `quay.io/buildbot/buildbot-master` or `quay.io/buildbot/buildbot-worker`.


### PR DESCRIPTION
This PR backports #8023 to 3.11.x.