### PR TITLE
3.11 backports: www: Make wsgi_dashboards routes backwards compatible with old plugin

### DIFF
--- a/newsfragments/www-fix-wsgi-url.bugfix
+++ b/newsfragments/www-fix-wsgi-url.bugfix
@@ -1,0 +1,1 @@
+Fix URL of WGSI dashboards to keep backward compatibility with the 3.x WSGI plugin.

--- a/www/react-wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
+++ b/www/react-wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
@@ -101,12 +101,12 @@ buildbotSetupPlugin((reg, config) => {
       caption: caption,
       icon: createElement(icon, {}),
       order: dashboard.order,
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       parentName: null,
     });
   
     reg.registerRoute({
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       group: name,
       element: () => <WSGIDashboardsView name={name}/>,
     });


### PR DESCRIPTION
This PR backports #7991 to 3.11.x.