### PR TITLE
worker: Fix exception when stopping command via stopCommand()

### DIFF
--- a/newsfragments/worker-exception-shutdown.bugfix
+++ b/newsfragments/worker-exception-shutdown.bugfix
@@ -1,0 +1,1 @@
+Fix exception when worker loses connection to master while a command is running.

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -278,7 +278,8 @@ class WorkerForBuilderPbLike(WorkerForBuilderBase):
 
     def lostRemoteStep(self, remotestep):
         log.msg("lost remote step")
-        self.protocol_command.command_ref = None
+        if self.protocol_command:
+            self.protocol_command.command_ref = None
         if self.stopCommandOnShutdown:
             self.stopCommand()
 


### PR DESCRIPTION
WorkerForBuilderPbLike.stopCommand() sets protocol_command to None and interrupts the command. It later calls lostRemoteStep which accesses protocol_command member which causes an exception:

```
Received SIGTERM, shutting down.
stopCommand: halting current command <buildbot_worker.commands.shell.WorkerShellCommand object at 0x7ef896b7c990>
(command <...>): command interrupted, attempting to kill (command <...>): trying to kill process group 221
(command <...>): signal 9 sent successfully
[Broker,client] lost remote step
[Broker,client] Unhandled Error
Traceback (most recent call last):
File ".../site-packages/twisted/spread/pb.py", line 707, in connectionLost
    notifier()
File ".../site-packages/twisted/spread/pb.py", line 322, in _disconnected
    callback(self)
File ".../site-packages/buildbot_worker/pb.py", line 281, in lostRemoteStep
   self.protocol_command.command_ref = None

builtins.AttributeError: 'NoneType' object has no attribute 'command_ref'
```

## Contributor Checklist:

* [not done] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
