### PR TITLE
Merge `docker-example-config`

### DIFF
--- a/master/docker-example/README.md
+++ b/master/docker-example/README.md
@@ -1,0 +1,2 @@
+# buildbot-docker-example-config
+example configuration for running buildbot in docker

--- a/master/docker-example/master.cfg
+++ b/master/docker-example/master.cfg
@@ -80,13 +80,13 @@ c['builders'].append(
       workernames=["example-worker"],
       factory=factory))
 
-####### STATUS TARGETS
+####### REPORTER TARGETS
 
-# 'status' is a list of Status Targets. The results of each build will be
-# pushed to these targets. buildbot/status/*.py has a variety to choose from,
+# 'services' is a list of Reporter Targets. The results of each build will be
+# pushed to these targets. buildbot/reporters/*.py has a variety to choose from,
 # like IRC bots.
 
-c['status'] = []
+c['services'] = []
 
 ####### PROJECT IDENTITY
 

--- a/master/docker-example/master.cfg
+++ b/master/docker-example/master.cfg
@@ -1,0 +1,108 @@
+# -*- python -*-
+# ex: set filetype=python:
+
+import os
+
+from buildbot.plugins import *
+
+# This is a sample buildmaster config file. It must be installed as
+# 'master.cfg' in your buildmaster's base directory.
+
+# This is the dictionary that the buildmaster pays attention to. We also use
+# a shorter alias to save typing.
+c = BuildmasterConfig = {}
+
+####### WORKERS
+
+# The 'workers' list defines the set of recognized workers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
+
+# here we configure a localworker, which will run in the same process as the master
+c['workers'] = [worker.LocalWorker("example-localworker")]
+
+# 'protocols' contains information about protocols which master will use for
+# communicating with workers. You must define at least 'port' option that workers
+# could connect to your master with this protocol.
+# 'port' must match the value configured into the workers (with their
+# --master option)
+c['protocols'] = {'pb': {'port': os.environ.get("BUILDBOT_WORKER_PORT", 9989)}}
+
+####### CHANGESOURCES
+
+# the 'change_source' setting tells the buildmaster how it should find out
+# about source code changes.  Here we point to the buildbot clone of pyflakes.
+
+c['change_source'] = []
+c['change_source'].append(changes.GitPoller(
+        'git://github.com/buildbot/pyflakes.git',
+        workdir='gitpoller-workdir', branch='master',
+        pollinterval=300))
+
+####### SCHEDULERS
+
+# Configure the Schedulers, which decide how to react to incoming changes.  In this
+# case, just kick off a 'runtests' build
+
+c['schedulers'] = []
+c['schedulers'].append(schedulers.SingleBranchScheduler(
+                            name="all",
+                            change_filter=util.ChangeFilter(branch='master'),
+                            treeStableTimer=None,
+                            builderNames=["runtests"]))
+c['schedulers'].append(schedulers.ForceScheduler(
+                            name="force",
+                            builderNames=["runtests"]))
+
+####### BUILDERS
+
+# The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
+# what steps, and which workers can execute them.  Note that any particular build will
+# only take place on one worker.
+
+factory = util.BuildFactory()
+# check out the source
+factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+# run the tests (note that this will require that 'trial' is installed)
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+
+c['builders'] = []
+c['builders'].append(
+    util.BuilderConfig(name="runtests",
+      workernames=["example-worker"],
+      factory=factory))
+
+####### STATUS TARGETS
+
+# 'status' is a list of Status Targets. The results of each build will be
+# pushed to these targets. buildbot/status/*.py has a variety to choose from,
+# like IRC bots.
+
+c['status'] = []
+
+####### PROJECT IDENTITY
+
+# the 'title' string will appear at the top of this buildbot installation's
+# home pages (linked to the 'titleURL').
+
+c['title'] = "Pyflakes"
+c['titleURL'] = "https://launchpad.net/pyflakes"
+
+# the 'buildbotURL' string should point to the location where the buildbot's
+# internal web server is visible. This typically uses the port number set in 
+# the 'www' entry below, but with an externally-visible host name which the 
+# buildbot cannot figure out without some help.
+
+c['buildbotURL'] = os.environ.get("BUILDBOT_WEB_URL", "http://localhost:8010/")
+
+# minimalistic config to activate new web UI
+c['www'] = dict(port=os.environ.get("BUILDBOT_WEB_PORT", 8010),
+                plugins=dict(waterfall_view={}, console_view={}))
+
+####### DB URL
+
+c['db'] = {
+    # This specifies what database buildbot uses to store its state.  You can leave
+    # this at its default for all but the largest installations.
+    'db_url' : os.environ.get("BUILDBOT_DB_URL", "sqlite://"),
+}

--- a/master/docker-example/master.cfg
+++ b/master/docker-example/master.cfg
@@ -45,7 +45,7 @@ c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
         'git://github.com/buildbot/pyflakes.git',
         workdir='gitpoller-workdir', branch='master',
-        pollinterval=300))
+        pollInterval=300))
 
 ####### SCHEDULERS
 

--- a/master/docker-example/master.cfg
+++ b/master/docker-example/master.cfg
@@ -18,9 +18,17 @@ c = BuildmasterConfig = {}
 # a Worker object, specifying a unique worker name and password.  The same
 # worker name and password must be configured on the worker.
 
-# here we configure a localworker, which will run in the same process as the master
-c['workers'] = [worker.LocalWorker("example-localworker")]
+c['workers'] = [worker.Worker("example-worker", 'pass')]
 
+if 'BUILDBOT_MQ_URL' in os.environ:
+    c['mq'] = {
+        'type' : 'wamp',
+        'router_url': os.environ['BUILDBOT_MQ_URL'],
+        'realm': os.environ.get('BUILDBOT_MQ_REALM', 'buildbot').decode('utf-8'),
+        'debug' : 'BUILDBOT_MQ_DEBUG' in os.environ,
+        'debug_websockets' : 'BUILDBOT_MQ_DEBUG' in os.environ,
+        'debug_lowlevel' : 'BUILDBOT_MQ_DEBUG' in os.environ,
+    }
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
@@ -62,7 +70,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 # check out the source
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='http://github.com/buildbot/pyflakes.git', mode='incremental'))
 # run the tests (note that this will require that 'trial' is installed)
 factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
 
@@ -89,8 +97,8 @@ c['title'] = "Pyflakes"
 c['titleURL'] = "https://launchpad.net/pyflakes"
 
 # the 'buildbotURL' string should point to the location where the buildbot's
-# internal web server is visible. This typically uses the port number set in 
-# the 'www' entry below, but with an externally-visible host name which the 
+# internal web server is visible. This typically uses the port number set in
+# the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
 
 c['buildbotURL'] = os.environ.get("BUILDBOT_WEB_URL", "http://localhost:8010/")
@@ -104,5 +112,5 @@ c['www'] = dict(port=os.environ.get("BUILDBOT_WEB_PORT", 8010),
 c['db'] = {
     # This specifies what database buildbot uses to store its state.  You can leave
     # this at its default for all but the largest installations.
-    'db_url' : os.environ.get("BUILDBOT_DB_URL", "sqlite://"),
+    'db_url' : os.environ.get("BUILDBOT_DB_URL", "sqlite://").format(**os.environ),
 }

--- a/master/docker-example/multimaster/README.md
+++ b/master/docker-example/multimaster/README.md
@@ -1,0 +1,27 @@
+This docker-compose environment show how to setup a buildbot in multimaster mode with docker and ha-proxy
+
+
+The network schema is as follow:
+
+
+           [ web users]
+                |  |
+    ------------------------
+    [workers]   | /
+         \|     |/
+       [  HAPROXY  ]
+         /     \
+        /       \
+    [master1]..[masterN]
+          |  \    / |
+          |   \ /   |
+          |   /\    |
+    [ postgre]  [crossbar]
+
+
+The same haproxy serves as load balancing for both web and worker protocols
+
+You can run this by using for example 4 masters
+
+    docker-compose up -d
+    docker-compose scale buildbot=4

--- a/master/docker-example/multimaster/db.env
+++ b/master/docker-example/multimaster/db.env
@@ -1,0 +1,6 @@
+# database parameters are shared between containers
+POSTGRES_PASSWORD=change_me
+POSTGRES_USER=buildbot
+POSTGRES_DB=buildbot
+# in master.cfg, this variable is str.format()ed with the environment variables
+BUILDBOT_DB_URL=postgresql+psycopg2://{POSTGRES_USER}:{POSTGRES_PASSWORD}@db/{POSTGRES_DB}

--- a/master/docker-example/multimaster/docker-compose.yml
+++ b/master/docker-example/multimaster/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '2'
+services:
+
+  lb:
+    image: dockercloud/haproxy
+    links:
+      - buildbot
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    expose:
+        - 8080
+        - 9989
+    ports:
+      - 8080:8080
+      - 9989:9989   # for external workers
+
+  buildbot:
+    image: buildbot/buildbot-master:latest
+    env_file: db.env
+    environment:
+        - BUILDBOT_CONFIG_DIR=config
+        - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
+        - BUILDBOT_WORKER_PORT=9989
+        - BUILDBOT_WEB_URL=http://localhost:8080/
+        - BUILDBOT_WEB_PORT=8080
+        - BUILDBOT_MQ_URL=ws://mq:8080/ws
+        - BUILDBOT_MQ_DEBUG=true
+        - BUILDBOT_MQ_REALM=realm1
+        - TCP_PORTS=8080,9989
+    links:
+      - db
+    expose:
+        - 8080
+        - 9989
+
+  db:
+    image: "postgres:9.4"
+    env_file: db.env
+    expose:
+        - 5432
+
+  mq:
+    image: "crossbario/crossbar"
+    env_file: db.env
+    expose:
+        - 8080
+
+  worker:
+    image: "buildbot/buildbot-worker:master"
+    environment:
+        BUILDMASTER: lb
+        BUILDMASTER_PORT: 9989
+        WORKERNAME: example-worker
+        WORKERPASS: pass
+        WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
+
+    links:
+        - lb

--- a/master/docker-example/pypy/master/Dockerfile
+++ b/master/docker-example/pypy/master/Dockerfile
@@ -1,2 +1,2 @@
-from pypy:2-onbuild
+from pypy:3-onbuild
 CMD /usr/src/app/start_buildbot.sh

--- a/master/docker-example/pypy/master/Dockerfile
+++ b/master/docker-example/pypy/master/Dockerfile
@@ -1,0 +1,2 @@
+from pypy:2-onbuild
+CMD /usr/src/app/start_buildbot.sh

--- a/master/docker-example/pypy/master/buildbot.tac
+++ b/master/docker-example/pypy/master/buildbot.tac
@@ -1,0 +1,16 @@
+import sys
+
+from buildbot.master import BuildMaster
+from twisted.application import service
+from twisted.python.log import FileLogObserver, ILogObserver
+
+basedir = '/usr/src/app'
+configfile = 'master.cfg'
+
+# note: this line is matched against to check that this is a buildmaster
+# directory; do not edit it.
+application = service.Application('buildmaster')
+application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
+
+m = BuildMaster(basedir, configfile, umask=None)
+m.setServiceParent(application)

--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,2 +1,2 @@
-buildbot==0.8.12
+buildbot[bundle]==0.9.2
 psycopg2cffi-compat

--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,2 +1,2 @@
-buildbot==0.8.14
+buildbot[bundle]
 psycopg2cffi-compat

--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,2 +1,2 @@
-buildbot[bundle]
+buildbot==0.8.12
 psycopg2cffi-compat

--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,0 +1,2 @@
+buildbot[bundle]
+psycopg2cffi-compat

--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,2 +1,2 @@
-buildbot[bundle]==0.9.2
+buildbot==0.8.14
 psycopg2cffi-compat

--- a/master/docker-example/pypy/master/start_buildbot.sh
+++ b/master/docker-example/pypy/master/start_buildbot.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# startup script for purely stateless master
+
+# we download the config from an arbitrary curl accessible tar.gz file (which github can generate for us)
+
+B=`pwd`
+
+if [ -z "$BUILDBOT_CONFIG_URL" ]
+then
+    if [ ! -f "$B/master.cfg" ]
+    then
+        echo No master.cfg found nor $$BUILDBOT_CONFIG_URL !
+        echo Please provide a master.cfg file in $B or provide a $$BUILDBOT_CONFIG_URL variable via -e
+        exit 1
+    fi
+
+else
+    BUILDBOT_CONFIG_DIR=${BUILDBOT_CONFIG_DIR:-config}
+    mkdir -p $B/$BUILDBOT_CONFIG_DIR
+    # if it ends with .tar.gz then its a tarball, else its directly the file
+    if echo "$BUILDBOT_CONFIG_URL" | grep '.tar.gz$' >/dev/null
+    then
+        until curl -sL $BUILDBOT_CONFIG_URL | tar -xz --strip-components=1 --directory=$B/$BUILDBOT_CONFIG_DIR
+        do
+            echo "Can't download from \$BUILDBOT_CONFIG_URL: $BUILDBOT_CONFIG_URL"
+            sleep 1
+        done
+
+        ln -sf $B/$BUILDBOT_CONFIG_DIR/master.cfg $B/master.cfg
+
+        if [ -f $B/$BUILDBOT_CONFIG_DIR/buildbot.tac ]
+        then
+            ln -sf $B/$BUILDBOT_CONFIG_DIR/buildbot.tac $B/buildbot.tac
+        fi
+    else
+        until curl -sL $BUILDBOT_CONFIG_URL > $B/master.cfg
+        do
+            echo "Can't download from $$BUILDBOT_CONFIG_URL: $BUILDBOT_CONFIG_URL"
+        done
+    fi
+fi
+# copy the default buildbot.tac if not provided by the config
+if [ ! -f $B/buildbot.tac ]
+then
+    cp /usr/src/buildbot/contrib/docker/master/buildbot.tac $B
+fi
+# wait for db to start by trying to upgrade the master
+until buildbot upgrade-master $B
+do
+    echo "Can't upgrade master yet. Waiting for database ready?"
+    sleep 1
+done
+
+# we use exec so that twistd use the pid 1 of the container, and so that signals are properly forwarded
+exec twistd -ny $B/buildbot.tac

--- a/master/docker-example/pypy/worker/Dockerfile
+++ b/master/docker-example/pypy/worker/Dockerfile
@@ -1,0 +1,2 @@
+from pypy:2-onbuild
+CMD ["twistd", "-ny", "buildbot.tac"]

--- a/master/docker-example/pypy/worker/buildbot.tac
+++ b/master/docker-example/pypy/worker/buildbot.tac
@@ -1,0 +1,40 @@
+import fnmatch
+import os
+import sys
+
+from twisted.application import service
+from twisted.python.log import FileLogObserver
+from twisted.python.log import ILogObserver
+
+from buildslave.bot import BuildSlave
+
+# setup worker
+basedir = os.path.abspath(os.path.dirname(__file__))
+application = service.Application('buildbot-worker')
+
+
+application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
+# and worker on the same process!
+buildmaster_host = os.environ.get("BUILDMASTER", 'localhost')
+port = int(os.environ.get("BUILDMASTER_PORT", 9989))
+workername = os.environ.get("WORKERNAME", 'docker')
+passwd = os.environ.get("WORKERPASS")
+
+# delete the password from the environ so that it is not leaked in the log
+blacklist = os.environ.get("WORKER_ENVIRONMENT_BLACKLIST", "WORKERPASS").split()
+for name in list(os.environ.keys()):
+    for toremove in blacklist:
+        if fnmatch.fnmatch(name, toremove):
+            del os.environ[name]
+
+keepalive = 600
+umask = None
+maxdelay = 300
+allow_shutdown = None
+usepty=False
+
+s = BuildSlave(buildmaster_host, port, workername, passwd, basedir,
+               keepalive, usepty, umask=umask, maxdelay=maxdelay,
+               allow_shutdown=allow_shutdown)
+
+s.setServiceParent(application)

--- a/master/docker-example/pypy/worker/requirements.txt
+++ b/master/docker-example/pypy/worker/requirements.txt
@@ -1,0 +1,1 @@
+buildbot-slave==0.8.14

--- a/master/docker-example/simple/db.env
+++ b/master/docker-example/simple/db.env
@@ -1,0 +1,6 @@
+# database parameters are shared between containers
+POSTGRES_PASSWORD=change_me
+POSTGRES_USER=buildbot
+POSTGRES_DB=buildbot
+# in master.cfg, this variable is str.format()ed with the environment variables
+BUILDBOT_DB_URL=postgresql+psycopg2://{POSTGRES_USER}:{POSTGRES_PASSWORD}@db/{POSTGRES_DB}

--- a/master/docker-example/simple/docker-compose.yml
+++ b/master/docker-example/simple/docker-compose.yml
@@ -3,13 +3,13 @@ services:
   buildbot:
     image: buildbot/buildbot-master:master
     env_file:
-        - db.env
+      - db.env
     environment:
-        - BUILDBOT_CONFIG_DIR=config
-        - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
-        - BUILDBOT_WORKER_PORT=9989
-        - BUILDBOT_WEB_URL=http://localhost:8080/
-        - BUILDBOT_WEB_PORT=8080
+      - BUILDBOT_CONFIG_DIR=config
+      - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
+      - BUILDBOT_WORKER_PORT=9989
+      - BUILDBOT_WEB_URL=http://localhost:8080/
+      - BUILDBOT_WEB_PORT=8080
     links:
       - db
     depends_on:
@@ -18,19 +18,19 @@ services:
       - "8080:8080"
   db:
     env_file:
-        - db.env
+      - db.env
     image: "postgres:9.4"
     expose:
-        - 5432
+      - 5432
 
   worker:
     image: "buildbot/buildbot-worker:master"
     environment:
-        BUILDMASTER: buildbot
-        BUILDMASTER_PORT: 9989
-        WORKERNAME: example-worker
-        WORKERPASS: pass
-        WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
+      BUILDMASTER: buildbot
+      BUILDMASTER_PORT: 9989
+      WORKERNAME: example-worker
+      WORKERPASS: pass
+      WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
 
     links:
-        - buildbot
+      - buildbot

--- a/master/docker-example/simple/docker-compose.yml
+++ b/master/docker-example/simple/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '2'
 services:
   buildbot:
-    image: buildbot/buildbot-master:latest
-    env_file: db.env
+    image: buildbot/buildbot-master:master
+    env_file:
+        - db.env
     environment:
         - BUILDBOT_CONFIG_DIR=config
         - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
@@ -16,7 +17,8 @@ services:
     ports:
       - "8080:8080"
   db:
-    env_file: db.env
+    env_file:
+        - db.env
     image: "postgres:9.4"
     expose:
         - 5432

--- a/master/docker-example/simple/docker-compose.yml
+++ b/master/docker-example/simple/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+  buildbot:
+    image: buildbot/buildbot-master:latest
+    env_file: db.env
+    environment:
+        - BUILDBOT_CONFIG_DIR=config
+        - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
+        - BUILDBOT_WORKER_PORT=9989
+        - BUILDBOT_WEB_URL=http://localhost:8080/
+        - BUILDBOT_WEB_PORT=8080
+    links:
+      - db
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+  db:
+    env_file: db.env
+    image: "postgres:9.4"
+    expose:
+        - 5432
+
+  worker:
+    image: "buildbot/buildbot-worker:master"
+    environment:
+        BUILDMASTER: buildbot
+        BUILDMASTER_PORT: 9989
+        WORKERNAME: example-worker
+        WORKERPASS: pass
+        WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
+
+    links:
+        - buildbot

--- a/master/docker-example/simple/docker-compose.yml
+++ b/master/docker-example/simple/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - db
     ports:
-      - "8080:8080"
+      - "8010:8010"
   db:
     env_file:
       - db.env

--- a/master/docker-example/simple/docker-compose.yml
+++ b/master/docker-example/simple/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - BUILDBOT_CONFIG_DIR=config
       - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
       - BUILDBOT_WORKER_PORT=9989
-      - BUILDBOT_WEB_URL=http://localhost:8080/
-      - BUILDBOT_WEB_PORT=8080
+      - BUILDBOT_WEB_URL=http://localhost:8010/
+      - BUILDBOT_WEB_PORT=tcp:port=8010
     links:
       - db
     depends_on:


### PR DESCRIPTION
buildbot/buildbot-docker-example-config repository was merged into main Buildbot repository, for docker examples to be more discoverable.
Fixes https://github.com/buildbot/buildbot/issues/8038.

