### PR TITLE
www: Fix empty ansi color reset code in log view

### DIFF
--- a/newsfragments/www-reset-ansi-colors-with-empty-reset-code.bugfix
+++ b/newsfragments/www-reset-ansi-colors-with-empty-reset-code.bugfix
@@ -1,0 +1,1 @@
+Fix ANSI color reset not resetting the color in Buildbot UI log output of a step.

--- a/www/base/src/util/AnsiEscapeCodes.test.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.test.tsx
@@ -135,6 +135,17 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
+    it('with empty reset code', () => {
+      // code sequence from protractor
+      const ret = parseEscapeCodesToSimple("\x1b[32m.\x1b[m\x1b[31mF\x1b[m\x1b[32m.\x1b[39m\x1b[32m.\x1b[m");
+      expect(ret).toEqual([
+        {class: "ansi32", text: "."},
+        {class: "ansi32 ansi31", text: "F"},
+        {class: "ansi32 ansi31", text: "."},
+        {class: "ansi32", text: "."},
+      ]);
+    });
+
     it('256 colors', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;71mDEBUG \x1b[38;5;72m[plugin]: \x1b[39mLoading plugin karma-jasmine.");

--- a/www/base/src/util/AnsiEscapeCodes.test.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.test.tsx
@@ -140,8 +140,8 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple("\x1b[32m.\x1b[m\x1b[31mF\x1b[m\x1b[32m.\x1b[39m\x1b[32m.\x1b[m");
       expect(ret).toEqual([
         {class: "ansi32", text: "."},
-        {class: "ansi32 ansi31", text: "F"},
-        {class: "ansi32 ansi31", text: "."},
+        {class: "ansi31", text: "F"},
+        {class: "ansi32", text: "."},
         {class: "ansi32", text: "."},
       ]);
     });

--- a/www/base/src/util/AnsiEscapeCodes.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.tsx
@@ -75,7 +75,9 @@ export function stripAnsiSgrEntry(ansiEntry: string): string {
 
 export function ansiSgrClassesToCss(ansiClasses: string[], cssClasses: {[key: string]: boolean}) {
   if (ansiClasses.length === 0) {
-    return cssClasses;
+    // According to ECMA-48 standard empty parameter set is interpreted as zero,
+    // which is a color reset code
+    return {};
   }
 
   const fgbg: {[key: string]: string} = {'38': 'fg', '48': 'bg'};


### PR DESCRIPTION
This PR completes and improves PR https://github.com/buildbot/buildbot/pull/7996.
Credit for solution goes to @q66. 

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
