### PR TITLE
db: janitor should cleanup builds _older than_ given timestamp

### DIFF
--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -167,14 +167,13 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
                 q = q.where(
                     (builds.c.complete_at >= older_than_timestamp) | (builds.c.complete_at == NULL)
                 )
+                # n.b.: in sqlite we need to filter on `>= older_than_timestamp` because of the following `NOT IN` clause...
 
                 q = build_data.delete().where(build_data.c.buildid.notin_(q))
             else:
                 q = build_data.delete()
                 q = q.where(builds.c.id == build_data.c.buildid)
-                q = q.where(
-                    (builds.c.complete_at >= older_than_timestamp) | (builds.c.complete_at == NULL)
-                )
+                q = q.where(builds.c.complete_at <= older_than_timestamp)
             res = conn.execute(q)
             conn.commit()
             res.close()

--- a/newsfragments/janitor-timehorizon.bugfix
+++ b/newsfragments/janitor-timehorizon.bugfix
@@ -1,0 +1,1 @@
+Fixes the timestamp comparison in janitor: it should cleanup builds 'older than' given timestamp - previously janitor would delete all build_data for builds 'newer than' the configured build data horizon.


### PR DESCRIPTION
Previously janitor would delete all build_data for builds _newer than_
the configured build_data_horizon.

Credit goes to https://github.com/luisbarrueco for finding this.

The unit tests only covered the sqlite implementation which is correct, this bug only existed for postgres queries. 

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
