### PR TITLE
auth: Allow default HTTPS request certificate verification

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -81,13 +81,13 @@ class OAuth2Auth(auth.AuthBase):
     tokenUriAdditionalParams = {}
     loginUri = None
     homeUri = None
-    sslVerify = None
 
-    def __init__(self, clientId, clientSecret, autologin=False, **kwargs):
+    def __init__(self, clientId, clientSecret, autologin=False, ssl_verify: bool = True, **kwargs):
         super().__init__(**kwargs)
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.autologin = autologin
+        self.ssl_verify = ssl_verify
 
     def reconfigAuth(self, master, new_config):
         self.master = master
@@ -132,7 +132,7 @@ class OAuth2Auth(auth.AuthBase):
             msg = f"OAuth2 session: creation failed: {error_description}"
             raise Error(503, msg)
         s.params = {'access_token': token['access_token']}
-        s.verify = self.sslVerify
+        s.verify = self.ssl_verify
         return s
 
     def get(self, session, path):
@@ -154,7 +154,7 @@ class OAuth2Auth(auth.AuthBase):
             else:
                 data.update({'client_id': client_id, 'client_secret': client_secret})
             data.update(self.tokenUriAdditionalParams)
-            response = requests.post(url, data=data, timeout=30, auth=auth, verify=self.sslVerify)
+            response = requests.post(url, data=data, timeout=30, auth=auth, verify=self.ssl_verify)
             response.raise_for_status()
             responseContent = bytes2unicode(response.content)
             try:
@@ -311,7 +311,7 @@ class GitHubAuth(OAuth2Auth):
             'Authorization': 'token ' + token['access_token'],
             'User-Agent': f'buildbot/{buildbot.version}',
         }
-        s.verify = self.sslVerify
+        s.verify = self.ssl_verify
         return s
 
     def getUserInfoFromOAuthClient_v4(self, c):

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -491,6 +491,7 @@ The available classes are described here:
 
     :param clientId: The client ID of your buildbot application
     :param clientSecret: The client secret of your buildbot application
+    :param boolean ssl_verify: If False disables SSL certificate verification
 
     This class implements an authentication with Google_ single sign-on.
     You can look at the Google_ oauth2 documentation on how to register your Buildbot instance to the Google systems.
@@ -528,6 +529,7 @@ The available classes are described here:
                                user's groups as ``org-name/team-name``.
     :param debug: When ``True`` and using ``apiVersion=4`` show some additional log calls with the
                   GraphQL queries and responses for debugging purposes.
+    :param boolean ssl_verify: If False disables SSL certificate verification
 
     This class implements an authentication with GitHub_ single sign-on.
     It functions almost identically to the :py:class:`~buildbot.www.oauth2.GoogleAuth` class.
@@ -596,6 +598,7 @@ The available classes are described here:
     :param instanceUri: The URI of your GitLab instance
     :param clientId: The client ID of your buildbot application
     :param clientSecret: The client secret of your buildbot application
+    :param boolean ssl_verify: If False disables SSL certificate verification
 
     This class implements an authentication with GitLab_ single sign-on.
     It functions almost identically to the :py:class:`~buildbot.www.oauth2.GoogleAuth` class.
@@ -624,6 +627,7 @@ The available classes are described here:
 
     :param clientId: The client ID of your buildbot application
     :param clientSecret: The client secret of your buildbot application
+    :param boolean ssl_verify: If False disables SSL certificate verification
 
     This class implements an authentication with Bitbucket_ single sign-on.
     It functions almost identically to the :py:class:`~buildbot.www.oauth2.GoogleAuth` class.


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/7992.


## Contributor Checklist:

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
