### PR TITLE
test: correctly dispose of sqla engine in enginestrategy test

### DIFF
--- a/master/buildbot/test/unit/db/test_enginestrategy.py
+++ b/master/buildbot/test/unit/db/test_enginestrategy.py
@@ -198,5 +198,8 @@ class BuildbotEngineStrategy(unittest.TestCase):
 
     def test_create_engine(self):
         engine = enginestrategy.create_engine('sqlite://', basedir="/base")
-        with engine.connect() as conn:
-            self.assertEqual(conn.scalar(sa.text("SELECT 13 + 14")), 27)
+        try:
+            with engine.connect() as conn:
+                self.assertEqual(conn.scalar(sa.text("SELECT 13 + 14")), 27)
+        finally:
+            engine.dispose()


### PR DESCRIPTION
SQLA Engine will keep a pool of connection to the database unless disposed which generate unclosed ressource warnings, failing tests.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
