### PR TITLE
4.0 backports: rest: remove usage of deprecated cgi module

### DIFF
--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import cgi
 import datetime
 import fnmatch
 import json
@@ -45,8 +44,9 @@ class ContentTypeParser:
         self.typeheader = contenttype
 
     def gettype(self):
-        mimetype, _ = cgi.parse_header(bytes2unicode(self.typeheader))
-        return mimetype
+        if self.typeheader is None:
+            return None
+        return bytes2unicode(self.typeheader).split(';', 1)[0]
 
 
 URL_ENCODED = b"application/x-www-form-urlencoded"


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/8067 to 4.0.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8055.