### PR TITLE
Require Twisted 22.1 or newer

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -37,8 +37,8 @@ matrix:
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=21.2.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.1.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=23.8.0 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=1.4.52 NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.8 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial

--- a/master/setup.py
+++ b/master/setup.py
@@ -651,7 +651,7 @@ py_38 = sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_inf
 if not py_38:
     raise RuntimeError("Buildbot master requires at least Python-3.8")
 
-twisted_ver = ">= 21.2.0"
+twisted_ver = ">= 22.1.0"
 
 bundle_version = version.split("-")[0]
 

--- a/newsfragments/twisted-min-21-2-0.removal
+++ b/newsfragments/twisted-min-21-2-0.removal
@@ -1,1 +1,0 @@
-Buildbot now requires Twisted 21.2.0 or newer.

--- a/newsfragments/twisted-min-22-1-0.removal
+++ b/newsfragments/twisted-min-22-1-0.removal
@@ -1,0 +1,1 @@
+Buildbot master now requires Twisted 22.1.0 or newer.


### PR DESCRIPTION
No distributions package Twisted between 21.2.0 (inclusive) and 22.1.0 (exclusive), thus this change will not introduce difficult compatibility problems for the end users (e.g. when using distribution Python packages). Users using virtualenv will be able to upgrade to newer Twisted easily, if they even use Twisted that old.

This change was necessary because newer Twisted is required for typing changes.
