### PR TITLE
www: fix ChoiceStringParameter when required and no default value

### DIFF
--- a/newsfragments/www-forcefield-choicestring-no-default.bugfix
+++ b/newsfragments/www-forcefield-choicestring-no-default.bugfix
@@ -1,0 +1,4 @@
+Fixes a regression where a ``ChoiceStringParameter`` requires a user selected
+value (no default value), but the force build form incorrectly displays the
+first choice as being selected and does not submit it to the backend which
+causes a validation error.

--- a/www/base/src/components/ForceBuildModal/Fields/FieldChoiceString.tsx
+++ b/www/base/src/components/ForceBuildModal/Fields/FieldChoiceString.tsx
@@ -55,12 +55,16 @@ export const FieldChoiceString = observer(({field, fieldsState}: FieldChoiceStri
       )
     );
   };
+  let options = field.choices.map(ValueToSelectOption);
+  if (!field.multiple && !field.default && !field.choices.includes(field.default)) {
+    options = [{value: field.default, label: 'Select an option'}, ...options];
+  }
 
   const props = {
     isMulti: field.multiple,
     defaultValue: field.multiple ? (state.value as string[]).map(ValueToSelectOption) : ValueToSelectOption(state.value as string),
-    onChange: onChange,
-    options: field.choices.map(ValueToSelectOption),
+    onChange,
+    options,
   };
 
   return (


### PR DESCRIPTION
This change fixes a regression where a ``ChoiceStringParameter`` requires a user selected value (required, but no default value), but the force build form incorrectly displays the first choice as being selected and does not submit it to the backend which causes a validation error.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
