### PR TITLE
test: Dispose DB engine in copydb test

### DIFF
--- a/master/buildbot/test/unit/scripts/test_copydb.py
+++ b/master/buildbot/test/unit/scripts/test_copydb.py
@@ -163,6 +163,7 @@ class TestCopyDbRealDb(misc.StdoutAssertionsMixin, RunMasterBase, dirs.DirsMixin
         engine = enginestrategy.create_engine(db_url, basedir='basedir')
         with engine.connect() as conn:
             db.thd_clean_database(conn)
+        engine.dispose()
 
     @async_to_deferred
     async def test_full(self):


### PR DESCRIPTION
This fixes unclosed socket ResourceWarning emitted when testing postgres database with pg8000 connector.
