### PR TITLE
scripts: Fix crash in copydb script when destination is postgres

### DIFF
--- a/master/buildbot/scripts/copydb.py
+++ b/master/buildbot/scripts/copydb.py
@@ -125,7 +125,9 @@ def _copy_single_table(
                             seq_name = f"{table_name}_{autoincrement_foreign_key_column}_seq"
                             transaction = conn.begin()
                             conn.execute(
-                                f"ALTER SEQUENCE {seq_name} RESTART WITH {max_column_id + 1}"
+                                sa.text(
+                                    f"ALTER SEQUENCE {seq_name} RESTART WITH {max_column_id + 1}"
+                                )
                             )
                             transaction.commit()
 


### PR DESCRIPTION
This is another SQLAlchemy 2.0 compatibility fix
