### PR TITLE
test: Remove duplicate tests for env passing to master subprocesses

### DIFF
--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -43,9 +43,6 @@ from buildbot.util import unicode2bytes
 from buildbot.util.git_credential import GitCredentialOptions
 from buildbot.util.twisted import async_to_deferred
 
-# Test that environment variables get propagated to subprocesses (See #2116)
-os.environ['TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'] = 'TRUE'
-
 
 class TestGitPollerBase(
     MasterRunProcessMixin,
@@ -460,11 +457,6 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_nothingNew(self):
-        # Test that environment variables get propagated to subprocesses
-        # (See #2116)
-        self.patch(os, 'environ', {'ENVVAR': 'TRUE'})
-        self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
-
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
@@ -1198,11 +1190,6 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_noChanges(self):
-        # Test that environment variables get propagated to subprocesses
-        # (See #2116)
-        self.patch(os, 'environ', {'ENVVAR': 'TRUE'})
-        self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
-
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),
@@ -1598,11 +1585,6 @@ class TestGitPoller(TestGitPollerBase):
 
     @defer.inlineCallbacks
     def test_poll_old(self):
-        # Test that environment variables get propagated to subprocesses
-        # (See #2116)
-        self.patch(os, 'environ', {'ENVVAR': 'TRUE'})
-        self.add_run_process_expect_env({'ENVVAR': 'TRUE'})
-
         self.expect_commands(
             ExpectMasterShell(['git', '--version']).stdout(b'git version 1.7.5\n'),
             ExpectMasterShell(['git', 'init', '--bare', self.POLLER_WORKDIR]),

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -25,7 +25,6 @@ from buildbot.test.runprocess import ExpectMasterShell
 from buildbot.test.runprocess import MasterRunProcessMixin
 from buildbot.test.util import changesource
 
-ENVIRON_2116_KEY = 'TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'
 LINESEP_BYTES = os.linesep.encode("ascii")
 PATHSEP_BYTES = os.pathsep.encode("ascii")
 
@@ -43,10 +42,6 @@ class TestHgPollerBase(
         self.setup_master_run_process()
         yield self.setUpChangeSource()
 
-        # To test that environment variables get propagated to subprocesses
-        # (See #2116)
-        os.environ[ENVIRON_2116_KEY] = 'TRUE'
-        yield self.setUpChangeSource()
         self.remote_repo = 'ssh://example.com/foo/baz'
         self.remote_hgweb = 'http://example.com/foo/baz/rev/{}'
         self.repo_ready = True
@@ -277,7 +272,6 @@ class TestHgPollerBookmarks(TestHgPollerBase):
 
 class TestHgPoller(TestHgPollerBase):
     def tearDown(self):
-        del os.environ[ENVIRON_2116_KEY]
         return self.tearDownChangeSource()
 
     def gpoFullcommandPattern(self, commandName, *expected_args):
@@ -312,10 +306,6 @@ class TestHgPoller(TestHgPollerBase):
     @defer.inlineCallbacks
     def test_poll_initial(self):
         self.repo_ready = False
-        # Test that environment variables get propagated to subprocesses
-        # (See #2116)
-        expected_env = {ENVIRON_2116_KEY: 'TRUE'}
-        self.add_run_process_expect_env(expected_env)
         self.expect_commands(
             ExpectMasterShell(['hg', 'init', '/some/dir']),
             ExpectMasterShell(['hg', 'pull', '-b', 'default', 'ssh://example.com/foo/baz']).workdir(


### PR DESCRIPTION
This is already tested in MasterShellCommand tests. This was historically needed because multiple implementations were used to implement subprocesses on master. Currently only one remains and thus single test suite is sufficient.

