### PR TITLE
www: Show build and step start and stop times on duration hover

### DIFF
--- a/newsfragments/www-build-step-start-complete-times-hover.feature
+++ b/newsfragments/www-build-step-start-complete-times-hover.feature
@@ -1,0 +1,1 @@
+Show build and step start and stop times when hovering on duration in build step table.

--- a/www/base/src/components/BuildSummary/BuildSummary.scss
+++ b/www/base/src/components/BuildSummary/BuildSummary.scss
@@ -12,7 +12,7 @@
   }
 
   .bb-build-summary-details,
-  .bb-build-summary-time {
+  .bb-build-summary-step-details {
     float: right;
   }
 

--- a/www/base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/base/src/components/BuildSummary/BuildSummary.tsx
@@ -26,7 +26,6 @@ import {
   BadgeStatus,
   ConfigContext,
   analyzeStepUrls,
-  buildDurationFormatWithLocks,
   stepDurationFormatWithLocks,
   useCurrentTime,
   useStateWithParentTrackingWithDefaultIfNotSet,
@@ -52,6 +51,7 @@ import {BuildRequestSummary} from "../BuildRequestSummary/BuildRequestSummary";
 import {Card} from "react-bootstrap";
 import {useScrollToAnchor} from "../../util/AnchorLinks";
 import {AnchorLink} from "../AnchorLink/AnchorLink";
+import {BuildSummaryStepDurationSpan, BuildSummaryBuildDurationSpan} from "./BuildSummaryDurationSpan";
 
 enum DetailLevel {
   None = 0,
@@ -124,8 +124,8 @@ const BuildSummaryStepLine = observer(({build, step, parentFullDisplay}: BuildSu
     }
 
     return (
-      <span className="bb-build-summary-time">
-          {stepDurationFormatWithLocks(step, now)}
+      <span className="bb-build-summary-step-details">
+        <BuildSummaryStepDurationSpan step={step} now={now}/>
         &nbsp;
         {step.state_string}
         </span>
@@ -283,8 +283,6 @@ export const BuildSummary = observer(({build, parentBuild, parentRelationship,
                           parentFullDisplay={fullDisplay}/>
   ));
 
-  const durationString = buildDurationFormatWithLocks(build, now);
-
   return (
     <Card className={"bb-build-summary " + results2class(build, null)}>
       <Card.Header>
@@ -306,7 +304,7 @@ export const BuildSummary = observer(({build, parentBuild, parentRelationship,
         }
         {reason !== null ? <span>| {reason}</span> : <></>}
         <div className={"bb-build-summary-details"}>
-          <span>{durationString}&nbsp;</span>
+          <BuildSummaryBuildDurationSpan build={build} now={now}/>&nbsp;
           <span>{build.state_string}&nbsp;</span>
           <BadgeStatus className={results2class(build, null)}>{results2text(build)}</BadgeStatus>
           {renderParentBuildLink()}

--- a/www/base/src/components/BuildSummary/BuildSummaryDurationSpan.scss
+++ b/www/base/src/components/BuildSummary/BuildSummaryDurationSpan.scss
@@ -1,0 +1,4 @@
+
+#bb-build-summary-duration-tooltip > .tooltip-inner {
+  max-width: 400px;
+}

--- a/www/base/src/components/BuildSummary/BuildSummaryDurationSpan.tsx
+++ b/www/base/src/components/BuildSummary/BuildSummaryDurationSpan.tsx
@@ -1,0 +1,80 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import './BuildSummaryDurationSpan.scss';
+import {Build, Step} from "buildbot-data-js";
+import {buildDurationFormatWithLocks, dateFormatSeconds, stepDurationFormatWithLocks} from "buildbot-ui";
+import {OverlayTrigger, Tooltip} from "react-bootstrap";
+import {OverlayInjectedProps} from "react-bootstrap/Overlay";
+
+type BuildSummaryDurationSpanProps = {
+  durationString: string;
+  startedAt: number|null;
+  completeAt: number|null
+}
+
+const BuildSummaryDurationSpan = ({durationString, startedAt, completeAt}: BuildSummaryDurationSpanProps) => {
+
+  const renderTimeOverlay = (props: OverlayInjectedProps) => {
+    const rows: JSX.Element[] = [];
+    if (startedAt !== null) {
+      rows.push(<tr key={"started-at"}><td>Started at: {dateFormatSeconds(startedAt)}</td></tr>)
+    }
+    if (completeAt !== null) {
+      rows.push(<tr key={"complete-at"}><td>Completed at: {dateFormatSeconds(completeAt)}</td></tr>)
+    }
+    return (
+      <Tooltip id="bb-build-summary-duration-tooltip" {...props}>
+        <table><tbody>{rows}</tbody></table>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <OverlayTrigger placement="bottom"
+                    overlay={renderTimeOverlay}>
+      <span className={"bb-build-summary-duration"}>{durationString}</span>
+    </OverlayTrigger>
+  );
+};
+
+type BuildSummaryStepDurationSpanProps = {
+  step: Step;
+  now: number;
+}
+
+export const BuildSummaryStepDurationSpan = ({step, now}: BuildSummaryStepDurationSpanProps) => {
+  const durationString = stepDurationFormatWithLocks(step, now);
+
+  return <BuildSummaryDurationSpan durationString={durationString}
+                                   startedAt={step.started_at}
+                                   completeAt={step.complete_at}/>;
+};
+
+type BuildSummaryBuildDurationSpanProps = {
+  build: Build;
+  now: number;
+}
+
+export const BuildSummaryBuildDurationSpan = ({build, now}: BuildSummaryBuildDurationSpanProps) => {
+
+  const durationString = buildDurationFormatWithLocks(build, now);
+
+  return <BuildSummaryDurationSpan durationString={durationString}
+                                   startedAt={build.started_at}
+                                   completeAt={build.complete_at}/>;
+};

--- a/www/ui/src/util/Moment.ts
+++ b/www/ui/src/util/Moment.ts
@@ -48,6 +48,10 @@ export function dateFormat(time: number) {
   return moment.unix(time).format('LLL');
 }
 
+export function dateFormatSeconds(time: number) {
+  return moment.unix(time).format('LL LTS');
+}
+
 export function durationFromNowFormat(time: number, now: number) {
   return moment.unix(time).from(moment.unix(now), false);
 }


### PR DESCRIPTION
This makes the timeline of the build clearer.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
