### PR TITLE
4.0 backports: www: Make wsgi_dashboards routes backwards compatible with old plugin

### DIFF
--- a/www/react-wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
+++ b/www/react-wsgi_dashboards/src/views/WSGIDashboardsView/WSGIDashboardsView.tsx
@@ -101,12 +101,12 @@ buildbotSetupPlugin((reg, config) => {
       caption: caption,
       icon: createElement(icon, {}),
       order: dashboard.order,
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       parentName: null,
     });
   
     reg.registerRoute({
-      route: `/wsgi/${name}`,
+      route: `/${name}`,
       group: name,
       element: () => <WSGIDashboardsView name={name}/>,
     });


### PR DESCRIPTION
Backport https://github.com/buildbot/buildbot/pull/7991 to branch 4.0.x.