### PR TITLE
scripts: Fix copydb script when rebuilt_buildid is present

### DIFF
--- a/newsfragments/copydb-rebuilt-buildid.bugfix
+++ b/newsfragments/copydb-rebuilt-buildid.bugfix
@@ -1,0 +1,1 @@
+Fixed ``copydb`` script when there are rebuilt builds in the database.


### PR DESCRIPTION
Since buildset.rebuilt_buildid creates a loop in table relationships, it must first be saved as NULL and then populated once the builds table is populated.

Tests haven't been added because they require new functionality in integration test layer.

## Contributor Checklist:

* [later] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
