### PR TITLE
3.11 backports: remove pipes module usage which is deprecated

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -125,9 +125,10 @@ warnings.filterwarnings('ignore', ".*stream argument is deprecated. Use stream p
 warnings.filterwarnings('ignore', ".*'urllib3.contrib.pyopenssl' module is deprecated",
                         category=DeprecationWarning)
 
-# pipes is still used in astroid and buildbot_worker in default installation
-warnings.filterwarnings('ignore', "'pipes' is deprecated and slated for removal in Python 3.13",
-                        category=DeprecationWarning)
+if sys.version_info[0] < 3:
+    # pipes is still used in astroid and buildbot_worker in default installation
+    warnings.filterwarnings('ignore', "'pipes' is deprecated and slated for removal in Python 3.13",
+                            category=DeprecationWarning)
 
 # boto3 shows this warning when on old Python
 warnings.filterwarnings('ignore', ".*Boto3 will no longer support Python .*",


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/7670 to 3.11.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8054.