### PR TITLE
www: some REST response improvements

### DIFF
--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -53,6 +53,9 @@ class FakeRequest:
     responseCode = 200
 
     def __init__(self, path=None):
+        # from twisted.web.http.Request. Used to detect connection dropped
+        self.channel = True
+
         self.headers = {}
         self.input_headers = {}
         self.prepath = []

--- a/master/buildbot/www/resource.py
+++ b/master/buildbot/www/resource.py
@@ -69,7 +69,7 @@ class Resource(resource.Resource):
         if writeError is None:
             writeError = writeErrorDefault
         try:
-            d = _callable(request)
+            d = defer.maybeDeferred(_callable, request)
         except Exception as e:
             d = defer.fail(e)
 

--- a/master/docs/developer/cls-www.rst
+++ b/master/docs/developer/cls-www.rst
@@ -40,7 +40,7 @@ Resources
         :param callable: the render function
         :param writeError: optional callable for rendering errors
 
-        This method will call ``callable``, which can return a Deferred, with the given ``request``.
+        This method will call ``callable``, which can be async or a Deferred, with the given ``request``.
         The value returned from this callable will be converted to an HTTP response.
         Exceptions, including ``Error`` subclasses, are handled properly.
         If the callable raises :py:class:`Redirect`, the response will be a suitable HTTP 302 redirect.


### PR DESCRIPTION
We have a Builder that never had a success.

Upon user visiting the build page, call to `builds/{buildid}/changes` would try to load about the full history of changes for the (long-lived) project.
Response would result in a huge list of changes, that needed to be json-encoded/compressed, all that on the main thread.
Since this would take too long, request would timeout, but the master would keep working on it.

So this PR does two things:
- check that the connection is still alive between json encode chunks, so work can be aborted on lost connection
- defer json-encode to thread to avoid blocking the main thread

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
