### PR TITLE
logs: Fix race condition in _async_iter_on_pool()

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -851,7 +851,7 @@ async def _async_iter_on_pool(
             for item in generator_sync():
                 with condition:
                     condition.wait_for(_can_put_in_queue)
-                queue.put(item)
+                reactor.callFromThread(queue.put, item)
         finally:
             if wait_backlog_consuption:
                 with condition:


### PR DESCRIPTION
Twisted is not thread safe, thus calling its functions from another thread is not safe. In particular case, DeferredQueue.put() is called from compression pool thread. This should happen via reactor.callFromThread().

cc @tdesveaux 
