### PR TITLE
Fix tests not using real database if it is available and configured

### DIFF
--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -34,6 +34,7 @@ from buildbot.test.fake import pbmanager
 from buildbot.test.fake.botmaster import FakeBotMaster
 from buildbot.test.fake.machine import FakeMachineManager
 from buildbot.test.fake.secrets import FakeSecretStorage
+from buildbot.test.util.db import resolve_test_db_url
 from buildbot.util import service
 from buildbot.util.twisted import async_to_deferred
 
@@ -148,6 +149,7 @@ async def make_master(
     wantGraphql=False,
     with_secrets: dict | None = None,
     url=None,
+    sqlite_memory=True,
     **kwargs,
 ) -> FakeMaster:
     if wantRealReactor:
@@ -168,8 +170,8 @@ async def make_master(
         await master.mq.setServiceParent(master)
     if wantDb:
         assert testcase is not None, "need testcase for wantDb"
-        master.db = fakedb.FakeDBConnector(master.basedir, testcase)
-        master.db.configured_url = 'sqlite://'
+        master.db = fakedb.FakeDBConnector(master.basedir, testcase, auto_upgrade=True)
+        master.db.configured_url = resolve_test_db_url(None, sqlite_memory)
         await master.db.setServiceParent(master)
         await master.db.setup()
         testcase.addCleanup(master.db._shutdown)

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -79,6 +79,16 @@ def resolve_test_index_in_db_url(db_url):
     return db_url
 
 
+def resolve_test_db_url(db_url, sqlite_memory):
+    default_sqlite = 'sqlite://'
+    if db_url is None:
+        db_url = os.environ.get('BUILDBOT_TEST_DB_URL', default_sqlite)
+        if not sqlite_memory and db_url == default_sqlite:
+            db_url = "sqlite:///tmp.sqlite"
+
+    return resolve_test_index_in_db_url(db_url)
+
+
 def thd_clean_database(conn):
     # In general it's nearly impossible to do "bullet proof" database cleanup with SQLAlchemy
     # that will work on a range of databases and they configurations.
@@ -215,13 +225,7 @@ class RealDatabaseMixin:
             table_names = []
         self.__want_pool = want_pool
 
-        default_sqlite = 'sqlite://'
-        if db_url is None:
-            db_url = os.environ.get('BUILDBOT_TEST_DB_URL', default_sqlite)
-            if not sqlite_memory and db_url == default_sqlite:
-                db_url = "sqlite:///tmp.sqlite"
-
-        self.db_url = resolve_test_index_in_db_url(db_url)
+        self.db_url = resolve_test_db_url(db_url, sqlite_memory)
 
         if not os.path.exists(basedir):
             os.makedirs(basedir)


### PR DESCRIPTION
This PR fixes most of integration tests not using real database if it is available. The problem was introduced during test migration from RealDatabaseMixin to fakemaster function.