### PR TITLE
worker: Remove usePTY argument to Worker

### DIFF
--- a/newsfragments/worker-usepty.removal
+++ b/newsfragments/worker-usepty.removal
@@ -1,0 +1,2 @@
+``Worker.__init__`` no longer accepts ``usePTY`` argument. It has been deprecated for a long time
+and no other values than ``None`` were accepted.

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -643,7 +643,6 @@ class Worker(WorkerBase):
         passwd,
         basedir,
         keepalive,
-        usePTY=None,
         keepaliveTimeout=None,
         umask=None,
         maxdelay=None,
@@ -657,7 +656,6 @@ class Worker(WorkerBase):
         delete_leftover_dirs=False,
         proxy_connection_string=None,
     ):
-        assert usePTY is None, "worker-side usePTY is not supported anymore"
         assert connection_string is None or (buildmaster_host, port) == (
             None,
             None,


### PR DESCRIPTION
It has been deprecated for a long time and no other values than ``None`` were accepted.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
