### PR TITLE
www: Add Builders tab to WorkerView, listing configured Builders for this worker

### DIFF
--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -69,12 +69,15 @@ class BuildersEndpoint(base.Endpoint):
         /builders
         /masters/n:masterid/builders
         /projects/n:projectid/builders
+        /workers/n:workerid/builders
     """
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
         bdicts = yield self.master.db.builders.getBuilders(
-            masterid=kwargs.get('masterid', None), projectid=kwargs.get('projectid', None)
+            masterid=kwargs.get('masterid', None),
+            projectid=kwargs.get('projectid', None),
+            workerid=kwargs.get('workerid', None),
         )
         return [_db2data(bd) for bd in bdicts]
 

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -149,6 +149,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
         self,
         masterid: int | None = None,
         projectid: int | None = None,
+        workerid: int | None = None,
         _builderid: int | None = None,
     ) -> defer.Deferred[list[BuilderModel]]:
         def thd(conn) -> list[BuilderModel]:
@@ -156,6 +157,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             bm_tbl = self.db.model.builder_masters
             builders_tags_tbl = self.db.model.builders_tags
             tags_tbl = self.db.model.tags
+            configured_workers_tbl = self.db.model.configured_workers
 
             j = bldr_tbl.outerjoin(bm_tbl)
             # if we want to filter by masterid, we must join to builder_masters
@@ -164,6 +166,8 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             if masterid is not None:
                 limiting_bm_tbl = bm_tbl.alias('limiting_bm')
                 j = j.join(limiting_bm_tbl, onclause=bldr_tbl.c.id == limiting_bm_tbl.c.builderid)
+            if workerid is not None:
+                j = j.join(configured_workers_tbl)
             q = (
                 sa.select(
                     bldr_tbl.c.id,
@@ -182,6 +186,8 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                 q = q.where(limiting_bm_tbl.c.masterid == masterid)
             if projectid is not None:
                 q = q.where(bldr_tbl.c.projectid == projectid)
+            if workerid is not None:
+                q = q.where(configured_workers_tbl.c.workerid == workerid)
             if _builderid is not None:
                 q = q.where(bldr_tbl.c.id == _builderid)
 

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -123,6 +123,9 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildersTags(builderid=5, tagid=4),
             fakedb.Master(id=13),
             fakedb.BuilderMaster(id=1, builderid=2, masterid=13),
+            fakedb.Worker(id=1, name='zero'),
+            fakedb.ConnectedWorker(id=1, workerid=1, masterid=13),
+            fakedb.ConfiguredWorker(id=1, workerid=1, buildermasterid=1),
         ])
 
     def tearDown(self):
@@ -154,6 +157,15 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             self.validateData(b)
 
         self.assertEqual(sorted([b['builderid'] for b in builders]), [3, 4])
+
+    @async_to_deferred
+    async def test_get_workerid(self):
+        builders = await self.callGet(('workers', 1, 'builders'))
+
+        for b in builders:
+            self.validateData(b)
+
+        self.assertEqual(sorted([b['builderid'] for b in builders]), [2])
 
     @defer.inlineCallbacks
     def test_get_masterid_missing(self):

--- a/master/docs/developer/database/builders.rst
+++ b/master/docs/developer/database/builders.rst
@@ -56,12 +56,14 @@ Builders connector
 
         Get the indicated builder.
 
-    .. py:method:: getBuilders(masterid=None, projectid=None)
+    .. py:method:: getBuilders(masterid=None, projectid=None, workerid=None)
 
         :param integer masterid: ID of the master to which the results should be limited
         :param integer masterid: ID of the project to which the results should be limited
+        :param integer workerid: ID of the configured worker to which the results should be limited
         :returns: list of :class:`BuilderModel` via Deferred
 
         Get all builders (in unspecified order).
         If ``masterid`` is specified, then only builders configured on that master are returned.
         If ``projectid`` is specified, then only builders for a particular project are returned.
+        If ``workerid`` is specified, then only builders for a particular configured worker are returned.

--- a/newsfragments/data-api-worker-builders.feature
+++ b/newsfragments/data-api-worker-builders.feature
@@ -1,0 +1,1 @@
+Add data API ``/workers/n:workerid/builders`` allowing to query the Builders assigned to a worker

--- a/newsfragments/www-worker-view-builders.feature
+++ b/newsfragments/www-worker-view-builders.feature
@@ -1,0 +1,1 @@
+Web UI's Worker view (``workers/{workerId}``) now has a ``Builders`` tab showing Builders configured on the worker

--- a/www/data-module/src/data/classes/Worker.ts
+++ b/www/data-module/src/data/classes/Worker.ts
@@ -10,6 +10,7 @@ import {BaseClass} from "./BaseClass";
 import {IDataDescriptor} from "./DataDescriptor";
 import {IDataAccessor} from "../DataAccessor";
 import {RequestQuery} from "../DataQuery";
+import {Builder, builderDescriptor} from "./Builder";
 
 export type ConfiguredBuilder = {
   builderid: number,
@@ -58,6 +59,10 @@ export class Worker extends BaseClass {
       graceful: this.graceful,
       workerinfo: this.workerinfo,
     };
+  }
+
+  getBuilders(query: RequestQuery = {}) {
+    return this.get<Builder>("builders", query, builderDescriptor);
   }
 
   static getAll(accessor: IDataAccessor, query: RequestQuery = {}) {


### PR DESCRIPTION
In the same way BuilderView has a tab listing it's workers, WorkerView now has a Builders tab.
It's pretty useful for instances that have a lot of workers with different workloads.

![image](https://github.com/user-attachments/assets/e3698d53-a80d-463f-97dd-a099b94eb915)

(it's not pretty, sorry, I'm really not a frontend person)

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
