### PR TITLE
Tear down TestReactorMixin explicitly, not using addCleanup()

### DIFF
--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -111,11 +111,13 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
     # save subclasses the trouble of calling our setUp and tearDown methods
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpUpgradeTest()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownUpgradeTest()
+        yield self.tearDownUpgradeTest()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def assertModelMatches(self):

--- a/master/buildbot/test/integration/worker/test_comm.py
+++ b/master/buildbot/test/integration/worker/test_comm.py
@@ -161,7 +161,7 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
 
         # set the worker port to a loopback address with unspecified
@@ -195,6 +195,7 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
         self.server_connection_string = "tcp:0:interface=127.0.0.1"
         self.client_connection_string_tpl = "tcp:host=127.0.0.1:port={port}"
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if self.broker:
             del self.broker
@@ -211,7 +212,8 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
         if self.buildworker and self.buildworker.detach_d:
             deferreds.append(self.buildworker.detach_d)
 
-        return defer.gatherResults(deferreds)
+        yield defer.gatherResults(deferreds)
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def addWorker(self, **kwargs):

--- a/master/buildbot/test/integration/worker/test_workerside.py
+++ b/master/buildbot/test/integration/worker/test_workerside.py
@@ -111,7 +111,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         # set the worker port to a loopback address with unspecified
         # port
@@ -154,6 +154,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         # if the worker is still attached, wait for it to detach, too
         if self.buildworker:
             yield self.buildworker.waitForCompleteShutdown()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def addMasterSideWorker(

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -32,11 +32,13 @@ class TestChangeSource(changesource.ChangeSourceMixin, TestReactorMixin, unittes
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpChangeSource()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownChangeSource()
+        yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_activation(self):
@@ -82,14 +84,16 @@ class TestReconfigurablePollingChangeSource(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         yield self.setUpChangeSource()
 
         yield self.attachChangeSource(self.Subclass(name="DummyCS"))
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownChangeSource()
+        yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def runClockFor(self, secs):

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -274,7 +274,7 @@ class TestBitbucketPullrequestPoller(
     changesource.ChangeSourceMixin, TestReactorMixin, LoggingMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpLogging()
 
         # create pull requests
@@ -304,8 +304,10 @@ class TestBitbucketPullrequestPoller(
 
         return self.setUpChangeSource()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownChangeSource()
+        yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     def _fakeGetPage(self, result):
         # Install a fake getPage that puts the requested URL in self.getPage_got_url

--- a/master/buildbot/test/unit/changes/test_changes.py
+++ b/master/buildbot/test/unit/changes/test_changes.py
@@ -52,7 +52,7 @@ class Change(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.change23 = changes.Change(**{  # using **dict(..) forces kwargs
             "category": 'devel',
@@ -104,6 +104,10 @@ class Change(unittest.TestCase, TestReactorMixin):
             "revision": 'deadbeef',
         })
         self.change25.number = 25
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_fromChdict(self):

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -98,7 +98,7 @@ class TestGerritChangeSource(
     unittest.TestCase,
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         self._got_events = []
         return self.setUpChangeSource()
@@ -108,6 +108,7 @@ class TestGerritChangeSource(
         if self.master.running:
             yield self.master.stopService()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def create_gerrit(self, host, user, *args, **kwargs):
@@ -1046,7 +1047,7 @@ class TestGerritEventLogPoller(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpChangeSource()
         yield self.master.startService()
 
@@ -1054,6 +1055,7 @@ class TestGerritEventLogPoller(
     def tearDown(self):
         yield self.master.stopService()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def newChangeSource(self, **kwargs):

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -180,7 +180,7 @@ class TestGitHubPullrequestPoller(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpChangeSource()
 
         fake_storage_service = FakeSecretStorage()
@@ -197,6 +197,7 @@ class TestGitHubPullrequestPoller(
     def tearDown(self):
         yield self.master.stopService()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def newChangeSource(self, owner, repo, endpoint='https://api.github.com', **kwargs):

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -66,7 +66,7 @@ class TestGitPollerBase(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         yield self.setUpChangeSource()
         yield self.master.startService()
@@ -77,6 +77,7 @@ class TestGitPollerBase(
     def tearDown(self):
         yield self.master.stopService()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @async_to_deferred
     async def set_last_rev(self, state: dict[str, str]) -> None:
@@ -2433,7 +2434,7 @@ class TestGitPollerConstructor(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpChangeSource()
         yield self.master.startService()
 
@@ -2441,6 +2442,7 @@ class TestGitPollerConstructor(
     def tearDown(self):
         yield self.master.stopService()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_deprecatedFetchRefspec(self):

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -39,7 +39,7 @@ class TestHgPollerBase(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         yield self.setUpChangeSource()
 
@@ -71,6 +71,7 @@ class TestHgPollerBase(
     def tearDown(self):
         yield self.master.stopService()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def check_current_rev(self, wished, branch='default'):

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -29,7 +29,7 @@ class TestMaildirSource(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.maildir = os.path.abspath("maildir")
 
         yield self.setUpChangeSource()
@@ -56,6 +56,7 @@ class TestMaildirSource(
     def tearDown(self):
         yield self.tearDownDirs()
         yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     # tests
 

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -28,15 +28,17 @@ from buildbot.test.reactor import TestReactorMixin
 class TestChangeManager(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
         self.cm = manager.ChangeManager()
         self.master.startService()
         yield self.cm.setServiceParent(self.master)
         self.new_config = mock.Mock()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     def make_sources(self, n, klass=base.ChangeSource, **kwargs):
         for i in range(n):

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -109,12 +109,14 @@ class TestP4Poller(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         yield self.setUpChangeSource()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownChangeSource()
+        yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     def add_p4_describe_result(self, number, result):
         self.expect_commands(

--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -40,11 +40,16 @@ class TestPBChangeSource(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpPBChangeSource()
         yield self.setUpChangeSource()
 
         self.master.pbmanager = self.pbmanager
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     def test_registration_no_workerport(self):
         return self._test_registration(None, exp_ConfigErrors=True, user='alice', passwd='sekrit')
@@ -212,8 +217,12 @@ class TestPBChangeSource(
 class TestChangePerspective(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
+
+        @defer.inlineCallbacks
+        def tearDown(self):
+            yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_addChange_noprefix(self):

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -259,12 +259,14 @@ class TestSVNPoller(
     MasterRunProcessMixin, changesource.ChangeSourceMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         return self.setUpChangeSource()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownChangeSource()
+        yield self.tearDownChangeSource()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def attachSVNPoller(self, *args, **kwargs):

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -26,7 +26,11 @@ from buildbot.test.util import endpoint
 
 class ResourceType(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def makeResourceTypeSubclass(self, **attributes):
         attributes.setdefault('name', 'thing')

--- a/master/buildbot/test/unit/data/test_build_data.py
+++ b/master/buildbot/test/unit/data/test_build_data.py
@@ -332,9 +332,13 @@ class TestBuildDatasNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestBuildData(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = build_data.BuildData(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_set_build_data(self):
         @self.assertArgSpecMatches(self.master.data.updates.setBuildData, self.rtype.setBuildData)

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -221,13 +221,17 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = builders.Builder(self.master)
         yield self.master.db.insert_test_data([
             fakedb.Master(id=13),
             fakedb.Master(id=14),
         ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_findBuilderId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -276,9 +276,13 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = buildrequests.BuildRequest(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def doTestCallthrough(

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -340,9 +340,13 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = builds.Build(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_callthrough(

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -126,7 +126,7 @@ class BuildsetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Buildset(TestReactorMixin, util_interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = buildsets.Buildset(self.master)
         yield self.master.db.insert_test_data([
@@ -142,6 +142,10 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests, unittest.TestCa
             fakedb.Builder(id=42, name='bldr1'),
             fakedb.Builder(id=43, name='bldr2'),
         ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     SS234_DATA = {
         'branch': 'br',

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -194,9 +194,13 @@ class Change(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = changes.Change(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_addChange(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_changesources.py
+++ b/master/buildbot/test/unit/data/test_changesources.py
@@ -148,9 +148,13 @@ class ChangeSourcesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class ChangeSource(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = changesources.ChangeSource(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_findChangeSourceId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -112,18 +112,26 @@ class Tests(interfaces.InterfaceTests):
 class TestFakeData(TestReactorMixin, unittest.TestCase, Tests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.data = self.master.data
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class TestDataConnector(TestReactorMixin, unittest.TestCase, Tests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True)
         self.data = connector.DataConnector()
         yield self.data.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class DataConnector(TestReactorMixin, unittest.TestCase):
@@ -131,12 +139,16 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         # don't load by default
         self.patch(connector.DataConnector, 'submodules', [])
         self.data = connector.DataConnector()
         yield self.data.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def patchFooPattern(self):
         cls = type('FooEndpoint', (base.Endpoint,), {})

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -200,9 +200,13 @@ class LogsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Log(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = logs.Log(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_callthrough(

--- a/master/buildbot/test/unit/data/test_masters.py
+++ b/master/buildbot/test/unit/data/test_masters.py
@@ -131,9 +131,13 @@ class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Master(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = masters.Master(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_masterActive(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_patches.py
+++ b/master/buildbot/test/unit/data/test_patches.py
@@ -24,8 +24,12 @@ from buildbot.test.reactor import TestReactorMixin
 class Patch(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = patches.Patch(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     # no update methods -> nothing to test

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -115,12 +115,16 @@ class ProjectsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Project(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = projects.Project(self.master)
         yield self.master.db.insert_test_data([
             fakedb.Project(id=13, name="fake_project"),
         ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_find_project_id(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -91,9 +91,13 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Properties(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=False, wantDb=True, wantData=True)
         self.rtype = properties.Properties(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_callthrough(

--- a/master/buildbot/test/unit/data/test_schedulers.py
+++ b/master/buildbot/test/unit/data/test_schedulers.py
@@ -145,9 +145,13 @@ class SchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Scheduler(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = schedulers.Scheduler(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_schedulerEnable(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_steps.py
+++ b/master/buildbot/test/unit/data/test_steps.py
@@ -217,9 +217,13 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = steps.Step(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_addStep(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -158,9 +158,13 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestResultSet(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = test_result_sets.TestResultSet(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_add_test_result_set(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -98,9 +98,13 @@ class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = test_results.TestResult(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_add_test_results(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -294,13 +294,17 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Worker(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = workers.Worker(self.master)
         yield self.master.db.insert_test_data([
             fakedb.Master(id=13),
             fakedb.Master(id=14),
         ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_signature_findWorkerId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -34,7 +34,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpRealDatabase(
             table_names=[
                 'changes',
@@ -65,6 +65,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin, unittest.TestCase)
             yield self.db.stopService()
 
         yield self.tearDownRealDatabase()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def startService(self, check_version=False):

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -30,11 +30,15 @@ from buildbot.test.reactor import TestReactorMixin
 class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
         self.botmaster = BotMaster()
         yield self.botmaster.setServiceParent(self.master)
         self.botmaster.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertReactorStopped(self, _=None):
         self.assertTrue(self.reactor.stop_called)
@@ -152,7 +156,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 class TestBotMaster(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.master.botmaster.disownServiceParent()
@@ -161,8 +165,10 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
         self.new_config = mock.Mock()
         self.botmaster.startService()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.botmaster.stopService()
+        yield self.botmaster.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -180,7 +180,7 @@ def makeControllableStepFactory():
 class TestBuild(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         r = FakeRequest()
         r.sources = [FakeSource()]
         r.sources[0].changes = [FakeChange()]
@@ -204,6 +204,10 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.build.workerforbuilder = self.workerforbuilder
         self.build.text = []
         self.build.buildid = 666
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertWorkerPreparationFailure(self, reason):
         states = "".join(self.master.data.updates.stepStateString.values())
@@ -887,7 +891,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 class TestMultipleSourceStamps(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.builder = FakeBuilder(self.master)
 
@@ -910,6 +914,10 @@ class TestMultipleSourceStamps(TestReactorMixin, unittest.TestCase):
         r.sources.extend([s1, s2, s3])
 
         self.build = Build([r], self.builder)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_buildReturnSourceStamp(self):
         """
@@ -934,7 +942,7 @@ class TestMultipleSourceStamps(TestReactorMixin, unittest.TestCase):
 class TestBuildBlameList(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.builder = FakeBuilder(self.master)
 
@@ -958,6 +966,10 @@ class TestBuildBlameList(TestReactorMixin, unittest.TestCase):
         self.patchSource.changes = []
         self.patchSource.revision = "67890"
         self.patchSource.patch_info = ("jeff", "jeff's new feature")
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_blamelist_for_changes(self):
         r = FakeRequest()
@@ -983,7 +995,7 @@ class TestSetupProperties_MultipleSources(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.props = {}
         self.r = FakeRequest()
         self.r.sources = []
@@ -1003,6 +1015,10 @@ class TestSetupProperties_MultipleSources(TestReactorMixin, unittest.TestCase):
         self.build.setStepFactories([])
         # record properties that will be set
         self.build.properties.setProperty = self.setProperty
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def setProperty(self, n, v, s, runtime=False):
         if s not in self.props:
@@ -1028,7 +1044,7 @@ class TestSetupProperties_SingleSource(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.props = {}
         self.r = FakeRequest()
         self.r.sources = []
@@ -1043,6 +1059,10 @@ class TestSetupProperties_SingleSource(TestReactorMixin, unittest.TestCase):
         self.build.setStepFactories([])
         # record properties that will be set
         self.build.properties.setProperty = self.setProperty
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def setProperty(self, n, v, s, runtime=False):
         if s not in self.props:

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -108,7 +108,7 @@ class FakeLatentWorker(AbstractLatentWorker):
 class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         # a collection of rows that would otherwise clutter up every test
         yield self.setUpBuilderMixin()
         self.base_rows = [
@@ -116,6 +116,10 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
             fakedb.Buildset(id=11, reason='because'),
             fakedb.BuildsetSourceStamp(buildsetid=11, sourcestampid=21),
         ]
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeBuilder(self, patch_random=False, startBuildsForSucceeds=True, **config_kwargs):
@@ -480,8 +484,12 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
 class TestGetBuilderId(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpBuilderMixin()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getBuilderId(self):
@@ -503,7 +511,7 @@ class TestGetBuilderId(TestReactorMixin, BuilderMixin, unittest.TestCase):
 class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -524,6 +532,10 @@ class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase
             fakedb.BuildRequest(id=555, submitted_at=2800, builderid=182, buildsetid=11),
         ]
         yield self.db.insert_test_data(self.base_rows)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_gort_unclaimed(self):
@@ -548,7 +560,7 @@ class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase
 class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -574,6 +586,10 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
         yield self.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
+
+    @defer.inlineCallbacks
     def test_gnct_completed(self):
         yield self.makeBuilder(name='bldr1')
         rqtime = yield self.bldr.getNewestCompleteTime()
@@ -589,7 +605,7 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
 class TestGetHighestPriority(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -613,6 +629,10 @@ class TestGetHighestPriority(TestReactorMixin, BuilderMixin, unittest.TestCase):
         yield self.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
+
+    @defer.inlineCallbacks
     def test_ghp_unclaimed(self):
         yield self.makeBuilder(name='bldr1')
         priority = yield self.bldr.get_highest_priority()
@@ -630,13 +650,17 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpBuilderMixin()
 
         yield self.db.insert_test_data([
             fakedb.Project(id=301, name='old_project'),
             fakedb.Project(id=302, name='new_project'),
         ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfig(self):

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -30,7 +30,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True)
         self.master.botmaster = mock.Mock(name='botmaster')
         self.master.botmaster.builders = {}
@@ -53,8 +53,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
 
         return bldr
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        pass
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_request_collapse(self, rows, brids, exp):
@@ -461,7 +462,11 @@ class TestSourceStamp(unittest.TestCase):
 
 class TestBuildRequest(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_fromBrdict(self):

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -47,7 +47,7 @@ def nth_worker(n):
 class TestBRDBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.botmaster = mock.Mock(name='botmaster')
         self.botmaster.builders = {}
         self.builders = {}
@@ -73,10 +73,11 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
             fakedb.BuildsetSourceStamp(sourcestampid=21, buildsetid=11),
         ]
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if self.brd.running:
-            return self.brd.stopService()
-        return None
+            yield self.brd.stopService()
+        yield self.tear_down_test_reactor()
 
     def make_workers(self, worker_count):
         rows = self.base_rows[:]

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -115,11 +115,13 @@ class TestBuildStep(
             return SUCCESS
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     # support
 
@@ -1090,9 +1092,13 @@ class InterfaceTests(interfaces.InterfaceTests):
 class TestFakeItfc(unittest.TestCase, TestBuildStepMixin, TestReactorMixin, InterfaceTests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setup_test_build_step()
         self.setup_step(buildstep.BuildStep())
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class TestRealItfc(unittest.TestCase, InterfaceTests):
@@ -1114,12 +1120,14 @@ class CommandMixinExample(buildstep.CommandMixin, buildstep.BuildStep):
 class TestCommandMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setup_test_build_step()
         self.setup_step(CommandMixinExample())
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_runRmdir(self):
@@ -1231,11 +1239,13 @@ class TestShellMixin(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setup_test_build_step(with_secrets={"s3cr3t": "really_safe_string"})
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_setupShellMixin_bad_arg(self):
         mixin = SimpleShellCommand()

--- a/master/buildbot/test/unit/process/test_debug.py
+++ b/master/buildbot/test/unit/process/test_debug.py
@@ -32,9 +32,13 @@ class FakeManhole(service.AsyncService):
 
 class TestDebugServices(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = mock.Mock(name='master')
         self.config = MasterConfig()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfigService_manhole(self):

--- a/master/buildbot/test/unit/process/test_log.py
+++ b/master/buildbot/test/unit/process/test_log.py
@@ -29,8 +29,12 @@ from buildbot.test.util import interfaces
 class Tests(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeLog(self, type, logEncoding='utf-8'):

--- a/master/buildbot/test/unit/process/test_logobserver.py
+++ b/master/buildbot/test/unit/process/test_logobserver.py
@@ -45,8 +45,12 @@ class MyLogObserver(logobserver.LogObserver):
 class TestLogObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -96,8 +100,12 @@ class MyLogLineObserver(logobserver.LogLineObserver):
 class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_sequence(self, consumer):
@@ -169,8 +177,12 @@ class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
 class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -209,8 +221,12 @@ class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
 class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -229,8 +245,12 @@ class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
 class TestBufferObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_sequence(self, lo):

--- a/master/buildbot/test/unit/process/test_metrics.py
+++ b/master/buildbot/test/unit/process/test_metrics.py
@@ -28,7 +28,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestMetricBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.observer = metrics.MetricLogObserver()
         self.observer.parent = self.master = yield fakemaster.make_master(self)
         self.master.config.metrics = {"log_interval": 0, "periodic_interval": 0}
@@ -36,9 +36,11 @@ class TestMetricBase(TestReactorMixin, unittest.TestCase):
         self.observer.startService()
         self.observer.reconfigServiceWithBuildbotConfig(self.master.config)
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if self.observer.running:
-            self.observer.stopService()
+            yield self.observer.stopService()
+        yield self.tear_down_test_reactor()
 
 
 class TestMetricCountEvent(TestMetricBase):

--- a/master/buildbot/test/unit/process/test_users_manual.py
+++ b/master/buildbot/test/unit/process/test_users_manual.py
@@ -47,8 +47,12 @@ class TestUsersBase(unittest.TestCase):
 
 class TestCommandlineUserManagerPerspective(TestReactorMixin, unittest.TestCase, ManualUsersMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpManualUsers()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def call_perspective_commandline(self, *args):
         persp = manual.CommandlineUserManagerPerspective(self.master)
@@ -246,12 +250,16 @@ class TestCommandlineUserManagerPerspective(TestReactorMixin, unittest.TestCase,
 class TestCommandlineUserManager(TestReactorMixin, unittest.TestCase, ManualUsersMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpManualUsers()
         self.manual_component = manual.CommandlineUserManager(
             username="user", passwd="userpw", port="9990"
         )
         yield self.manual_component.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_no_userpass(self):
         d = defer.maybeDeferred(manual.CommandlineUserManager)

--- a/master/buildbot/test/unit/process/test_users_users.py
+++ b/master/buildbot/test/unit/process/test_users_users.py
@@ -28,10 +28,14 @@ from buildbot.test.reactor import TestReactorMixin
 class UsersTests(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.test_sha = users.encrypt("cancer")
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def verify_users(self, users):

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -40,10 +40,14 @@ class TestReporterBase(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.setUpLogging()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupNotifier(self, generators):

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -38,7 +38,7 @@ class TestBitbucketStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
@@ -62,6 +62,7 @@ class TestBitbucketStatusPush(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.bsp.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):
@@ -271,7 +272,7 @@ class TestBitbucketStatusPushProperties(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
@@ -310,6 +311,7 @@ class TestBitbucketStatusPushProperties(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.bsp.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_properties(self):
@@ -375,7 +377,7 @@ class TestBitbucketStatusPushConfig(ConfigErrorsMixin, unittest.TestCase):
 class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         self.bsp = BitbucketStatusPush(Interpolate('key'), Interpolate('secret'))
@@ -385,6 +387,7 @@ class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.bsp.stopService()
+        yield self.tear_down_test_reactor()
 
     def parse(self, repourl):
         return tuple(self.bsp.get_owner_and_repo(repourl))

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -54,7 +54,7 @@ class TestBitbucketServerStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -72,6 +72,7 @@ class TestBitbucketServerStatusPush(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_start_and_finish_build(self, build):
@@ -219,7 +220,7 @@ class TestBitbucketServerCoreAPIStatusPush(
 ):
     @defer.inlineCallbacks
     def setupReporter(self, token=None, **kwargs):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
@@ -251,8 +252,10 @@ class TestBitbucketServerCoreAPIStatusPush(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.master and self.master.running:
-            yield self.master.stopService()
+        if self.master:
+            if self.master.running:
+                yield self.master.stopService()
+            yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_start_and_finish_build(self, build, parentPlan=False, epoch=False):
@@ -628,7 +631,7 @@ class TestBitbucketServerPRCommentPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -666,6 +669,7 @@ class TestBitbucketServerPRCommentPush(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults, set_pr=True):

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -35,9 +35,13 @@ from buildbot.warnings import DeprecatedApiWarning
 class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(
@@ -297,9 +301,13 @@ class TestBuildStartEndGenerator(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -36,13 +36,17 @@ class TestBuildRequestGenerator(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         builder = Mock(spec=Builder)
         builder.master = self.master
         self.master.botmaster.getBuilderById = Mock(return_value=builder)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @parameterized.expand([
         ('tags', 'tag'),

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -34,9 +34,13 @@ class TestBuildSetGeneratorBase(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_generators_utils.py
+++ b/master/buildbot/test/unit/reporters/test_generators_utils.py
@@ -36,9 +36,13 @@ from buildbot.test.util.reporter import ReporterTestMixin
 class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_generators_worker.py
+++ b/master/buildbot/test/unit/reporters/test_generators_worker.py
@@ -26,8 +26,12 @@ from buildbot.test.util.config import ConfigErrorsMixin
 class TestWorkerMissingGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def _get_worker_dict(self, worker_name):
         return {

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -122,9 +122,13 @@ def sampleSummaryCBDeferred(buildInfoList, results, master, arg):
 class TestGerritStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupGerritStatusPushSimple(self, *args, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -39,7 +39,7 @@ class TestGerritVerifyStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.reporter_test_props = {'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]}
 
@@ -57,8 +57,10 @@ class TestGerritVerifyStatusPush(
         self.sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)
         yield self.sp.setServiceParent(self.master)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -35,7 +35,7 @@ class TestGitHubStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.setup_reporter_test()
         # project must be in the form <owner>/<project>
@@ -58,8 +58,10 @@ class TestGitHubStatusPush(
     def createService(self):
         return GitHubStatusPush(Interpolate('XXYYZZ'))
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):
@@ -300,7 +302,7 @@ class TestGitHubStatusPush(
 class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.setup_reporter_test()
         # project must be in the form <owner>/<project>
@@ -324,8 +326,10 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
     def createService(self):
         return GitHubStatusPush('XXYYZZ')
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_ssh(self):

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -38,7 +38,7 @@ class TestGitLabStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.setup_reporter_test()
         # repository must be in the form http://gitlab/<owner>/<project>
@@ -68,8 +68,10 @@ class TestGitLabStatusPush(
         builder.setup_properties = setup_properties
         self.master.botmaster.getBuilderById = mock.Mock(return_value=builder)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_buildrequest(self):

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -30,7 +30,7 @@ from buildbot.test.util.reporter import ReporterTestMixin
 class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin, ConfigErrorsMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -53,6 +53,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin,
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -41,9 +41,13 @@ from buildbot.util import ssl
 class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupMailNotifier(self, *args, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -160,8 +160,12 @@ class TestMessageFormatting(unittest.TestCase):
 class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_db(self, results1, results2, with_steps=False, extra_build_properties=None):

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -34,8 +34,12 @@ from buildbot.util import httpclientservice
 class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     # returns a Deferred
     def setupFakeHttp(self, base_url='https://api.pushjet.io'):

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -34,8 +34,12 @@ from buildbot.util import httpclientservice
 class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     # returns a Deferred
     def setupFakeHttp(self):

--- a/master/buildbot/test/unit/reporters/test_telegram.py
+++ b/master/buildbot/test/unit/reporters/test_telegram.py
@@ -554,10 +554,14 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.patch(reactor, 'callLater', self.reactor.callLater)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         self.http = None
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_http_service(self):

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -39,8 +39,12 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupDb(self):
@@ -612,8 +616,12 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 class TestURLUtils(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_UrlForBuild(self):
         self.assertEqual(

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -48,7 +48,7 @@ class ContactMixin(TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self) -> Generator[Any, None, None]:
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.patch(reactor, 'callLater', self.reactor.callLater)
         self.patch(reactor, 'seconds', self.reactor.seconds)
         self.patch(reactor, 'stop', self.reactor.stop)
@@ -87,6 +87,10 @@ class ContactMixin(TestReactorMixin):
         self.contact = self.contactClass(user=self.USER, channel=self.bot.getChannel(self.CHANNEL))
         yield self.contact.channel.setServiceParent(self.master)
         yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def patch_send(self):
         self.sent = []

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -30,7 +30,7 @@ class TestZulipStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(
             testcase=self, wantData=True, wantDb=True, wantMq=True
@@ -40,6 +40,7 @@ class TestZulipStatusPush(
     def tearDown(self):
         if self.master.running:
             yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupZulipStatusPush(self, endpoint="http://example.com", token="123", stream=None):

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -37,11 +37,13 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
+        yield self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, name='testsched', builderNames=None, properties=None, codebases=None):

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -102,11 +102,13 @@ class BaseBasicScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     # tests
 
@@ -352,11 +354,13 @@ class SingleBranchScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_constructor_no_reason(self):
@@ -593,11 +597,13 @@ class AnyBranchScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     def test_constructor_branch_forbidden(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -49,7 +49,7 @@ class TestFilterSet(unittest.TestCase):
 
 class TestOldBuildrequestTracker(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         filter = _OldBuildFilterSet()
 
         ss_filter = SourceStampFilter(
@@ -60,6 +60,10 @@ class TestOldBuildrequestTracker(unittest.TestCase, TestReactorMixin):
         self.tracker = _OldBuildrequestTracker(
             self.reactor, filter, lambda ss: ss['branch'], self.on_cancel
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def on_cancel(self, brid):
         self.cancellations.append(brid)
@@ -384,7 +388,7 @@ class TestOldBuildCancellerUtils(ConfigErrorsMixin, unittest.TestCase):
 class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.master.mq.verifyMessages = False
 
@@ -393,8 +397,10 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
         yield self.master.startService()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     def create_ss_dict(self, project, codebase, repository, branch):
         # Changes have the same structure for the attributes that we're using, so we reuse this

--- a/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
@@ -28,7 +28,7 @@ from buildbot.util.ssfilter import SourceStampFilter
 class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.master.mq.verifyMessages = False
 
@@ -37,8 +37,10 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
         yield self.master.startService()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_test_data(self):

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -38,11 +38,13 @@ UPSTREAM_NAME = 'uppy'
 class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, upstream=None):

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -48,11 +48,13 @@ class TestForceScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, name='testsched', builderNames=None, **kw):

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -116,11 +116,13 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unitte
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     def assertConsumingChanges(self, **kwargs):
         self.assertEqual(self.consumingChanges, kwargs)

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -31,8 +31,13 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):
         return self.attachScheduler(timed.NightlyBase(**kwargs), self.OBJECTID, self.SCHEDULERID)

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -48,11 +48,13 @@ class NightlyTriggerable(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     # utilities
 

--- a/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
@@ -33,8 +33,13 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, firstBuildDuration=0, firstBuildError=False, exp_branch=None, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_timed_Timed.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Timed.py
@@ -27,11 +27,13 @@ class Timed(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     class Subclass(timed.Timed):
         def getNextBuildTime(self, lastActuation):

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -38,15 +38,17 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         # Necessary to get an assertable submitted_at time.
         self.reactor.advance(946684799)
 
         yield self.setUpScheduler()
         self.subscription = None
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, overrideBuildsetMethods=False, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -35,11 +35,13 @@ class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     def makeScheduler(self, **kwargs):
         return self.attachScheduler(
@@ -130,14 +132,16 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
         self.jobdir = None
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
         if self.jobdir:
             shutil.rmtree(self.jobdir)
+        yield self.tear_down_test_reactor()
 
     # tests
 
@@ -874,11 +878,13 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin, unitt
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     def makeScheduler(self, **kwargs):
         return self.attachScheduler(
@@ -1051,11 +1057,13 @@ class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpScheduler()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownScheduler()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, **kwargs):

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -78,7 +78,7 @@ class TestCleanupDb(
     misc.StdoutAssertionsMixin, dirs.DirsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpDirs('basedir')
         with open(os.path.join('basedir', 'buildbot.tac'), "w", encoding='utf-8') as f:
             f.write(
@@ -90,8 +90,10 @@ class TestCleanupDb(
         self.setUpStdoutAssertions()
         self.ensureNoSqliteMemory()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownDirs()
+        yield self.tear_down_test_reactor()
 
     def ensureNoSqliteMemory(self):
         # test may use mysql or pg if configured in env

--- a/master/buildbot/test/unit/scripts/test_create_master.py
+++ b/master/buildbot/test/unit/scripts/test_create_master.py
@@ -91,13 +91,15 @@ class TestCreateMasterFunctions(
     unittest.TestCase,
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownDirs()
+        yield self.tear_down_test_reactor()
 
     def assertInTacFile(self, str):
         with open(os.path.join('test', 'buildbot.tac'), encoding='utf-8') as f:

--- a/master/buildbot/test/unit/scripts/test_logwatcher.py
+++ b/master/buildbot/test/unit/scripts/test_logwatcher.py
@@ -48,9 +48,13 @@ class TestLogWatcher(unittest.TestCase, dirs.DirsMixin, TestReactorMixin):
         self.setUpDirs('workdir')
         self.addCleanup(self.tearDownDirs)
 
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.spawned_process = mock.Mock()
         self.reactor.spawnProcess = mock.Mock(return_value=self.spawned_process)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_start(self):
         lw = MockedLogWatcher('workdir/test.log', _reactor=self.reactor)

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -114,13 +114,15 @@ class TestUpgradeMasterFunctions(
     unittest.TestCase,
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.tearDownDirs()
+        yield self.tear_down_test_reactor()
 
     def writeFile(self, path, contents):
         with open(path, "w", encoding='utf-8') as f:

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -28,11 +28,13 @@ from buildbot.test.steps import TestBuildStepMixin
 class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def expect_and_run_command(self, *params):
         command = [CMake.DEFAULT_CMAKE, *list(params)]

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.properties import WithProperties
@@ -27,11 +28,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class Cppcheck(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(cppcheck.Cppcheck(enable=['all'], inconclusive=True))

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -66,7 +66,7 @@ class TestPage(Resource):
 
 class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         if txrequests is None:
             raise unittest.SkipTest("Need to install txrequests to test http steps")
 
@@ -89,6 +89,7 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             yield self.site.close_connections()
         finally:
             yield self.tear_down_test_build_step()
+            yield self.tear_down_test_reactor()
 
     def get_connection_string(self):
         return f"http://127.0.0.1:{self.port}"

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -36,19 +36,21 @@ _COMSPEC_ENV = 'COMSPEC'
 
 class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         if runtime.platformType == 'win32':
             self.comspec = os.environ.get(_COMSPEC_ENV)
             os.environ[_COMSPEC_ENV] = r'C:\WINDOWS\system32\cmd.exe'
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if runtime.platformType == 'win32':
             if self.comspec:
                 os.environ[_COMSPEC_ENV] = self.comspec
             else:
                 del os.environ[_COMSPEC_ENV]
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_constr_args(self):
         self.setup_step(
@@ -168,11 +170,13 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class TestSetProperty(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_simple(self):
         self.setup_step(
@@ -190,11 +194,13 @@ class TestSetProperty(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestLogRenderable(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_simple(self):
         self.setup_step(
@@ -211,11 +217,13 @@ class TestLogRenderable(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestsSetProperties(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def doOneTest(self, **kwargs):
         # all three tests should create a 'a' property with 'b' value, all with different
@@ -242,11 +250,13 @@ class TestsSetProperties(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
 class TestAssert(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_eq_pass(self):
         self.setup_step(master.Assert(Property("test_prop") == "foo"))

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -26,11 +27,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestShellCommandExecution(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_testdir_required(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -35,11 +35,13 @@ class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
     """
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def _run_simple_test(
         self,

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -25,11 +26,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestDebLintian(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_fileloc(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -15,6 +15,7 @@
 
 import time
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -30,11 +31,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_new(self):
         self.setup_step(pbuilder.DebPbuilder())
@@ -488,11 +491,13 @@ class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_new(self):
         self.setup_step(pbuilder.DebCowbuilder())
@@ -639,11 +644,13 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_distribution(self):
         with self.assertRaises(config.ConfigErrors):
@@ -691,11 +698,13 @@ class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestUbuCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_distribution(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -27,7 +28,7 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
     def tearDown(self):
@@ -108,11 +109,13 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_spec(self):
         with self.assertRaises(config.ConfigErrors):
@@ -149,11 +152,13 @@ class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestMockRebuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_srpm(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -30,11 +30,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class RpmBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_specfile(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS
@@ -24,11 +25,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestRpmLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(rpmlint.RpmLint())

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -125,11 +125,13 @@ Warning: Unable to extract the base list for
 
 class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_sample(self):
         self.setup_step(python.BuildEPYDoc())
@@ -142,11 +144,13 @@ class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @parameterized.expand([('no_results', True), ('with_results', False)])
     def test_success(self, name, store_results):
@@ -439,11 +443,13 @@ class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(python.PyFlakes())
@@ -525,11 +531,13 @@ class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_builddir_required(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -15,6 +15,7 @@
 
 import textwrap
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.properties import Property
@@ -93,11 +94,13 @@ FAILED (failures=8)
 
 class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_run_env(self):
         self.setup_step(
@@ -397,11 +400,13 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_run_ok(self):
         self.setup_build(build_files=['foo.xhtml'])
@@ -466,11 +471,13 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_run_ok(self):
         self.setup_step(python_twisted.RemovePYCs())

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.buildstep import BuildStep
@@ -32,11 +33,13 @@ class TestBuildStepNameIsRenderable(
     TestBuildStepMixin, unittest.TestCase, TestReactorMixin, configmixin.ConfigErrorsMixin
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_name_is_renderable(self):
         step = TestBuildStep(name=Interpolate('%(kw:foo)s', foo='bar'))

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -40,11 +40,13 @@ class TestShellCommandExecution(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_doStepIf_False(self):
         self.setup_step(shell.ShellCommand(command="echo hello", doStepIf=False))
@@ -180,11 +182,13 @@ class TestShellCommandExecution(
 
 class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_run_success(self):
         self.setup_step(shell.TreeSize())
@@ -216,11 +220,13 @@ class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_constructor_conflict(self):
         with self.assertRaises(config.ConfigErrors):
@@ -349,11 +355,13 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_new_version_success(self):
         self.setup_step(shell.PerlModuleTest(command="cmd"))
@@ -462,11 +470,13 @@ class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class Configure(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_class_attrs(self):
         step = shell.Configure()
@@ -484,11 +494,13 @@ class WarningCountingShellCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_no_warnings(self):
         self.setup_step(shell.WarningCountingShellCommand(workdir='w', command=['make']))
@@ -812,11 +824,13 @@ class WarningCountingShellCommand(
 
 class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_class_args(self):
         # since this step is just a pre-configured WarningCountingShellCommand,
@@ -832,11 +846,13 @@ class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class Test(TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_setTestResults(self):
         step = self.setup_step(shell.Test())

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -38,7 +38,7 @@ class TestOneShellCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -32,11 +32,13 @@ class OldStyleSourceStep(Source):
 
 class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def setup_deferred_mock(self):
         m = mock.Mock()
@@ -168,11 +170,13 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCas
 
 class TestSourceDescription(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_constructor_args_strings(self):
         step = Source(
@@ -204,11 +208,13 @@ class AttrGroup(Source):
 
 class TestSourceAttrGroup(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_attrgroup_hasattr(self):
         step = AttrGroup()

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -16,6 +16,7 @@
 
 import os
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
@@ -37,11 +38,13 @@ from buildbot.test.util import sourcesteps
 
 class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def test_mode_full(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -15,6 +15,7 @@
 
 import time
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
@@ -37,11 +38,13 @@ from buildbot.test.util import sourcesteps
 
 class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def setup_step(self, step, *args, **kwargs):
         super().setup_step(step, *args, **kwargs)

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
@@ -33,11 +34,13 @@ from buildbot.test.util import sourcesteps
 
 class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def test_no_empty_step_config(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS
@@ -29,11 +30,13 @@ class TestGerrit(
     sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def test_mode_full_clean(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -48,12 +48,14 @@ class TestGit(
     stepClass = git.Git
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def test_mode_full_filters_2_26(self):
         self.setup_step(
@@ -4185,7 +4187,7 @@ class TestGitPush(
     stepClass = git.GitPush
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
     def tearDown(self):
@@ -4668,7 +4670,7 @@ class TestGitTag(TestBuildStepMixin, config.ConfigErrorsMixin, TestReactorMixin,
     stepClass = git.GitTag
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
     def tearDown(self):
@@ -4764,14 +4766,16 @@ class TestGitCommit(
     stepClass = git.GitCommit
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.message_list = ['my commit', '42']
         self.path_list = ['file1.txt', 'file2.txt']
 
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_add_fail(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS
@@ -31,7 +32,7 @@ class TestGitLab(
     stepClass = gitlab.GitLab
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 
@@ -53,8 +54,10 @@ class TestGitLab(
         step.build.properties.setProperty("target_project_id", 239, "gitlab target project ID")
         return step
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def test_with_merge_branch(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
@@ -34,11 +35,13 @@ from buildbot.test.util import sourcesteps
 
 class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def patch_workerVersionIsOlderThan(self, result):
         self.patch(mercurial.Mercurial, 'workerVersionIsOlderThan', lambda x, y, z: result)

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
@@ -41,11 +42,13 @@ class TestMonotone(
     MTN_VER = 'monotone 1.0 (base revision: UNKNOWN_REV)'
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def test_mode_full_clean(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -17,6 +17,7 @@
 import platform
 import textwrap
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.python import reflect
 from twisted.trial import unittest
@@ -36,11 +37,13 @@ _is_windows = platform.system() == 'Windows'
 
 class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def setup_step(self, step, args=None, patch=None, **kwargs):
         if args is None:

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.changes.changes import Change
@@ -60,13 +61,15 @@ class RepoURL(unittest.TestCase):
 
 class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.shouldRetry = False
         self.logEnviron = True
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def shouldLogEnviron(self):
         r = self.logEnviron

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -121,11 +121,13 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                             </info>"""
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setUpSourceStep()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownSourceStep()
+        yield self.tearDownSourceStep()
+        yield self.tear_down_test_reactor()
 
     def patch_workerVersionIsOlderThan(self, result):
         self.patch(svn.SVN, 'workerVersionIsOlderThan', lambda x, y, z: result)

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -17,6 +17,7 @@ import io
 import re
 import sys
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import FAILURE
@@ -55,11 +56,13 @@ class TestSubUnit(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         if TestProtocolClient is None:
             raise unittest.SkipTest("Need to install python-subunit to test subunit step")
 
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_empty(self):
         self.setup_step(subunit.SubunitShellCommand(command='test'))

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -43,16 +43,18 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def testConstructorModeType(self):
         with self.assertRaises(config.ConfigErrors):
@@ -309,18 +311,20 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_step(transfer.DirectoryUpload(workersrc="srcdir", masterdest=self.destdir))
@@ -493,18 +497,20 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
 class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def testEmpty(self):
         self.setup_step(transfer.MultipleFileUpload(workersrcs=[], masterdest=self.destdir))
@@ -936,16 +942,19 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class TestFileDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-        return self.tear_down_test_build_step()
+
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_init_workerdest_keyword(self):
         step = transfer.FileDownload(mastersrc='srcfile', workerdest='dstfile')
@@ -1046,11 +1055,13 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     # check that ConfigErrors is raised on invalid 'mode' argument
 
@@ -1154,11 +1165,13 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
 class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testBasic(self):
@@ -1255,11 +1268,13 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testBasic(self):

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -100,11 +100,13 @@ def BRID_TO_BUILD_NUMBER(brid):
 
 class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_step(self, step, sourcestampsInBuild=None, gotRevisionsInBuild=None, *args, **kwargs):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -228,11 +228,13 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     """
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_default_config(self):
         vs = vstudio.VisualStudio()
@@ -349,11 +351,13 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
         include = [
@@ -447,11 +451,13 @@ class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestVC7(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
         include = [
@@ -582,11 +588,13 @@ class VC8ExpectedEnvMixin:
 
 class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_args(self):
         self.setup_step(vstudio.VC8(projectfile='pf', config='cfg', project='pj', arch='arch'))
@@ -643,11 +651,13 @@ class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
 
 class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_args(self):
         self.setup_step(vstudio.VCExpress9(projectfile='pf', config='cfg', project='pj'))
@@ -700,11 +710,13 @@ class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, 
 
 class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC9(projectfile='pf', config='cfg', project='pj'))
@@ -721,11 +733,13 @@ class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
 
 class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC10(projectfile='pf', config='cfg', project='pj'))
@@ -742,11 +756,13 @@ class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unitte
 
 class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC11(projectfile='pf', config='cfg', project='pj'))
@@ -763,11 +779,13 @@ class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unitte
 
 class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_platform(self):
@@ -865,11 +883,13 @@ class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_platform(self):
@@ -985,11 +1005,13 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMsBuild16(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_version_range_is_correct(self):
         self.setup_step(
@@ -1012,11 +1034,13 @@ class TestMsBuild16(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMsBuild17(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_version_range_is_correct(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -42,11 +42,13 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_simple(self):
         self.setup_step(
@@ -81,11 +83,13 @@ class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin, unittest.Te
 
 class TestFileExists(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_found(self):
         self.setup_step(worker.FileExists(file="x"))
@@ -123,11 +127,13 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(worker.CopyDirectory(src="s", dest="d"))
@@ -166,11 +172,13 @@ class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(worker.RemoveDirectory(dir="d"))
@@ -194,11 +202,13 @@ class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
 class TestMakeDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(worker.MakeDirectory(dir="d"))
@@ -235,11 +245,13 @@ class CompositeUser(buildstep.BuildStep, worker.CompositeStepMixin):
 
 class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_runRemoteCommand(self):
         cmd_args = ('foo', {'bar': False})

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -17,6 +17,7 @@
 import os
 import stat
 
+from twisted.internet import defer
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
@@ -37,14 +38,16 @@ class TestDownloadFileSecretToWorkerCommand(
     TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_step(
@@ -79,14 +82,16 @@ class TestDownloadFileSecretToWorkerCommand(
 
 class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_build(worker_version={'*': '3.0'})
@@ -119,14 +124,16 @@ class TestRemoveFileSecretToWorkerCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_step(

--- a/master/buildbot/test/unit/test_fake_httpclientservice.py
+++ b/master/buildbot/test/unit/test_fake_httpclientservice.py
@@ -43,7 +43,7 @@ class myTestedService(service.BuildbotService):
 class Test(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        yield self.setup_test_reactor()
+        yield self.setup_test_reactor(auto_tear_down=False)
 
         baseurl = 'http://127.0.0.1:8080'
         master = yield fakemaster.make_master(self)
@@ -53,6 +53,10 @@ class Test(unittest.TestCase, TestReactorMixin):
 
         yield self.tested.setServiceParent(master)
         yield master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_root(self):

--- a/master/buildbot/test/unit/test_fake_secrets_manager.py
+++ b/master/buildbot/test/unit/test_fake_secrets_manager.py
@@ -11,11 +11,15 @@ from buildbot.test.reactor import TestReactorMixin
 class TestSecretsManager(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.master.config.secretsProviders = [
             FakeSecretStorage(secretdict={"foo": "bar", "other": "value"})
         ]
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testGetManagerService(self):

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -21,7 +21,7 @@ class FakeBuildWithMaster(FakeBuild):
 class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase, ConfigErrorsMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"foo": "bar", "other": "value"})
@@ -29,6 +29,10 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase, ConfigErrorsMi
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
         self.build = FakeBuildWithMaster(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret(self):
@@ -48,9 +52,13 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase, ConfigErrorsMi
 class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase, ConfigErrorsMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.build = FakeBuildWithMaster(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret(self):
@@ -64,7 +72,7 @@ class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase, Confi
 class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         password = "bar"
@@ -75,6 +83,10 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
         self.build = FakeBuildWithMaster(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret(self):

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -68,12 +68,14 @@ class LogChunksJanitorTests(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setup_test_build_step()
         self.patch(janitor, "now", lambda: datetime.datetime(year=2017, month=1, day=1))
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/test_machine_generic.py
+++ b/master/buildbot/test/unit/test_machine_generic.py
@@ -55,11 +55,12 @@ class TestActions(
     MasterRunProcessMixin, config.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        pass
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_local_wake_action(self):
@@ -262,11 +263,15 @@ class TestActions(
 class TestHttpAction(config.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, "http://localhost/request"
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_http_wrong_method(self):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -80,7 +80,7 @@ class InitTests(unittest.SynchronousTestCase):
 class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpLogging()
         self.basedir = os.path.abspath('basedir')
         yield self.setUpDirs(self.basedir)
@@ -107,8 +107,10 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
         self.data = self.master.data = fakedata.FakeDataConnector(self.master, self)
         yield self.data.setServiceParent(self.master)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tearDownDirs()
+        yield self.tearDownDirs()
+        yield self.tear_down_test_reactor()
 
     # tests
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -133,16 +133,24 @@ class RealTests(tuplematching.TupleMatchingMixin, Tests):
 class TestFakeMQ(TestReactorMixin, unittest.TestCase, Tests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True)
         self.mq = self.master.mq
         self.mq.verifyMessages = False
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class TestSimpleMQ(TestReactorMixin, unittest.TestCase, RealTests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         yield self.mq.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -42,11 +42,15 @@ class FakeMQ(service.ReconfigurableServiceMixin, base.MQBase):
 class MQConnector(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.mqconfig = self.master.config.mq = {}
         self.conn = connector.MQConnector()
         yield self.conn.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def patchFakeMQ(self, name='fake'):
         self.patch(

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -26,7 +26,7 @@ from buildbot.test.reactor import TestReactorMixin
 class SimpleMQ(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         self.mq.setServiceParent(self.master)
@@ -36,6 +36,7 @@ class SimpleMQ(TestReactorMixin, unittest.TestCase):
     def tearDown(self):
         if self.mq.running:
             yield self.mq.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_forward_data(self):

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -126,7 +126,7 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.master.wamp = FakeWampConnector()
         self.mq = wamp.WampMQ()
@@ -137,6 +137,7 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
     def tearDown(self):
         if self.mq.running:
             yield self.mq.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_startConsuming_basic(self):
@@ -248,7 +249,7 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         if "WAMP_ROUTER_URL" not in os.environ:
             raise unittest.SkipTest(self.HOW_TO_RUN)
         self.master = yield fakemaster.make_master(self)
@@ -261,8 +262,10 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
         config.mq['router_url'] = os.environ["WAMP_ROUTER_URL"]
         yield self.connector.reconfigServiceWithBuildbotConfig(config)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_forward_data(self):

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -33,7 +33,7 @@ class TestSecretInPass(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         self.master = yield fakemaster.make_master(self)
         with mock.patch.object(Path, "is_file", return_value=True):
@@ -45,6 +45,7 @@ class TestSecretInPass(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.srvpass.stopService()
+        yield self.tear_down_test_reactor()
 
     def create_temp_dir(self, dirname):
         tempdir = FilePath(self.mktemp())

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -25,7 +25,7 @@ class FakeServiceUsingSecrets(BuildbotService):
 class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage(secretdict={"foo": "bar", "other": "value"})
         self.secretsrv = SecretManager()
@@ -38,6 +38,7 @@ class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret_rendered(self):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -45,7 +45,7 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
 
         yield self.master.db.insert_test_data([
@@ -62,6 +62,7 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
 
 class TestStatsServicesConfiguration(TestStatsServicesBase):

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process import results
@@ -32,11 +33,13 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         skip = 'unidiff is required for GitDiffInfo tests'
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     def test_merge_base_failure(self):
         self.setup_step(gitdiffinfo.GitDiffInfo())

--- a/master/buildbot/test/unit/test_steps_mixin.py
+++ b/master/buildbot/test/unit/test_steps_mixin.py
@@ -48,11 +48,13 @@ class TestStep(buildstep.ShellMixin, buildstep.BuildStep):
 
 class TestTestBuildStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.tear_down_test_build_step()
+        yield self.tear_down_test_build_step()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_setup_build(self):

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -59,7 +59,7 @@ class TestedWampConnector(connector.WampConnector):
 class WampConnector(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         master = yield fakemaster.make_master(self)
         self.connector = TestedWampConnector()
 
@@ -68,6 +68,10 @@ class WampConnector(TestReactorMixin, unittest.TestCase):
         yield self.connector.setServiceParent(master)
         yield master.startService()
         yield self.connector.reconfigServiceWithBuildbotConfig(config)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfig_same_config(self):

--- a/master/buildbot/test/unit/util/test_backoff.py
+++ b/master/buildbot/test/unit/util/test_backoff.py
@@ -28,7 +28,11 @@ class TestException(Exception):
 
 class ExponentialBackoffEngineAsyncTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_construct_asserts(self):
         with self.assertRaises(ValueError):

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -42,10 +42,14 @@ class TestAbsoluteSourceStampsMixin(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.db = self.master.db
         self.object = FakeObject(self.master, self.codebases)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def mkch(self, **kwargs):

--- a/master/buildbot/test/unit/util/test_deferwaiter.py
+++ b/master/buildbot/test/unit/util/test_deferwaiter.py
@@ -76,7 +76,11 @@ class WaiterTests(unittest.TestCase):
 
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_does_not_add_action_on_start(self):
@@ -428,7 +432,11 @@ class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
 
 class NonRepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_does_not_add_action_on_start(self):

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -106,7 +106,7 @@ class KubeClientServiceTestKubeHardcodedConfig(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, "http://localhost:8001"
@@ -116,6 +116,7 @@ class KubeClientServiceTestKubeHardcodedConfig(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     def test_basic(self):
         self.config = kubeclientservice.KubeHardcodedConfig(

--- a/master/buildbot/test/unit/util/test_misc.py
+++ b/master/buildbot/test/unit/util/test_misc.py
@@ -86,8 +86,12 @@ class deferredLocked(unittest.TestCase):
 
 class TestCancelAfter(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.d = defer.Deferred()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_succeeds(self):
         d = misc.cancelAfter(10, self.d, self.reactor)

--- a/master/buildbot/test/unit/util/test_poll.py
+++ b/master/buildbot/test/unit/util/test_poll.py
@@ -31,7 +31,7 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
             raise RuntimeError('oh noes')
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = mock.Mock()
         self.master.reactor = self.reactor
 
@@ -39,9 +39,11 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
         self.calls = 0
         self.fail_after_running = False
 
+    @defer.inlineCallbacks
     def tearDown(self):
         poll.reset_poll_methods()
         self.assertEqual(self.reactor.getDelayedCalls(), [])
+        yield self.tear_down_test_reactor()
 
     def test_call_not_started_does_nothing(self):
         self.reactor.advance(100)
@@ -190,7 +192,7 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
             raise RuntimeError('oh noes')
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = mock.Mock()
         self.master.reactor = self.reactor
 
@@ -200,8 +202,10 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.duration = 1
         self.fail_after_running = False
 
+    @defer.inlineCallbacks
     def tearDown(self):
         poll.reset_poll_methods()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_call_when_started_forces_run(self):

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -37,10 +37,14 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
     FAKE_PID = 1234
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpLogging()
         self.process = None
         self.reactor.spawnProcess = self.fake_spawn_process
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def fake_spawn_process(self, pp, command, args, env, workdir, usePTY=False):
         self.assertIsNone(self.process)

--- a/master/buildbot/test/unit/util/test_service.py
+++ b/master/buildbot/test/unit/util/test_service.py
@@ -103,12 +103,13 @@ class ClusteredBuildbotService(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.svc = self.makeService()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        pass
+        yield self.tear_down_test_reactor()
 
     def makeService(self, attach_to_master=True, name=SVC_NAME, serviceid=SVC_ID):
         svc = self.DummyService(name=name)

--- a/master/buildbot/test/unit/util/test_state.py
+++ b/master/buildbot/test/unit/util/test_state.py
@@ -34,9 +34,13 @@ class TestStateMixin(TestReactorMixin, StateTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.object = FakeObject(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getState(self):

--- a/master/buildbot/test/unit/util/test_test_result_submitter.py
+++ b/master/buildbot/test/unit/util/test_test_result_submitter.py
@@ -25,7 +25,7 @@ from buildbot.util.test_result_submitter import TestResultSubmitter
 class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True)
         yield self.master.startService()
 
@@ -44,6 +44,7 @@ class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_complete_empty(self):

--- a/master/buildbot/test/unit/util/test_watchdog.py
+++ b/master/buildbot/test/unit/util/test_watchdog.py
@@ -15,6 +15,7 @@
 
 from unittest import mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.reactor import TestReactorMixin
@@ -23,7 +24,11 @@ from buildbot.util.watchdog import Watchdog
 
 class TestWatchdog(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_not_started_no_calls(self):
         m = mock.Mock()

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -115,8 +115,12 @@ class WorkerInterfaceTests(interfaces.InterfaceTests):
 
 class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.wrk = ConcreteWorker('wrk', 'pa')
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def callAttached(self):
@@ -133,9 +137,13 @@ class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
 class FakeWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.wrk = worker.FakeWorker(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def callAttached(self):
         self.conn = fakeprotocol.FakeConnection(self.wrk)
@@ -145,13 +153,17 @@ class FakeWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
 class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setUpLogging()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
         yield self.workers.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def createWorker(self, name='bot', password='pass', attached=False, configured=True, **kwargs):
@@ -916,12 +928,16 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
 class TestAbstractLatentWorker(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
         yield self.workers.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_reconfigService(self, old, new, existingRegistration=True):

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -47,7 +47,7 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         return self._client
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.patch(dockerworker, 'docker', docker)
 
@@ -60,6 +60,10 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         self.build2 = Properties(image='busybox:latest', builder='docker_worker2', distro='wheezy')
         docker.Client.containerCreated = False
         docker.Client.start_exception = None
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_constructor_noimage_nodockerfile(self):

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -63,7 +63,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
     worker = None
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, config=None, **kwargs):
@@ -85,6 +85,10 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
         self.assertTrue(config.running)
         self.addCleanup(self.master.stopService)
         return worker
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def get_expected_metadata(self):
         return {"name": "buildbot-worker-87de7e"}

--- a/master/buildbot/test/unit/worker/test_libvirt.py
+++ b/master/buildbot/test/unit/worker/test_libvirt.py
@@ -67,11 +67,15 @@ class TestException(Exception):
 
 class TestLibVirtWorker(TestReactorMixin, MasterRunProcessMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         self.connections = {}
         self.patch(libvirtworker, "libvirt", libvirtfake)
         self.threadpool = TestServerThreadPool(self)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def libvirt_open(self, uri):
         if uri not in self.connections:

--- a/master/buildbot/test/unit/worker/test_local.py
+++ b/master/buildbot/test/unit/worker/test_local.py
@@ -32,10 +32,14 @@ class TestLocalWorker(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         self.workers = self.master.workers
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def createWorker(self, name='bot', attached=False, configured=True, **kwargs):
         worker = local.LocalWorker(name, **kwargs)

--- a/master/buildbot/test/unit/worker/test_manager.py
+++ b/master/buildbot/test/unit/worker/test_manager.py
@@ -47,7 +47,7 @@ class FakeWorker2(FakeWorker):
 class TestWorkerManager(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.workers = workermanager.WorkerManager(self.master)
@@ -61,8 +61,10 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
         self.new_config = mock.Mock()
         self.workers.startService()
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.workers.stopService()
+        yield self.workers.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfigServiceWorkers_add_remove(self):

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -29,10 +29,11 @@ from buildbot.worker.marathon import MarathonLatentWorker
 
 class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.build = Properties(image="busybox:latest", builder="docker_worker")
         self.worker = None
 
+    @defer.inlineCallbacks
     def tearDown(self):
         if self.worker is not None:
 
@@ -40,8 +41,9 @@ class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
                 code = 200
 
             self._http.delete = lambda _: defer.succeed(FakeResult())
-            self.worker.master.stopService()
+            yield self.worker.master.stopService()
         self.flushLoggedErrors(LatentWorkerSubstantiatiationCancelled)
+        yield self.tear_down_test_reactor()
 
     def test_constructor_normal(self):
         worker = MarathonLatentWorker('bot', 'tcp://marathon.local', 'foo', 'bar', 'debian:wheezy')

--- a/master/buildbot/test/unit/worker/test_openstack.py
+++ b/master/buildbot/test/unit/worker/test_openstack.py
@@ -43,7 +43,7 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
     bs_image_args = {"flavor": 1, "image": '28a65eb4-f354-4420-97dc-253b826547f7', **os_auth}
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.patch(openstack, "client", novaclient)
         self.patch(openstack, "loading", novaclient)
         self.patch(openstack, "session", novaclient)
@@ -54,6 +54,10 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
             meta_value='value',
         )
         self.masterhash = hashlib.sha1(b'fake:/master').hexdigest()[:6]
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):

--- a/master/buildbot/test/unit/worker/test_protocols_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_base.py
@@ -15,6 +15,7 @@
 
 from unittest import mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakeprotocol
@@ -25,16 +26,24 @@ from buildbot.worker.protocols import base
 
 class TestFakeConnection(protocols.ConnectionInterfaceTest, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.worker = mock.Mock()
         self.conn = fakeprotocol.FakeConnection(self.worker)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class TestConnection(protocols.ConnectionInterfaceTest, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.worker = mock.Mock()
         self.conn = base.Connection(self.worker.workername)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_notify(self):
         cb = mock.Mock()

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -32,8 +32,12 @@ from buildbot.worker.protocols import msgpack
 class TestListener(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_constructor(self):
         listener = msgpack.Listener(self.master)
@@ -84,20 +88,28 @@ class TestConnectionApi(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.conn = msgpack.Connection(self.master, mock.Mock(), mock.Mock())
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class TestConnection(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.protocol = mock.Mock()
         self.worker = mock.Mock()
         self.worker.workername = 'test_worker'
         self.conn = msgpack.Connection(self.master, self.worker, self.protocol)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_constructor(self):
         self.assertEqual(self.conn.protocol, self.protocol)

--- a/master/buildbot/test/unit/worker/test_protocols_pb.py
+++ b/master/buildbot/test/unit/worker/test_protocols_pb.py
@@ -30,8 +30,12 @@ from buildbot.worker.protocols import pb
 class TestListener(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def makeListener(self):
         listener = pb.Listener(self.master)
@@ -85,18 +89,26 @@ class TestConnectionApi(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.conn = pb.Connection(self.master, mock.Mock(), mock.Mock())
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
 
 class TestConnection(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self)
         self.mind = mock.Mock()
         self.worker = mock.Mock()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_constructor(self):
         conn = pb.Connection(self.master, self.worker, self.mind)

--- a/master/buildbot/test/unit/worker/test_upcloud.py
+++ b/master/buildbot/test/unit/worker/test_upcloud.py
@@ -81,7 +81,11 @@ class TestUpcloudWorker(TestReactorMixin, unittest.TestCase):
     worker = None
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):

--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -42,9 +42,13 @@ class AuthResourceMixin:
 class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpAuthResource()
         self.rsrc = auth.AuthRootResource(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_getChild_login(self):
         glr = mock.Mock(name='glr')
@@ -62,11 +66,15 @@ class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, un
 class AuthBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.auth = auth.AuthBase()
         self.master = yield self.make_master(url='h:/a/b/')
         self.auth.master = self.master
         self.req = self.make_request(b'/')
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin(self):
@@ -103,10 +111,14 @@ class NoAuth(unittest.TestCase):
 class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         yield self.make_master()
         self.request = self.make_request(b'/')
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin(self):
@@ -143,10 +155,14 @@ class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         self.auth = auth.NoAuth()
         yield self.make_master()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_requestAvatar(self):
         realm = auth.AuthRealm(self.master, self.auth)
@@ -157,7 +173,7 @@ class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 class TwistedICredAuthBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
     # twisted.web makes it difficult to simulate the authentication process, so
     # this only tests the mechanics of the getLoginResource method.
@@ -192,7 +208,11 @@ class CustomAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             return us == 'fellow' and ps == 'correct'
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_callable(self):
@@ -208,8 +228,12 @@ class CustomAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class LoginResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpAuthResource()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -227,9 +251,13 @@ class PreAuthenticatedLoginResource(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpAuthResource()
         self.rsrc = auth.PreAuthenticatedLoginResource(self.master, 'him')
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -252,9 +280,13 @@ class PreAuthenticatedLoginResource(
 class LogoutResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpAuthResource()
         self.rsrc = auth.LogoutResource(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):

--- a/master/buildbot/test/unit/www/test_authz.py
+++ b/master/buildbot/test/unit/www/test_authz.py
@@ -36,7 +36,7 @@ from buildbot.www.authz.roles import RolesFromOwner
 class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         authzcfg = authz.Authz(
             # simple matcher with '*' glob character
             stringsMatcher=authz.fnmatchStrMatcher,
@@ -106,6 +106,10 @@ class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
                 id=15, builderid=77, masterid=88, workerid=13, buildrequestid=82, number=5
             ),
         ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def setAllowRules(self, allow_rules):
         # we should add links to authz and master instances in each new rule

--- a/master/buildbot/test/unit/www/test_avatar.py
+++ b/master/buildbot/test/unit/www/test_avatar.py
@@ -32,7 +32,11 @@ class TestAvatar(avatar.AvatarBase):
 
 class AvatarResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_default(self):
@@ -530,7 +534,7 @@ github_commit_search_not_found_reply = {"total_count": 0, "incomplete_results": 
 class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         master = yield self.make_master(
             url='http://a/b/',
@@ -558,6 +562,7 @@ class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_username(self):
@@ -732,7 +737,7 @@ class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class GitHubAvatarBasicAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         avatar_method = avatar.AvatarGitHub(client_id="oauth_id", client_secret="oauth_secret")
         master = yield self.make_master(
@@ -760,6 +765,7 @@ class GitHubAvatarBasicAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCas
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     def test_incomplete_credentials(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -51,7 +51,11 @@ class Utils(unittest.TestCase):
 
 class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -84,7 +88,11 @@ class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 class IndexResourceTest(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def get_react_base_path(self):
         path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/master/buildbot/test/unit/www/test_endpointmatchers.py
+++ b/master/buildbot/test/unit/www/test_endpointmatchers.py
@@ -27,12 +27,16 @@ from buildbot.www.authz import endpointmatchers
 class EndpointBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url='h:/a/b/')
         self.db = self.master.db
         self.matcher = self.makeMatcher()
         self.matcher.setAuthz(self.master.authz)
         yield self.insertData()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def makeMatcher(self):
         raise NotImplementedError()

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -225,10 +225,14 @@ class DisabledV3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCa
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url="http://server/path/")
         self.rsrc = graphql.V3RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic_disabled(self):

--- a/master/buildbot/test/unit/www/test_hooks_base.py
+++ b/master/buildbot/test/unit/www/test_hooks_base.py
@@ -39,8 +39,12 @@ def _prepare_request(payload, headers=None):
 class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.changeHook = yield _prepare_base_change_hook(self)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_base_with_change(self, payload):
@@ -98,7 +102,7 @@ class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCustomBase(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         class CustomBase(BaseHookHandler):
             def getChanges(self, request):
@@ -112,6 +116,10 @@ class TestChangeHookConfiguredWithCustomBase(unittest.TestCase, TestReactorMixin
                 return ([chdict], None)
 
         self.changeHook = yield _prepare_base_change_hook(self, custom_class=CustomBase)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_base_with_change(self, payload):

--- a/master/buildbot/test/unit/www/test_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucket.py
@@ -139,11 +139,15 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase, TestReactor
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         master = yield fakeMasterForHooks(self)
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucket': True}, master=master
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testGitWithChange(self):

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
@@ -684,7 +684,7 @@ def _prepare_request(payload, headers=None, change_dict=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         master = yield fakeMasterForHooks(self)
         self.change_hook = change_hook.ChangeHookResource(
             dialects={
@@ -694,6 +694,10 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
             },
             master=master,
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
@@ -709,7 +709,7 @@ def _prepare_request(payload, headers=None, change_dict=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         master = yield fakeMasterForHooks(self)
         self.change_hook = change_hook.ChangeHookResource(
             dialects={
@@ -719,6 +719,10 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
             },
             master=master,
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -609,7 +609,7 @@ def _prepare_request(event, payload, _secret=None, headers=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"]
         )
@@ -628,6 +628,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}
@@ -886,7 +887,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"], pullrequest_ref="head"
         )
@@ -905,6 +906,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_git_pull_request_with_custom_ref(self):
@@ -927,7 +929,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
             self,
@@ -954,6 +956,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_git_pull_request_with_custom_ref(self):
@@ -977,7 +980,7 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         self.changeHook = yield _prepare_github_change_hook(
             self,
@@ -1012,6 +1015,7 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_git_pull_request(self):
@@ -1030,7 +1034,7 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, skips=[r'\[ *bb *skip *\]'], token=_token
@@ -1053,6 +1057,7 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReac
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_push_with_skip_message(self, payload):
@@ -1121,7 +1126,7 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReac
 class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
@@ -1145,6 +1150,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}
@@ -1243,7 +1249,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, github_api_endpoint='https://black.magic.io'
         )
@@ -1262,6 +1268,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMi
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_pull_request(self, payload):
@@ -1281,7 +1288,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMi
 class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
@@ -1305,6 +1312,7 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase, TestR
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_pull_request(self, payload):
@@ -1326,7 +1334,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"secret_key": self._SECRET})
@@ -1338,6 +1346,10 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
             self, strict=True, secret=util.Secret("secret_key")
         )
         self.changeHook.master.addService(secretService)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_signature_ok(self):
@@ -1430,8 +1442,12 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.changeHook = yield _prepare_github_change_hook(self, codebase='foobar')
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_git_with_change(self, payload):
@@ -1455,8 +1471,12 @@ def _codebase_function(payload):
 class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.changeHook = yield _prepare_github_change_hook(self, codebase=_codebase_function)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_git_with_change(self, payload):
@@ -1476,7 +1496,7 @@ class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase, TestReacto
 class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         class CustomGitHubEventHandler(GitHubEventHandler):
             def handle_ping(self, _, __):
@@ -1486,6 +1506,10 @@ class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase, TestReac
         self.changeHook = yield _prepare_github_change_hook(
             self, **{'class': CustomGitHubEventHandler}
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_ping(self):

--- a/master/buildbot/test/unit/www/test_hooks_gitlab.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitlab.py
@@ -1019,9 +1019,13 @@ def FakeRequestMR(content):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         master = yield fakeMasterForHooks(self)
         self.changeHook = change_hook.ChangeHookResource(dialects={'gitlab': True}, master=master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def check_changes_tag_event(self, r, project='', codebase=None):
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
@@ -1248,7 +1252,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakeMasterForHooks(self)
 
         fakeStorageService = FakeSecretStorage()
@@ -1261,6 +1265,10 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase, TestReactorMixin):
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitlab': {'secret': util.Secret("secret_key")}}, master=self.master
         )
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_missing_secret(self):

--- a/master/buildbot/test/unit/www/test_hooks_gitorious.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitorious.py
@@ -64,10 +64,14 @@ gitJsonPayload = b"""
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         dialects = {'gitorious': True}
         master = yield fakeMasterForHooks(self)
         self.changeHook = change_hook.ChangeHookResource(dialects=dialects, master=master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     # Test 'base' hook with attributes. We should get a json string
     # representing a Change object as a dictionary. All values show be set.

--- a/master/buildbot/test/unit/www/test_hooks_poller.py
+++ b/master/buildbot/test/unit/www/test_hooks_poller.py
@@ -35,7 +35,7 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
             self.called = True
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
     @defer.inlineCallbacks
     def setUpRequest(self, args, options=True, activate=True):
@@ -66,8 +66,10 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
         yield self.request.test_render(self.changeHook)
         yield util.asyncSleep(0.1)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.master.stopService()
+        yield self.master.stopService()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_args(self):

--- a/master/buildbot/test/unit/www/test_ldapuserinfo.py
+++ b/master/buildbot/test/unit/www/test_ldapuserinfo.py
@@ -186,7 +186,7 @@ class LdapAvatar(CommonTestCase, TestReactorMixin, WwwTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
         CommonTestCase.setUp(self)
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         master = yield self.make_master(url='http://a/b/', avatar_methods=[self.userInfoProvider])
 
@@ -194,6 +194,10 @@ class LdapAvatar(CommonTestCase, TestReactorMixin, WwwTestMixin):
         self.rsrc.reconfigResource(master.config)
 
         yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def makeUserInfoProvider(self):
         self.userInfoProvider = ldapuserinfo.LdapUserInfo(

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -60,7 +60,7 @@ class FakeResponse:
 class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
 
@@ -112,6 +112,10 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
         secret_service.services = [fake_storage_service]
         yield secret_service.setServiceParent(self._master)
         self.githubAuth_secret.reconfigAuth(master, master.config)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getGoogleLoginURL(self):
@@ -553,7 +557,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
@@ -584,6 +588,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
         for reader in reactor.getReaders():
             if isinstance(reader, Server):
                 reader.connectionLost(f)
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_E2E(self):

--- a/master/buildbot/test/unit/www/test_resource.py
+++ b/master/buildbot/test/unit/www/test_resource.py
@@ -28,7 +28,11 @@ class ResourceSubclass(resource.Resource):
 
 class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_base_url(self):
@@ -45,7 +49,11 @@ class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 class RedirectResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_redirect(self):

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -37,8 +37,12 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     maxVersion = 3
 
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         _ = graphql  # used for import side effect
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -71,11 +75,15 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class V2RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url='http://server/path/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertSimpleError(self, message, responseCode):
         content = json.dumps({'error': message})
@@ -140,7 +148,7 @@ class V2RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url='h:/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
@@ -152,6 +160,10 @@ class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
             return defer.succeed(None)
 
         self.rsrc.renderRest = renderRest
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertOk(self, expectHeaders=True, content=b'ok', origin=b'h://good'):
         hdrs = (
@@ -260,7 +272,7 @@ class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
 class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url='h:/')
         self.master.config.www['debug'] = True
         self.master.data._scanModule(endpoint)
@@ -276,6 +288,10 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
         endpoint.TestsEndpoint.rtype = mock.MagicMock()
         endpoint.Test.kind = EndpointKind.COLLECTION
         endpoint.Test.rtype = endpoint.Test
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertRestCollection(
         self, typeName, items, total=None, contentType=None, orderSignificant=False
@@ -753,7 +769,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
 class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url='h:/')
 
         def allow(*args, **kw):
@@ -764,6 +780,10 @@ class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin, unittest.TestC
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def assertJsonRpcError(self, message, responseCode=400, jsonrpccode=None):
         got = {}

--- a/master/buildbot/test/unit/www/test_service.py
+++ b/master/buildbot/test/unit/www/test_service.py
@@ -59,10 +59,14 @@ class NeedsReconfigResource(resource.Resource):
 class Test(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield self.make_master(url='h:/a/b/')
         self.svc = self.master.www = service.WWWService()
         yield self.svc.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def makeConfig(self, **kwargs):
         w = {"port": None, "auth": auth.NoAuth(), "logfileName": 'l'}

--- a/master/buildbot/test/unit/www/test_sse.py
+++ b/master/buildbot/test/unit/www/test_sse.py
@@ -32,9 +32,13 @@ from buildbot.www import sse
 class EventResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = master = yield self.make_master(url=b'h:/a/b/')
         self.sse = sse.EventResource(master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tear_down_test_reactor()
 
     def test_simpleapi(self):
         self.render_resource(self.sse, b'/changes/*/*')

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -52,7 +52,7 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
     @defer.inlineCallbacks
     def setUpConnectorComponent(self, table_names=None, basedir='basedir', dialect_name='sqlite'):
         """Set up C{self.db}, using the given db_url and basedir."""
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
 
         if table_names is None:
             table_names = []
@@ -74,6 +74,7 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
         del self.db.pool
         del self.db.model
         del self.db
+        yield self.tear_down_test_reactor()
 
 
 class FakeConnectorComponentMixin(TestReactorMixin):
@@ -81,8 +82,12 @@ class FakeConnectorComponentMixin(TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUpConnectorComponent(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insert_test_data = self.db.insert_test_data
+
+    @defer.inlineCallbacks
+    def tearDownConnectorComponent(self):
+        yield self.tear_down_test_reactor()

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -38,7 +38,7 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def setUpEndpoint(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.db = self.master.db
         self.mq = self.master.mq
@@ -68,8 +68,9 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
             if pp is not None
         ]
 
+    @defer.inlineCallbacks
     def tearDownEndpoint(self):
-        pass
+        yield self.tear_down_test_reactor()
 
     def validateData(self, object):
         validation.verifyData(self, self.rtype.entityType, {}, object)

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -85,11 +85,13 @@ def getMaster(case, reactor, config_dict):
 
 class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
     def setUp(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.setupDebugIntegrationLogs()
 
+    @defer.inlineCallbacks
     def tearDown(self):
         self.assertFalse(self.master.running, "master is still running!")
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_master(self, config_dict):

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
     @defer.inlineCallbacks
     def setUpMigrateTest(self):
-        self.setup_test_reactor()
+        self.setup_test_reactor(auto_tear_down=False)
         self.basedir = os.path.abspath("basedir")
         self.setUpDirs('basedir')
 
@@ -57,9 +57,11 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
         yield self.db.setServiceParent(master)
         self.db.pool = self.db_pool
 
+    @defer.inlineCallbacks
     def tearDownMigrateTest(self):
         self.tearDownDirs()
-        return self.tearDownRealDatabase()
+        yield self.tearDownRealDatabase()
+        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_migration(self, base_revision, target_revision, setup_thd_cb, verify_thd_cb):

--- a/master/docs/manual/configuration/tests/reactor.rst
+++ b/master/docs/manual/configuration/tests/reactor.rst
@@ -15,8 +15,17 @@ TestReactorMixin
 
     For more information see the documentation of `twisted.internet.task.Clock <https://twistedmatrix.com/documents/current/api/twisted.internet.task.Clock.html>`_.
 
-    .. py:method:: setup_test_reactor(use_asyncio=False)
+    .. py:method:: setup_test_reactor(use_asyncio=False, auto_tear_down=True)
 
-        :param bool use_asyncio Whether to enable asyncio integration.
+        :param bool use_asyncio: Whether to enable asyncio integration.
+        :param bool auto_tear_down: Whether to automatically tear down the test reactor. This
+            option is deprecated in favor of ``tear_down_test_reactor()`` as the automatic tear
+            down can only run before ``tearDown()`` and thus in many tests the test reactor is
+            shut down prematurely.
 
         Call this function in the ``setUp()`` of the test case to setup fake reactor.
+
+    .. py:method:: tear_down_test_reactor()
+
+        Call this function in the ``tearDown()`` of the test case to tear down fake reactor.
+        The function returns a ``Deferred``.

--- a/master/docs/manual/configuration/tests/steps.rst
+++ b/master/docs/manual/configuration/tests/steps.rst
@@ -16,12 +16,15 @@ TestBuildStepMixin
 
         class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
+            @defer.inlineCallbacks
             def setUp(self):
-                self.setup_test_reactor()
-                return self.setup_test_build_step()
+                yield self.setup_test_reactor(auto_tear_down=False)
+                yield self.setup_test_build_step()
 
+            @defer.inlineCallbacks
             def tearDown(self):
-                return self.tear_down_test_build_step()
+                yield self.tear_down_test_build_step()
+                yield self.tear_down_test_reactor()
 
             @defer.inlineCallbacks
             def test_run_ok(self):
@@ -32,7 +35,7 @@ TestBuildStepMixin
                     .exit(0)
                 )
                 self.expect_outcome(result=SUCCESS, state_string='remove .pycs')
-                return self.run_step()
+                yield self.run_step()
 
     Basic workflow is as follows:
 

--- a/newsfragments/teast-reactor-mixin-explicit-tear-down.feature
+++ b/newsfragments/teast-reactor-mixin-explicit-tear-down.feature
@@ -1,0 +1,1 @@
+Added a way to setup ``TestReactorMixin`` with explicit tear down function.


### PR DESCRIPTION
`addCleanup` runs before `tearDown`. Tearing down TestReactorMixin in `addCleanup` functions results in database being unavailable in `tearDown`, so any shutdown code there will most likely fail. This PR introduces a way to control shutdown of TestReactorMixin explicitly so that it's possible to run it as the very last thing.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
