### PR TITLE
cidb: MariaDB/MySQL healthchecks

### DIFF
--- a/.github/workflows/cidb.yml
+++ b/.github/workflows/cidb.yml
@@ -20,22 +20,22 @@ jobs:
           - name: MariaDB Server latest
             database: mariadb:latest
             connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
-            check: mariadb-admin ping
+            check: healthcheck.sh --connect --innodb_initialized
 
           - name: MariaDB Server LTS
             database: mariadb:lts
             connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
-            check: mariadb-admin ping
+            check: healthcheck.sh --connect --innodb_initialized
             
           - name: MySQL 5
             database: mysql:5
             connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
-            check: mysqladmin ping
+            check: mysqladmin --protocol tcp ping
 
           - name: MySQL latest
             database: mysql:latest
             connection: 'mysql+mysqldb://buildbot:buildbot@127.0.0.1:3306/bbtest?storage_engine=InnoDB'
-            check: mysqladmin ping
+            check: mysqladmin --protocol tcp ping
 
           - name: PostgreSQL 12 / psycopg2
             database: postgres:12


### PR DESCRIPTION
{mariadb/mysql}admin ping has the property that it tests the liveness over a unix socket.

Both MySQL and MariaDB containers in the initialization phases are running with --skip-networking to bootstrap the database files. As such a healthy check might result just before the database is restarted without skip-networking.

MariaDB has a healthcheck.sh to encapsulate the logic.

MySQL we use the protocol tcp option to force a connection attempt on the tcp socket which won't exist during --skip-networking.

Follow up to #8218

ref: https://mariadb.com/kb/en/using-healthcheck-sh-script/

## Contributor Checklist:

* [N/A ] I have updated the unit tests
* [Nope - not user visible] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation
