### PR TITLE
docs: Fix Scheduler documentation regarding the "owner" property

### DIFF
--- a/master/docs/manual/configuration/schedulers.rst
+++ b/master/docs/manual/configuration/schedulers.rst
@@ -135,14 +135,14 @@ There are several common arguments for schedulers, although not all are availabl
 ``properties`` (optional)
 
     This is a dictionary specifying properties that will be transmitted to all builds started by this scheduler.
-    The ``owner`` property may be of particular interest, as its contents (list) will be added to the list of "interested users" (:ref:`Doing-Things-With-Users`) for each triggered build.
+    The ``owner`` property may be of particular interest, as its content (string) will be added to the list of "interested users" (:ref:`Doing-Things-With-Users`) for each triggered build.
     For example:
 
     .. code-block:: python
 
         sched = Scheduler(...,
             properties = {
-                'owner': ['zorro@example.com', 'silver@example.com']
+                'owner': 'zorro@example.com'
             })
 
 .. _Scheduler-Attr-Codebases:

--- a/newsfragments/singular-sheduler-owner-property.doc
+++ b/newsfragments/singular-sheduler-owner-property.doc
@@ -1,0 +1,2 @@
+Fixed Scheduler documentation to indicate that owner property is a string, not a list, and contains only one owner.
+This property was changed to singular and to string in Buildbot 1.0, but documentation was not updated.


### PR DESCRIPTION
This PR completes https://github.com/buildbot/buildbot/pull/8066 by adding a requested newsfragments file.
Thanks to @mattock for noticing the discrepancy and updating Buildbot documentation.

* [not_needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
