### PR TITLE
db: Extract hashColumns() to be reusable

### DIFF
--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import sqlalchemy as sa
 
 from buildbot.util import unicode2bytes
+from buildbot.util.sautils import hash_columns
 
 if TYPE_CHECKING:
     from buildbot.db.connector import DBConnector
@@ -127,14 +128,7 @@ class DBConnectorComponent:
         return self.db.pool.do(thd)
 
     def hashColumns(self, *args):
-        def encode(x):
-            if x is None:
-                return b'\xf5'
-            elif isinstance(x, str):
-                return x.encode('utf-8')
-            return str(x).encode('utf-8')
-
-        return hashlib.sha1(b'\0'.join(map(encode, args))).hexdigest()
+        return hash_columns(*args)
 
     def doBatch(self, batch, batch_n=500):
         iterator = iter(batch)

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -23,6 +23,7 @@ import sqlalchemy as sa
 from twisted.internet import defer
 
 from buildbot.db import base
+from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
 
 
@@ -57,7 +58,7 @@ class BuilderModel:
 class BuildersConnectorComponent(base.DBConnectorComponent):
     def findBuilderId(self, name, autoCreate=True):
         tbl = self.db.model.builders
-        name_hash = self.hashColumns(name)
+        name_hash = hash_columns(name)
         return self.findSomethingId(
             tbl=tbl,
             whereclause=(tbl.c.name_hash == name_hash),

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -22,6 +22,7 @@ from twisted.internet import defer
 
 from buildbot.db import NULL
 from buildbot.db import base
+from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
 
 
@@ -57,7 +58,7 @@ class ChangeSourceModel:
 class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
     def findChangeSourceId(self, name):
         tbl = self.db.model.changesources
-        name_hash = self.hashColumns(name)
+        name_hash = hash_columns(name)
         return self.findSomethingId(
             tbl=tbl,
             whereclause=(tbl.c.name_hash == name_hash),

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -24,6 +24,7 @@ from twisted.python import versions
 
 from buildbot.db import base
 from buildbot.util import epoch2datetime
+from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
@@ -67,7 +68,7 @@ class MastersConnectorComponent(base.DBConnectorComponent):
 
     def findMasterId(self, name: str) -> defer.Deferred[int]:
         tbl = self.db.model.masters
-        name_hash = self.hashColumns(name)
+        name_hash = hash_columns(name)
         return self.findSomethingId(
             tbl=tbl,
             whereclause=(tbl.c.name_hash == name_hash),

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -537,7 +537,7 @@ class Model(base.DBConnectorComponent):
         metadata,
         sa.Column('id', sa.Integer, primary_key=True),
         # hash of the branch, revision, patchid, repository, codebase, and
-        # project, using hashColumns.
+        # project, using hash_columns.
         sa.Column('ss_hash', sa.String(hash_length), nullable=False),
         # the branch to check out.  When branch is NULL, that means
         # the main branch (trunk, master, etc.)

--- a/master/buildbot/db/projects.py
+++ b/master/buildbot/db/projects.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from twisted.internet import defer
 
 from buildbot.db import base
+from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
 
 
@@ -52,7 +53,7 @@ class ProjectModel:
 
 class ProjectsConnectorComponent(base.DBConnectorComponent):
     def find_project_id(self, name: str, auto_create: bool = True) -> defer.Deferred[int | None]:
-        name_hash = self.hashColumns(name)
+        name_hash = hash_columns(name)
         return self.findSomethingId(
             tbl=self.db.model.projects,
             whereclause=(self.db.model.projects.c.name_hash == name_hash),

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -23,6 +23,7 @@ from twisted.internet import defer
 
 from buildbot.db import NULL
 from buildbot.db import base
+from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
@@ -146,7 +147,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
 
     def findSchedulerId(self, name: str) -> int:
         tbl = self.db.model.schedulers
-        name_hash = self.hashColumns(name)
+        name_hash = hash_columns(name)
         return self.findSomethingId(
             tbl=tbl,
             whereclause=(tbl.c.name_hash == name_hash),

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -29,6 +29,7 @@ from buildbot.db import base
 from buildbot.util import bytes2unicode
 from buildbot.util import epoch2datetime
 from buildbot.util import unicode2bytes
+from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
@@ -172,7 +173,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
 
         patchid = yield self.db.pool.do(thd)
 
-        ss_hash = self.hashColumns(branch, revision, repository, project, codebase, patchid)
+        ss_hash = hash_columns(branch, revision, repository, project, codebase, patchid)
         sourcestampid, found = yield self.findOrCreateSomethingId(
             tbl=tbl,
             whereclause=tbl.c.ss_hash == ss_hash,

--- a/master/buildbot/test/unit/db/test_base.py
+++ b/master/buildbot/test/unit/db/test_base.py
@@ -68,24 +68,6 @@ class TestBase(unittest.TestCase):
         # run that again since the method gets stubbed out
         self.comp.checkLength(self.tbl.c.str32, "long string" * 5)
 
-    def _sha1(self, s):
-        return hashlib.sha1(s).hexdigest()
-
-    def test_hashColumns_single(self):
-        self.assertEqual(self.comp.hashColumns('master'), self._sha1(b'master'))
-
-    def test_hashColumns_multiple(self):
-        self.assertEqual(self.comp.hashColumns('a', None, 'b', 1), self._sha1(b'a\0\xf5\x00b\x001'))
-
-    def test_hashColumns_None(self):
-        self.assertEqual(self.comp.hashColumns(None), self._sha1(b'\xf5'))
-
-    def test_hashColumns_integer(self):
-        self.assertEqual(self.comp.hashColumns(11), self._sha1(b'11'))
-
-    def test_hashColumns_unicode_ascii_match(self):
-        self.assertEqual(self.comp.hashColumns('master'), self.comp.hashColumns('master'))
-
 
 class TestBaseAsConnectorComponent(unittest.TestCase, connector_component.ConnectorComponentMixin):
     @defer.inlineCallbacks

--- a/master/buildbot/util/sautils.py
+++ b/master/buildbot/util/sautils.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -236,3 +237,14 @@ def _column_value_kwargs(values: Sequence[tuple[sa.Column, Any]]) -> dict[str, A
 
 def _column_values_where_clause(values: Sequence[tuple[sa.Column, Any]]) -> ColumnElement[bool]:
     return BooleanClauseList.and_(*[c == v for (c, v) in values])
+
+
+def hash_columns(*args):
+    def encode(x):
+        if x is None:
+            return b'\xf5'
+        elif isinstance(x, str):
+            return x.encode('utf-8')
+        return str(x).encode('utf-8')
+
+    return hashlib.sha1(b'\0'.join(map(encode, args))).hexdigest()


### PR DESCRIPTION
There are two copies of the same code, this PR resolves this problem.