### PR TITLE
test: convert Twisted's inlineCallbacks to async in fake

### DIFF
--- a/master/buildbot/test/fake/connection.py
+++ b/master/buildbot/test/fake/connection.py
@@ -15,6 +15,8 @@
 
 from twisted.internet import defer
 
+from buildbot.util.twisted import async_to_deferred
+
 
 class FakeConnection:
     is_fake_test_connection = True
@@ -30,19 +32,21 @@ class FakeConnection:
         self._next_command_number = 0
         self._blocked_deferreds = []
 
-    @defer.inlineCallbacks
-    def remoteStartCommand(self, remote_command, builder_name, command_id, command_name, args):
+    @async_to_deferred
+    async def remoteStartCommand(
+        self, remote_command, builder_name, command_id, command_name, args
+    ) -> None:
         self._waiting_for_interrupt = False
         if self._next_command_number in self._commands_numbers_to_interrupt:
             self._waiting_for_interrupt = True
 
-            yield self.step.interrupt('interrupt reason')
+            await self.step.interrupt('interrupt reason')
 
             if self._waiting_for_interrupt:
                 raise RuntimeError("Interrupted step, but command was not interrupted")
 
         self._next_command_number += 1
-        yield self.testcase._connection_remote_start_command(remote_command, self, builder_name)
+        await self.testcase._connection_remote_start_command(remote_command, self, builder_name)
 
         # running behaviors may still attempt interrupt the command
         if self._waiting_for_interrupt:

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import json
 
 from twisted.internet import defer
@@ -23,6 +25,7 @@ from buildbot.data import resultspec
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.test.util import validation
 from buildbot.util import service
+from buildbot.util.twisted import async_to_deferred
 
 
 class FakeUpdates(service.AsyncService):
@@ -149,8 +152,8 @@ class FakeUpdates(service.AsyncService):
     def expireMasters(self, forceHouseKeeping=False):
         return defer.succeed(None)
 
-    @defer.inlineCallbacks
-    def addBuildset(
+    @async_to_deferred
+    async def addBuildset(
         self,
         waited_for,
         scheduler=None,
@@ -163,7 +166,7 @@ class FakeUpdates(service.AsyncService):
         parent_buildid=None,
         parent_relationship=None,
         priority=0,
-    ):
+    ) -> tuple[int, dict[int, int]]:
         if sourcestamps is None:
             sourcestamps = []
         if properties is None:
@@ -187,7 +190,7 @@ class FakeUpdates(service.AsyncService):
 
         # call through to the db layer, since many scheduler tests expect to
         # find the buildset in the db later - TODO fix this!
-        bsid, brids = yield self.master.db.buildsets.addBuildset(
+        bsid, brids = await self.master.db.buildsets.addBuildset(
             sourcestamps=sourcestamps,
             reason=reason,
             properties=properties,
@@ -204,8 +207,8 @@ class FakeUpdates(service.AsyncService):
         self.maybeBuildsetCompleteCalls += 1
         return defer.succeed(None)
 
-    @defer.inlineCallbacks
-    def claimBuildRequests(self, brids, claimed_at=None):
+    @async_to_deferred
+    async def claimBuildRequests(self, brids, claimed_at=None) -> bool:
         validation.verifyType(
             self.testcase, 'brids', brids, validation.ListValidator(validation.IntValidator())
         )
@@ -218,7 +221,7 @@ class FakeUpdates(service.AsyncService):
         if not brids:
             return True
         try:
-            yield self.master.db.buildrequests.claimBuildRequests(
+            await self.master.db.buildrequests.claimBuildRequests(
                 brids=brids, claimed_at=claimed_at
             )
         except AlreadyClaimedError:
@@ -226,14 +229,14 @@ class FakeUpdates(service.AsyncService):
         self.claimedBuildRequests.update(set(brids))
         return True
 
-    @defer.inlineCallbacks
-    def unclaimBuildRequests(self, brids):
+    @async_to_deferred
+    async def unclaimBuildRequests(self, brids) -> None:
         validation.verifyType(
             self.testcase, 'brids', brids, validation.ListValidator(validation.IntValidator())
         )
         self.claimedBuildRequests.difference_update(set(brids))
         if brids:
-            yield self.master.db.buildrequests.unclaimBuildRequests(brids)
+            await self.master.db.buildrequests.unclaimBuildRequests(brids)
 
     def completeBuildRequests(self, brids, results, complete_at=None):
         validation.verifyType(
@@ -251,16 +254,16 @@ class FakeUpdates(service.AsyncService):
     def rebuildBuildrequest(self, buildrequest):
         return defer.succeed(None)
 
-    @defer.inlineCallbacks
-    def update_project_info(
+    @async_to_deferred
+    async def update_project_info(
         self,
         projectid,
         slug,
         description,
         description_format,
         description_html,
-    ):
-        yield self.master.db.projects.update_project_info(
+    ) -> None:
+        await self.master.db.projects.update_project_info(
             projectid, slug, description, description_format, description_html
         )
 
@@ -275,11 +278,11 @@ class FakeUpdates(service.AsyncService):
         self.builderNames = builderNames
         return defer.succeed(None)
 
-    @defer.inlineCallbacks
-    def updateBuilderInfo(
+    @async_to_deferred
+    async def updateBuilderInfo(
         self, builderid, description, description_format, description_html, projectid, tags
-    ):
-        yield self.master.db.builders.updateBuilderInfo(
+    ) -> None:
+        await self.master.db.builders.updateBuilderInfo(
             builderid, description, description_format, description_html, projectid, tags
         )
 
@@ -364,11 +367,11 @@ class FakeUpdates(service.AsyncService):
         validation.verifyType(self.testcase, 'source', source, validation.StringValidator())
         return defer.succeed(None)
 
-    @defer.inlineCallbacks
-    def setBuildProperties(self, buildid, properties):
+    @async_to_deferred
+    async def setBuildProperties(self, buildid, properties) -> None:
         for k, v, s in properties.getProperties().asList():
             self.properties.append((buildid, k, v, s))
-            yield self.setBuildProperty(buildid, k, v, s)
+            await self.setBuildProperty(buildid, k, v, s)
 
     def addStep(self, buildid, name):
         validation.verifyType(self.testcase, 'buildid', buildid, validation.IntValidator())
@@ -477,17 +480,19 @@ class FakeUpdates(service.AsyncService):
         return self.master.db.workers.set_worker_graceful(workerid, graceful)
 
     # methods form BuildData resource
-    @defer.inlineCallbacks
-    def setBuildData(self, buildid, name, value, source):
+    @async_to_deferred
+    async def setBuildData(self, buildid, name, value, source) -> None:
         validation.verifyType(self.testcase, 'buildid', buildid, validation.IntValidator())
         validation.verifyType(self.testcase, 'name', name, validation.StringValidator())
         validation.verifyType(self.testcase, 'value', value, validation.BinaryValidator())
         validation.verifyType(self.testcase, 'source', source, validation.StringValidator())
-        yield self.master.db.build_data.setBuildData(buildid, name, value, source)
+        await self.master.db.build_data.setBuildData(buildid, name, value, source)
 
     # methods from TestResultSet resource
-    @defer.inlineCallbacks
-    def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+    @async_to_deferred
+    async def addTestResultSet(
+        self, builderid, buildid, stepid, description, category, value_unit
+    ) -> int:
         validation.verifyType(self.testcase, 'builderid', builderid, validation.IntValidator())
         validation.verifyType(self.testcase, 'buildid', buildid, validation.IntValidator())
         validation.verifyType(self.testcase, 'stepid', stepid, validation.IntValidator())
@@ -497,13 +502,15 @@ class FakeUpdates(service.AsyncService):
         validation.verifyType(self.testcase, 'category', category, validation.StringValidator())
         validation.verifyType(self.testcase, 'value_unit', value_unit, validation.StringValidator())
 
-        test_result_setid = yield self.master.db.test_result_sets.addTestResultSet(
+        test_result_setid = await self.master.db.test_result_sets.addTestResultSet(
             builderid, buildid, stepid, description, category, value_unit
         )
         return test_result_setid
 
-    @defer.inlineCallbacks
-    def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+    @async_to_deferred
+    async def completeTestResultSet(
+        self, test_result_setid, tests_passed=None, tests_failed=None
+    ) -> None:
         validation.verifyType(
             self.testcase, 'test_result_setid', test_result_setid, validation.IntValidator()
         )
@@ -520,14 +527,14 @@ class FakeUpdates(service.AsyncService):
             validation.NoneOk(validation.IntValidator()),
         )
 
-        yield self.master.db.test_result_sets.completeTestResultSet(
+        await self.master.db.test_result_sets.completeTestResultSet(
             test_result_setid, tests_passed, tests_failed
         )
 
     # methods from TestResult resource
-    @defer.inlineCallbacks
-    def addTestResults(self, builderid, test_result_setid, result_values):
-        yield self.master.db.test_results.addTestResults(
+    @async_to_deferred
+    async def addTestResults(self, builderid, test_result_setid, result_values) -> None:
+        await self.master.db.test_results.addTestResults(
             builderid, test_result_setid, result_values
         )
 

--- a/master/buildbot/test/fake/fakemq.py
+++ b/master/buildbot/test/fake/fakemq.py
@@ -21,6 +21,7 @@ from buildbot.test.util import validation
 from buildbot.util import deferwaiter
 from buildbot.util import service
 from buildbot.util import tuplematch
+from buildbot.util.twisted import async_to_deferred
 
 
 class FakeMQConnector(service.AsyncMultiService, base.MQBase):
@@ -39,10 +40,10 @@ class FakeMQConnector(service.AsyncMultiService, base.MQBase):
         self.qrefs = []
         self._deferwaiter = deferwaiter.DeferWaiter()
 
-    @defer.inlineCallbacks
-    def stopService(self):
-        yield self._deferwaiter.wait()
-        yield super().stopService()
+    @async_to_deferred
+    async def stopService(self) -> None:
+        await self._deferwaiter.wait()
+        await super().stopService()
 
     def setup(self):
         self.setup_called = True
@@ -102,10 +103,10 @@ class FakeMQConnector(service.AsyncMultiService, base.MQBase):
             self.testcase.assertEqual(sorted(self.productions), sorted(exp))
         self.productions = []
 
-    @defer.inlineCallbacks
-    def wait_consumed(self):
+    @async_to_deferred
+    async def wait_consumed(self) -> None:
         # waits until all messages have been consumed
-        yield self._deferwaiter.wait()
+        await self._deferwaiter.wait()
 
 
 class FakeQueueRef:

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -22,6 +22,7 @@ from twisted.trial.unittest import SkipTest
 
 from buildbot.test.fake.worker import SeverWorkerConnectionMixin
 from buildbot.test.fake.worker import disconnect_master_side_worker
+from buildbot.util.twisted import async_to_deferred
 from buildbot.worker import AbstractLatentWorker
 
 RemoteWorker: type | None = None
@@ -104,43 +105,43 @@ class LatentController(SeverWorkerConnectionMixin):
         if self.auto_start_flag and self.state == States.STARTING:
             self.start_instance(True)
 
-    @defer.inlineCallbacks
-    def start_instance(self, result):
-        yield self.do_start_instance(result)
+    @async_to_deferred
+    async def start_instance(self, result) -> None:
+        await self.do_start_instance(result)
         d = self._start_deferred
         self._start_deferred = None
         d.callback(result)
 
-    @defer.inlineCallbacks
-    def do_start_instance(self, result):
+    @async_to_deferred
+    async def do_start_instance(self, result) -> None:
         assert self.state == States.STARTING
         self.state = States.STARTED
         if self.auto_connect_worker and result is True:
-            yield self.connect_worker()
+            await self.connect_worker()
 
-    @defer.inlineCallbacks
-    def auto_stop(self, result):
+    @async_to_deferred
+    async def auto_stop(self, result) -> None:
         self.auto_stop_flag = result
         if self.auto_stop_flag and self.state == States.STOPPING:
-            yield self.stop_instance(True)
+            await self.stop_instance(True)
 
-    @defer.inlineCallbacks
-    def stop_instance(self, result):
-        yield self.do_stop_instance()
+    @async_to_deferred
+    async def stop_instance(self, result):
+        await self.do_stop_instance()
         d = self._stop_deferred
         self._stop_deferred = None
         d.callback(result)
 
-    @defer.inlineCallbacks
-    def do_stop_instance(self):
+    @async_to_deferred
+    async def do_stop_instance(self):
         assert self.state == States.STOPPING
         self.state = States.STOPPED
         self._started_kind = None
         if self.auto_disconnect_worker:
-            yield self.disconnect_worker()
+            await self.disconnect_worker()
 
-    @defer.inlineCallbacks
-    def connect_worker(self):
+    @async_to_deferred
+    async def connect_worker(self):
         if self.remote_worker is not None:
             return
         if RemoteWorker is None:
@@ -148,11 +149,11 @@ class LatentController(SeverWorkerConnectionMixin):
         workdir = FilePath(self.case.mktemp())
         workdir.createDirectory()
         self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
-        yield self.remote_worker.setServiceParent(self.worker)
+        await self.remote_worker.setServiceParent(self.worker)
 
-    @defer.inlineCallbacks
-    def disconnect_worker(self):
-        yield super().disconnect_worker()
+    @async_to_deferred
+    async def disconnect_worker(self) -> None:
+        await super().disconnect_worker()
         if self.remote_worker is None:
             return
 
@@ -160,7 +161,7 @@ class LatentController(SeverWorkerConnectionMixin):
 
         disconnect_master_side_worker(self.worker)
 
-        yield worker.disownServiceParent()
+        await worker.disownServiceParent()
 
     def setup_kind(self, build):
         if build:
@@ -168,10 +169,10 @@ class LatentController(SeverWorkerConnectionMixin):
         else:
             self._started_kind_deferred = self.kind
 
-    @defer.inlineCallbacks
-    def get_started_kind(self):
+    @async_to_deferred
+    async def get_started_kind(self):
         if self._started_kind_deferred:
-            self._started_kind = yield self._started_kind_deferred
+            self._started_kind = await self._started_kind_deferred
             self._started_kind_deferred = None
         return self._started_kind
 
@@ -208,13 +209,13 @@ class ControllableLatentWorker(AbstractLatentWorker):
         self._random_password_id += 1
         return f'password_{self._random_password_id}'
 
-    @defer.inlineCallbacks
-    def isCompatibleWithBuild(self, build_props):
+    @async_to_deferred
+    async def isCompatibleWithBuild(self, build_props) -> bool:
         if self._controller.state == States.STOPPED:
             return True
 
-        requested_kind = yield build_props.render(self._controller.kind)
-        curr_kind = yield self._controller.get_started_kind()
+        requested_kind = await build_props.render(self._controller.kind)
+        curr_kind = await self._controller.get_started_kind()
         return requested_kind == curr_kind
 
     def start_instance(self, build):
@@ -230,16 +231,16 @@ class ControllableLatentWorker(AbstractLatentWorker):
         self._controller._start_deferred = defer.Deferred()
         return self._controller._start_deferred
 
-    @defer.inlineCallbacks
-    def stop_instance(self, fast):
+    @async_to_deferred
+    async def stop_instance(self, fast: bool = False) -> bool:
         assert self._controller.state == States.STARTED
         self._controller.state = States.STOPPING
 
         if self._controller.auto_stop_flag:
-            yield self._controller.do_stop_instance()
+            await self._controller.do_stop_instance()
             return True
         self._controller._stop_deferred = defer.Deferred()
-        return (yield self._controller._stop_deferred)
+        return await self._controller._stop_deferred
 
     def check_instance(self):
         return (not self._controller.has_crashed, "")

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -17,6 +17,7 @@ from twisted.internet import defer
 
 from buildbot import util
 from buildbot.util import lineboundaries
+from buildbot.util.twisted import async_to_deferred
 
 
 class FakeLogFile:
@@ -117,8 +118,8 @@ class FakeLogFile:
     def had_errors(self):
         return self._had_errors
 
-    @defer.inlineCallbacks
-    def finish(self):
+    @async_to_deferred
+    async def finish(self) -> None:
         assert not self.finished
 
         self.flushFakeLogfile()
@@ -127,7 +128,7 @@ class FakeLogFile:
         # notify subscribers *after* finishing the log
         self.subPoint.deliver(None, None)
 
-        yield self.subPoint.waitForDeliveriesToFinish()
+        await self.subPoint.waitForDeliveriesToFinish()
         self._had_errors = len(self.subPoint.pop_exceptions()) > 0
 
         # notify those waiting for finish

--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -36,6 +36,8 @@ from twisted.python import log
 from twisted.python.failure import Failure
 from zope.interface import implementer
 
+from buildbot.util.twisted import async_to_deferred
+
 # The code here is based on the implementations in
 # https://twistedmatrix.com/trac/ticket/8295
 # https://twistedmatrix.com/trac/ticket/8296
@@ -291,12 +293,10 @@ class TestReactor(ProcessReactor, NonReactor, CoreReactor, Clock):
 
         self._pendingCurrentCalls = False
 
-    @defer.inlineCallbacks
-    def _catchPrintExceptions(self, what, *a, **kw):
+    @async_to_deferred
+    async def _catchPrintExceptions(self, what, *a, **kw) -> None:
         try:
-            r = what(*a, **kw)
-            if isinstance(r, defer.Deferred):
-                yield r
+            await defer.maybeDeferred(what, *a, **kw)
         except Exception as e:
             log.msg('Unhandled exception from deferred when doing TestReactor.advance()', e)
             raise

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -20,14 +20,15 @@ from twisted.internet import defer
 from twisted.web import server
 
 from buildbot.test.fake import fakemaster
+from buildbot.util.twisted import async_to_deferred
 
 
-@defer.inlineCallbacks
-def fakeMasterForHooks(testcase):
+@async_to_deferred
+async def fakeMasterForHooks(testcase) -> fakemaster.FakeMaster:
     # testcase must derive from TestReactorMixin and setup_test_reactor()
     # must be called before calling this function.
 
-    master = yield fakemaster.make_master(testcase, wantData=True)
+    master = await fakemaster.make_master(testcase, wantData=True)
     master.www = Mock()
     return master
 

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -99,15 +99,17 @@ class SeverWorkerConnectionMixin:
     _connection_severed = False
     _severed_deferreds = None
 
-    def disconnect_worker(self):
+    def disconnect_worker(self) -> defer.Deferred[None]:
         if not self._connection_severed:
-            return
+            return defer.succeed(None)
 
         if self._severed_deferreds is not None:
             for d in self._severed_deferreds:
                 d.errback(pb.PBConnectionLost('lost connection'))
 
         self._connection_severed = False
+
+        return defer.succeed(None)
 
     def sever_connection(self):
         # stubs the worker connection so that it appears that the TCP connection

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -23,6 +23,7 @@ from twisted.trial.unittest import SkipTest
 
 from buildbot.process import properties
 from buildbot.test.fake import fakeprotocol
+from buildbot.util.twisted import async_to_deferred
 from buildbot.worker import Worker
 
 RemoteWorker: type | None = None
@@ -81,8 +82,8 @@ class FakeWorker:
         pass
 
 
-@defer.inlineCallbacks
-def disconnect_master_side_worker(worker):
+@async_to_deferred
+async def disconnect_master_side_worker(worker) -> None:
     # Force disconnection because the LocalWorker does not disconnect itself. Note that
     # the worker may have already been disconnected by something else (e.g. if it's not
     # responding). We need to call detached() explicitly because the order in which
@@ -90,9 +91,9 @@ def disconnect_master_side_worker(worker):
     if worker.conn is not None:
         worker._detached_sub.unsubscribe()
         conn = worker.conn
-        yield worker.detached()
+        await worker.detached()
         conn.loseConnection()
-    yield worker.waitForCompleteShutdown()
+    await worker.waitForCompleteShutdown()
 
 
 class SeverWorkerConnectionMixin:
@@ -179,8 +180,8 @@ class WorkerController(SeverWorkerConnectionMixin):
         self.worker = worker_class(name, self, **kwargs)
         self.remote_worker = None
 
-    @defer.inlineCallbacks
-    def connect_worker(self):
+    @async_to_deferred
+    async def connect_worker(self):
         if self.remote_worker is not None:
             return
         if RemoteWorker is None:
@@ -188,15 +189,15 @@ class WorkerController(SeverWorkerConnectionMixin):
         workdir = FilePath(self.case.mktemp())
         workdir.createDirectory()
         self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
-        yield self.remote_worker.setServiceParent(self.worker)
+        self.remote_worker.setServiceParent(self.worker)
 
-    @defer.inlineCallbacks
-    def disconnect_worker(self):
-        yield super().disconnect_worker()
+    @async_to_deferred
+    async def disconnect_worker(self):
+        await super().disconnect_worker()
         if self.remote_worker is None:
             return
 
         worker = self.remote_worker
         self.remote_worker = None
-        disconnect_master_side_worker(self.worker)
-        yield worker.disownServiceParent()
+        await worker.disownServiceParent()
+        await disconnect_master_side_worker(self.worker)

--- a/master/buildbot/test/reactor.py
+++ b/master/buildbot/test/reactor.py
@@ -15,7 +15,6 @@
 
 import asyncio
 
-from twisted.internet import defer
 from twisted.internet import threads
 from twisted.python import threadpool
 
@@ -55,7 +54,7 @@ class TestReactorMixin:
             self.addCleanup(self.tear_down_test_reactor)
         self._reactor_tear_down_called = False
 
-    def tear_down_test_reactor(self):
+    def tear_down_test_reactor(self) -> None:
         if self._reactor_tear_down_called:
             return
 
@@ -72,5 +71,3 @@ class TestReactorMixin:
         self.reactor.stop()
         self.reactor.assert_no_remaining_calls()
         _setReactor(None)
-
-        return defer.succeed(None)

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -222,22 +222,22 @@ class AbstractLatentWorker(AbstractWorker):
                 ).format(action_str, self)
             )
 
-    def start_instance(self, build):
+    def start_instance(self, build) -> defer.Deferred[bool]:
         # responsible for starting instance that will try to connect with this
         # master.  Should return deferred with either True (instance started)
         # or False (instance not started, so don't run a build here).  Problems
         # should use an errback.
         raise NotImplementedError
 
-    def stop_instance(self, fast=False):
+    def stop_instance(self, fast=False) -> defer.Deferred[bool]:
         # responsible for shutting down instance.
         raise NotImplementedError
 
-    def check_instance(self):
+    def check_instance(self) -> tuple[bool, str]:
         return (True, "")
 
     @property
-    def substantiated(self):
+    def substantiated(self) -> bool:
         return self.state == States.SUBSTANTIATED and self.conn is not None
 
     def substantiate(self, wfb: Any, build: Any) -> defer.Deferred[bool]:


### PR DESCRIPTION
As discussed [here](https://github.com/buildbot/buildbot/pull/8131#discussion_r1798603994), typing inlineCallbacks is pretty messy.
Simpler way is to convert them to async functions.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
