### PR TITLE
reporters: Use single implementation of logs data extraction

### DIFF
--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -69,6 +69,7 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
             want_steps=self.formatter.want_steps,
             want_previous_build=want_previous_build,
             want_logs=self.formatter.want_logs,
+            add_logs=self.add_logs,
             want_logs_content=self.formatter.want_logs_content,
         )
 
@@ -125,6 +126,7 @@ class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
             want_properties=formatter.want_properties,
             want_steps=formatter.want_steps,
             want_logs=formatter.want_logs,
+            add_logs=self.add_logs,
             want_logs_content=formatter.want_logs_content,
         )
 

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -92,7 +92,7 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
         for build in builds:
             patches.extend(self._get_patches_for_build(build))
 
-            build_logs = yield self._get_logs_for_build(master, build, formatter)
+            build_logs = yield self._get_logs_for_build(build)
             logs.extend(build_logs)
 
             blamelist = yield reporter.getResponsibleUsersForBuild(master, build['buildid'])

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -343,6 +343,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                                         'num_lines': 2,
                                         'slug': 'stdio',
                                         'stepid': 120,
+                                        'stepname': 'step1',
                                         'type': 's',
                                         'url': 'http://localhost:8080/#/builders/80/builds/2/steps/29/logs/stdio',
                                     }
@@ -466,6 +467,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
                                         'num_lines': 2,
                                         'slug': 'stdio',
                                         'stepid': 121,
+                                        'stepname': 'step1',
                                         'type': 's',
                                         'url': 'http://localhost:8080/#/builders/80/builds/3/steps/29/logs/stdio',
                                     }

--- a/master/docs/manual/configuration/reporters/reporter_base.rst
+++ b/master/docs/manual/configuration/reporters/reporter_base.rst
@@ -52,6 +52,20 @@ This documents frequently used keys within the dictionaries that are passed to t
  - ``builds`` (a list of build dictionaries as reported by the data API)
     A list of builds that the report describes.
 
+    Many message formatters support ``want_steps`` argument. If it is set, then build will contain
+    ``steps`` key with a list of step dictionaries as reported by the data API.
+
+    Many message formatters support ``want_logs`` argument. If it is set, then steps will contain
+    ``logs`` key with a list of logs dictionaries as reported by the data API.
+
+    The logs dictionaries contain the following keys in addition to what the data API provides:
+
+    - ``stepname`` (string) The name of the step that produced the log.
+
+    - ``content`` (optional string) The content of the log. The content of the log is attached only
+        if directed by ``want_logs_content`` argument of message formatters or ``add_logs``
+        argument of report generators.
+
  - ``buildset`` (a buildset dictionary as reported by the data API)
     The buildset that is being described.
 
@@ -63,11 +77,8 @@ This documents frequently used keys within the dictionaries that are passed to t
 
  - ``logs`` (a list of dictionaries corresponding to logs as reported by the data API)
     A list of logs produced by the build(s) so far.
-    The following two keys are provided in addition to what the data API provides:
-
-    - ``stepname`` (string) The name of the step that produced the log.
-
-    - ``content`` (string) The content of the log.
+    The log dictionaries have the same enhancements that are described in the ``build`` section
+    above.
 
  - ``extra_info`` (a dictionary of dictionaries with string keys in both)
     A list of additional reporter-specific data to apply.

--- a/newsfragments/reporters-consistent-logs.bugfix
+++ b/newsfragments/reporters-consistent-logs.bugfix
@@ -1,0 +1,3 @@
+The reports produced by report generators now contain consistent logs data. In particular, ``stepname``
+key is consistently attached to logs regardless if they come with build steps or with the global
+``logs`` key.


### PR DESCRIPTION
This makes the exposed log data consistent regardless of which part of the report it comes from.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
