### PR TITLE
process: Expose worker base directory as normal property

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -258,16 +258,18 @@ class Build(properties.PropertiesMixin):
             props.setProperty("codebase", source.codebase, "Build")
             props.setProperty("project", source.project, "Build")
 
-    def setupWorkerBuildirProperty(self, workerforbuilder):
+    def setupWorkerProperties(self, workerforbuilder):
         path_module = workerforbuilder.worker.path_module
 
         # navigate our way back to the L{buildbot.worker.Worker}
         # object that came from the config, and get its properties
-        if workerforbuilder.worker.worker_basedir:
+        worker_basedir = workerforbuilder.worker.worker_basedir
+        if worker_basedir:
             builddir = path_module.join(
-                bytes2unicode(workerforbuilder.worker.worker_basedir),
+                bytes2unicode(worker_basedir),
                 bytes2unicode(self.builder.config.workerbuilddir),
             )
+            self.setProperty("basedir", worker_basedir, "Worker")
             self.setProperty("builddir", builddir, "Worker")
 
     def setupWorkerForBuilder(self, workerforbuilder: AbstractWorkerForBuilder):
@@ -434,11 +436,11 @@ class Build(properties.PropertiesMixin):
 
         self.conn = workerforbuilder.worker.conn
 
-        # To retrieve the builddir property, the worker must be attached as we
-        # depend on its path_module. Latent workers become attached only after
-        # preparing them, so we can't setup the builddir property earlier like
-        # the rest of properties
-        self.setupWorkerBuildirProperty(workerforbuilder)
+        # To retrieve the worker properties, the worker must be attached as we depend on its
+        # path_module for at least the builddir property. Latent workers become attached only after
+        # preparing them, so we can't setup the builddir property earlier like the rest of
+        # properties
+        self.setupWorkerProperties(workerforbuilder)
         self.setupWorkerForBuilder(workerforbuilder)
         self.subs = self.conn.notifyOnDisconnect(self.lostRemote)
 

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -171,6 +171,11 @@ class RunSteps(RunFakeMasterTestCase):
             },
         )
 
+    def _check_and_pop_dynamic_properties(self, properties):
+        for property in ('builddir', 'basedir'):
+            self.assertIn(property, properties)
+            properties.pop(property)
+
     @defer.inlineCallbacks
     def test_all_properties(self):
         builder_id = yield self.create_config_for_step(SucceedingCustomStep())
@@ -178,9 +183,7 @@ class RunSteps(RunFakeMasterTestCase):
         yield self.do_test_build(builder_id)
 
         properties = yield self.master.data.get(("builds", 1, "properties"))
-
-        self.assertIn("builddir", properties)
-        properties.pop("builddir")
+        self._check_and_pop_dynamic_properties(properties)
 
         self.assertEqual(
             properties,
@@ -204,9 +207,7 @@ class RunSteps(RunFakeMasterTestCase):
         yield self.do_test_build(builder_id)
 
         properties = yield self.master.data.get(('builds', 1, 'properties'))
-
-        self.assertIn('builddir', properties)
-        properties.pop('builddir')
+        self._check_and_pop_dynamic_properties(properties)
 
         self.assertEqual(
             properties,

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -361,7 +361,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         b.getProperties = Mock()
         b.setProperty = Mock()
 
-        b.setupWorkerBuildirProperty(self.workerforbuilder)
+        b.setupWorkerProperties(self.workerforbuilder)
 
         expected_path = '/srv/buildbot/worker/test'
 
@@ -719,6 +719,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.assertEqual(
             got_properties,
             [
+                (10, 'basedir', '/wrk', 'Worker'),
                 (10, 'branch', None, 'Build'),
                 (10, 'buildnumber', 1, 'Build'),
                 (10, 'codebase', '', 'Build'),

--- a/newsfragments/worker-basedir-property.feature
+++ b/newsfragments/worker-basedir-property.feature
@@ -1,0 +1,1 @@
+Worker base directory has been exposed as a normal build property called ``basedir``.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
