### PR TITLE
BuildBot database tests with MariaDB Server

### DIFF
--- a/.github/workflows/cidb.yml
+++ b/.github/workflows/cidb.yml
@@ -17,6 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: MariaDB Server latest
+            database: mariadb:latest
+            connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
+            check: mariadb-admin ping
+
+          - name: MariaDB Server LTS
+            database: mariadb:lts
+            connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
+            check: mariadb-admin ping
+            
           - name: MySQL 5
             database: mysql:5
             connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
@@ -56,6 +66,10 @@ jobs:
       database:
         image: ${{ matrix.database }}
         env:
+          MARIADB_USER: buildbot
+          MARIADB_PASSWORD: buildbot
+          MARIADB_DATABASE: bbtest     
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
           MYSQL_USER: buildbot
           MYSQL_PASSWORD: buildbot
           MYSQL_DATABASE: bbtest


### PR DESCRIPTION
At MariaDB, we've been using BuildBot for several years at buildbot.mariadb.org, with MariaDB Server as the backend database. We would like to ensure that the latest BuildBot code is tested with both the latest stable version and the most recent LTS release of the database server, so we can gain confidence when upgrading BuildBot.

Thank you for your time and for all the great work over the years.
