### PR TITLE
Ensure consumeErrors=True is passed to gatherResults and DeferredList

### DIFF
--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -77,9 +77,10 @@ class LockRetrieverMixin:
     @defer.inlineCallbacks
     def getLockFromLockAccesses(self, accesses, config_version):
         # converts locks to their real forms
-        locks = yield defer.gatherResults([
-            self.getLockFromLockAccess(access, config_version) for access in accesses
-        ])
+        locks = yield defer.gatherResults(
+            [self.getLockFromLockAccess(access, config_version) for access in accesses],
+            consumeErrors=True,
+        )
         return zip(locks, accesses)
 
 
@@ -194,7 +195,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
                 log.msg("No running jobs, starting shutdown immediately")
             else:
                 log.msg(f"Waiting for {len(dl)} build(s) to finish")
-                yield defer.DeferredList(dl)
+                yield defer.DeferredList(dl, consumeErrors=True)
 
             # Check that there really aren't any running builds
             n = 0

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -166,9 +166,10 @@ class BuildChooserBase:
 
     def _getUnclaimedBuildRequests(self):
         # Retrieve the list of BuildRequest objects for all unclaimed builds
-        return defer.gatherResults([
-            self._getBuildRequestForBrdict(brdict) for brdict in self.unclaimedBrdicts
-        ])
+        return defer.gatherResults(
+            [self._getBuildRequestForBrdict(brdict) for brdict in self.unclaimedBrdicts],
+            consumeErrors=True,
+        )
 
 
 class BasicBuildChooser(BuildChooserBase):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -501,7 +501,7 @@ class _Lookup(util.ComparableMixin):
     def getRenderingFor(self, build):
         value = build.render(self.value)
         index = build.render(self.index)
-        value, index = yield defer.gatherResults([value, index])
+        value, index = yield defer.gatherResults([value, index], consumeErrors=True)
         if index not in value:
             rv = yield build.render(self.default)
         else:
@@ -947,7 +947,7 @@ class _ListRenderer:
         self.value = value
 
     def getRenderingFor(self, build):
-        return defer.gatherResults([build.render(e) for e in self.value])
+        return defer.gatherResults([build.render(e) for e in self.value], consumeErrors=True)
 
 
 registerAdapter(_ListRenderer, list, IRenderable)
@@ -963,7 +963,7 @@ class _TupleRenderer:
         self.value = value
 
     def getRenderingFor(self, build):
-        d = defer.gatherResults([build.render(e) for e in self.value])
+        d = defer.gatherResults([build.render(e) for e in self.value], consumeErrors=True)
         d.addCallback(tuple)
         return d
 

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -302,7 +302,7 @@ class MailNotifier(ReporterBase):
                 dl = []
                 for u in users:
                     dl.append(defer.maybeDeferred(self.lookup.getAddress, u))
-                users = yield defer.gatherResults(dl)
+                users = yield defer.gatherResults(dl, consumeErrors=True)
 
             for r in users:
                 if r is None:  # getAddress didn't like this address

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -234,11 +234,14 @@ class MessageFormatterBase(util.ComparableMixin):
         yield self.buildAdditionalContext(master, context)
         context.update(self.context)
 
-        body, subject, extra_info = yield defer.gatherResults([
-            defer.maybeDeferred(self.render_message_body, context),
-            defer.maybeDeferred(self.render_message_subject, context),
-            defer.maybeDeferred(self.render_message_extra_info, context),
-        ])
+        body, subject, extra_info = yield defer.gatherResults(
+            [
+                defer.maybeDeferred(self.render_message_body, context),
+                defer.maybeDeferred(self.render_message_subject, context),
+                defer.maybeDeferred(self.render_message_extra_info, context),
+            ],
+            consumeErrors=True,
+        )
 
         return {
             "body": body,

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -509,4 +509,6 @@ class Try_Userpass(TryBase):
         if not self.enabled:
             return
 
-        yield defer.gatherResults([reg.unregister() for reg in self.registrations])
+        yield defer.gatherResults(
+            [reg.unregister() for reg in self.registrations], consumeErrors=True
+        )

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -400,10 +400,13 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
             return SKIPPED
 
         if self.glob:
-            results = yield defer.gatherResults([
-                self.runGlob(os.path.join(self.workdir, source), abandonOnFailure=False)
-                for source in sources
-            ])
+            results = yield defer.gatherResults(
+                [
+                    self.runGlob(os.path.join(self.workdir, source), abandonOnFailure=False)
+                    for source in sources
+                ],
+                consumeErrors=True,
+            )
             sources = [self.workerPathToMasterPath(p) for p in flatten(results)]
 
         log.msg(f"MultipleFileUpload started, from worker {sources!r} to master {masterdest!r}")

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -329,7 +329,7 @@ class Trigger(BuildStep):
         self.triggeredNames = triggeredNames
 
         if self.waitForFinish:
-            self.waitForFinishDeferred = defer.DeferredList(dl, consumeErrors=1)
+            self.waitForFinishDeferred = defer.DeferredList(dl, consumeErrors=True)
             try:
                 rclist = yield self.waitForFinishDeferred
             except defer.CancelledError:

--- a/master/buildbot/test/integration/worker/test_comm.py
+++ b/master/buildbot/test/integration/worker/test_comm.py
@@ -212,7 +212,7 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
         if self.buildworker and self.buildworker.detach_d:
             deferreds.append(self.buildworker.detach_d)
 
-        yield defer.gatherResults(deferreds)
+        yield defer.gatherResults(deferreds, consumeErrors=True)
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -178,9 +178,10 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_get_commit_comments(self):
         comments = ['this is a commit message\n\nthat is multiline', 'single line message', '']
-        return defer.DeferredList([
-            self._test_get_commit_comments(commentStr) for commentStr in comments
-        ])
+        return defer.DeferredList(
+            [self._test_get_commit_comments(commentStr) for commentStr in comments],
+            consumeErrors=True,
+        )
 
     def test_get_commit_files(self):
         filesBytes = b'\n\nfile1\nfile2\n"\146ile_octal"\nfile space'

--- a/master/buildbot/test/unit/db/test_pool.py
+++ b/master/buildbot/test/unit/db/test_pool.py
@@ -155,7 +155,7 @@ class Stress(unittest.TestCase):
         d2.addCallback(lambda _: self.pool.do(write2))
         reactor.callLater(0.1, d2.callback, None)
 
-        yield defer.DeferredList([d1, d2])
+        yield defer.DeferredList([d1, d2], consumeErrors=True)
 
     # don't run this test, since it takes 30s
     del test_inserts

--- a/master/buildbot/test/unit/db/test_steps.py
+++ b/master/buildbot/test/unit/db/test_steps.py
@@ -339,13 +339,16 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_addURL_race(self):
         yield self.insert_test_data([*self.backgroundData, self.stepRows[2]])
-        yield defer.gatherResults([
-            # only a tiny sleep is required to see the problem.
-            self.db.steps.addURL(
-                stepid=72, name='foo', url='bar', _racehook=lambda: time.sleep(0.01)
-            ),
-            self.db.steps.addURL(stepid=72, name='foo2', url='bar2'),
-        ])
+        yield defer.gatherResults(
+            [
+                # only a tiny sleep is required to see the problem.
+                self.db.steps.addURL(
+                    stepid=72, name='foo', url='bar', _racehook=lambda: time.sleep(0.01)
+                ),
+                self.db.steps.addURL(stepid=72, name='foo2', url='bar2'),
+            ],
+            consumeErrors=True,
+        )
 
         stepdict = yield self.db.steps.getStep(stepid=72)
 
@@ -364,10 +367,13 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_addURL_no_duplicate(self):
         yield self.insert_test_data([*self.backgroundData, self.stepRows[2]])
-        yield defer.gatherResults([
-            self.db.steps.addURL(stepid=72, name='foo', url='bar'),
-            self.db.steps.addURL(stepid=72, name='foo', url='bar'),
-        ])
+        yield defer.gatherResults(
+            [
+                self.db.steps.addURL(stepid=72, name='foo', url='bar'),
+                self.db.steps.addURL(stepid=72, name='foo', url='bar'),
+            ],
+            consumeErrors=True,
+        )
 
         stepdict = yield self.db.steps.getStep(stepid=72)
 

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -437,7 +437,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         e = eBuild.startBuild(eWorker)
         c = cBuild.startBuild(cWorker)
-        d = defer.DeferredList([e, c])
+        d = defer.DeferredList([e, c], consumeErrors=True)
 
         real_lock.release(b3, b3_access)
 

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -91,9 +91,10 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
             ),
         )
 
-        actual_sourcestamps = yield defer.gatherResults([
-            self.master.db.sourcestamps.getSourceStamp(ssid) for ssid in buildset.sourcestamps
-        ])
+        actual_sourcestamps = yield defer.gatherResults(
+            [self.master.db.sourcestamps.getSourceStamp(ssid) for ssid in buildset.sourcestamps],
+            consumeErrors=True,
+        )
 
         self.assertEqual(len(sourcestamps), len(actual_sourcestamps))
         for expected_ss, actual_ss in zip(sourcestamps, actual_sourcestamps):

--- a/master/buildbot/test/unit/util/test_httpclientservice.py
+++ b/master/buildbot/test/unit/util/test_httpclientservice.py
@@ -467,7 +467,7 @@ class HTTPClientServiceTestTxRequestE2E(unittest.TestCase):
             return d
 
         dl = [oneReq() for i in range(self.NUM_PARALLEL)]
-        yield defer.gatherResults(dl)
+        yield defer.gatherResults(dl, consumeErrors=True)
 
 
 class HTTPClientServiceTestTReqE2E(HTTPClientServiceTestTxRequestE2E):

--- a/master/buildbot/test/unit/util/test_lru.py
+++ b/master/buildbot/test/unit/util/test_lru.py
@@ -476,7 +476,7 @@ class AsyncLRUCacheTest(unittest.TestCase):
             d.addCallback(self.check_result, short(c))
             return d
 
-        yield defer.gatherResults([check(c, self.lru.get(c)) for c in chars])
+        yield defer.gatherResults([check(c, self.lru.get(c)) for c in chars], consumeErrors=True)
 
         self.assertEqual(misses[0], 26)
         self.assertEqual(self.lru.misses, 26)
@@ -502,7 +502,7 @@ class AsyncLRUCacheTest(unittest.TestCase):
             reactor.callLater(0.02 * i, do_get, d, 'x')
             ds.append(d)
 
-        yield defer.gatherResults(ds)
+        yield defer.gatherResults(ds, consumeErrors=True)
 
         self.assertEqual((self.lru.hits, self.lru.misses), (7, 1))
 

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -588,7 +588,7 @@ class AbstractWorker(service.BuildbotService):
             if b:
                 d1 = self.attachBuilder(b)
                 dl.append(d1)
-        yield defer.DeferredList(dl)
+        yield defer.DeferredList(dl, consumeErrors=True)
 
     def attachBuilder(self, builder):
         return builder.attached(self, self.worker_commands)

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -389,9 +389,13 @@ class BotPbLike(BotBase):
         # disown any builders no longer desired
         to_remove = list(set(self.builders.keys()) - wanted_names)
         if to_remove:
-            yield defer.gatherResults([
-                defer.maybeDeferred(self.builders[name].disownServiceParent) for name in to_remove
-            ])
+            yield defer.gatherResults(
+                [
+                    defer.maybeDeferred(self.builders[name].disownServiceParent)
+                    for name in to_remove
+                ],
+                consumeErrors=True,
+            )
 
         # and *then* remove them from the builder list
         for name in to_remove:

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -176,7 +176,7 @@ VERSION_ID="1"
         d2 = self.bot.callRemote("shutdown")
         # don't return until both the shutdown method has returned, and
         # reactor.stop has been called
-        return defer.gatherResults([d1, d2])
+        return defer.gatherResults([d1, d2], consumeErrors=True)
 
 
 class FakeStep:

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -260,7 +260,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         interrupt_d.addCallback(do_interrupt)
 
-        yield defer.DeferredList([d, interrupt_d])
+        yield defer.DeferredList([d, interrupt_d], consumeErrors=True)
 
         self.assertUpdates([
             ('header', f'sending {self.datafile}\n'),
@@ -593,6 +593,6 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         interrupt_d.addCallback(do_interrupt)
 
-        yield defer.DeferredList([d, interrupt_d])
+        yield defer.DeferredList([d, interrupt_d], consumeErrors=True)
 
         self.assertUpdates(['read(s)', 'close', ('rc', 1)])

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -715,7 +715,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
             self.assertDead(self.pid)
 
         runproc_d.addCallback(check_dead)
-        return defer.gatherResults([pidfile_d, runproc_d])
+        return defer.gatherResults([pidfile_d, runproc_d], consumeErrors=True)
 
     def test_sigterm(self, interruptSignal=None):
         # Tests that the process will receive SIGTERM if sigtermTimeout
@@ -762,7 +762,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
             self.assertDead(self.pid)
 
         runproc_d.addCallback(check_dead)
-        return defer.gatherResults([pidfile_d, runproc_d])
+        return defer.gatherResults([pidfile_d, runproc_d], consumeErrors=True)
 
     def test_pgroup_usePTY(self):
         return self.do_test_pgroup(usePTY=True)
@@ -797,7 +797,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         # wait for both processes to start up, then call s.kill
         parent_pidfile_d = self.waitForPidfile(parent_pidfile)
         child_pidfile_d = self.waitForPidfile(child_pidfile)
-        pidfiles_d = defer.gatherResults([parent_pidfile_d, child_pidfile_d])
+        pidfiles_d = defer.gatherResults([parent_pidfile_d, child_pidfile_d], consumeErrors=True)
 
         def got_pids(pids):
             self.parent_pid, self.child_pid = pids
@@ -810,7 +810,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         pidfiles_d.addCallback(kill)
 
         # check that both processes are dead after RunProcess is done
-        yield defer.gatherResults([pidfiles_d, runproc_d])
+        yield defer.gatherResults([pidfiles_d, runproc_d], consumeErrors=True)
 
         self.assertDead(self.parent_pid)
         if expectChildSurvival:
@@ -853,7 +853,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         # wait for both processes to start up, then call s.kill
         parent_pidfile_d = self.waitForPidfile(parent_pidfile)
         child_pidfile_d = self.waitForPidfile(child_pidfile)
-        pidfiles_d = defer.gatherResults([parent_pidfile_d, child_pidfile_d])
+        pidfiles_d = defer.gatherResults([parent_pidfile_d, child_pidfile_d], consumeErrors=True)
 
         def got_pids(pids):
             self.parent_pid, self.child_pid = pids
@@ -866,7 +866,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         pidfiles_d.addCallback(kill)
 
         # check that both processes are dead after RunProcess is done
-        yield defer.gatherResults([pidfiles_d, runproc_d])
+        yield defer.gatherResults([pidfiles_d, runproc_d], consumeErrors=True)
 
         self.assertDead(self.parent_pid)
         if expectChildSurvival:


### PR DESCRIPTION
Any instance of defer.gatherResults() or defer.DeferredList that are used with consumeErrors=False is a race condition in tests. If more than one error is present in the list of deferreds that are waited for, it will be passed to subsequent callbacks/errbacks attached to the deferred. If there are no callbacks or errbacks, then an error will be sent to the logs once the deferred is garbage collected. This may happen at any time and in many cases will cause a subsequent test to fail.

The error results of the second and subsequent failing deferreds is not needed. defer.gatherResults() or defer.DeferredList will include the error result of the first failing deferred. This will still present an error message for the user to address.

Accordingly, setting consumeErrors=True has few downsides yet it solves the race conditions in tests.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
