### PR TITLE
db: ZStdCompressor re-use (De)Compressor

### DIFF
--- a/master/buildbot/db/compression/zstd.py
+++ b/master/buildbot/db/compression/zstd.py
@@ -15,8 +15,23 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+from threading import Lock
+from typing import TYPE_CHECKING
+from typing import Generic
+from typing import TypeVar
+
 from buildbot.db.compression.protocol import CompressObjInterface
 from buildbot.db.compression.protocol import CompressorInterface
+
+if TYPE_CHECKING:
+    from typing import Callable
+    from typing import ClassVar
+    from typing import Generator
+
+
+_T = TypeVar('_T')
 
 try:
     import zstandard
@@ -26,42 +41,114 @@ except ImportError:
     HAS_ZSTD = False
 
 
+class _Pool(Generic[_T]):
+    """zstandard ZstdCompressor/ZstdDecompressor are provide better performance when re-used, but are not thread-safe"""
+
+    def __init__(self, item_ctor: Callable[[], _T], max_size: int | None = None) -> None:
+        if max_size is None:
+            max_size = 1
+            if cpu_count := os.cpu_count():
+                max_size = max(cpu_count, max_size)
+
+        self._item_ctor = item_ctor
+        self._pool: list[_T] = []
+        self._lock = Lock()
+        self.max_size = max_size
+
+    def acquire(self) -> _T:
+        with self._lock:
+            if self._pool:
+                return self._pool.pop(-1)
+            # pool is empty, create a new object
+            return self._item_ctor()
+
+    def release(self, item: _T) -> None:
+        with self._lock:
+            if len(self._pool) < self.max_size:
+                self._pool.append(item)
+
+    @contextlib.contextmanager
+    def item(self) -> Generator[_T, None, None]:
+        item = self.acquire()
+        try:
+            yield item
+        finally:
+            self.release(item)
+
+    def set_max_size(self, new_size: int) -> None:
+        with self._lock:
+            if len(self._pool) > new_size:
+                self._pool = self._pool[:new_size]
+            self.max_size = new_size
+
+
 class ZStdCompressor(CompressorInterface):
     name = "zstd"
     available = HAS_ZSTD
 
     COMPRESS_LEVEL = 9
 
-    @staticmethod
-    def dumps(data: bytes) -> bytes:
-        return zstandard.compress(data, level=ZStdCompressor.COMPRESS_LEVEL)
+    if HAS_ZSTD:
+        _compressor_pool: ClassVar[_Pool[zstandard.ZstdCompressor]] = _Pool(
+            lambda: zstandard.ZstdCompressor(level=ZStdCompressor.COMPRESS_LEVEL)
+        )
+        _decompressor_pool: ClassVar[_Pool[zstandard.ZstdDecompressor]] = _Pool(
+            zstandard.ZstdDecompressor
+        )
 
-    @staticmethod
-    def read(data: bytes) -> bytes:
+    @classmethod
+    def set_pools_max_size(cls, new_size: int):
+        cls._compressor_pool.set_max_size(new_size)
+        cls._decompressor_pool.set_max_size(new_size)
+
+    @classmethod
+    def dumps(cls, data: bytes) -> bytes:
+        with cls._compressor_pool.item() as compressor:
+            return compressor.compress(data)
+
+    @classmethod
+    def read(cls, data: bytes) -> bytes:
         # data compressed with streaming APIs will not
         # contains the content size in it's frame header
         # which is expected by ZstdDecompressor.decompress
         # use ZstdDecompressionObj instead
         # see: https://github.com/indygreg/python-zstandard/issues/150
-        decompress_obj = zstandard.ZstdDecompressor().decompressobj()
-        return decompress_obj.decompress(data) + decompress_obj.flush()
+        with cls._decompressor_pool.item() as decompressor:
+            decompress_obj = decompressor.decompressobj()
+            return decompress_obj.decompress(data) + decompress_obj.flush()
 
     class CompressObj(CompressObjInterface):
         def __init__(self) -> None:
             # zstd compressor is safe to re-use
             # Note that it's not thread safe
-            self._compressor = zstandard.ZstdCompressor(level=ZStdCompressor.COMPRESS_LEVEL)
-            self._create_compressobj()
-
-        def _create_compressobj(self) -> None:
-            self._compressobj = self._compressor.compressobj()
+            self._compressor: zstandard.ZstdCompressor | None = None
+            self._compressobj: zstandard.ZstdCompressionObj | None = None
 
         def compress(self, data: bytes) -> bytes:
+            if self._compressor is None:
+                self._compressor = ZStdCompressor._compressor_pool.acquire()
+                self._compressobj = self._compressor.compressobj()
+            else:
+                assert (
+                    self._compressobj is not None
+                ), "Programming error: _compressobj is None when _compressor is not"
+
             return self._compressobj.compress(data)
 
         def flush(self) -> bytes:
+            assert (
+                self._compressor is not None
+            ), "Programming error: Flush called without previous compress"
+            assert (
+                self._compressobj is not None
+            ), "Programming error: _compressobj is None when _compressor is not"
+
             try:
                 return self._compressobj.flush(flush_mode=zstandard.COMPRESSOBJ_FLUSH_FINISH)
             finally:
-                # recreate compressobj so this instance can be re-used
-                self._create_compressobj()
+                # release _compressobj as it's not re-usable
+                self._compressobj = None
+                # return instance of compressor to pool
+                compressor = self._compressor
+                self._compressor = None
+                ZStdCompressor._compressor_pool.release(compressor)

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -17,6 +17,7 @@ import builtins
 import os
 import re
 import textwrap
+from importlib.util import find_spec
 from unittest import mock
 
 from parameterized import parameterized
@@ -45,12 +46,14 @@ from buildbot.util import service
 from buildbot.warnings import ConfigWarning
 from buildbot.warnings import DeprecatedApiWarning
 
+HAS_ZSTD = find_spec('zstandard') is not None
+
 global_defaults = {
     "title": 'Buildbot',
     "titleURL": 'http://buildbot.net/',
     "buildbotURL": 'http://localhost:8080/',
     "logCompressionLimit": 4096,
-    "logCompressionMethod": 'zstd',
+    "logCompressionMethod": 'zstd' if HAS_ZSTD else 'gz',
     "logEncoding": 'utf-8',
     "logMaxTailSize": None,
     "logMaxSize": None,

--- a/newsfragments/re-use-zstandard-compressors.misc
+++ b/newsfragments/re-use-zstandard-compressors.misc
@@ -1,0 +1,2 @@
+Improve logs compression operation performance with zstd.
+Logs compression/decompression tasks now re-use ``zstandard``'s ``ZstdCompressor`` and ``ZstdDecompressor`` objects, as advised in the documentation.


### PR DESCRIPTION
This greatly improve performances (as advised in [zstandard.compress](https://python-zstandard.readthedocs.io/en/latest/misc_apis.html#compress)).

eg.
buildbot.test.unit.db.test_logs.TestRealDB.test_deleteOldLogChunks_basic with compression level 22
from >5s (timeout cutoff) to ~.3s

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
