### PR TITLE
configurators: extend ConfiguratorBase to include more common fields

### DIFF
--- a/master/buildbot/configurators/__init__.py
+++ b/master/buildbot/configurators/__init__.py
@@ -35,15 +35,10 @@ class ConfiguratorBase:
 
     def configure(self, config_dict):
         self.config_dict = c = config_dict
-        if 'schedulers' not in c:
-            c['schedulers'] = []
-        self.schedulers = c['schedulers']
-        if 'protocols' not in c:
-            c['protocols'] = {}
-        self.protocols = c['protocols']
-        if 'builders' not in c:
-            c['builders'] = []
-        self.builders = c['builders']
-        if 'workers' not in c:
-            c['workers'] = []
-        self.workers = c['workers']
+        self.schedulers = c.setdefault('schedulers', [])
+        self.protocols = c.setdefault('protocols', {})
+        self.builders = c.setdefault('builders', [])
+        self.workers = c.setdefault('workers', [])
+        self.projects = c.setdefault('projects', [])
+        self.secretsProviders = c.setdefault('secretsProviders', [])
+        self.www = c.setdefault('www', {})

--- a/master/buildbot/test/unit/test_configurator_base.py
+++ b/master/buildbot/test/unit/test_configurator_base.py
@@ -25,6 +25,15 @@ class ConfiguratorBaseTests(configurators.ConfiguratorMixin, unittest.Synchronou
     def test_basic(self):
         self.setupConfigurator()
         self.assertEqual(
-            self.config_dict, {'schedulers': [], 'protocols': {}, 'workers': [], 'builders': []}
+            self.config_dict,
+            {
+                'schedulers': [],
+                'protocols': {},
+                'builders': [],
+                'workers': [],
+                'projects': [],
+                'secretsProviders': [],
+                'www': {},
+            },
         )
         self.assertEqual(self.configurator.workers, [])


### PR DESCRIPTION
This PR improves changes of PR https://github.com/buildbot/buildbot/pull/7209 (and fixes broken tests).
Credit for main solution goes to @Mic92.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
