### PR TITLE
www: Fix crash in build view when clicking on changes tab

### DIFF
--- a/www/base/src/views/BuildView/BuildView.tsx
+++ b/www/base/src/views/BuildView/BuildView.tsx
@@ -154,7 +154,7 @@ const ChangesTabWidget = ({build}: TabWidgetProps) => {
 
   const changesQuery = useDataApiSingleElementQuery(
     build, [changesFetchLimit],
-    b => b.getChanges({query: {limit: changesFetchLimit, field: ['changeid']}})
+    b => b.getChanges({query: {limit: changesFetchLimit}})
   );
   if (!changesQuery.isResolved()) {
     return <LoadingSpan />


### PR DESCRIPTION
The changeid field is insufficient to populate ChangesTable.

cc @tdesveaux 