### PR TITLE
4.0 backports: PropertiesTable.scss: wrap long property values

### DIFF
--- a/newsfragments/www-property-table-wrap.bugfix
+++ b/newsfragments/www-property-table-wrap.bugfix
@@ -1,0 +1,1 @@
+Build property values are now wrapped when displayed.

--- a/www/base/src/components/PropertiesTable/PropertiesTable.scss
+++ b/www/base/src/components/PropertiesTable/PropertiesTable.scss
@@ -6,6 +6,7 @@
   display: inline-block;
   border: unset;
   background-color: unset;
+  white-space: pre-wrap;
 }
 
 .bb-properties-copy {

--- a/www/react-base/src/components/PropertiesTable/PropertiesTable.scss
+++ b/www/react-base/src/components/PropertiesTable/PropertiesTable.scss
@@ -6,6 +6,7 @@
   display: inline-block;
   border: unset;
   background-color: unset;
+  white-space: pre-wrap;
 }
 
 .bb-properties-copy {


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/8070 to 4.0.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8055.