### PR TITLE
Fix issues in "Scheduled biweekly dependency update for week 42" 

### DIFF
--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,2 +1,2 @@
 buildbot[bundle]==4.1.0
-psycopg2cffi-compat
+psycopg2cffi-compat==1.1

--- a/master/docker-example/pypy/master/requirements.txt
+++ b/master/docker-example/pypy/master/requirements.txt
@@ -1,2 +1,2 @@
-buildbot[bundle]
+buildbot[bundle]==4.1.0
 psycopg2cffi-compat

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -67,7 +67,7 @@ PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.3
 ruff==0.7.0
-s3transfer==0.10.2
+s3transfer==0.10.3
 service-identity==24.1.0
 setuptools-trial==0.6.0
 six==1.16.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -14,7 +14,7 @@ mypy==1.12.1
 mypy-zope==1.0.6
 graphql-core==3.3.0a6; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
 graphql-core==3.2.5; python_version < "3.12"
-psutil==6.0.0
+psutil==6.1.0
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests
 # are reproducible. The versions should be upgraded whenever we see new versions to catch problems

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -71,7 +71,7 @@ s3transfer==0.10.3
 service-identity==24.1.0
 setuptools-trial==0.6.0
 six==1.16.0
-SQLAlchemy==2.0.35
+SQLAlchemy==2.0.36
 treq==24.9.1;  python_version >= "3.9"
 treq==22.2.0;  python_version < "3.9" # pyup: ignore
 Twisted==24.7.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -48,7 +48,8 @@ lz4==4.3.3
 zstandard==0.23.0
 Brotli==1.1.0
 Mako==1.3.5
-MarkupSafe==2.1.5
+MarkupSafe==3.0.2;  python_version >= "3.9"
+MarkupSafe==2.1.5;  python_version < "3.9" # pyup: ignore
 moto==5.0.16
 msgpack==1.1.0
 mypy-extensions==1.0.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,7 +10,7 @@ coverage==7.6.1; python_version < "3.9" # pyup: ignore
 docker==7.1.0
 hvac==2.3.0
 ldap3==2.9.1
-mypy==1.11.2
+mypy==1.12.1
 mypy-zope==1.0.6
 graphql-core==3.3.0a6; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
 graphql-core==3.2.4; python_version < "3.12"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -31,7 +31,7 @@ boto3==1.35.44
 botocore==1.35.44
 certifi==2024.8.30
 cffi==1.17.1
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
 constantly==23.10.4
 croniter==3.0.3
 cryptography==43.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,7 +11,7 @@ docker==7.1.0
 hvac==2.3.0
 ldap3==2.9.1
 mypy==1.12.1
-mypy-zope==1.0.6
+mypy-zope==1.0.8
 graphql-core==3.3.0a6; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
 graphql-core==3.2.5; python_version < "3.12"
 psutil==6.1.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 -e worker
 -e pkg
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
-buildbot-www==4.0.3
+buildbot-www==4.1.0
 
 Markdown==3.7
 coverage==7.6.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -66,7 +66,7 @@ pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.3
-ruff==0.6.9
+ruff==0.7.0
 s3transfer==0.10.2
 service-identity==24.1.0
 setuptools-trial==0.6.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -82,7 +82,7 @@ unidiff==0.7.5
 # botocore depends on urllib3<1.27
 urllib3==1.26.19  # pyup: ignore
 Werkzeug==3.0.4
-xmltodict==0.13.0
+xmltodict==0.14.2
 zope.event==5.0
 zope.interface==7.0.3
 zope.schema==7.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -84,5 +84,5 @@ urllib3==1.26.19  # pyup: ignore
 Werkzeug==3.0.4
 xmltodict==0.14.2
 zope.event==5.0
-zope.interface==7.0.3
+zope.interface==7.1.0
 zope.schema==7.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -28,7 +28,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
 boto3==1.35.44
-botocore==1.35.34
+botocore==1.35.44
 certifi==2024.8.30
 cffi==1.17.1
 charset-normalizer==3.3.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -50,7 +50,7 @@ Brotli==1.1.0
 Mako==1.3.5
 MarkupSafe==3.0.2;  python_version >= "3.9"
 MarkupSafe==2.1.5;  python_version < "3.9" # pyup: ignore
-moto==5.0.16
+moto==5.0.18
 msgpack==1.1.0
 mypy-extensions==1.0.0
 packaging==24.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,7 +13,7 @@ ldap3==2.9.1
 mypy==1.12.1
 mypy-zope==1.0.6
 graphql-core==3.3.0a6; python_version >= "3.12" # pyup: ignore (temporary switch to PRE-RELEASE version; remove this once 3.3.0 or newer is released as RELEASE version)
-graphql-core==3.2.4; python_version < "3.12"
+graphql-core==3.2.5; python_version < "3.12"
 psutil==6.0.0
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,7 +5,8 @@
 buildbot-www==4.1.0
 
 Markdown==3.7
-coverage==7.6.1
+coverage==7.6.4;  python_version >= "3.9"
+coverage==7.6.1; python_version < "3.9" # pyup: ignore
 docker==7.1.0
 hvac==2.3.0
 ldap3==2.9.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
-boto3==1.35.34
+boto3==1.35.44
 botocore==1.35.34
 certifi==2024.8.30
 cffi==1.17.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
 charset-normalizer==3.4.0
 constantly==23.10.4
 croniter==3.0.3
-cryptography==43.0.1
+cryptography==43.0.3
 dill==0.3.9
 evalidate==2.0.3
 greenlet==3.1.1

--- a/requirements-cidb.txt
+++ b/requirements-cidb.txt
@@ -1,5 +1,5 @@
 psycopg2-binary==2.9.10
-mysqlclient==2.2.4
+mysqlclient==2.2.5
 pg8000==1.31.2
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/requirements-cidb.txt
+++ b/requirements-cidb.txt
@@ -1,4 +1,4 @@
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 mysqlclient==2.2.4
 pg8000==1.31.2
 

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -3,7 +3,7 @@ Sphinx==7.4.7;  python_version == "3.9" # pyup: ignore
 Sphinx==8.1.3;  python_version >= "3.10"
 sphinx-jinja==2.0.2
 sphinx-rtd-theme==2.0.0;  python_version < "3.10" # pyup: ignore
-sphinx-rtd-theme==3.0.0;  python_version >= "3.10"
+sphinx-rtd-theme==3.0.1;  python_version >= "3.10"
 sphinxcontrib-applehelp==1.0.4;  python_version < "3.9" # pyup: ignore
 sphinxcontrib-applehelp==2.0.0;  python_version >= "3.9"
 sphinxcontrib-devhelp==1.0.2;  python_version < "3.9" # pyup: ignore

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,6 +1,6 @@
 Sphinx==7.1.2;  python_version < "3.9" # pyup: ignore
 Sphinx==7.4.7;  python_version == "3.9" # pyup: ignore
-Sphinx==8.0.2;  python_version >= "3.10"
+Sphinx==8.1.3;  python_version >= "3.10"
 sphinx-jinja==2.0.2
 sphinx-rtd-theme==2.0.0;  python_version < "3.10" # pyup: ignore
 sphinx-rtd-theme==3.0.0;  python_version >= "3.10"

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -17,7 +17,7 @@ mock==5.1.0
 parameterized==0.9.0
 pbr==6.1.0
 PyHamcrest==1.9.0
-psutil==6.0.0
+psutil==6.1.0
 pycparser==2.21;  python_version < "3.8" # pyup: ignore
 pycparser==2.22;  python_version >= "3.8"
 six==1.16.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -27,5 +27,5 @@ txaio==23.1.1
 typing-extensions==4.7.1;  python_version < "3.8" # pyup: ignore
 typing-extensions==4.12.2;  python_version >= "3.8"
 zope.interface==6.4.post2;  python_version < "3.8" # pyup: ignore
-zope.interface==7.0.3;  python_version >= "3.8"
+zope.interface==7.1.0;  python_version >= "3.8"
 -e worker

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -7,7 +7,7 @@ cffi==1.15.1;  python_version < "3.8"  # pyup: ignore
 cffi==1.17.1;  python_version >= "3.8"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==43.0.1
+cryptography==43.0.3
 funcsigs==1.0.2
 hyperlink==21.0.0
 idna==3.10

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -16,7 +16,7 @@ incremental==24.7.2;  python_version >= "3.8"
 mock==5.1.0
 parameterized==0.9.0
 pbr==6.1.0
-PyHamcrest==1.9.0
+PyHamcrest==2.1.0
 psutil==6.1.0
 pycparser==2.21;  python_version < "3.8" # pyup: ignore
 pycparser==2.22;  python_version >= "3.8"

--- a/requirements-master-docker-extras.txt
+++ b/requirements-master-docker-extras.txt
@@ -1,4 +1,4 @@
 requests==2.32.3
-psycopg2==2.9.9
+psycopg2==2.9.10
 txrequests==0.9.6
 pycairo==1.27.0

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,6 +1,6 @@
 pip==24.0; python_version < "3.8"  # pyup: ignore
 pip==24.2; python_version >= "3.8"
 setuptools==68.0.0; python_version < "3.8"  # pyup: ignore
-setuptools==75.1.0; python_version >= "3.8"
+setuptools==75.2.0; python_version >= "3.8"
 wheel==0.42.0; python_version < "3.8"  # pyup: ignore
 wheel==0.44.0; python_version >= "3.8"


### PR DESCRIPTION
This PR is based on https://github.com/buildbot/buildbot/pull/8147 with these modifications:

* updated `mypy-zope` to 1.0.8 see https://github.com/Shoobx/mypy-zope/pull/123
* removed `pyasn1` upgrade because `ladp3` depends on it and generates warning: "builtins.DeprecationWarning: tagMap is deprecated. Please use TAG_MAP instead." see https://github.com/cannatag/ldap3/issues/1159
* [conditional update](https://github.com/buildbot/buildbot/pull/8152/commits/1ed35a612d7f44219617b0100fb4afddbf89a318) of `coverage` due to 7.6.2 dropped support for Python 3.8 see https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-762--2024-10-09
* [conditional update](https://github.com/buildbot/buildbot/pull/8152/commits/fb87e1dcf1e3a0a2ea5d887986d49e0b264e46bb) of `MarkupSafe` due to 3.0.0 dropped support for Python 3.8 see https://github.com/pallets/markupsafe/blob/main/CHANGES.rst#version-300

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
