### PR TITLE
 db: LogsConnectorComponent.compressLog run compression outside DB thread

### DIFF
--- a/master/buildbot/db/compression/brotli.py
+++ b/master/buildbot/db/compression/brotli.py
@@ -15,24 +15,55 @@
 
 from __future__ import annotations
 
+from buildbot.db.compression.protocol import CompressObjInterface
 from buildbot.db.compression.protocol import CompressorInterface
 
 try:
     import brotli
 
+    MODE_TEXT = brotli.MODE_TEXT
+
     HAS_BROTLI = True
 except ImportError:
     HAS_BROTLI = False
+    MODE_TEXT = None
 
 
 class BrotliCompressor(CompressorInterface):
     name = "br"
     available = HAS_BROTLI
 
+    COMPRESS_QUALITY = 11
+    MODE = MODE_TEXT
+
     @staticmethod
     def dumps(data: bytes) -> bytes:
-        return brotli.compress(data, mode=brotli.MODE_TEXT, quality=11)
+        return brotli.compress(
+            data,
+            mode=BrotliCompressor.MODE,
+            quality=BrotliCompressor.COMPRESS_QUALITY,
+        )
 
     @staticmethod
     def read(data: bytes) -> bytes:
         return brotli.decompress(data)
+
+    class CompressObj(CompressObjInterface):
+        def __init__(self) -> None:
+            self._create_compressobj()
+
+        def _create_compressobj(self) -> None:
+            self._compressobj = brotli.Compressor(
+                mode=BrotliCompressor.MODE,
+                quality=BrotliCompressor.COMPRESS_QUALITY,
+            )
+
+        def compress(self, data: bytes) -> bytes:
+            return self._compressobj.process(data)
+
+        def flush(self) -> bytes:
+            try:
+                return self._compressobj.finish()
+            finally:
+                # recreate compressobj so this instance can be re-used
+                self._create_compressobj()

--- a/master/buildbot/db/compression/native.py
+++ b/master/buildbot/db/compression/native.py
@@ -18,28 +18,67 @@ from __future__ import annotations
 import bz2
 import zlib
 
+from buildbot.db.compression.protocol import CompressObjInterface
 from buildbot.db.compression.protocol import CompressorInterface
 
 
 class GZipCompressor(CompressorInterface):
     name = "gz"
 
+    COMPRESS_LEVEL = zlib.Z_BEST_COMPRESSION
+
     @staticmethod
     def dumps(data: bytes) -> bytes:
-        return zlib.compress(data, 9)
+        return zlib.compress(data, level=GZipCompressor.COMPRESS_LEVEL)
 
     @staticmethod
     def read(data: bytes) -> bytes:
         return zlib.decompress(data)
 
+    class CompressObj(CompressObjInterface):
+        def __init__(self) -> None:
+            self._create_compressobj()
+
+        def _create_compressobj(self) -> None:
+            self._compressobj = zlib.compressobj(level=GZipCompressor.COMPRESS_LEVEL)
+
+        def compress(self, data: bytes) -> bytes:
+            return self._compressobj.compress(data)
+
+        def flush(self) -> bytes:
+            try:
+                return self._compressobj.flush(zlib.Z_FINISH)
+            finally:
+                # recreate compressobj so this instance can be re-used
+                self._create_compressobj()
+
 
 class BZipCompressor(CompressorInterface):
     name = "bz2"
 
+    COMPRESS_LEVEL = 9
+
     @staticmethod
     def dumps(data: bytes) -> bytes:
-        return bz2.compress(data, 9)
+        return bz2.compress(data, BZipCompressor.COMPRESS_LEVEL)
 
     @staticmethod
     def read(data: bytes) -> bytes:
         return bz2.decompress(data)
+
+    class CompressObj(CompressObjInterface):
+        def __init__(self) -> None:
+            self._create_compressobj()
+
+        def _create_compressobj(self) -> None:
+            self._compressobj = bz2.BZ2Compressor(BZipCompressor.COMPRESS_LEVEL)
+
+        def compress(self, data: bytes) -> bytes:
+            return self._compressobj.compress(data)
+
+        def flush(self) -> bytes:
+            try:
+                return self._compressobj.flush()
+            finally:
+                # recreate compressobj so this instance can be re-used
+                self._create_compressobj()

--- a/master/buildbot/db/compression/protocol.py
+++ b/master/buildbot/db/compression/protocol.py
@@ -23,9 +23,24 @@ if TYPE_CHECKING:
     from typing import ClassVar
 
 
+class CompressObjInterface(Protocol):
+    def __init__(self) -> None:
+        pass
+
+    @abstractmethod
+    def compress(self, data: bytes) -> bytes:
+        raise NotImplementedError
+
+    @abstractmethod
+    def flush(self) -> bytes:
+        raise NotImplementedError
+
+
 class CompressorInterface(Protocol):
     name: ClassVar[str]
     available: ClassVar[bool] = True
+
+    CompressObj: ClassVar[type[CompressObjInterface]]
 
     @staticmethod
     @abstractmethod

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -30,10 +30,13 @@ from buildbot.db.compression import GZipCompressor
 from buildbot.db.compression import LZ4Compressor
 from buildbot.db.compression import ZStdCompressor
 from buildbot.db.compression.protocol import CompressObjInterface
+from buildbot.util.twisted import async_to_deferred
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     from typing import Literal
+
+    from sqlalchemy.engine import Connection as SAConnection
 
     LogType = Literal['s', 't', 'h', 'd']
 
@@ -222,17 +225,12 @@ class LogsConnectorComponent(base.DBConnectorComponent):
 
         return self.db.pool.do(thdAddLog)
 
-    def thdCompressChunk(self, chunk: bytes) -> tuple[bytes, int]:
+    def _get_configured_compressor(self) -> tuple[int, type[CompressorInterface]]:
         compress_method: str = self.master.config.logCompressionMethod
-        # unknown compression method
-        if compress_method not in self.COMPRESSION_MODE:
-            return chunk, self.NO_COMPRESSION_ID
+        return self.COMPRESSION_MODE.get(compress_method, (self.NO_COMPRESSION_ID, RawCompressor))
 
-        compressed_id, compressor = self.COMPRESSION_MODE[compress_method]
-        # compression method is not available (missing dependency most likely)
-        if not compressor.available or compressed_id == self.NO_COMPRESSION_ID:
-            return chunk, self.NO_COMPRESSION_ID
-
+    def thdCompressChunk(self, chunk: bytes) -> tuple[bytes, int]:
+        compressed_id, compressor = self._get_configured_compressor()
         compressed_chunk = compressor.dumps(chunk)
         # Is it useful to compress the chunk?
         if len(chunk) <= len(compressed_chunk):
@@ -337,104 +335,169 @@ class LogsConnectorComponent(base.DBConnectorComponent):
 
         return self.db.pool.do_with_transaction(thdfinishLog)
 
-    def compressLog(self, logid: int, force: bool = False) -> defer.Deferred[int]:
-        def thdcompressLog(conn) -> int:
-            tbl = self.db.model.logchunks
-            q = sa.select(
-                tbl.c.first_line,
-                tbl.c.last_line,
-                sa.func.length(tbl.c.content),
-                tbl.c.compressed,
+    @async_to_deferred
+    async def compressLog(self, logid: int, force: bool = False) -> int:
+        """
+        returns the size (in bytes) saved.
+        """
+        tbl = self.db.model.logchunks
+
+        def _thd_gather_chunks_to_process(conn: SAConnection) -> list[tuple[int, int]]:
+            """
+            returns the total size of chunks and a list of chunks to group.
+            chunks list is empty if not force, and no chunks would be grouped.
+            """
+            q = (
+                sa.select(
+                    tbl.c.first_line,
+                    tbl.c.last_line,
+                    sa.func.length(tbl.c.content),
+                )
+                .where(tbl.c.logid == logid)
+                .order_by(tbl.c.first_line)
             )
-            q = q.where(tbl.c.logid == logid)
-            q = q.order_by(tbl.c.first_line)
 
             rows = conn.execute(q)
-            todo_gather_list = []
-            numchunks = 0
-            totlength = 0
-            todo_numchunks = 0
-            todo_first_line = 0
-            todo_last_line = 0
-            todo_length = 0
+
+            # get the first chunk to seed new_chunks list
+            first_chunk = next(rows, None)
+            if first_chunk is None:
+                # no chunks in log, early out
+                return []
+
+            grouped_chunks: list[tuple[int, int]] = [
+                (first_chunk.first_line, first_chunk.last_line)
+            ]
+
+            # keep track of how many chunks we use now
+            # to compare with grouped chunks and
+            # see if we need to do some work
+            # start at 1 since we already queries one above
+            current_chunk_count = 1
+
+            current_group_new_size = first_chunk.length_1
             # first pass, we fetch the full list of chunks (without content) and find out
             # the chunk groups which could use some gathering.
             for row in rows:
-                if (
-                    todo_length + row.length_1 > self.MAX_CHUNK_SIZE
-                    or (row.last_line - todo_first_line) > self.MAX_CHUNK_LINES
-                ):
-                    if todo_numchunks > 1 or (force and todo_numchunks):
-                        # this group is worth re-compressing
-                        todo_gather_list.append((todo_first_line, todo_last_line))
-                    todo_first_line = row.first_line
-                    todo_length = 0
-                    todo_numchunks = 0
+                current_chunk_count += 1
 
-                todo_last_line = row.last_line
-                # note that we count the compressed size for efficiency reason
-                # unlike to the on-the-flow chunk splitter
-                todo_length += row.length_1
-                totlength += row.length_1
-                todo_numchunks += 1
-                numchunks += 1
+                chunk_first_line: int = row.first_line
+                chunk_last_line: int = row.last_line
+                chunk_size: int = row.length_1
+
+                group_first_line, _group_last_line = grouped_chunks[-1]
+
+                can_merge_chunks = (
+                    # note that we count the compressed size for efficiency reason
+                    # unlike to the on-the-flow chunk splitter
+                    current_group_new_size + chunk_size <= self.MAX_CHUNK_SIZE
+                    and (chunk_last_line - group_first_line) <= self.MAX_CHUNK_LINES
+                )
+                if can_merge_chunks:
+                    # merge chunks, since we ordered the query by 'first_line'
+                    # and we assume that chunks are contiguous, it's pretty easy
+                    grouped_chunks[-1] = (group_first_line, chunk_last_line)
+                    current_group_new_size += chunk_size
+                else:
+                    grouped_chunks.append((chunk_first_line, chunk_last_line))
+                    current_group_new_size = chunk_size
+
             rows.close()
 
-            if totlength == 0:
-                # empty log
-                return 0
+            if not force and current_chunk_count <= len(grouped_chunks):
+                return []
 
-            if todo_numchunks > 1 or (force and todo_numchunks):
-                # last chunk group
-                todo_gather_list.append((todo_first_line, todo_last_line))
-            for todo_first_line, todo_last_line in todo_gather_list:
-                # decompress this group of chunks. Note that the content is binary bytes.
-                # no need to decode anything as we are going to put in back stored as bytes anyway
-                q = sa.select(tbl.c.first_line, tbl.c.last_line, tbl.c.content, tbl.c.compressed)
-                q = q.where(tbl.c.logid == logid)
-                q = q.where(tbl.c.first_line >= todo_first_line)
-                q = q.where(tbl.c.last_line <= todo_last_line)
-                q = q.order_by(tbl.c.first_line)
-                rows = conn.execute(q)
-                chunks: list[bytes] = []
-                for row in rows:
-                    compressed_chunk = self._get_compressor(row.compressed).read(row.content)
-                    if compressed_chunk:
-                        chunks.append(compressed_chunk)
-                rows.close()
+            return grouped_chunks
 
+        def _thd_get_chunks_content(
+            conn: SAConnection,
+            first_line: int,
+            last_line: int,
+        ) -> list[tuple[int, bytes]]:
+            q = (
+                sa.select(tbl.c.content, tbl.c.compressed)
+                .where(tbl.c.logid == logid)
+                .where(tbl.c.first_line >= first_line)
+                .where(tbl.c.last_line <= last_line)
+                .order_by(tbl.c.first_line)
+            )
+            rows = conn.execute(q)
+            content = [(row.compressed, row.content) for row in rows]
+            rows.close()
+            return content
+
+        def _thd_replace_chunks_by_new_grouped_chunk(
+            conn: SAConnection,
+            first_line: int,
+            last_line: int,
+            new_compressed_id: int,
+            new_content: bytes,
+        ) -> None:
+            # Transaction is necessary so that readers don't see disappeared chunks
+            with conn.begin():
                 # we remove the chunks that we are compressing
-                d = tbl.delete()
-                d = d.where(tbl.c.logid == logid)
-                d = d.where(tbl.c.first_line >= todo_first_line)
-                d = d.where(tbl.c.last_line <= todo_last_line)
+                deletion_query = (
+                    tbl.delete()
+                    .where(tbl.c.logid == logid)
+                    .where(tbl.c.first_line >= first_line)
+                    .where(tbl.c.last_line <= last_line)
+                )
+                conn.execute(deletion_query).close()
 
-                # Transaction is necessary so that readers don't see disappeared chunks
-                with conn.begin_nested():
-                    conn.execute(d).close()
-
-                    # and we recompress them in one big chunk
-                    chunk, compressed_id = self.thdCompressChunk(b'\n'.join(chunks))
-                    conn.execute(
-                        tbl.insert(),
-                        {
-                            "logid": logid,
-                            "first_line": todo_first_line,
-                            "last_line": todo_last_line,
-                            "content": chunk,
-                            "compressed": compressed_id,
-                        },
-                    ).close()
+                # and we recompress them in one big chunk
+                conn.execute(
+                    tbl.insert(),
+                    {
+                        "logid": logid,
+                        "first_line": first_line,
+                        "last_line": last_line,
+                        "content": new_content,
+                        "compressed": new_compressed_id,
+                    },
+                ).close()
 
                 conn.commit()
 
-            # calculate how many bytes we saved
-            q = sa.select(sa.func.sum(sa.func.length(tbl.c.content)))
-            q = q.where(tbl.c.logid == logid)
-            newsize = conn.execute(q).fetchone()[0]
-            return totlength - newsize
+        chunk_groups = await self.db.pool.do(_thd_gather_chunks_to_process)
+        if not chunk_groups:
+            return 0
 
-        return self.db.pool.do(thdcompressLog)
+        total_bytes_saved: int = 0
+
+        compressed_id, compressor = self._get_configured_compressor()
+        compress_obj = compressor.CompressObj()
+        for group_first_line, group_last_line in chunk_groups:
+            compressed_chunks = await self.db.pool.do(
+                _thd_get_chunks_content,
+                first_line=group_first_line,
+                last_line=group_last_line,
+            )
+            # decompress this group of chunks. Note that the content is binary bytes.
+            # no need to decode anything as we are going to put in back stored as bytes anyway
+            chunks: list[bytes] = []
+            for idx, (chunk_compress_id, chunk_content) in enumerate(compressed_chunks):
+                total_bytes_saved += len(chunk_content)
+
+                # trailing line-ending is stripped from chunks
+                # need to add it back, except for the last one
+                if idx != 0:
+                    chunks.append(compress_obj.compress(b'\n'))
+
+                uncompressed_content = self._get_compressor(chunk_compress_id).read(chunk_content)
+                chunks.append(compress_obj.compress(uncompressed_content))
+
+            chunks.append(compress_obj.flush())
+            new_content = b''.join(chunks)
+            total_bytes_saved -= len(new_content)
+            await self.db.pool.do(
+                _thd_replace_chunks_by_new_grouped_chunk,
+                first_line=group_first_line,
+                last_line=group_last_line,
+                new_compressed_id=compressed_id,
+                new_content=new_content,
+            )
+
+        return total_bytes_saved
 
     def deleteOldLogChunks(self, older_than_timestamp: int) -> defer.Deferred[int]:
         def thddeleteOldLogs(conn) -> int:

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -29,6 +29,7 @@ from buildbot.db.compression import CompressorInterface
 from buildbot.db.compression import GZipCompressor
 from buildbot.db.compression import LZ4Compressor
 from buildbot.db.compression import ZStdCompressor
+from buildbot.db.compression.protocol import CompressObjInterface
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
@@ -83,6 +84,13 @@ class RawCompressor(CompressorInterface):
     @staticmethod
     def read(data: bytes) -> bytes:
         return data
+
+    class CompressObj(CompressObjInterface):
+        def compress(self, data: bytes) -> bytes:
+            return data
+
+        def flush(self) -> bytes:
+            return b''
 
 
 class LogsConnectorComponent(base.DBConnectorComponent):

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -124,6 +124,7 @@ class Log:
         # it to complete
         d = self.master.data.updates.compressLog(self.logid)
         d.addErrback(log.err, f"while compressing log {self.logid} (ignored)")
+        self.master.db.run_db_task(d)
         self._finishing = False
 
 

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -171,6 +171,7 @@ def make_master(
         master.db.configured_url = 'sqlite://'
         yield master.db.setServiceParent(master)
         yield master.db.setup()
+        testcase.addCleanup(master.db._shutdown)
 
     if wantData:
         master.data = fakedata.FakeDataConnector(master, testcase)

--- a/master/buildbot/test/unit/db/test_logs_compressors.py
+++ b/master/buildbot/test/unit/db/test_logs_compressors.py
@@ -1,0 +1,82 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from twisted.trial import unittest
+
+from buildbot.db import compression
+from buildbot.db.logs import RawCompressor
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+
+    from buildbot.db.compression.protocol import CompressorInterface
+
+
+class TestRawCompressor(unittest.TestCase):
+    # default no-op compressor
+    CompressorCls: ClassVar[type[CompressorInterface]] = RawCompressor
+
+    def test_dumps_read(self) -> None:
+        if not self.CompressorCls.available:
+            raise unittest.SkipTest(f"Compressor '{self.CompressorCls.name}' is unavailable")
+
+        data = b'xy' * 10000
+        compressed_data = self.CompressorCls.dumps(data)
+        self.assertEqual(data, self.CompressorCls.read(compressed_data))
+
+    def test_compressobj_read(self) -> None:
+        if not self.CompressorCls.available:
+            raise unittest.SkipTest(f"Compressor '{self.CompressorCls.name}' is unavailable")
+
+        input_buffer = [f'xy{idx}'.encode() * 10000 for idx in range(10)]
+
+        compress_obj = self.CompressorCls.CompressObj()
+
+        def _test():
+            result_buffer = [compress_obj.compress(e) for e in input_buffer]
+            result_buffer.append(compress_obj.flush())
+
+            self.assertEqual(
+                b''.join(input_buffer), self.CompressorCls.read(b''.join(result_buffer))
+            )
+
+        _test()
+
+        # make sure re-using the same compress obj works
+        _test()
+
+
+class TestGZipCompressor(TestRawCompressor):
+    CompressorCls = compression.GZipCompressor
+
+
+class TestBZipCompressor(TestRawCompressor):
+    CompressorCls = compression.BZipCompressor
+
+
+class TestLZ4Compressor(TestRawCompressor):
+    CompressorCls = compression.LZ4Compressor
+
+
+class TestBrotliCompressor(TestRawCompressor):
+    CompressorCls = compression.BrotliCompressor
+
+
+class TestZStdCompressor(TestRawCompressor):
+    CompressorCls = compression.ZStdCompressor

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -77,6 +77,14 @@ The DB Connector and Components
     If you are adding a new connector component, import its module and create
     an instance of it in this class's constructor.
 
+    .. py:method:: run_db_task(deferred_task: defer.Deferred) -> None
+
+        For use when the deferred resulting from a DB operation is not awaited.
+        If a function that will run DB operation is not awaited, a shutdown of the master could
+        sever the connection to the database before the function completes.
+        To avoid this issue, register the deferred to the connector so it can properly await it's
+        completion in such cases.
+
 .. py:module:: buildbot.db.base
 
 .. py:class:: DBConnectorComponent


### PR DESCRIPTION
So, this is a relatively big one.

We upgraded our instance to 4.1 and enabled log compression with zstd. I was even greedy and modified the compression level from 9 to 22 as usually, we were more pressured on DB IO than CPU.

I did notice before that compression occurred in a DB thread, so took a mental note. Now, the time spent on compression is pretty significant since we host the master on a relatively weak host.

Anyway, our instance has the DB thread pool locked by compression tasks, leading to the webUI not responding or being overall sluggish.

I'll wait for feedback on this to do the same for `getLogLines`, and `thdSplitAndAppendChunk`.

Did not add a newsfragment. It's neither a bug nor feature, but might be worth to mention it anyway in a misc or change?

PS: the fact the trailing `\n` is removed from logchunks makes it really awkward to work with in most of the code. But I don't see an easy way to change this, as it would need a DB migration that rewrite all chunks...

## Contributor Checklist:

* [x] I have updated the unit tests
* [?] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
