### PR TITLE
www: Add more tests for parseEscapeCodesToClasses()

### DIFF
--- a/www/base/src/util/AnsiEscapeCodes.test.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.test.tsx
@@ -155,6 +155,582 @@ describe('AnsiEscapeCodes', () => {
         {class: '', text: 'Loading plugin karma-jasmine.'}]);
     });
 
+    it('SGRbg-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: 'ansi42 ansi43', text: 'TEXT2 '},
+        ]);
+    });
+
+    it('SGRbg-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[31mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: 'ansi42 ansi31', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRbg-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[43;31mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: 'ansi42 ansi43 ansi31', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRbg-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: 'ansibg-34', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRbg-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: 'ansifg-226', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRbg-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRbg-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRbg-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[42mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: 'ansi31 ansi42', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: 'ansi31 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[42;32mTEXT2 \x1b[0m"); // pridėti kitą bg spalvą¸kad parodytų, kaip permuša? Nebent vėliau permušantis testas bus
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: 'ansi31 ansi42 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m"); // pridėta pirmojo bg permušanti spalva
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: 'ansibg-34', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: 'ansifg-226', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRfg-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[31mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi31', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: 'ansi42 ansi31 ansi43', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: 'ansi42 ansi31 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: 'ansi42 ansi31 ansi43 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: 'ansibg-34', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: 'ansifg-226', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('SGRboth-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[42;31mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansi42 ansi31', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: 'ansibg-34 ansi43', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: 'ansibg-34 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: 'ansibg-34 ansi43 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: 'ansibg-36', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: 'ansifg-226', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256bg-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansibg-34', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: 'ansifg-196 ansi43', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: 'ansifg-196 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: 'ansifg-196 ansi43 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: 'ansibg-36', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: 'ansifg-226', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256fg-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[38;5;196mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: 'ansifg-196', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi43', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi43 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansibg-36', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansifg-228', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('256both-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;34;38;5;226mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi43', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi43 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansibg-36', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansifg-228', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-SGRbg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[43mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi43', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-SGRfg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-SGRboth', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansi43 ansi32', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-256bg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansibg-36', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-256fg', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: 'ansifg-228', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-256both', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-reset0m', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[0mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('resetm-resetm', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[mTEXT1 \x1b[mTEXT2 \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: 'TEXT1 '},
+        {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
     it('joint codes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[1;36mDEBUG [plugin]: \x1b[39mLoading plugin karma-jasmine.");


### PR DESCRIPTION
This PR adds more tests for parseEscapeCodesToClasses().

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
