### PR TITLE
util: explicit async_to_deferred return-type

### DIFF
--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
     _P = ParamSpec('_P')
 
 
-def async_to_deferred(fn: Callable[_P, Coroutine[Any, Any, _T]]):
+def async_to_deferred(
+    fn: Callable[_P, Coroutine[Any, Any, _T]],
+) -> Callable[_P, defer.Deferred[_T]]:
     @wraps(fn)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> defer.Deferred[_T]:
         try:


### PR DESCRIPTION
Inferred return type is
`_Wrapped[_P, Coroutine[Any, Any, _T], _P, Deferred[_T]]`

which generate errors on class method overrides.

eg.
```python
T = TypeVar('T')
InlineCallbacksType = Generator[defer.Deferred[Any], Any, T]

class Base:
    def method(self) -> Deferred[None]:
        return defer.succeed(None)

class Child(Base):
    @inlineCallbacks
    def method(self) -> InlineCallbacksType[None]:
        yield defer.succeed(None)
        return None

class AsyncChild(Child):
    @async_to_deferred
    async def method(self) -> None:
        return None
```

would generate a typing error on AsyncChild.method

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
