### PR TITLE
db: fix logs compression tasks blocking main thread

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -308,6 +308,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 ),
                 reactor=self.master.reactor,
                 provider_threadpool=self._compression_pool,
+                # disable limit as we process one chunk at a time
+                max_backlog=0,
             ):
                 yield line
 
@@ -486,6 +488,13 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             ),
             reactor=self.master.reactor,
             provider_threadpool=self._compression_pool,
+            # In theory, memory usage could grow to:
+            # MAX_CHUNK_SIZE * max_backlog PER thread (capped by _compression_pool.maxthreads)
+            # with:
+            #   - MAX_CHUNK_SIZE = 64KB
+            #   - max_backlog = 100
+            # ~6MB per thread
+            max_backlog=100,
         ):
             last_line = chunk_first_line + chunk_lines_count - 1
 


### PR DESCRIPTION
As mentioned [here](https://github.com/buildbot/buildbot/pull/8157#issuecomment-2447845229), this fix a pretty serious issue introduced in #8157.

Running a function which is a Generator in a thread, will result in the Generator work being done on the consumer thread.

Solution here is to use a queue to communicate between the threads. Capped at 1 element so that, if for some reason, the DB thread is not quick enough to flush the queue, the compression thread will only have one chunk in memory at a time.

Annoyingly, in tests, the (~`NullPool`~ -> )`NonThreadPool` is used, which run the workload on the current thread, cause a deadlock, leading to the uncapping of the queue conditioned on `get_is_in_unit_tests`.

I could modify (~`NullPool`~ -> )`NonThreadPool` to be have a single thread (maybe one per test case to handle `trial -jX` runs). (EDIT: integration tests do not use `NonThreadPool`, so we can rely on them)

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
