### PR TITLE
PropertiesTable.scss: wrap long property values

### DIFF
--- a/newsfragments/www-property-table-wrap.bugfix
+++ b/newsfragments/www-property-table-wrap.bugfix
@@ -1,0 +1,1 @@
+Build property values are now wrapped when displayed.

--- a/www/base/src/components/PropertiesTable/PropertiesTable.scss
+++ b/www/base/src/components/PropertiesTable/PropertiesTable.scss
@@ -6,6 +6,7 @@
   display: inline-block;
   border: unset;
   background-color: unset;
+  white-space: pre-wrap;
 }
 
 .bb-properties-copy {


### PR DESCRIPTION
fixes #8068

before:
![image](https://github.com/user-attachments/assets/58d50684-34b2-4ccf-9f16-3c98225d9f6f)

after:
![image](https://github.com/user-attachments/assets/250af48d-1e89-4a85-ba9a-4bdc5bf4e196)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
