### PR TITLE
scripts: Support ignoring rows failing foreign key checks in copy-db

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -766,6 +766,7 @@ class CopyDBOptions(base.BasedirMixin, base.SubcommandOptions):
 
     optFlags = [
         ('quiet', 'q', "Don't display error messages or tracebacks"),
+        ('ignore-fk-error-rows', None, 'Ignore rows that have foreign key constraint errors'),
     ]
 
     def getSynopsis(self):

--- a/master/buildbot/test/unit/scripts/test_copydb.py
+++ b/master/buildbot/test/unit/scripts/test_copydb.py
@@ -38,6 +38,7 @@ def get_script_config(destination_url='sqlite://', **kwargs):
         "quiet": False,
         "basedir": os.path.abspath('basedir'),
         'destination_url': destination_url,
+        'ignore-fk-error-rows': True,
     }
     config.update(kwargs)
     return config

--- a/newsfragments/copydb-skip-foreign-key-constraint-errors.feature
+++ b/newsfragments/copydb-skip-foreign-key-constraint-errors.feature
@@ -1,0 +1,4 @@
+Added ``ignore-fk-error-rows`` option to ``copy-db`` script. It allows ignoring
+all rows that fail foreign key constraint checks. This is useful in cases when
+migrating from a database engine that does not support foreign key constraints
+to one that does.


### PR DESCRIPTION
This PR adds ``ignore-fk-error-rows`` option to ``copy-db`` script. It allows ignoring all rows that fail foreign key constraint checks. This is useful in cases when migrating from a database engine that does not support foreign key constraints to one that does.