### PR TITLE
Downgrade evalidate to an extra dependency

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -661,7 +661,6 @@ setup_args['install_requires'] = [
     'Twisted ' + twisted_ver,
     'treq >= 20.9',
     'Jinja2 >= 2.1',
-    'evalidate >= 2.0.0',
     'msgpack >= 0.6.0',
     "croniter >= 1.3.0",
     'importlib-resources >= 5; python_version < "3.9"',
@@ -742,6 +741,9 @@ setup_args['extras_require'] = {
     ],
     'zstd': [
         'zstandard>=0.23.0',
+    ],
+    'configurable': [
+        'evalidate >= 2.0.0',
     ],
 }
 


### PR DESCRIPTION
'evalidate' dependency is only used by "experimental and not documented" steps in buildbot.steps.configurable (5a21eb4) and actually is not required. Therefore, downgraded to 'extras_require'.
Credit for suggestion (issue https://github.com/buildbot/buildbot/issues/7933) goes to @yan12125.

* [not_needed] I have updated the unit tests
* [not_needed ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed ] I have updated the appropriate documentation
