### PR TITLE
ruff: enable flake8-future-annotations (FA) rules

### DIFF
--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -17,6 +17,8 @@
 Parse various kinds of 'CVS notify' email.
 """
 
+from __future__ import annotations
+
 import calendar
 import datetime
 import re

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -29,7 +29,6 @@ from email.utils import mktime_tz
 from email.utils import parseaddr
 from email.utils import parsedate_tz
 from typing import ClassVar
-from typing import Optional
 from typing import Sequence
 
 from twisted.internet import defer
@@ -47,7 +46,7 @@ class MaildirSource(MaildirService, util.ComparableMixin):
 
     compare_attrs: ClassVar[Sequence[str]] = ("basedir", "pollInterval", "prefix")
     # twisted is marked as typed, but doesn't specify this type correctly
-    name: Optional[str] = 'MaildirSource'  # type: ignore[assignment]
+    name: str | None = 'MaildirSource'  # type: ignore[assignment]
 
     def __init__(self, maildir, prefix=None, category='', repository=''):
         super().__init__(maildir)

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 from typing import Optional
 
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -15,12 +15,10 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager
 
 
 class ChangeManager(MeasuredBuildbotServiceManager):
-    name: Optional[str] = "ChangeManager"  # type: ignore[assignment]
+    name: str | None = "ChangeManager"  # type: ignore[assignment]
     managed_services_name = "changesources"
     config_attr = "change_sources"

--- a/master/buildbot/data/graphql.py
+++ b/master/buildbot/data/graphql.py
@@ -19,7 +19,6 @@ import asyncio
 import functools
 import textwrap
 from types import ModuleType
-from typing import Optional
 
 from buildbot.asyncio import AsyncIOLoopWithTwisted
 from buildbot.asyncio import as_deferred
@@ -29,7 +28,7 @@ from buildbot.data.base import EndpointKind
 from buildbot.data.types import Entity
 from buildbot.util import service
 
-graphql: Optional[ModuleType] = None
+graphql: ModuleType | None = None
 try:
     import graphql
     from graphql.execution.execute import default_field_resolver

--- a/master/buildbot/data/graphql.py
+++ b/master/buildbot/data/graphql.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 import asyncio
 import functools

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -11,7 +11,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright Buildbot Team Members
+# Copyright Buildbot Team Member
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/master/buildbot/data/patches.py
+++ b/master/buildbot/data/patches.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+from __future__ import annotations
+
 from typing import List
 from typing import Type
 

--- a/master/buildbot/data/patches.py
+++ b/master/buildbot/data/patches.py
@@ -16,9 +16,6 @@
 
 from __future__ import annotations
 
-from typing import List
-from typing import Type
-
 from buildbot.data import base
 from buildbot.data import types
 
@@ -28,7 +25,7 @@ from buildbot.data import types
 class Patch(base.ResourceType):
     name = "patch"
     plural = "patches"
-    endpoints: List[Type[base.Endpoint]] = []
+    endpoints: list[type[base.Endpoint]] = []
     keyField = 'patchid'
 
     class EntityType(types.Entity):

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -33,7 +33,7 @@ def capitalize(word):
 
 
 class Type:
-    name: Union["Identifier", "String", str, None] = None
+    name: Union[Identifier, String, str, None] = None
     doc = None
     graphQLType = "unknown"
 
@@ -354,7 +354,7 @@ class Entity(Type):
     #  * buildsets.Buildset.entityType or
     #  * self.master.data.rtypes.buildsets.entityType
 
-    name: Union["Identifier", "String", str, None] = None  # set in constructor
+    name: Union[Identifier, String, str, None] = None  # set in constructor
     graphql_name = None  # set in constructor
     fields: Dict[str, Type] = {}
     fieldNames: Set[str] = set([])

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -19,9 +19,6 @@ from __future__ import annotations
 import datetime
 import json
 import re
-from typing import Dict
-from typing import Set
-from typing import Tuple
 from typing import Union
 
 from buildbot import util
@@ -121,7 +118,7 @@ class NoneOk(Type):
 
 
 class Instance(Type):
-    types: Tuple[type, ...] = ()
+    types: tuple[type, ...] = ()
     ramlType = "unknown"
     graphQLType = "unknown"
 
@@ -356,8 +353,8 @@ class Entity(Type):
 
     name: Union[Identifier, String, str, None] = None  # set in constructor
     graphql_name = None  # set in constructor
-    fields: Dict[str, Type] = {}
-    fieldNames: Set[str] = set([])
+    fields: dict[str, Type] = {}
+    fieldNames: set[str] = set([])
 
     def __init__(self, name, graphql_name):
         fields = {}

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import datetime
 import json
 import re
-from typing import Union
 
 from buildbot import util
 from buildbot.util import bytes2unicode
@@ -30,7 +29,7 @@ def capitalize(word):
 
 
 class Type:
-    name: Union[Identifier, String, str, None] = None
+    name: Identifier | String | str | None = None
     doc = None
     graphQLType = "unknown"
 
@@ -351,7 +350,7 @@ class Entity(Type):
     #  * buildsets.Buildset.entityType or
     #  * self.master.data.rtypes.buildsets.entityType
 
-    name: Union[Identifier, String, str, None] = None  # set in constructor
+    name: Identifier | String | str | None = None  # set in constructor
     graphql_name = None  # set in constructor
     fields: dict[str, Type] = {}
     fieldNames: set[str] = set([])

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 # See "Type Validation" in master/docs/developer/tests.rst
+from __future__ import annotations
+
 import datetime
 import json
 import re

--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 import json

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 import dataclasses

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 import dataclasses

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 import dataclasses

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
 
 from zope.interface import Attribute
 from zope.interface import Interface
@@ -122,7 +120,7 @@ class ISourceStamp(Interface):
         """
         raise NotImplementedError
 
-    def mergeWith(others: List[ISourceStamp]) -> ISourceStamp:
+    def mergeWith(others: list[ISourceStamp]) -> ISourceStamp:
         """Generate a SourceStamp for the merger of me and all the other
         SourceStamps. This is called by a Build when it starts, to figure
         out what its sourceStamp should be."""
@@ -348,7 +346,7 @@ class IBuildStep(IPlugin):
 
 
 class IConfigured(Interface):
-    def getConfigDict() -> Dict[str, Any]:
+    def getConfigDict() -> dict[str, Any]:
         return {}  # return something to silence warnings at call sites
 
 
@@ -387,7 +385,7 @@ class IHttpResponse(Interface):
 
 
 class IConfigurator(Interface):
-    def configure(config_dict: Dict[str, Any]) -> None:
+    def configure(config_dict: dict[str, Any]) -> None:
         """
         Alter the buildbot config_dict, as defined in master.cfg
 

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -116,19 +116,19 @@ class ISourceStamp(Interface):
     @type repository: string
     """
 
-    def canBeMergedWith(other: 'ISourceStamp') -> bool:
+    def canBeMergedWith(other: ISourceStamp) -> bool:
         """
         Can this SourceStamp be merged with OTHER?
         """
         raise NotImplementedError
 
-    def mergeWith(others: List['ISourceStamp']) -> 'ISourceStamp':
+    def mergeWith(others: List[ISourceStamp]) -> ISourceStamp:
         """Generate a SourceStamp for the merger of me and all the other
         SourceStamps. This is called by a Build when it starts, to figure
         out what its sourceStamp should be."""
         raise NotImplementedError
 
-    def getAbsoluteSourceStamp(got_revision: str) -> 'ISourceStamp':
+    def getAbsoluteSourceStamp(got_revision: str) -> ISourceStamp:
         """Get a new SourceStamp object reflecting the actual revision found
         by a Source step."""
         raise NotImplementedError
@@ -147,7 +147,7 @@ class IEmailSender(Interface):
 
 
 class IEmailLookup(Interface):
-    def getAddress(user: str) -> "Deferred":
+    def getAddress(user: str) -> Deferred:
         """Turn a User-name string into a valid email address. Either return
         a string (with an @ in it), None (to indicate that the user cannot
         be reached by email), or a Deferred which will fire with the same."""
@@ -160,14 +160,14 @@ class ILogObserver(Interface):
     """
 
     # internal methods
-    def setStep(step: "IBuildStep") -> None:
+    def setStep(step: IBuildStep) -> None:
         pass
 
-    def setLog(log: "Log") -> None:
+    def setLog(log: Log) -> None:
         pass
 
     # methods called by the LogFile
-    def logChunk(build: "Build", step: "IBuildStep", log: "Log", channel: str, text: str) -> None:
+    def logChunk(build: Build, step: IBuildStep, log: Log, channel: str, text: str) -> None:
         pass
 
 
@@ -184,7 +184,7 @@ class ILatentWorker(IWorker):
         'Whether the latent worker is currently substantiated with a real instance.',
     )
 
-    def substantiate() -> "Deferred":
+    def substantiate() -> Deferred:
         """Request that the worker substantiate with a real instance.
 
         Returns a deferred that will callback when a real instance has
@@ -193,7 +193,7 @@ class ILatentWorker(IWorker):
 
     # there is an insubstantiate too, but that is not used externally ATM.
 
-    def buildStarted(wfb: "LatentWorkerForBuilder") -> None:
+    def buildStarted(wfb: LatentWorkerForBuilder) -> None:
         """Inform the latent worker that a build has started.
 
         @param wfb: a L{LatentWorkerForBuilder}.  The wfb is the one for whom the
@@ -201,7 +201,7 @@ class ILatentWorker(IWorker):
         """
         raise NotImplementedError
 
-    def buildFinished(wfb: "LatentWorkerForBuilder") -> None:
+    def buildFinished(wfb: LatentWorkerForBuilder) -> None:
         """Inform the latent worker that a build has finished.
 
         @param wfb: a L{LatentWorkerForBuilder}.  The wfb is the one for whom the
@@ -215,7 +215,7 @@ class IMachine(Interface):
 
 
 class IMachineAction(Interface):
-    def perform(manager: IMachine) -> "Deferred":
+    def perform(manager: IMachine) -> Deferred:
         """Perform an action on the machine managed by manager. Returns a
         deferred evaluating to True if it was possible to execute the
         action.
@@ -229,7 +229,7 @@ class ILatentMachine(IMachine):
 class IRenderable(Interface):
     """An object that can be interpolated with properties from a build."""
 
-    def getRenderingFor(iprops: "IProperties") -> "Deferred":
+    def getRenderingFor(iprops: IProperties) -> Deferred:
         """Return a deferred that fires with interpolation with the given properties
 
         @param iprops: the L{IProperties} provider supplying the properties.
@@ -286,7 +286,7 @@ class IProperties(Interface):
         @type runtime: boolean
         """
 
-    def getProperties() -> "Properties":
+    def getProperties() -> Properties:
         """Get the L{buildbot.process.properties.Properties} instance storing
         these properties.  Note that the interface for this class is not
         stable, so where possible the other methods of this interface should be
@@ -296,7 +296,7 @@ class IProperties(Interface):
         """
         raise NotImplementedError
 
-    def getBuild() -> "Build":
+    def getBuild() -> Build:
         """Get the L{buildbot.process.build.Build} instance for the current
         build.  Note that this object is not available after the build is
         complete, at which point this method will return None.
@@ -308,7 +308,7 @@ class IProperties(Interface):
         """
         raise NotImplementedError
 
-    def render(value: Any) -> "IRenderable":
+    def render(value: Any) -> IRenderable:
         """Render @code{value} as an L{IRenderable}.  This essentially coerces
         @code{value} to an L{IRenderable} and calls its @L{getRenderingFor}
         method.
@@ -354,13 +354,13 @@ class IConfigured(Interface):
 
 class IReportGenerator(Interface):
     def generate(
-        master: "IConfigured", reporter: "ReporterBase", key: str, build: "Build"
-    ) -> "Deferred[None]":
+        master: IConfigured, reporter: ReporterBase, key: str, build: Build
+    ) -> Deferred[None]:
         raise NotImplementedError
 
 
 class IConfigLoader(Interface):
-    def loadConfig() -> "MasterConfig":
+    def loadConfig() -> MasterConfig:
         """
         Load the specified configuration.
 
@@ -370,13 +370,13 @@ class IConfigLoader(Interface):
 
 
 class IHttpResponse(Interface):
-    def content() -> "Deferred":
+    def content() -> Deferred:
         """
         :returns: raw (``bytes``) content of the response via deferred
         """
         raise NotImplementedError
 
-    def json() -> "Deferred":
+    def json() -> Deferred:
         """
         :returns: json decoded content of the response via deferred
         """

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -23,6 +23,8 @@ Define the interfaces that are implemented by various buildbot classes.
 # pylint: disable=no-method-argument
 # pylint: disable=inherit-non-class
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict

--- a/master/buildbot/machine/manager.py
+++ b/master/buildbot/machine/manager.py
@@ -13,6 +13,7 @@
 #
 # Portions Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 from typing import Optional
 

--- a/master/buildbot/machine/manager.py
+++ b/master/buildbot/machine/manager.py
@@ -15,15 +15,13 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from buildbot.util import service
 from buildbot.worker.manager import WorkerManager
 
 
 class MachineManager(service.BuildbotServiceManager):
     reconfig_priority = WorkerManager.reconfig_priority + 1
-    name: Optional[str] = 'MachineManager'  # type: ignore[assignment]
+    name: str | None = 'MachineManager'  # type: ignore[assignment]
     managed_services_name = 'machines'
     config_attr = 'machines'
 

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 from typing import Optional
 
 from twisted.internet import defer

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -15,8 +15,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from twisted.internet import defer
 from twisted.python.reflect import namedObject
 
@@ -34,7 +32,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
             'keys': set(["router_url", "realm", "wamp_debug_level"]),
         },
     }
-    name: Optional[str] = 'mq'  # type: ignore[assignment]
+    name: str | None = 'mq'  # type: ignore[assignment]
 
     def __init__(self):
         super().__init__()

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 from typing import Optional
 
 from twisted.internet import defer

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -15,15 +15,13 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from twisted.internet import defer
 
 from buildbot.util import service
 
 
 class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiService):
-    name: Optional[str] = 'debug_services'  # type: ignore[assignment]
+    name: str | None = 'debug_services'  # type: ignore[assignment]
 
     def __init__(self):
         super().__init__()

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import re
 from typing import Dict
 from typing import Type

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -16,8 +16,6 @@
 from __future__ import annotations
 
 import re
-from typing import Dict
-from typing import Type
 
 from twisted.internet import defer
 from twisted.python import log
@@ -27,7 +25,7 @@ from buildbot.util import lineboundaries
 
 
 class Log:
-    _byType: Dict[str, Type[Log]] = {}
+    _byType: dict[str, type[Log]] = {}
 
     def __init__(self, master, name, type, logid, decoder):
         self.type = type

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -27,7 +27,7 @@ from buildbot.util import lineboundaries
 
 
 class Log:
-    _byType: Dict[str, Type["Log"]] = {}
+    _byType: Dict[str, Type[Log]] = {}
 
     def __init__(self, master, name, type, logid, decoder):
         self.type = type

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import hashlib
 from typing import Optional
 from urllib.parse import urlparse

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Optional
 from urllib.parse import urlparse
 
 from twisted.internet import defer
@@ -42,7 +41,7 @@ _GET_TOKEN_DATA = {'grant_type': 'client_credentials'}
 
 
 class BitbucketStatusPush(ReporterBase):
-    name: Optional[str] = "BitbucketStatusPush"  # type: ignore[assignment]
+    name: str | None = "BitbucketStatusPush"  # type: ignore[assignment]
 
     def checkConfig(
         self,

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import Optional
 from urllib.parse import urlparse
 
 from twisted.internet import defer
@@ -52,7 +51,7 @@ HTTP_CREATED = 201
 
 
 class BitbucketServerStatusPush(ReporterBase):
-    name: Optional[str] = "BitbucketServerStatusPush"  # type: ignore[assignment]
+    name: str | None = "BitbucketServerStatusPush"  # type: ignore[assignment]
 
     def checkConfig(
         self,
@@ -176,7 +175,7 @@ class BitbucketServerStatusPush(ReporterBase):
 
 
 class BitbucketServerCoreAPIStatusPush(ReporterBase):
-    name: Optional[str] = "BitbucketServerCoreAPIStatusPush"  # type: ignore[assignment]
+    name: str | None = "BitbucketServerCoreAPIStatusPush"  # type: ignore[assignment]
     secrets = ["token", "auth"]
 
     def checkConfig(
@@ -440,7 +439,7 @@ class BitbucketServerCoreAPIStatusPush(ReporterBase):
 
 
 class BitbucketServerPRCommentPush(ReporterBase):
-    name: Optional[str] = "BitbucketServerPRCommentPush"  # type: ignore[assignment]
+    name: str | None = "BitbucketServerPRCommentPush"  # type: ignore[assignment]
 
     @defer.inlineCallbacks
     def reconfigService(

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import datetime
 import re
 from typing import Optional

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -16,6 +16,8 @@
 Push events to Gerrit
 """
 
+from __future__ import annotations
+
 import time
 import warnings
 from typing import Optional

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import time
 import warnings
-from typing import Optional
 
 from packaging.version import parse as parse_version
 from twisted.internet import defer
@@ -320,7 +319,7 @@ class GerritBuildEndStatusGenerator(GerritStatusGeneratorBase):
 class GerritStatusPush(ReporterBase):
     """Event streamer to a gerrit ssh server."""
 
-    name: Optional[str] = "GerritStatusPush"  # type: ignore[assignment]
+    name: str | None = "GerritStatusPush"  # type: ignore[assignment]
     gerrit_server = None
     gerrit_username = None
     gerrit_port = None

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -11,7 +11,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright Buildbot Team Members
+# Copyright Buildbot Team Member
+
+from __future__ import annotations
+
 from typing import Optional
 
 from twisted.internet import defer

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -15,8 +15,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from twisted.internet import defer
 from twisted.logger import Logger
 from twisted.python import failure
@@ -39,7 +37,7 @@ log = Logger()
 
 
 class GerritVerifyStatusPush(ReporterBase):
-    name: Optional[str] = "GerritVerifyStatusPush"  # type: ignore[assignment]
+    name: str | None = "GerritVerifyStatusPush"  # type: ignore[assignment]
     # overridable constants
     RESULTS_TABLE = {
         SUCCESS: 1,

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import re
-from typing import Dict
 from typing import Generator
 from typing import Optional
 
@@ -116,7 +115,7 @@ class GitHubStatusPush(ReporterBase):
     @defer.inlineCallbacks
     def _get_auth_header(
         self, props: Properties
-    ) -> Generator[defer.Deferred[str], None, Dict[str, str]]:
+    ) -> Generator[defer.Deferred[str], None, dict[str, str]]:
         token = yield props.render(self.token)
         return {'Authorization': f"token {token}"}
 

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import re
 from typing import Generator
-from typing import Optional
 
 from twisted.internet import defer
 from twisted.python import log
@@ -43,7 +42,7 @@ HOSTED_BASE_URL = 'https://api.github.com'
 
 
 class GitHubStatusPush(ReporterBase):
-    name: Optional[str] = "GitHubStatusPush"  # type: ignore[assignment]
+    name: str | None = "GitHubStatusPush"  # type: ignore[assignment]
 
     def checkConfig(
         self,

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+from __future__ import annotations
+
 import re
 from typing import Dict
 from typing import Generator

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -11,7 +11,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright Buildbot Team Members
+# Copyright Buildbot Team Member
+
+from __future__ import annotations
+
 from typing import Optional
 from urllib.parse import quote_plus as urlquote_plus
 

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
 from urllib.parse import quote_plus as urlquote_plus
 
 from twisted.internet import defer
@@ -41,7 +40,7 @@ HOSTED_BASE_URL = 'https://gitlab.com'
 
 
 class GitLabStatusPush(ReporterBase):
-    name: Optional[str] = "GitLabStatusPush"  # type: ignore[assignment]
+    name: str | None = "GitLabStatusPush"  # type: ignore[assignment]
 
     def checkConfig(
         self,

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -15,8 +15,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from twisted.internet import defer
 from twisted.python import log
 
@@ -27,7 +25,7 @@ from buildbot.util import httpclientservice
 
 
 class HttpStatusPush(ReporterBase):
-    name: Optional[str] = "HttpStatusPush"  # type: ignore[assignment]
+    name: str | None = "HttpStatusPush"  # type: ignore[assignment]
     secrets = ["auth"]
 
     def checkConfig(

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import annotations
+
 from typing import Optional
 
 from twisted.internet import defer

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import io
 import json
 import random

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -21,7 +21,6 @@ import random
 import shlex
 from typing import Any
 from typing import ClassVar
-from typing import Optional
 from typing import Sequence
 
 from twisted.internet import defer
@@ -884,7 +883,7 @@ class TelegramStatusBot(StatusBot):
 
 
 class TelegramWebhookBot(TelegramStatusBot):
-    name: Optional[str] = "TelegramWebhookBot"  # type: ignore[assignment]
+    name: str | None = "TelegramWebhookBot"  # type: ignore[assignment]
 
     def __init__(self, token, *args, certificate=None, **kwargs):
         TelegramStatusBot.__init__(self, token, *args, **kwargs)
@@ -927,7 +926,7 @@ class TelegramWebhookBot(TelegramStatusBot):
 
 
 class TelegramPollingBot(TelegramStatusBot):
-    name: Optional[str] = "TelegramPollingBot"  # type: ignore[assignment]
+    name: str | None = "TelegramPollingBot"  # type: ignore[assignment]
 
     def __init__(self, *args, poll_timeout=120, **kwargs):
         super().__init__(*args, **kwargs)

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -21,7 +21,6 @@ import random
 import shlex
 from typing import Any
 from typing import ClassVar
-from typing import Dict
 from typing import Optional
 from typing import Sequence
 
@@ -624,7 +623,7 @@ class TelegramStatusBot(StatusBot):
     idle_string = "idle 💤"
     running_string = "running 🌀:"
 
-    query_cache: Dict[int, Dict[str, Any]] = {}
+    query_cache: dict[int, dict[str, Any]] = {}
 
     @property
     def commandSuffix(self):

--- a/master/buildbot/reporters/zulip.py
+++ b/master/buildbot/reporters/zulip.py
@@ -11,7 +11,10 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright Buildbot Team Members
+# Copyright Buildbot Team Member
+
+from __future__ import annotations
+
 from typing import Optional
 
 from twisted.internet import defer

--- a/master/buildbot/reporters/zulip.py
+++ b/master/buildbot/reporters/zulip.py
@@ -15,8 +15,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from twisted.internet import defer
 from twisted.logger import Logger
 
@@ -29,7 +27,7 @@ log = Logger()
 
 
 class ZulipStatusPush(ReporterBase):
-    name: Optional[str] = "ZulipStatusPush"  # type: ignore[assignment]
+    name: str | None = "ZulipStatusPush"  # type: ignore[assignment]
 
     def checkConfig(self, endpoint, token, stream=None, debug=None, verify=None):
         if not isinstance(endpoint, str):

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import annotations
+
 from typing import ClassVar
 from typing import Dict
 from typing import Sequence

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from typing import ClassVar
-from typing import Dict
 from typing import Sequence
 
 from twisted.internet import defer
@@ -33,7 +32,7 @@ from buildbot.util.state import StateMixin
 
 @implementer(interfaces.IScheduler)
 class BaseScheduler(ClusteredBuildbotService, StateMixin):
-    DEFAULT_CODEBASES: Dict[str, Dict[str, str]] = {'': {}}
+    DEFAULT_CODEBASES: dict[str, dict[str, str]] = {'': {}}
 
     compare_attrs: ClassVar[Sequence[str]] = (
         *ClusteredBuildbotService.compare_attrs,

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -19,7 +19,6 @@ import re
 import traceback
 from typing import Any
 from typing import ClassVar
-from typing import List
 from typing import Optional
 from typing import Sequence
 
@@ -301,7 +300,7 @@ class ChoiceStringParameter(BaseParameter):
 
     spec_attributes = ["choices", "strict"]
     type = "list"
-    choices: List[str] = []
+    choices: list[str] = []
     strict = True
 
     def parse_from_arg(self, s):

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import re
 import traceback
 from typing import Any

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -19,7 +19,6 @@ import re
 import traceback
 from typing import Any
 from typing import ClassVar
-from typing import Optional
 from typing import Sequence
 
 from twisted.internet import defer
@@ -98,7 +97,7 @@ class BaseParameter:
     regex = None
     debug = True
     hide = False
-    maxsize: Optional[int] = None
+    maxsize: int | None = None
     autopopulate = None
     tooltip = ""
 
@@ -427,7 +426,7 @@ class NestedParameter(BaseParameter):
     type = 'nested'
     layout = 'vertical'
     fields = None
-    columns: Optional[int] = None
+    columns: int | None = None
 
     def __init__(self, name, fields, **kwargs):
         super().__init__(fields=fields, name=name, **kwargs)
@@ -658,14 +657,14 @@ class ForceScheduler(base.BaseScheduler):
         self,
         name,
         builderNames,
-        username: Optional[UserNameParameter] = None,
-        reason: Optional[StringParameter] = None,
+        username: UserNameParameter | None = None,
+        reason: StringParameter | None = None,
         reasonString="A build was forced by '%(owner)s': %(reason)s",
         buttonName=None,
         codebases=None,
         label=None,
         properties=None,
-        priority: Optional[IntParameter] = None,
+        priority: IntParameter | None = None,
     ):
         """
         Initialize a ForceScheduler.

--- a/master/buildbot/schedulers/manager.py
+++ b/master/buildbot/schedulers/manager.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 from typing import Optional
 
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager

--- a/master/buildbot/schedulers/manager.py
+++ b/master/buildbot/schedulers/manager.py
@@ -15,12 +15,10 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager
 
 
 class SchedulerManager(MeasuredBuildbotServiceManager):
-    name: Optional[str] = "SchedulerManager"  # type: ignore[assignment]
+    name: str | None = "SchedulerManager"  # type: ignore[assignment]
     managed_services_name = "schedulers"
     config_attr = "schedulers"

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -22,7 +22,6 @@ import stat
 import sys
 import traceback
 from contextlib import contextmanager
-from typing import List
 from typing import Optional
 
 from twisted.python import runtime
@@ -176,10 +175,10 @@ class SubcommandOptions(usage.Options):
     # .buildbot/options file.  Note that this *only* works with optParameters,
     # not optFlags.  Example:
     # buildbotOptions = [ [ 'optfile-name', 'parameter-name' ], .. ]
-    buildbotOptions: Optional[List[List[str]]] = None
+    buildbotOptions: Optional[list[list[str]]] = None
 
     # set this to options that must have non-None values
-    requiredOptions: List[str] = []
+    requiredOptions: list[str] = []
 
     def __init__(self, *args):
         # for options in self.buildbotOptions, optParameters, and the options

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import copy
 import errno
 import os

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -22,7 +22,6 @@ import stat
 import sys
 import traceback
 from contextlib import contextmanager
-from typing import Optional
 
 from twisted.python import runtime
 from twisted.python import usage
@@ -175,7 +174,7 @@ class SubcommandOptions(usage.Options):
     # .buildbot/options file.  Note that this *only* works with optParameters,
     # not optFlags.  Example:
     # buildbotOptions = [ [ 'optfile-name', 'parameter-name' ], .. ]
-    buildbotOptions: Optional[list[list[str]]] = None
+    buildbotOptions: list[list[str]] | None = None
 
     # set this to options that must have non-None values
     requiredOptions: list[str] = []

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -19,6 +19,8 @@
 # Also don't forget to mirror your changes on command-line options in manual
 # pages and reStructuredText documentation.
 
+from __future__ import annotations
+
 import getpass
 import sys
 import textwrap

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -25,9 +25,7 @@ import getpass
 import sys
 import textwrap
 from typing import Any
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 import sqlalchemy as sa
 from twisted.python import reflect
@@ -71,7 +69,7 @@ class UpgradeMasterOptions(base.BasedirMixin, base.SubcommandOptions):
         ],
         ["replace", "r", "Replace any modified files without confirmation."],
     ]
-    optParameters: List[Tuple[str, Optional[str], Any, str]] = []
+    optParameters: list[tuple[str, Optional[str], Any, str]] = []
 
     def getSynopsis(self):
         return "Usage:    buildbot upgrade-master [options] [<basedir>]"
@@ -744,7 +742,7 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
         # when this command has several maintenance jobs, we should make
         # them optional here. For now there is only one.
     ]
-    optParameters: List[Tuple[str, Optional[str], Any, str]] = []
+    optParameters: list[tuple[str, Optional[str], Any, str]] = []
 
     def getSynopsis(self):
         return "Usage:    buildbot cleanupdb [options] [<basedir>]"

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -25,7 +25,6 @@ import getpass
 import sys
 import textwrap
 from typing import Any
-from typing import Optional
 
 import sqlalchemy as sa
 from twisted.python import reflect
@@ -69,7 +68,7 @@ class UpgradeMasterOptions(base.BasedirMixin, base.SubcommandOptions):
         ],
         ["replace", "r", "Replace any modified files without confirmation."],
     ]
-    optParameters: list[tuple[str, Optional[str], Any, str]] = []
+    optParameters: list[tuple[str, str | None, Any, str]] = []
 
     def getSynopsis(self):
         return "Usage:    buildbot upgrade-master [options] [<basedir>]"
@@ -742,7 +741,7 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
         # when this command has several maintenance jobs, we should make
         # them optional here. For now there is only one.
     ]
-    optParameters: list[tuple[str, Optional[str], Any, str]] = []
+    optParameters: list[tuple[str, str | None, Any, str]] = []
 
     def getSynopsis(self):
         return "Usage:    buildbot cleanupdb [options] [<basedir>]"

--- a/master/buildbot/secrets/manager.py
+++ b/master/buildbot/secrets/manager.py
@@ -18,8 +18,6 @@ manage providers and handle secrets
 
 from __future__ import annotations
 
-from typing import Optional
-
 from twisted.internet import defer
 
 from buildbot.secrets.providers.base import SecretProviderBase
@@ -32,7 +30,7 @@ class SecretManager(service.BuildbotServiceManager):
     Secret manager
     """
 
-    name: Optional[str] = 'secrets'  # type: ignore[assignment]
+    name: str | None = 'secrets'  # type: ignore[assignment]
     config_attr = "secretsProviders"
 
     @defer.inlineCallbacks

--- a/master/buildbot/secrets/manager.py
+++ b/master/buildbot/secrets/manager.py
@@ -16,6 +16,8 @@
 manage providers and handle secrets
 """
 
+from __future__ import annotations
+
 from typing import Optional
 
 from twisted.internet import defer

--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -16,6 +16,8 @@
 file based provider
 """
 
+from __future__ import annotations
+
 import os
 import stat
 from typing import Optional

--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import os
 import stat
-from typing import Optional
 
 from buildbot import config
 from buildbot.secrets.providers.base import SecretProviderBase
@@ -31,7 +30,7 @@ class SecretInAFile(SecretProviderBase):
     secret is stored in a separate file under the given directory name
     """
 
-    name: Optional[str] = "SecretInAFile"  # type: ignore[assignment]
+    name: str | None = "SecretInAFile"  # type: ignore[assignment]
 
     def checkFileIsReadOnly(self, dirname, secretfile):
         filepath = os.path.join(dirname, secretfile)

--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional
 
 from twisted.internet import defer
 
@@ -34,7 +33,7 @@ class SecretInPass(SecretProviderBase):
     secret is stored in a password store
     """
 
-    name: Optional[str] = "SecretInPass"  # type: ignore[assignment]
+    name: str | None = "SecretInPass"  # type: ignore[assignment]
 
     def checkPassIsInPath(self):
         if not any((Path(p) / "pass").is_file() for p in os.environ["PATH"].split(":")):

--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -16,6 +16,8 @@
 password store based provider
 """
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import Optional

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -16,6 +16,8 @@
 HVAC based providers
 """
 
+from __future__ import annotations
+
 import importlib.metadata
 from typing import Optional
 

--- a/master/buildbot/secrets/providers/vault_hvac.py
+++ b/master/buildbot/secrets/providers/vault_hvac.py
@@ -19,7 +19,6 @@ HVAC based providers
 from __future__ import annotations
 
 import importlib.metadata
-from typing import Optional
 
 from packaging.version import parse as parse_version
 from twisted.internet import defer
@@ -69,7 +68,7 @@ class HashiCorpVaultKvSecretProvider(SecretProviderBase):
     In case more secret engines are going to be supported, each engine should have it's own class.
     """
 
-    name: Optional[str] = 'SecretInVaultKv'  # type: ignore[assignment]
+    name: str | None = 'SecretInVaultKv'  # type: ignore[assignment]
 
     def checkConfig(
         self,

--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -17,6 +17,8 @@
 Steps and objects related to lintian
 """
 
+from __future__ import annotations
+
 from typing import List
 
 from twisted.internet import defer

--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -19,8 +19,6 @@ Steps and objects related to lintian
 
 from __future__ import annotations
 
-from typing import List
-
 from twisted.internet import defer
 
 from buildbot import config
@@ -48,7 +46,7 @@ class DebLintian(buildstep.ShellMixin, buildstep.BuildStep):
     descriptionDone = "Lintian"
 
     fileloc = None
-    suppressTags: List[str] = []
+    suppressTags: list[str] = []
 
     flunkOnFailure = False
     warnOnFailure = True

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -17,6 +17,8 @@
 Steps and objects related to pbuilder
 """
 
+from __future__ import annotations
+
 import re
 import stat
 import time

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import re
 import stat
 import time
-from typing import Optional
 
 from twisted.internet import defer
 from twisted.python import log
@@ -47,14 +46,14 @@ class DebPbuilder(WarningCountingShellCommand):
     warningPattern = r".*(warning[: ]|\sW: ).*"
 
     architecture = None
-    distribution: Optional[str] = 'stable'
+    distribution: str | None = 'stable'
     basetgz = None
     _default_basetgz = "/var/cache/pbuilder/{distribution}-{architecture}-buildbot.tgz"
     mirror = "http://cdn.debian.net/debian/"
     othermirror = ""
     extrapackages: list[str] = []
     keyring = None
-    components: Optional[str] = None
+    components: str | None = None
 
     maxAge = 60 * 60 * 24 * 7
     pbuilder = '/usr/sbin/pbuilder'

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import re
 import stat
 import time
-from typing import List
 from typing import Optional
 
 from twisted.internet import defer
@@ -53,7 +52,7 @@ class DebPbuilder(WarningCountingShellCommand):
     _default_basetgz = "/var/cache/pbuilder/{distribution}-{architecture}-buildbot.tgz"
     mirror = "http://cdn.debian.net/debian/"
     othermirror = ""
-    extrapackages: List[str] = []
+    extrapackages: list[str] = []
     keyring = None
     components: Optional[str] = None
 

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -19,7 +19,6 @@ BuildSteps that are specific to the Twisted source tree
 from __future__ import annotations
 
 import re
-from typing import List
 
 from twisted.internet import defer
 from twisted.python import log
@@ -189,7 +188,7 @@ class Trial(buildstep.ShellMixin, buildstep.BuildStep):
     trial = "trial"
     trialMode = ["--reporter=bwverbose"]  # requires Twisted-2.1.0 or newer
     # for Twisted-2.0.0 or 1.3.0, use ["-o"] instead
-    trialArgs: List[str] = []
+    trialArgs: list[str] = []
     jobs = None
     testpath = UNSPECIFIED  # required (but can be None)
     testChanges = False  # TODO: needs better name

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -16,6 +16,8 @@
 BuildSteps that are specific to the Twisted source tree
 """
 
+from __future__ import annotations
+
 import re
 from typing import List
 

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 # Portions Copyright 2013 Bad Dog Consulting
 
+from __future__ import annotations
+
 import re
 from typing import Optional
 

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 from twisted.internet import defer
 from twisted.python import log
@@ -73,7 +72,7 @@ class P4(Source):
         p4line_end='local',
         p4viewspec=None,
         p4viewspec_suffix='...',
-        p4client: Optional[Interpolate] = None,
+        p4client: Interpolate | None = None,
         p4client_spec_options='allwrite rmdir',
         p4client_type=None,
         p4extra_args=None,

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 from twisted.internet import defer
 
@@ -80,8 +79,8 @@ class VisualStudio(buildstep.ShellMixin, buildstep.BuildStep):
 
     logobserver = None
 
-    installdir: Optional[str] = None
-    default_installdir: Optional[str] = None
+    installdir: str | None = None
+    default_installdir: str | None = None
 
     # One of build, clean or rebuild
     mode = "rebuild"

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import re
-from typing import List
 from typing import Optional
 
 from twisted.internet import defer
@@ -91,9 +90,9 @@ class VisualStudio(buildstep.ShellMixin, buildstep.BuildStep):
     config = None
     useenv = False
     project = None
-    PATH: List[str] = []
-    INCLUDE: List[str] = []
-    LIB: List[str] = []
+    PATH: list[str] = []
+    INCLUDE: list[str] = []
+    LIB: list[str] = []
 
     renderables = ['projectfile', 'config', 'project', 'mode']
 

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -15,6 +15,7 @@
 
 # Visual studio steps
 
+from __future__ import annotations
 
 import re
 from typing import List

--- a/master/buildbot/test/fake/change.py
+++ b/master/buildbot/test/fake/change.py
@@ -15,8 +15,6 @@
 
 from __future__ import annotations
 
-from typing import Union
-
 from buildbot.process.properties import Properties
 from buildbot.test.fake.state import State
 
@@ -27,7 +25,7 @@ class Change(State):
     branch = ''
     category = ''
     codebase = ''
-    properties: Union[dict, Properties] = {}
+    properties: dict | Properties = {}
 
     def __init__(self, **kw):
         super().__init__(**kw)

--- a/master/buildbot/test/fake/change.py
+++ b/master/buildbot/test/fake/change.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 from typing import Union
 
 from buildbot.process.properties import Properties

--- a/master/buildbot/test/fakedb/base.py
+++ b/master/buildbot/test/fakedb/base.py
@@ -14,13 +14,11 @@
 # Copyright Buildbot Team Members
 from __future__ import annotations
 
-from typing import Dict
-
 from buildbot.data import resultspec
 
 
 class FakeDBComponent:
-    data2db: Dict[str, str] = {}
+    data2db: dict[str, str] = {}
 
     def __init__(self, db, testcase, reactor=None):
         self.db = db

--- a/master/buildbot/test/fakedb/base.py
+++ b/master/buildbot/test/fakedb/base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import annotations
+
 from typing import Dict
 
 from buildbot.data import resultspec

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
 from unittest import SkipTest
 
 from twisted.internet import defer
@@ -42,7 +41,7 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
         return fakehttpclientservice.HTTPClientService.getService(self.master, self, base_url)
 
     @defer.inlineCallbacks
-    def setupPushjetNotifier(self, secret: Optional[Interpolate] = None, **kwargs):
+    def setupPushjetNotifier(self, secret: Interpolate | None = None, **kwargs):
         if secret is None:
             secret = Interpolate("1234")
         pn = PushjetNotifier(secret, **kwargs)

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import os
 from typing import Optional
 from unittest import SkipTest

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 import os
 from typing import Optional

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
 from unittest import SkipTest
 
 from twisted.internet import defer
@@ -45,7 +44,7 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def setupPushoverNotifier(
-        self, user_key="1234", api_token: Optional[Interpolate] = None, **kwargs
+        self, user_key="1234", api_token: Interpolate | None = None, **kwargs
     ):
         if api_token is None:
             api_token = Interpolate("abcd")

--- a/master/buildbot/util/maildir.py
+++ b/master/buildbot/util/maildir.py
@@ -19,6 +19,8 @@ linux dirwatcher API (if available) to look for new files. The
 relative to the top of the maildir (so it will look like "new/blahblah").
 """
 
+from __future__ import annotations
+
 import os
 from typing import Optional
 

--- a/master/buildbot/util/maildir.py
+++ b/master/buildbot/util/maildir.py
@@ -22,7 +22,6 @@ relative to the top of the maildir (so it will look like "new/blahblah").
 from __future__ import annotations
 
 import os
-from typing import Optional
 
 from twisted.application import internet
 from twisted.internet import defer
@@ -47,7 +46,7 @@ class NoSuchMaildir(Exception):
 
 class MaildirService(service.BuildbotService):
     pollInterval = 10  # only used if we don't have DNotify
-    name: Optional[str] = 'MaildirService'  # type: ignore
+    name: str | None = 'MaildirService'  # type: ignore
 
     def __init__(self, basedir=None):
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ target-version = "py38"
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
 
         # Temporary disable following 'FA' rules addition
-        "UP006",
         "UP007",
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,6 @@ target-version = "py38"
         # Might be nice to have in future, but requires significant refactoring for now.
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
-
-        # Temporary disable following 'FA' rules addition
-        "UP007",
     ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 target-version = "py38"
 
 [tool.ruff.lint]
-    select = ["W", "E", "F", "I", "PL", "UP", "T100", "B", "RUF"]
+    select = ["W", "E", "F", "I", "PL", "UP", "T100", "B", "RUF", "FA"]
     ignore = [
         "E711", # comparison to None should be 'if cond is None:'
         "E712", # comparison to False should be 'if cond is False:' or 'if not cond:'
@@ -37,6 +37,11 @@ target-version = "py38"
         # Might be nice to have in future, but requires significant refactoring for now.
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
+
+        # Temporary disable following 'FA' rules addition
+        "UP006",
+        "UP007",
+        "UP037",
     ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ target-version = "py38"
         # Temporary disable following 'FA' rules addition
         "UP006",
         "UP007",
-        "UP037",
     ]
 
 [tool.ruff.lint.isort]

--- a/worker/buildbot_worker/test/__init__.py
+++ b/worker/buildbot_worker/test/__init__.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import sys
 from typing import Any
 from typing import List

--- a/worker/buildbot_worker/test/__init__.py
+++ b/worker/buildbot_worker/test/__init__.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import sys
 from typing import Any
-from typing import List
 
 import twisted
 from twisted.trial import unittest
@@ -63,7 +62,7 @@ def add_debugging_monkeypatches():
 
 add_debugging_monkeypatches()
 
-__all__: List[Any] = []
+__all__: list[Any] = []
 
 # import mock so we bail out early if it's not installed
 try:


### PR DESCRIPTION
EDIT: #8114 should be merged first

Related discussion started in https://github.com/buildbot/buildbot/pull/8115#issuecomment-2406915799

Using `from __future__ import annotations` with typing add a lot of convenience:
- no need to quote annotations, even for forward declaration
- use basic types from stdlib instead of from typing (`List` -> `list`)
- ` | ` instead of `Union[]`
- ` | None` instead of `Optional`

I noticed the worker still supports py3.5 in setup.py. Is it a simple missed deprecation or a conscious choice?
This would prevent the merge of this PR as the import was introduced in py3.7.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
