### PR TITLE
 Fix issues in "Scheduled biweekly dependency update for week 48"

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,7 +5,7 @@
 buildbot-www==4.1.0
 
 Markdown==3.7
-coverage==7.6.7;  python_version >= "3.9"
+coverage==7.6.8;  python_version >= "3.9"
 coverage==7.6.1; python_version < "3.9" # pyup: ignore
 docker==7.1.0
 hvac==2.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -60,7 +60,7 @@ pyasn1-modules==0.4.1
 pycparser==2.22
 PyJWT==2.10.1;  python_version >= "3.9"
 PyJWT==2.9.0; python_version < "3.9" # pyup: ignore
-pyOpenSSL==24.2.1
+pyOpenSSL==24.3.0
 pypugjs==5.11.0
 python-dateutil==2.9.0.post0
 pytz==2024.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -86,5 +86,5 @@ Werkzeug==3.1.3;  python_version >= "3.9"
 Werkzeug==3.0.6;  python_version < "3.9" # pyup: ignore
 xmltodict==0.14.2
 zope.event==5.0
-zope.interface==7.1.1
+zope.interface==7.2
 zope.schema==7.0.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -28,7 +28,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
 boto3==1.35.72
-botocore==1.35.72
+botocore==1.35.63
 certifi==2024.8.30
 cffi==1.17.1
 charset-normalizer==3.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -28,7 +28,7 @@ autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
 boto3==1.35.72
-botocore==1.35.63
+botocore==1.35.72
 certifi==2024.8.30
 cffi==1.17.1
 charset-normalizer==3.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
 charset-normalizer==3.4.0
 constantly==23.10.4
 croniter==5.0.1
-cryptography==43.0.3
+cryptography==44.0.0
 dill==0.3.9
 evalidate==2.0.3
 greenlet==3.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ autobahn==24.4.2;  python_version >= "3.9"
 autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
 Automat==24.8.1
 boto==2.49.0
-boto3==1.35.63
+boto3==1.35.72
 botocore==1.35.63
 certifi==2024.8.30
 cffi==1.17.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -50,7 +50,7 @@ Brotli==1.1.0
 Mako==1.3.6
 MarkupSafe==3.0.2;  python_version >= "3.9"
 MarkupSafe==2.1.5;  python_version < "3.9" # pyup: ignore
-moto==5.0.21
+moto==5.0.22
 msgpack==1.1.0
 mypy-extensions==1.0.0
 packaging==24.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -68,7 +68,7 @@ PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.3
 ruff==0.7.4
-s3transfer==0.10.3
+s3transfer==0.10.4
 service-identity==24.2.0
 setuptools-trial==0.6.0
 six==1.16.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -7,7 +7,7 @@ cffi==1.15.1;  python_version < "3.8"  # pyup: ignore
 cffi==1.17.1;  python_version >= "3.8"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==43.0.3
+cryptography==44.0.0
 funcsigs==1.0.2
 hyperlink==21.0.0
 idna==3.10

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -27,5 +27,5 @@ txaio==23.1.1
 typing-extensions==4.7.1;  python_version < "3.8" # pyup: ignore
 typing-extensions==4.12.2;  python_version >= "3.8"
 zope.interface==6.4.post2;  python_version < "3.8" # pyup: ignore
-zope.interface==7.1.1;  python_version >= "3.8"
+zope.interface==7.2;  python_version >= "3.8"
 -e worker

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -2,6 +2,6 @@ pip==24.0; python_version < "3.8"  # pyup: ignore
 pip==24.3.1; python_version >= "3.8"
 setuptools==68.0.0; python_version < "3.8"  # pyup: ignore
 setuptools==75.3.0; python_version == "3.8"  # pyup: ignore
-setuptools==75.5.0; python_version >= "3.9"
+setuptools==75.6.0; python_version >= "3.9"
 wheel==0.42.0; python_version < "3.8"  # pyup: ignore
 wheel==0.45.0; python_version >= "3.8"

--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -4,4 +4,4 @@ setuptools==68.0.0; python_version < "3.8"  # pyup: ignore
 setuptools==75.3.0; python_version == "3.8"  # pyup: ignore
 setuptools==75.6.0; python_version >= "3.9"
 wheel==0.42.0; python_version < "3.8"  # pyup: ignore
-wheel==0.45.0; python_version >= "3.8"
+wheel==0.45.1; python_version >= "3.8"


### PR DESCRIPTION
This PR is based on #8237 with these modifications:
- removed `Update ruff from 0.7.4 to 0.8.1` - note: I'm not able reproduce reported issues with ruff 0.8.1 on (Windows with Python 3.12 & Ubuntu with python 3.13,3.12, 3.9)
- removed `Update twisted from 24.10.0 to 24.11.0` and moved it into separate PR #8263
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
