### PR TITLE
Fixes issue #8162

### DIFF
--- a/newsfragments/8162.bugfix
+++ b/newsfragments/8162.bugfix
@@ -1,0 +1,1 @@
+Fixes an `Access is denied` error on WIN32 when calling `AssignProcessToJobObject`. (:issue:`8162`)

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -54,6 +54,7 @@ if runtime.platformType == 'win32':
     import win32api
     import win32con
     import win32job
+    import win32process
 
 
 def win32_batch_quote(cmd_list, unicode_encoding='utf-8'):
@@ -638,10 +639,10 @@ class RunProcess:
                     processProtocol, executable, args, env, path, usePTY=usePTY
                 )
             pHandle = win32api.OpenProcess(win32con.PROCESS_ALL_ACCESS, False, int(process.pid))
-
-            # use JobObject to group subprocesses
-            self.job_object = self._create_job_object()
-            win32job.AssignProcessToJobObject(self.job_object, pHandle)
+            if win32process.GetExitCodeProcess(pHandle) == win32con.STILL_ACTIVE:
+                # use JobObject to group subprocesses
+                self.job_object = self._create_job_object()
+                win32job.AssignProcessToJobObject(self.job_object, pHandle)
             return process
 
         # use the ProcGroupProcess class, if available

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -554,6 +554,21 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         d = s._spawnAsBatch(s.pp, s.command, "args", tempEnviron, "path", False)
         return d
 
+    @defer.inlineCallbacks
+    @compat.skipUnlessPlatformIs("win32")
+    def test_assign_exited_process(self):
+        s = runprocess.RunProcess(
+            0,
+            ["cmd.exe", "/c", "exit"],
+            self.basedir,
+            'utf-8',
+            self.send_update,
+        )
+        yield s.start()
+
+        # Assert that the process completed successfully
+        self.assertTrue(('rc', 0) in self.updates, self.show())
+
     def test_spawnAsBatchCommandString(self):
         return self._test_spawnAsBatch("dir c:/", "cmd.exe")
 


### PR DESCRIPTION
Fix Access is denied error on WIN32 when assigning processes to job objects. On Windows, attempting to assign an already-exited process to a job object fails with an Access is denied error. This change checks if the process is still active before calling AssignProcessToJobObject, avoiding attempts to assign exited processes, which resolves the error.

`win32process.GetExitCodeProcess(pHandle) == win32con.STILL_ACTIVE:` will check if return code is 259 (macro STILL_ACTIVE) which indicate that process does not exit yet, and it is safe to assign in to the job.


## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
