### PR TITLE
Use standard URL syntax for Git steps to enable the use of a dedicated SSH port

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -83,6 +83,7 @@ class Git(Source, GitStepMixin):
     def __init__(
         self,
         repourl=None,
+        port=22,
         branch='HEAD',
         mode='incremental',
         method=None,
@@ -111,6 +112,7 @@ class Git(Source, GitStepMixin):
         self.branch = branch
         self.method = method
         self.repourl = repourl
+        self.port = port
         self.reference = reference
         self.retryFetch = retryFetch
         self.submodules = submodules
@@ -617,6 +619,7 @@ class GitPush(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
         self,
         workdir=None,
         repourl=None,
+        port=22,
         branch=None,
         force=False,
         env=None,
@@ -632,6 +635,7 @@ class GitPush(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
     ):
         self.workdir = workdir
         self.repourl = repourl
+        self.port = port
         self.branch = branch
         self.force = force
         self.env = env
@@ -723,6 +727,7 @@ class GitTag(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
 
         # These attributes are required for GitStepMixin but not useful to tag
         self.repourl = " "
+        self.port = None
 
         super().__init__(**kwargs)
 
@@ -804,6 +809,7 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
         # The repourl attribute is required by
         # GitStepMixin, but isn't needed by git add and commit operations
         self.repourl = " "
+        self.port = None
 
         super().__init__(**kwargs)
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -123,12 +123,12 @@ class TestGit(
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
-    def test_mode_full_clean(self):
-        self.setup_step(
-            self.stepClass(
-                repourl='http://github.com/buildbot/buildbot.git', mode='full', method='clean'
-            )
-        )
+    @parameterized.expand([
+        ('url', 'ssh://github.com/test/test.git', 'ssh://github.com/test/test.git'),
+        ('ssh_host_and_path', 'host:path/to/git', 'ssh://host:22/path/to/git'),
+    ])
+    def test_mode_full_clean(self, name, url, pull_url):
+        self.setup_step(self.stepClass(repourl=url, mode='full', method='clean'))
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['git', '--version'])
             .stdout('git version 1.7.5')
@@ -143,7 +143,7 @@ class TestGit(
                     'fetch',
                     '-f',
                     '--progress',
-                    'http://github.com/buildbot/buildbot.git',
+                    pull_url,
                     'HEAD',
                 ],
             ).exit(0),
@@ -4189,15 +4189,17 @@ class TestGitPush(
     def tearDown(self):
         return self.tear_down_test_build_step()
 
-    def test_push_simple(self):
-        url = 'ssh://github.com/test/test.git'
-
+    @parameterized.expand([
+        ('url', 'ssh://github.com/test/test.git', 'ssh://github.com/test/test.git'),
+        ('host_path', 'host:path/to/git', 'ssh://host:22/path/to/git'),
+    ])
+    def test_push_simple(self, name, url, push_url):
         self.setup_step(self.stepClass(workdir='wkdir', repourl=url, branch='testbranch'))
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['git', '--version'])
             .stdout('git version 1.7.5')
             .exit(0),
-            ExpectShell(workdir='wkdir', command=['git', 'push', url, 'testbranch']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'push', push_url, 'testbranch']).exit(0),
         )
         self.expect_outcome(result=SUCCESS)
         return self.run_step()

--- a/master/buildbot/test/unit/util/test_git.py
+++ b/master/buildbot/test/unit/util/test_git.py
@@ -22,6 +22,7 @@ from buildbot.util.git import check_ssh_config
 from buildbot.util.git import ensureSshKeyNewline
 from buildbot.util.git import escapeShellArgIfNeeded
 from buildbot.util.git import getSshKnownHostsContents
+from buildbot.util.git import scp_style_to_url_syntax
 
 
 class TestEscapeShellArgIfNeeded(unittest.TestCase):
@@ -187,3 +188,14 @@ base64encodedkeydata
         self.assertEqual(
             self.sshGoodPrivateKey, ensureSshKeyNewline(self.sshMissingNewlinePrivateKey)
         )
+
+
+class TestScpStyleToUrlSyntax(unittest.TestCase):
+    @parameterized.expand([
+        ('normal_url', 'ssh://path/to/git', 'ssh://path/to/git'),
+        ('unix_path', '/path/to/git', '/path/to/git'),
+        ('windows_path', 'C:\\path\\to\\git', 'C:\\path\\to\\git'),
+        ('scp_path', 'host:path/to/git', 'ssh://host:23/path/to/git'),
+    ])
+    def test(self, name, url, expected):
+        self.assertEqual(scp_style_to_url_syntax(url, port=23), expected)

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -66,6 +66,14 @@ def getSshCommand(keyPath, knownHostsPath):
     return ' '.join(command)
 
 
+def scp_style_to_url_syntax(address, port=22, scheme='ssh'):
+    if any(['://' in address, ':\\' in address, ':' not in address]):
+        # the address already has a URL syntax or is a local path
+        return address
+    host, path = address.split(':')
+    return f'{scheme}://{host}:{port}/{path}'
+
+
 def check_ssh_config(
     logname: str,
     ssh_private_key: IRenderable | None,
@@ -175,6 +183,9 @@ class GitStepMixin(GitMixin):
 
         if not hasattr(self, '_git_auth'):
             self._git_auth = GitStepAuth(self)
+
+        # Use standard URL syntax to enable the use of a dedicated SSH port
+        self.repourl = scp_style_to_url_syntax(self.repourl, self.port)
 
     def setup_git_auth(
         self,

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -25,7 +25,10 @@ The Git step takes the following arguments:
 ``repourl`` (required)
    The URL of the upstream Git repository.
 
-``branch`` (optional)
+``port`` (optional, default: ``22``)
+   The SSH port of the Git server.
+
+``branch`` (optional, default: ``HEAD``)
    This specifies the name of the branch or the tag to use when a Build does not provide one of its own.
    If this parameter is not specified, and the Build does not provide a branch, the default branch of the remote repository will be used.
    If ``alwaysUseLatest`` is ``True`` then the branch and revision information that comes with the Build is ignored and the branch specified in this parameter is used.

--- a/newsfragments/README.txt
+++ b/newsfragments/README.txt
@@ -11,7 +11,7 @@ towncrier has a few standard types of news fragments, signified by the file exte
 .change: Signifying a change of behavior
 .misc: Miscellaneous change
 
-The core of the filename can be the fixed issue number of any unique text relative to your work.
+The core of the filename can be the fixed issue number or any unique text relative to your work.
 Buildbot project does not require a tracking ticket to be made for each contribution even if this is appreciated.
 
 Please point to the trac bug using syntax: (:bug:`NNN`)

--- a/newsfragments/allow-use-of-ssh-port.feature
+++ b/newsfragments/allow-use-of-ssh-port.feature
@@ -1,0 +1,1 @@
+Use standard URL syntax for Git steps to enable the use of a dedicated SSH port


### PR DESCRIPTION
- Added function for converting from SCP style to URL syntax and passing the repository address to it when setting up the Git step
- Added a missing default value in the documentation of the 'branch' parameter for the source step 'Git'
- Fixed typo in 'newsfragments' README