### PR TITLE
Add release notes for 3.11.9

### DIFF
--- a/master/docs/relnotes/3.x.rst
+++ b/master/docs/relnotes/3.x.rst
@@ -1,3 +1,13 @@
+Buildbot ``3.11.9`` ( ``2024-10-13`` )
+======================================
+
+Bug fixes
+---------
+
+- Fixed missing builder force scheduler route ``/builders/:builderid/force/:scheduler``.
+- Fixed URL of WGSI dashboards to keep backward compatibility with the old non-React WSGI plugin.
+- Fixed display of long property values by wrapping them
+
 Buildbot ``3.11.8`` ( ``2024-09-27`` )
 ======================================
 


### PR DESCRIPTION
Just so that documentation in 4.0.x releases contains all other releases.