### PR TITLE
4.0 backports: fix /builders/:builderid/force/:scheduler route not implemented

### DIFF
--- a/newsfragments/www-builder-force-modal.bugfix
+++ b/newsfragments/www-builder-force-modal.bugfix
@@ -1,0 +1,1 @@
+Fix missing builder force scheduler route ``/builders/:builderid/force/:scheduler``.

--- a/www/base/src/views/BuilderView/BuilderView.tsx
+++ b/www/base/src/views/BuilderView/BuilderView.tsx
@@ -101,6 +101,7 @@ const buildTopbarActions = (builds: DataCollection<Build>,
 
 export const BuilderView = observer(() => {
   const builderid = Number.parseInt(useParams<"builderid">().builderid ?? "");
+  const activeSchedulerName = useParams<"scheduler">().scheduler;
   const navigate = useNavigate();
 
   const accessor = useDataAccessor([builderid]);
@@ -182,16 +183,23 @@ export const BuilderView = observer(() => {
   const [shownForceScheduler, setShownForceScheduler] = useState<null|Forcescheduler>(null);
 
   const actions = buildTopbarActions(builds, buildrequests, forceschedulers, isCancelling,
-    cancelWholeQueue, (sch) => setShownForceScheduler(sch));
+    cancelWholeQueue, (sch) => navigate(`/builders/${builderid}/force/${sch.name}`));
 
   useTopbarActions(actions);
 
+  const activeScheduler = forceschedulers.array.find((sch) => sch.name === activeSchedulerName);
+  if (activeScheduler && shownForceScheduler?.name !== activeScheduler.name) {
+    setShownForceScheduler(activeScheduler);
+  } else if (activeSchedulerName == null && shownForceScheduler) {
+    setShownForceScheduler(null);
+  }
+
   const onForceBuildModalClose = (buildRequestNumber: string | null) => {
-    if (buildRequestNumber === null) {
-      setShownForceScheduler(null);
-    } else {
-      navigate(`/buildrequests/${buildRequestNumber}?redirect_to_build=true`);
-    }
+    navigate(
+      buildRequestNumber === null
+        ? `/builders/${builderid}`
+        : `/buildrequests/${buildRequestNumber}?redirect_to_build=true`
+    );
   };
 
   const renderDescription = (builder: Builder) => {
@@ -255,7 +263,13 @@ export const BuilderView = observer(() => {
 buildbotSetupPlugin((reg) => {
   reg.registerRoute({
     route: "builders/:builderid",
-      group: null,
-      element: () => <BuilderView/>,
+    group: null,
+    element: () => <BuilderView/>,
+  });
+
+  reg.registerRoute({
+    route: "builders/:builderid/force/:scheduler",
+    group: null,
+    element: () => <BuilderView/>,
   });
 });

--- a/www/react-base/src/views/BuilderView/BuilderView.tsx
+++ b/www/react-base/src/views/BuilderView/BuilderView.tsx
@@ -101,6 +101,7 @@ const buildTopbarActions = (builds: DataCollection<Build>,
 
 export const BuilderView = observer(() => {
   const builderid = Number.parseInt(useParams<"builderid">().builderid ?? "");
+  const activeSchedulerName = useParams<"scheduler">().scheduler;
   const navigate = useNavigate();
 
   const accessor = useDataAccessor([builderid]);
@@ -182,16 +183,23 @@ export const BuilderView = observer(() => {
   const [shownForceScheduler, setShownForceScheduler] = useState<null|Forcescheduler>(null);
 
   const actions = buildTopbarActions(builds, buildrequests, forceschedulers, isCancelling,
-    cancelWholeQueue, (sch) => setShownForceScheduler(sch));
+    cancelWholeQueue, (sch) => navigate(`/builders/${builderid}/force/${sch.name}`));
 
   useTopbarActions(actions);
 
+  const activeScheduler = forceschedulers.array.find((sch) => sch.name === activeSchedulerName);
+  if (activeScheduler && shownForceScheduler?.name !== activeScheduler.name) {
+    setShownForceScheduler(activeScheduler);
+  } else if (activeSchedulerName == null && shownForceScheduler) {
+    setShownForceScheduler(null);
+  }
+
   const onForceBuildModalClose = (buildRequestNumber: string | null) => {
-    if (buildRequestNumber === null) {
-      setShownForceScheduler(null);
-    } else {
-      navigate(`/buildrequests/${buildRequestNumber}?redirect_to_build=true`);
-    }
+    navigate(
+      buildRequestNumber === null
+        ? `/builders/${builderid}`
+        : `/buildrequests/${buildRequestNumber}?redirect_to_build=true`
+    );
   };
 
   const renderDescription = (builder: Builder) => {
@@ -255,7 +263,13 @@ export const BuilderView = observer(() => {
 buildbotSetupPlugin((reg) => {
   reg.registerRoute({
     route: "builders/:builderid",
-      group: null,
-      element: () => <BuilderView/>,
+    group: null,
+    element: () => <BuilderView/>,
+  });
+
+  reg.registerRoute({
+    route: "builders/:builderid/force/:scheduler",
+    group: null,
+    element: () => <BuilderView/>,
   });
 });


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/8072 to 4.0.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8055.