### PR TITLE
test: Reuse resolve_test_db_url() in fakemaster.make_master()

### DIFF
--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -86,7 +86,7 @@ class UpgradeTestMixin(TestReactorMixin):
             sqlite_memory=False,
             auto_upgrade=False,
             check_version=False,
-            auto_clean=False,
+            auto_clean=False if self.source_tarball else True,
         )
 
         self._sql_log_handler = querylog.start_log_queries()

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -71,16 +71,18 @@ class UpgradeTestMixin(TestReactorMixin):
             # get the top-level dir from the tarball
             assert len(prefixes) == 1, "tarball has multiple top-level dirs!"
             self.basedir = prefixes.pop()
+            db_url = 'sqlite:///' + os.path.abspath(os.path.join(self.basedir, 'state.sqlite'))
         else:
             if not os.path.exists("basedir"):
                 os.makedirs("basedir")
             self.basedir = os.path.abspath("basedir")
+            db_url = None
 
         self.master = yield fakemaster.make_master(
             self,
             basedir=self.basedir,
             wantDb=True,
-            db_url='sqlite:///' + os.path.abspath(os.path.join(self.basedir, 'state.sqlite')),
+            db_url=db_url,
             sqlite_memory=False,
             auto_upgrade=False,
             check_version=False,

--- a/master/buildbot/test/unit/process/test_users_manual.py
+++ b/master/buildbot/test/unit/process/test_users_manual.py
@@ -139,8 +139,8 @@ class TestCommandlineUserManagerPerspective(TestReactorMixin, unittest.TestCase,
         yield self.call_perspective_commandline(
             'add', None, None, None, [{'identifier': 'h@c', 'git': 'hi <h@c>'}]
         )
-        yield self.call_perspective_commandline('remove', None, None, ['x'], None)
-        res = yield self.master.db.users.getUser('x')
+        yield self.call_perspective_commandline('remove', None, None, ['h@c'], None)
+        res = yield self.master.db.users.getUser(1)
         self.assertEqual(res, None)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -31,6 +31,10 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import logging
 
 
+def sort_builds(builds):
+    return sorted(builds, key=lambda key: key['buildid'])
+
+
 class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     LOGCONTENT = textwrap.dedent("""\
         line zero
@@ -174,6 +178,9 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
             self.master, 98, want_properties=True, want_steps=True, want_previous_build=True
         )
         self.assertEqual(len(res['builds']), 2)
+
+        res['builds'] = sort_builds(res['builds'])
+
         build1 = res['builds'][0]
         build2 = res['builds'][1]
         buildset = res['buildset']
@@ -239,7 +246,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
             want_logs_content=True,
         )
 
-        build1 = res['builds'][0]
+        build1 = sort_builds(res['builds'])[0]
         self.assertEqual(
             build1['steps'][0]['logs'][0]['content']['content'], self.LOGCONTENT + "\n"
         )
@@ -261,6 +268,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
             want_logs=True,
             want_logs_content=True,
         )
+
+        res['builds'] = sort_builds(res['builds'])
 
         self.assertEqual(
             res,

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -58,7 +58,6 @@ class FakeResponse:
 
 
 class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
-    @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor(auto_tear_down=False)
         if requests is None:
@@ -68,50 +67,85 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
         self.patch(requests, 'post', mock.Mock(spec=requests.post))
         self.patch(requests, 'get', mock.Mock(spec=requests.get))
 
-        self.googleAuth = oauth2.GoogleAuth("ggclientID", "clientSECRET")
-        self.githubAuth = oauth2.GitHubAuth("ghclientID", "clientSECRET")
-        self.githubAuth_v4 = oauth2.GitHubAuth("ghclientID", "clientSECRET", apiVersion=4)
-        self.githubAuth_v4_teams = oauth2.GitHubAuth(
-            "ghclientID", "clientSECRET", apiVersion=4, getTeamsMembership=True
-        )
-        self.githubAuthEnt = oauth2.GitHubAuth(
-            "ghclientID", "clientSECRET", serverURL="https://git.corp.fakecorp.com"
-        )
-        self.githubAuthEnt_v4 = oauth2.GitHubAuth(
-            "ghclientID",
-            "clientSECRET",
-            apiVersion=4,
-            getTeamsMembership=True,
-            serverURL="https://git.corp.fakecorp.com",
-        )
-        self.gitlabAuth = oauth2.GitLabAuth("https://gitlab.test/", "glclientID", "clientSECRET")
-        self.bitbucketAuth = oauth2.BitbucketAuth("bbclientID", "clientSECRET")
+    @defer.inlineCallbacks
+    def setup_google_auth(self):
+        auth = oauth2.GoogleAuth("ggclientID", "clientSECRET")
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
 
-        for auth in [
-            self.googleAuth,
-            self.githubAuth,
-            self.githubAuth_v4,
-            self.githubAuth_v4_teams,
-            self.githubAuthEnt,
-            self.gitlabAuth,
-            self.bitbucketAuth,
-            self.githubAuthEnt_v4,
-        ]:
-            self._master = master = yield self.make_master(url='h:/a/b/', auth=auth)
-            auth.reconfigAuth(master, master.config)
+    @defer.inlineCallbacks
+    def setup_github_auth(self):
+        auth = oauth2.GitHubAuth("ghclientID", "clientSECRET")
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
 
-        self.githubAuth_secret = oauth2.GitHubAuth(
-            Secret("client-id"), Secret("client-secret"), apiVersion=4
-        )
-        self._master = master = yield self.make_master(url='h:/a/b/', auth=auth)
+    @defer.inlineCallbacks
+    def setup_github_auth_v4(self):
+        auth = oauth2.GitHubAuth("ghclientID", "clientSECRET", apiVersion=4)
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
+
+    @defer.inlineCallbacks
+    def setup_github_auth_v4_secret(self):
+        auth = oauth2.GitHubAuth(Secret("client-id"), Secret("client-secret"), apiVersion=4)
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
         fake_storage_service = FakeSecretStorage()
         fake_storage_service.reconfigService(
             secretdict={"client-id": "secretClientId", "client-secret": "secretClientSecret"}
         )
         secret_service = SecretManager()
         secret_service.services = [fake_storage_service]
-        yield secret_service.setServiceParent(self._master)
-        self.githubAuth_secret.reconfigAuth(master, master.config)
+        yield secret_service.setServiceParent(master)
+        auth.reconfigAuth(master, master.config)
+        return auth
+
+    @defer.inlineCallbacks
+    def setup_github_auth_v4_teams(self):
+        auth = oauth2.GitHubAuth(
+            "ghclientID", "clientSECRET", apiVersion=4, getTeamsMembership=True
+        )
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
+
+    @defer.inlineCallbacks
+    def setup_github_auth_enterprise(self):
+        auth = oauth2.GitHubAuth(
+            "ghclientID", "clientSECRET", serverURL="https://git.corp.fakecorp.com"
+        )
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
+
+    @defer.inlineCallbacks
+    def setup_github_auth_enterprise_v4(self):
+        auth = oauth2.GitHubAuth(
+            "ghclientID",
+            "clientSECRET",
+            apiVersion=4,
+            getTeamsMembership=True,
+            serverURL="https://git.corp.fakecorp.com",
+        )
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
+
+    @defer.inlineCallbacks
+    def setup_gitlab_auth(self):
+        auth = oauth2.GitLabAuth("https://gitlab.test/", "glclientID", "clientSECRET")
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
+
+    @defer.inlineCallbacks
+    def setup_bitbucket_auth(self):
+        auth = oauth2.BitbucketAuth("bbclientID", "clientSECRET")
+        master = yield self.make_master(url='h:/a/b/', auth=auth)
+        auth.reconfigAuth(master, master.config)
+        return auth
 
     @defer.inlineCallbacks
     def tearDown(self):
@@ -119,7 +153,8 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getGoogleLoginURL(self):
-        res = yield self.googleAuth.getLoginURL('http://redir')
+        auth = yield self.setup_google_auth()
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://accounts.google.com/o/oauth2/auth?client_id=ggclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -128,7 +163,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.googleAuth.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://accounts.google.com/o/oauth2/auth?client_id=ggclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -140,7 +175,8 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getGithubLoginURL(self):
-        res = yield self.githubAuth.getLoginURL('http://redir')
+        auth = yield self.setup_github_auth()
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://github.com/login/oauth/authorize?client_id=ghclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -148,7 +184,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.githubAuth.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://github.com/login/oauth/authorize?client_id=ghclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -158,7 +194,8 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getGithubLoginURL_with_secret(self):
-        res = yield self.githubAuth_secret.getLoginURL('http://redir')
+        auth = yield self.setup_github_auth_v4_secret()
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://github.com/login/oauth/authorize?client_id=secretClientId&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -166,7 +203,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.githubAuth_secret.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://github.com/login/oauth/authorize?client_id=secretClientId&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -176,7 +213,9 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getGithubELoginURL(self):
-        res = yield self.githubAuthEnt.getLoginURL('http://redir')
+        auth = yield self.setup_github_auth_enterprise()
+
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -184,7 +223,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.githubAuthEnt.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -194,7 +233,9 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getGithubLoginURL_v4(self):
-        res = yield self.githubAuthEnt_v4.getLoginURL('http://redir')
+        auth = yield self.setup_github_auth_enterprise_v4()
+
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -202,7 +243,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.githubAuthEnt_v4.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
             "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
@@ -212,7 +253,9 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getGitLabLoginURL(self):
-        res = yield self.gitlabAuth.getLoginURL('http://redir')
+        auth = yield self.setup_gitlab_auth()
+
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://gitlab.test/oauth/authorize"
             "?client_id=glclientID&"
@@ -221,7 +264,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.gitlabAuth.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://gitlab.test/oauth/authorize"
             "?client_id=glclientID&"
@@ -232,7 +275,9 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_getBitbucketLoginURL(self):
-        res = yield self.bitbucketAuth.getLoginURL('http://redir')
+        auth = yield self.setup_bitbucket_auth()
+
+        res = yield auth.getLoginURL('http://redir')
         exp = (
             "https://bitbucket.org/site/oauth2/authorize?"
             "client_id=bbclientID&"
@@ -241,7 +286,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             "state=redirect%3Dhttp%253A%252F%252Fredir"
         )
         self.assertEqual(res, exp)
-        res = yield self.bitbucketAuth.getLoginURL(None)
+        res = yield auth.getLoginURL(None)
         exp = (
             "https://bitbucket.org/site/oauth2/authorize?"
             "client_id=bbclientID&"
@@ -252,12 +297,14 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_GoogleVerifyCode(self):
+        auth = yield self.setup_google_auth()
+
         requests.get.side_effect = []
         requests.post.side_effect = [FakeResponse({"access_token": 'TOK3N'})]
-        self.googleAuth.get = mock.Mock(
+        auth.get = mock.Mock(
             side_effect=[{"name": 'foo bar', "email": 'bar@foo', "picture": 'http://pic'}]
         )
-        res = yield self.googleAuth.verifyCode("code!")
+        res = yield auth.verifyCode("code!")
         self.assertEqual(
             {
                 'avatar_url': 'http://pic',
@@ -270,6 +317,8 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_GithubVerifyCode(self):
+        auth = yield self.setup_github_auth()
+
         test = self
         requests.get.side_effect = []
         requests.post.side_effect = [FakeResponse({"access_token": 'TOK3N'})]
@@ -296,9 +345,9 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
                 ]
             return None
 
-        self.githubAuth.get = fake_get
+        auth.get = fake_get
 
-        res = yield self.githubAuth.verifyCode("code!")
+        res = yield auth.verifyCode("code!")
         self.assertEqual(
             {
                 'email': 'bar@foo',
@@ -311,9 +360,11 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_GithubVerifyCode_v4(self):
+        auth = yield self.setup_github_auth_v4()
+
         requests.get.side_effect = []
         requests.post.side_effect = [FakeResponse({"access_token": 'TOK3N'})]
-        self.githubAuth_v4.post = mock.Mock(
+        auth.post = mock.Mock(
             side_effect=[
                 {
                     'data': {
@@ -329,7 +380,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
                 }
             ]
         )
-        res = yield self.githubAuth_v4.verifyCode("code!")
+        res = yield auth.verifyCode("code!")
         self.assertEqual(
             {
                 'email': 'bar@foo',
@@ -342,9 +393,11 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_GithubVerifyCode_v4_teams(self):
+        auth = yield self.setup_github_auth_v4_teams()
+
         requests.get.side_effect = []
         requests.post.side_effect = [FakeResponse({"access_token": 'TOK3N'})]
-        self.githubAuth_v4_teams.post = mock.Mock(
+        auth.post = mock.Mock(
             side_effect=[
                 {
                     'data': {
@@ -387,7 +440,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
                 },
             ]
         )
-        res = yield self.githubAuth_v4_teams.verifyCode("code!")
+        res = yield auth.verifyCode("code!")
         self.assertEqual(
             {
                 'email': 'bar@foo',
@@ -424,9 +477,11 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_GitlabVerifyCode(self):
+        auth = yield self.setup_gitlab_auth()
+
         requests.get.side_effect = []
         requests.post.side_effect = [FakeResponse({"access_token": 'TOK3N'})]
-        self.gitlabAuth.get = mock.Mock(
+        auth.get = mock.Mock(
             side_effect=[
                 {  # /user
                     "name": "Foo Bar",
@@ -442,7 +497,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
                 ],
             ]
         )
-        res = yield self.gitlabAuth.verifyCode("code!")
+        res = yield auth.verifyCode("code!")
         self.assertEqual(
             {
                 "full_name": "Foo Bar",
@@ -456,9 +511,11 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_BitbucketVerifyCode(self):
+        auth = yield self.setup_bitbucket_auth()
+
         requests.get.side_effect = []
         requests.post.side_effect = [FakeResponse({"access_token": 'TOK3N'})]
-        self.bitbucketAuth.get = mock.Mock(
+        auth.get = mock.Mock(
             side_effect=[
                 {"username": 'bar', "display_name": 'foo bar'},  # /user
                 {
@@ -470,7 +527,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
                 {"values": [{'slug': 'hello'}, {'slug': 'grp'}]},  # /workspaces?role=member
             ]
         )
-        res = yield self.bitbucketAuth.verifyCode("code!")
+        res = yield auth.verifyCode("code!")
         self.assertEqual(
             {
                 'email': 'bar@foo',
@@ -483,6 +540,8 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
 
     @defer.inlineCallbacks
     def test_loginResource(self):
+        auth = yield self.setup_github_auth()
+
         class fakeAuth:
             homeUri = "://me"
             getLoginURL = mock.Mock(side_effect=lambda x: defer.succeed("://"))
@@ -490,7 +549,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
             acceptToken = mock.Mock(side_effect=lambda token: defer.succeed({"username": "bar"}))
             userInfoProvider = None
 
-        rsrc = self.githubAuth.getLoginResource()
+        rsrc = auth.getLoginResource()
         rsrc.auth = fakeAuth()
         res = yield self.render_resource(rsrc, b'/')
         rsrc.auth.getLoginURL.assert_called_once_with(None)
@@ -507,21 +566,35 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
         res = yield self.render_resource(rsrc, b'/?token=token!')
         rsrc.auth.getLoginURL.assert_called_once()
 
-    def test_getConfig(self):
+    @defer.inlineCallbacks
+    def test_getConfig_github(self):
+        auth = yield self.setup_github_auth()
         self.assertEqual(
-            self.githubAuth.getConfigDict(),
+            auth.getConfigDict(),
             {'fa_icon': 'fa-github', 'autologin': False, 'name': 'GitHub', 'oauth2': True},
         )
+
+    @defer.inlineCallbacks
+    def test_getConfig_google(self):
+        auth = yield self.setup_google_auth()
         self.assertEqual(
-            self.googleAuth.getConfigDict(),
+            auth.getConfigDict(),
             {'fa_icon': 'fa-google-plus', 'autologin': False, 'name': 'Google', 'oauth2': True},
         )
+
+    @defer.inlineCallbacks
+    def test_getConfig_gitlab(self):
+        auth = yield self.setup_gitlab_auth()
         self.assertEqual(
-            self.gitlabAuth.getConfigDict(),
+            auth.getConfigDict(),
             {'fa_icon': 'fa-git', 'autologin': False, 'name': 'GitLab', 'oauth2': True},
         )
+
+    @defer.inlineCallbacks
+    def test_getConfig_bitbucket(self):
+        auth = yield self.setup_bitbucket_auth()
         self.assertEqual(
-            self.bitbucketAuth.getConfigDict(),
+            auth.getConfigDict(),
             {'fa_icon': 'fa-bitbucket', 'autologin': False, 'name': 'Bitbucket', 'oauth2': True},
         )
 


### PR DESCRIPTION
This fixes most of integration tests not using real database if it is available.

