### PR TITLE
4.0 backports: www: Make wsgi_dashboards routes backwards compatible with old plugin

### DIFF
--- a/newsfragments/www-fix-wsgi-url.bugfix
+++ b/newsfragments/www-fix-wsgi-url.bugfix
@@ -1,0 +1,1 @@
+Fix URL of WGSI dashboards to keep backward compatibility with the 3.x WSGI plugin.

--- a/www/wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
+++ b/www/wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
@@ -101,12 +101,12 @@ buildbotSetupPlugin((reg, config) => {
       caption: caption,
       icon: createElement(icon, {}),
       order: dashboard.order,
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       parentName: null,
     });
   
     reg.registerRoute({
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       group: name,
       element: () => <WSGIDashboardsView name={name}/>,
     });


### PR DESCRIPTION
Backport #7991 to branch 4.0.x.


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
