### PR TITLE
ruff: apply rule B028

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -334,6 +334,7 @@ class MasterConfig(util.ComparableMixin):
             warnings.warn(
                 'WARNING: Title is too long to be displayed. ' + '"Buildbot" will be used instead.',
                 category=ConfigWarning,
+                stacklevel=1,
             )
 
         copy_str_url_param_with_trailing_slash('titleURL')
@@ -360,6 +361,7 @@ class MasterConfig(util.ComparableMixin):
                     'You can `opt-out` by setting this variable to None.\n'
                     'Or `opt-in` for more information by setting it to "full".\n',
                     category=ConfigWarning,
+                    stacklevel=1,
                 )
         copy_str_or_callable_param('buildbotNetUsageData')
 
@@ -637,6 +639,7 @@ class MasterConfig(util.ComparableMixin):
                         "Perhaps you meant to specify workerbuilddir instead."
                     ),
                     category=ConfigWarning,
+                    stacklevel=1,
                 )
 
         self.builders = builders

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -57,7 +57,7 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
 
     @property
     def expectations(self):
-        warnings.warn("'Builder.expectations' is deprecated.")
+        warnings.warn("'Builder.expectations' is deprecated.", stacklevel=2)
         return None
 
     def __init__(self, name):

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -57,7 +57,8 @@ def _old_add_label(label, value):
     elif label == GERRIT_LABEL_REVIEWED:
         return [f"--code-review {int(value)}"]
     warnings.warn(
-        'Gerrit older than 2.6 does not support custom labels. ' f'Setting {label} is ignored.'
+        'Gerrit older than 2.6 does not support custom labels. ' f'Setting {label} is ignored.',
+        stacklevel=1,
     )
     return []
 

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -64,7 +64,7 @@ class FakeEntry:
         handle loading
         """
         for w in self._warnings:
-            warnings.warn(w, DeprecationWarning)
+            warnings.warn(w, DeprecationWarning, stacklevel=2)
         return self._value
 
 

--- a/master/buildbot/test/unit/test_test_util_warnings.py
+++ b/master/buildbot/test/unit/test_test_util_warnings.py
@@ -36,14 +36,14 @@ class TestWarningsFilter(unittest.TestCase):
     def test_warnigs_caught(self):
         # Assertion is correct.
         with assertProducesWarning(SomeWarning):
-            warnings.warn("test", SomeWarning)
+            warnings.warn("test", SomeWarning, stacklevel=1)
 
     def test_warnigs_caught_num_check(self):
         # Assertion is correct.
         with assertProducesWarnings(SomeWarning, num_warnings=3):
-            warnings.warn("1", SomeWarning)
-            warnings.warn("2", SomeWarning)
-            warnings.warn("3", SomeWarning)
+            warnings.warn("1", SomeWarning, stacklevel=1)
+            warnings.warn("2", SomeWarning, stacklevel=1)
+            warnings.warn("3", SomeWarning, stacklevel=1)
 
     def test_warnigs_caught_num_check_fail(self):
         def f1():
@@ -55,16 +55,16 @@ class TestWarningsFilter(unittest.TestCase):
 
         def f2():
             with assertProducesWarnings(SomeWarning, num_warnings=2):
-                warnings.warn("1", SomeWarning)
+                warnings.warn("1", SomeWarning, stacklevel=1)
 
         with self.assertRaises(AssertionError):
             f2()
 
         def f3():
             with assertProducesWarnings(SomeWarning, num_warnings=2):
-                warnings.warn("1", SomeWarning)
-                warnings.warn("2", SomeWarning)
-                warnings.warn("3", SomeWarning)
+                warnings.warn("1", SomeWarning, stacklevel=1)
+                warnings.warn("2", SomeWarning, stacklevel=1)
+                warnings.warn("3", SomeWarning, stacklevel=1)
 
         with self.assertRaises(AssertionError):
             f3()
@@ -72,13 +72,13 @@ class TestWarningsFilter(unittest.TestCase):
     def test_warnigs_caught_pattern_check(self):
         # Assertion is correct.
         with assertProducesWarning(SomeWarning, message_pattern=r"t.st"):
-            warnings.warn("The test", SomeWarning)
+            warnings.warn("The test", SomeWarning, stacklevel=1)
 
     def test_warnigs_caught_pattern_check_fail(self):
         def f():
             # Assertion fails.
             with assertProducesWarning(SomeWarning, message_pattern=r"other"):
-                warnings.warn("The test", SomeWarning)
+                warnings.warn("The test", SomeWarning, stacklevel=1)
 
         with self.assertRaises(AssertionError):
             f()
@@ -86,15 +86,15 @@ class TestWarningsFilter(unittest.TestCase):
     def test_warnigs_caught_patterns_check(self):
         # Assertion is correct.
         with assertProducesWarnings(SomeWarning, messages_patterns=["1", "2", "3"]):
-            warnings.warn("log 1 message", SomeWarning)
-            warnings.warn("log 2 message", SomeWarning)
-            warnings.warn("log 3 message", SomeWarning)
+            warnings.warn("log 1 message", SomeWarning, stacklevel=1)
+            warnings.warn("log 2 message", SomeWarning, stacklevel=1)
+            warnings.warn("log 3 message", SomeWarning, stacklevel=1)
 
     def test_warnigs_caught_patterns_check_fails(self):
         def f1():
             # Assertion fails.
             with assertProducesWarnings(SomeWarning, messages_patterns=["1", "2"]):
-                warnings.warn("msg 1", SomeWarning)
+                warnings.warn("msg 1", SomeWarning, stacklevel=1)
 
         with self.assertRaises(AssertionError):
             f1()
@@ -102,8 +102,8 @@ class TestWarningsFilter(unittest.TestCase):
         def f2():
             # Assertion fails.
             with assertProducesWarnings(SomeWarning, messages_patterns=["1", "2"]):
-                warnings.warn("msg 2", SomeWarning)
-                warnings.warn("msg 1", SomeWarning)
+                warnings.warn("msg 2", SomeWarning, stacklevel=1)
+                warnings.warn("msg 1", SomeWarning, stacklevel=1)
 
         with self.assertRaises(AssertionError):
             f2()
@@ -111,9 +111,9 @@ class TestWarningsFilter(unittest.TestCase):
         def f3():
             # Assertion fails.
             with assertProducesWarnings(SomeWarning, messages_patterns=["1", "2"]):
-                warnings.warn("msg 1", SomeWarning)
-                warnings.warn("msg 2", SomeWarning)
-                warnings.warn("msg 3", SomeWarning)
+                warnings.warn("msg 1", SomeWarning, stacklevel=1)
+                warnings.warn("msg 2", SomeWarning, stacklevel=1)
+                warnings.warn("msg 3", SomeWarning, stacklevel=1)
 
         with self.assertRaises(AssertionError):
             f3()
@@ -124,26 +124,26 @@ class TestWarningsFilter(unittest.TestCase):
 
         with ignoreWarning(OtherWarning):
             with assertNotProducesWarnings(SomeWarning):
-                warnings.warn("msg 3", OtherWarning)
+                warnings.warn("msg 3", OtherWarning, stacklevel=1)
 
     def test_warnigs_filter(self):
         with ignoreWarning(OtherWarning):
             with assertProducesWarnings(SomeWarning, messages_patterns=["1", "2", "3"]):
-                warnings.warn("other", OtherWarning)
-                warnings.warn("log 1 message", SomeWarning)
-                warnings.warn("other", OtherWarning)
-                warnings.warn("log 2 message", SomeWarning)
-                warnings.warn("other", OtherWarning)
-                warnings.warn("log 3 message", SomeWarning)
-                warnings.warn("other", OtherWarning)
+                warnings.warn("other", OtherWarning, stacklevel=1)
+                warnings.warn("log 1 message", SomeWarning, stacklevel=1)
+                warnings.warn("other", OtherWarning, stacklevel=1)
+                warnings.warn("log 2 message", SomeWarning, stacklevel=1)
+                warnings.warn("other", OtherWarning, stacklevel=1)
+                warnings.warn("log 3 message", SomeWarning, stacklevel=1)
+                warnings.warn("other", OtherWarning, stacklevel=1)
 
     def test_nested_filters(self):
         with assertProducesWarnings(SomeWarning, messages_patterns=["some 1"]):
             with assertProducesWarnings(OtherWarning, messages_patterns=["other 1"]):
-                warnings.warn("other 1", OtherWarning)
-                warnings.warn("some 1", SomeWarning)
+                warnings.warn("other 1", OtherWarning, stacklevel=1)
+                warnings.warn("some 1", SomeWarning, stacklevel=1)
 
     def test_ignore_warnings(self):
         with assertNotProducesWarnings(SomeWarning):
             with ignoreWarning(SomeWarning):
-                warnings.warn("some 1", SomeWarning)
+                warnings.warn("some 1", SomeWarning, stacklevel=1)

--- a/master/contrib/post_build_request.py
+++ b/master/contrib/post_build_request.py
@@ -40,7 +40,9 @@ except AttributeError:
     import sys
     import warnings
 
-    warnings.warn("Use simplejson, not the old json module.")
+    warnings.warn(
+        "Use simplejson, not the old json module.", category=DeprecationWarning, stacklevel=1
+    )
     sys.modules.pop('json')  # get rid of the bad json module
     import simplejson as json
 


### PR DESCRIPTION
See https://docs.astral.sh/ruff/rules/no-explicit-stacklevel

changes master/buildbot/test/unit/test_test_util_warnings.py are a bit more noisy than ideal.
I found two cases where increased stack level depth would make things easier to debug.
Most configuration related warnings I kept on the default.