### PR TITLE
test: Fix typing error in definition of CoreReactor.resolve()

### DIFF
--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -72,7 +72,9 @@ class CoreReactor:
     def callWhenRunning(self, callable: Callable[..., Any], *args, **kwargs):
         callable(*args, **kwargs)
 
-    def resolve(self, name: str, timeout: Sequence[int]) -> defer.Deferred[str]:
+    def resolve(self, name: str, timeout: Sequence[int]) -> defer.Deferred[str]:  # type: ignore
+        # Twisted 24.11 changed the default value of timeout, thus to support
+        # both versions typing is disabled
         raise NotImplementedError("resolve() is not implemented in this reactor")
 
     def stop(self) -> None:


### PR DESCRIPTION
Twisted 24.11 changed the typing of resolve() from:

def resolve(name: str, timeout: Sequence[int]) -> "Deferred[str]"

to

def resolve(name: str, timeout: Sequence[int] = (1, 3, 11, 45)) ->
"Deferred[str]":

As a result it's not possible to support both and accordingly typing errors are ignored on that line.