### PR TITLE
process: Remove uses of twisted.python.constants

### DIFF
--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -15,12 +15,11 @@
 
 from __future__ import annotations
 
+import enum
 from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python.constants import NamedConstant
-from twisted.python.constants import Names
 
 if TYPE_CHECKING:
     from buildbot.process.builder import Builder
@@ -28,13 +27,13 @@ if TYPE_CHECKING:
     from buildbot.worker.latent import AbstractLatentWorker
 
 
-class States(Names):
+class States(enum.Enum):
     # The worker isn't attached, or is in the process of attaching.
-    DETACHED = NamedConstant()
+    DETACHED = 0
     # The worker is available to build: either attached, or a latent worker.
-    AVAILABLE = NamedConstant()
+    AVAILABLE = 1
     # The worker is building.
-    BUILDING = NamedConstant()
+    BUILDING = 2
 
 
 class AbstractWorkerForBuilder:

--- a/newsfragments/twisted-python-constants.bugfix
+++ b/newsfragments/twisted-python-constants.bugfix
@@ -1,0 +1,1 @@
+Fixed compatibility with Twisted 24.11.0 due to ``twisted.python.constants`` module being moved.


### PR DESCRIPTION
This has been deprecated in Twisted and are no longer shipping in Twisted 24.11.0.

## Contributor Checklist:

* [not needed] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
