### PR TITLE
www: Allow setting LogViewer background and foreground simultaneously

### DIFF
--- a/newsfragments/allow-setting-LogViewer-fg-bg-simultaneously.bugfix
+++ b/newsfragments/allow-setting-LogViewer-fg-bg-simultaneously.bugfix
@@ -1,0 +1,1 @@
+Allows setting background and foreground colors simultaneously by ANSI escape codes in LogViewer. (:issue:`8151`)

--- a/www/base/src/components/LogViewer/LogViewerText.scss
+++ b/www/base/src/components/LogViewer/LogViewerText.scss
@@ -57,6 +57,51 @@
       color: #60fdff;
     }
   }
+  .ansi40 {
+    background-color: #000000;
+  }
+  .ansi41 {
+    background-color: #c91b00;
+  }
+  .ansi42 {
+    background-color: #00c200;
+  }
+  .ansi43 {
+    background-color: #c7c400;
+  }
+  .ansi44 {
+    background-color: #0225c7;
+  }
+  .ansi45 {
+    background-color: #ca30c7;
+  }
+  .ansi46 {
+    background-color: #00c5c7;
+  }
+  // bright colors
+  .ansi1 {
+    &.ansi40 {
+      background-color: #ffffff;
+    }
+    &.ansi41 {
+      background-color: #ff6e67;
+    }
+    &.ansi42 {
+      background-color: #5ffa68;
+    }
+    &.ansi43 {
+      background-color: #fffc67;
+    }
+    &.ansi44 {
+      background-color: #6871ff;
+    }
+    &.ansi45 {
+      background-color: #f075f0;
+    }
+    &.ansi47 {
+      background-color: #60fdff;
+    }
+  }
 }
 
 .bb-logviewer-text-row {

--- a/www/base/src/util/AnsiEscapeCodes.test.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.test.tsx
@@ -151,7 +151,63 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[48;5;71mDEBUG \x1b[38;5;72m[plugin]: \x1b[39mLoading plugin karma-jasmine.");
       expect(ret).toEqual([
         {class: 'ansibg-71', text: 'DEBUG '},
-        {class: 'ansifg-72', text: '[plugin]: '},
+        {class: 'ansifg-72 ansibg-71', text: '[plugin]: '},
+        {class: 'ansibg-71', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous fg256 bg256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;71;38;5;72;33;45mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansi45 ansi33', text: 'DEBUG [plugin]: '},
+        {class: '', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous bg256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;71;43mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansi43', text: 'DEBUG [plugin]: '},
+        {class: '', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous fg256 bg256 with another 256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[48;5;71;38;5;72;48;5;81;38;5;82mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansibg-81 ansifg-82', text: 'DEBUG [plugin]: '},
+        {class: '', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous fg bg with 256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[33;45;48;5;81;38;5;82mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansibg-81 ansifg-82', text: 'DEBUG [plugin]: '},
+        {class: '', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous fg with 256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[33;38;5;82mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansifg-82', text: 'DEBUG [plugin]: '},
+        {class: '', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous fg with 256 add bg256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[33;38;5;82;48;5;81mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansibg-81 ansifg-82', text: 'DEBUG [plugin]: '},
+        {class: '', text: 'Loading plugin karma-jasmine.'}]);
+    });
+
+    it('reset previous fg with 0 add bg256 same instruction', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[33;0;48;5;81mDEBUG [plugin]: \x1b[0mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: 'ansibg-81', text: 'DEBUG [plugin]: '},
         {class: '', text: 'Loading plugin karma-jasmine.'}]);
     });
 
@@ -160,7 +216,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42', text: 'TEXT1 '},
-        {class: 'ansi42 ansi43', text: 'TEXT2 '},
+        {class: 'ansi43', text: 'TEXT2 '},
         ]);
     });
 
@@ -169,7 +225,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42mTEXT1 \x1b[31mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42', text: 'TEXT1 '},
-        {class: 'ansi42 ansi31', text: 'TEXT2 '},
+        {class: 'ansi31 ansi42', text: 'TEXT2 '},
       ]);
     });
 
@@ -178,7 +234,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42mTEXT1 \x1b[43;31mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42', text: 'TEXT1 '},
-        {class: 'ansi42 ansi43 ansi31', text: 'TEXT2 '},
+        {class: 'ansi43 ansi31', text: 'TEXT2 '},
       ]);
     });
 
@@ -196,7 +252,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42', text: 'TEXT1 '},
-        {class: 'ansifg-226', text: 'TEXT2 '},
+        {class: 'ansifg-226 ansi42', text: 'TEXT2 '},
       ]);
     });
 
@@ -205,7 +261,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -232,7 +288,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[31mTEXT1 \x1b[42mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi31', text: 'TEXT1 '},
-        {class: 'ansi31 ansi42', text: 'TEXT2 '},
+        {class: 'ansi42 ansi31', text: 'TEXT2 '},
       ]);
     });
 
@@ -241,25 +297,25 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[31mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi31', text: 'TEXT1 '},
-        {class: 'ansi31 ansi32', text: 'TEXT2 '},
+        {class: 'ansi32', text: 'TEXT2 '},
       ]);
     });
 
     it('SGRfg SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
-        "\x1b[31mTEXT1 \x1b[42;32mTEXT2 \x1b[0m"); // pridėti kitą bg spalvą¸kad parodytų, kaip permuša? Nebent vėliau permušantis testas bus
+        "\x1b[31mTEXT1 \x1b[42;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi31', text: 'TEXT1 '},
-        {class: 'ansi31 ansi42 ansi32', text: 'TEXT2 '},
+        {class: 'ansi42 ansi32', text: 'TEXT2 '},
       ]);
     });
 
     it('SGRfg 256bg', () => {
       const ret = parseEscapeCodesToSimple(
-        "\x1b[31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m"); // pridėta pirmojo bg permušanti spalva
+        "\x1b[31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi31', text: 'TEXT1 '},
-        {class: 'ansibg-34', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansi31', text: 'TEXT2 '},
       ]);
     });
 
@@ -277,7 +333,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[31mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi31', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -304,7 +360,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42;31mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42 ansi31', text: 'TEXT1 '},
-        {class: 'ansi42 ansi31 ansi43', text: 'TEXT2 '},
+        {class: 'ansi43 ansi31', text: 'TEXT2 '},
       ]);
     });
 
@@ -313,7 +369,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42;31mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42 ansi31', text: 'TEXT1 '},
-        {class: 'ansi42 ansi31 ansi32', text: 'TEXT2 '},
+        {class: 'ansi32 ansi42', text: 'TEXT2 '},
       ]);
     });
 
@@ -322,7 +378,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42;31mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42 ansi31', text: 'TEXT1 '},
-        {class: 'ansi42 ansi31 ansi43 ansi32', text: 'TEXT2 '},
+        {class: 'ansi43 ansi32', text: 'TEXT2 '},
       ]);
     });
 
@@ -331,7 +387,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42;31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42 ansi31', text: 'TEXT1 '},
-        {class: 'ansibg-34', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansi31', text: 'TEXT2 '},
       ]);
     });
 
@@ -340,7 +396,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42;31mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42 ansi31', text: 'TEXT1 '},
-        {class: 'ansifg-226', text: 'TEXT2 '},
+        {class: 'ansifg-226 ansi42', text: 'TEXT2 '},
       ]);
     });
 
@@ -349,7 +405,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[42;31mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansi42 ansi31', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -376,7 +432,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[48;5;34mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansibg-34', text: 'TEXT1 '},
-        {class: 'ansibg-34 ansi43', text: 'TEXT2 '},
+        {class: 'ansi43', text: 'TEXT2 '},
       ]);
     });
 
@@ -385,7 +441,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[48;5;34mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansibg-34', text: 'TEXT1 '},
-        {class: 'ansibg-34 ansi32', text: 'TEXT2 '},
+        {class: 'ansi32 ansibg-34', text: 'TEXT2 '},
       ]);
     });
 
@@ -394,7 +450,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[48;5;34mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansibg-34', text: 'TEXT1 '},
-        {class: 'ansibg-34 ansi43 ansi32', text: 'TEXT2 '},
+        {class: 'ansi43 ansi32', text: 'TEXT2 '},
       ]);
     });
 
@@ -412,7 +468,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[48;5;34mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansibg-34', text: 'TEXT1 '},
-        {class: 'ansifg-226', text: 'TEXT2 '},
+        {class: 'ansifg-226 ansibg-34', text: 'TEXT2 '},
       ]);
     });
 
@@ -421,7 +477,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[48;5;34mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansibg-34', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -448,7 +504,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[38;5;196mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansifg-196', text: 'TEXT1 '},
-        {class: 'ansifg-196 ansi43', text: 'TEXT2 '},
+        {class: 'ansi43 ansifg-196', text: 'TEXT2 '},
       ]);
     });
 
@@ -457,7 +513,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[38;5;196mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansifg-196', text: 'TEXT1 '},
-        {class: 'ansifg-196 ansi32', text: 'TEXT2 '},
+        {class: 'ansi32', text: 'TEXT2 '},
       ]);
     });
 
@@ -466,7 +522,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[38;5;196mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansifg-196', text: 'TEXT1 '},
-        {class: 'ansifg-196 ansi43 ansi32', text: 'TEXT2 '},
+        {class: 'ansi43 ansi32', text: 'TEXT2 '},
       ]);
     });
 
@@ -475,7 +531,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[38;5;196mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansifg-196', text: 'TEXT1 '},
-        {class: 'ansibg-36', text: 'TEXT2 '},
+        {class: 'ansibg-36 ansifg-196', text: 'TEXT2 '},
       ]);
     });
 
@@ -493,7 +549,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[38;5;196mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: 'ansifg-196', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -519,8 +575,8 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
-        {class: 'ansi43', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
+        {class: 'ansi43 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -528,8 +584,8 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
-        {class: 'ansi32', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
+        {class: 'ansi32 ansibg-34', text: 'TEXT2 '},
       ]);
     });
 
@@ -537,7 +593,7 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
         {class: 'ansi43 ansi32', text: 'TEXT2 '},
       ]);
     });
@@ -546,8 +602,8 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
-        {class: 'ansibg-36', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
+        {class: 'ansibg-36 ansifg-226', text: 'TEXT2 '},
       ]);
     });
 
@@ -555,8 +611,8 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
-        {class: 'ansifg-228', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
+        {class: 'ansifg-228 ansibg-34', text: 'TEXT2 '},
       ]);
     });
 
@@ -564,8 +620,8 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
+        {class: 'ansibg-164 ansifg-228', text: 'TEXT2 '},
       ]);
     });
 
@@ -573,7 +629,7 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
         {class: '', text: 'TEXT2 '},
       ]);
     });
@@ -582,7 +638,7 @@ describe('AnsiEscapeCodes', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
-        {class: '', text: 'TEXT1 '},
+        {class: 'ansibg-34 ansifg-226', text: 'TEXT1 '},
         {class: '', text: 'TEXT2 '},
       ]);
     });
@@ -637,7 +693,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[0mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: '', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-228', text: 'TEXT2 '},
       ]);
     });
 
@@ -709,7 +765,7 @@ describe('AnsiEscapeCodes', () => {
         "\x1b[mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
         {class: '', text: 'TEXT1 '},
-        {class: '', text: 'TEXT2 '},
+        {class: 'ansibg-164 ansifg-228', text: 'TEXT2 '},
       ]);
     });
 
@@ -728,6 +784,39 @@ describe('AnsiEscapeCodes', () => {
       expect(ret).toEqual([
         {class: '', text: 'TEXT1 '},
         {class: '', text: 'TEXT2 '},
+      ]);
+    });
+
+    it('reset0m reset0m no text no spaces', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0m\x1b[0m\x1b[0m");
+      expect(ret).toEqual([]);
+    });
+
+    it('reset0m resetm no text no spaces', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[0m\x1b[m\x1b[0m");
+      expect(ret).toEqual([]);
+    });
+
+    it('resetm reset0m no text no spaces', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[m\x1b[0m\x1b[0m");
+      expect(ret).toEqual([]);
+    });
+
+    it('resetm resetm no text no spaces', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[m\x1b[m\x1b[0m");
+      expect(ret).toEqual([]);
+    });
+
+    it('resetm resetm no text spaces', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[m \x1b[m \x1b[0m");
+      expect(ret).toEqual([
+        {class: '', text: ' '},
+        {class: '', text: ' '},
       ]);
     });
 

--- a/www/base/src/util/AnsiEscapeCodes.test.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.test.tsx
@@ -146,7 +146,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256 colors', () => {
+    it('256 colors reset only fg last instruction', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;71mDEBUG \x1b[38;5;72m[plugin]: \x1b[39mLoading plugin karma-jasmine.");
       expect(ret).toEqual([
@@ -155,7 +155,7 @@ describe('AnsiEscapeCodes', () => {
         {class: '', text: 'Loading plugin karma-jasmine.'}]);
     });
 
-    it('SGRbg-SGRbg', () => {
+    it('SGRbg SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -164,7 +164,7 @@ describe('AnsiEscapeCodes', () => {
         ]);
     });
 
-    it('SGRbg-SGRfg', () => {
+    it('SGRbg SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[31mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -173,7 +173,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRbg-SGRboth', () => {
+    it('SGRbg SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[43;31mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -182,7 +182,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRbg-256bg', () => {
+    it('SGRbg 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -191,7 +191,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRbg-256fg', () => {
+    it('SGRbg 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -200,7 +200,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRbg-256both', () => {
+    it('SGRbg 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -209,7 +209,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRbg-reset0m', () => {
+    it('SGRbg reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -218,7 +218,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRbg-resetm', () => {
+    it('SGRbg resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -227,7 +227,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-SGRbg', () => {
+    it('SGRfg SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[42mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -236,7 +236,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-SGRfg', () => {
+    it('SGRfg SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -245,7 +245,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-SGRboth', () => {
+    it('SGRfg SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[42;32mTEXT2 \x1b[0m"); // pridėti kitą bg spalvą¸kad parodytų, kaip permuša? Nebent vėliau permušantis testas bus
       expect(ret).toEqual([
@@ -254,7 +254,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-256bg', () => {
+    it('SGRfg 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m"); // pridėta pirmojo bg permušanti spalva
       expect(ret).toEqual([
@@ -263,7 +263,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-256fg', () => {
+    it('SGRfg 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -272,7 +272,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-256both', () => {
+    it('SGRfg 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -281,7 +281,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-reset0m', () => {
+    it('SGRfg reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -290,7 +290,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRfg-resetm', () => {
+    it('SGRfg resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[31mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -299,7 +299,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-SGRbg', () => {
+    it('SGRboth SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -308,7 +308,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-SGRfg', () => {
+    it('SGRboth SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -317,7 +317,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-SGRboth', () => {
+    it('SGRboth SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -326,7 +326,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-256bg', () => {
+    it('SGRboth 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[48;5;34mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -335,7 +335,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-256fg', () => {
+    it('SGRboth 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -344,7 +344,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-256both', () => {
+    it('SGRboth 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -353,7 +353,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-reset0m', () => {
+    it('SGRboth reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -362,7 +362,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('SGRboth-resetm', () => {
+    it('SGRboth resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[42;31mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -371,7 +371,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-SGRbg', () => {
+    it('256bg SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -380,7 +380,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-SGRfg', () => {
+    it('256bg SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -389,7 +389,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-SGRboth', () => {
+    it('256bg SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -398,7 +398,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-256bg', () => {
+    it('256bg 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -407,7 +407,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-256fg', () => {
+    it('256bg 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -416,7 +416,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-256both', () => {
+    it('256bg 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -425,7 +425,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-reset0m', () => {
+    it('256bg reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -434,7 +434,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256bg-resetm', () => {
+    it('256bg resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -443,7 +443,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-SGRbg', () => {
+    it('256fg SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -452,7 +452,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-SGRfg', () => {
+    it('256fg SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -461,7 +461,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-SGRboth', () => {
+    it('256fg SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -470,7 +470,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-256bg', () => {
+    it('256fg 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -479,7 +479,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-256fg', () => {
+    it('256fg 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -488,7 +488,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-256both', () => {
+    it('256fg 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[48;5;164;38;5;226mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -497,7 +497,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-reset0m', () => {
+    it('256fg reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -506,7 +506,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256fg-resetm', () => {
+    it('256fg resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[38;5;196mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -515,7 +515,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-SGRbg', () => {
+    it('256both SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -524,7 +524,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-SGRfg', () => {
+    it('256both SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -533,7 +533,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-SGRboth', () => {
+    it('256both SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -542,7 +542,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-256bg', () => {
+    it('256both 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -551,7 +551,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-256fg', () => {
+    it('256both 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -560,7 +560,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-256both', () => {
+    it('256both 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -569,7 +569,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-reset0m', () => {
+    it('256both reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -578,7 +578,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('256both-resetm', () => {
+    it('256both resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;34;38;5;226mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -587,7 +587,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-SGRbg', () => {
+    it('reset0m SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -596,7 +596,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-SGRfg', () => {
+    it('reset0m SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -605,7 +605,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-SGRboth', () => {
+    it('reset0m SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -614,7 +614,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-256bg', () => {
+    it('reset0m 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -623,7 +623,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-256fg', () => {
+    it('reset0m 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -632,7 +632,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-256both', () => {
+    it('reset0m 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -641,7 +641,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-reset0m', () => {
+    it('reset0m reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -650,7 +650,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('reset0m-resetm', () => {
+    it('reset0m resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[0mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -659,7 +659,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-SGRbg', () => {
+    it('resetm SGRbg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[43mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -668,7 +668,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-SGRfg', () => {
+    it('resetm SGRfg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -677,7 +677,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-SGRboth', () => {
+    it('resetm SGRboth', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[43;32mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -686,7 +686,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-256bg', () => {
+    it('resetm 256bg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[48;5;36mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -695,7 +695,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-256fg', () => {
+    it('resetm 256fg', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -704,7 +704,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-256both', () => {
+    it('resetm 256both', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[48;5;164;38;5;228mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -713,7 +713,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-reset0m', () => {
+    it('resetm reset0m', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[0mTEXT2 \x1b[0m");
       expect(ret).toEqual([
@@ -722,7 +722,7 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
-    it('resetm-resetm', () => {
+    it('resetm resetm', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[mTEXT1 \x1b[mTEXT2 \x1b[0m");
       expect(ret).toEqual([


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/8151.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
