### PR TITLE
Add a way to return all test result sets

### DIFF
--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -45,6 +45,7 @@ class Db2DataMixin:
 class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
+        /test_result_sets
         /builders/n:builderid/test_result_sets
         /builders/s:buildername/test_result_sets
         /builds/n:buildid/test_result_sets
@@ -75,11 +76,14 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
                 result_spec=resultSpec,
             )
 
-        else:
-            # The following is true: 'buildername' in kwargs or 'builderid' in kwargs:
+        elif 'buildername' in kwargs or 'builderid' in kwargs:
             builderid = yield self.getBuilderId(kwargs)
             sets = yield self.master.db.test_result_sets.getTestResultSets(
                 builderid, complete=complete, result_spec=resultSpec
+            )
+        else:
+            sets = yield self.master.db.test_result_sets.getTestResultSets(
+                complete=complete, result_spec=resultSpec
             )
 
         return [self.db2data(model) for model in sets]

--- a/master/buildbot/db/test_result_sets.py
+++ b/master/buildbot/db/test_result_sets.py
@@ -104,7 +104,7 @@ class TestResultSetsConnectorComponent(base.DBConnectorComponent):
 
     def getTestResultSets(
         self,
-        builderid: int,
+        builderid: int | None = None,
         buildid: int | None = None,
         stepid: int | None = None,
         complete: bool | None = None,
@@ -112,7 +112,9 @@ class TestResultSetsConnectorComponent(base.DBConnectorComponent):
     ) -> defer.Deferred[list[TestResultSetModel]]:
         def thd(conn) -> list[TestResultSetModel]:
             sets_table = self.db.model.test_result_sets
-            q = sets_table.select().where(sets_table.c.builderid == builderid)
+            q = sets_table.select()
+            if builderid is not None:
+                q = q.where(sets_table.c.builderid == builderid)
             if buildid is not None:
                 q = q.where(sets_table.c.buildid == buildid)
             if stepid is not None:

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -127,6 +127,13 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.tearDownEndpoint()
 
     @defer.inlineCallbacks
+    def test_get_result_sets_all(self):
+        results = yield self.callGet(('test_result_sets',))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['test_result_setid'] for r in results], [13, 14])
+
+    @defer.inlineCallbacks
     def test_get_result_sets_builders_builderid(self):
         results = yield self.callGet(('builders', 88, 'test_result_sets'))
         for result in results:

--- a/master/buildbot/test/unit/db/test_test_result_sets.py
+++ b/master/buildbot/test/unit/db/test_test_result_sets.py
@@ -92,7 +92,7 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     def test_signature_get_test_result_sets(self):
         @self.assertArgSpecMatches(self.db.test_result_sets.getTestResultSets)
         def getTestResultSets(
-            self, builderid, buildid=None, stepid=None, complete=None, result_spec=None
+            self, builderid=None, buildid=None, stepid=None, complete=None, result_spec=None
         ):
             pass
 
@@ -196,11 +196,13 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
             ),
         ])
 
-        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88)
-        self.assertEqual([d.id for d in set_dicts], [91, 93, 94, 95])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets()
+        self.assertEqual([d.id for d in set_dicts], [91, 92, 93, 94, 95])
         for d in set_dicts:
             self.assertIsInstance(d, test_result_sets.TestResultSetModel)
 
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88)
+        self.assertEqual([d.id for d in set_dicts], [91, 93, 94, 95])
         set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=89)
         self.assertEqual([d.id for d in set_dicts], [92])
         set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, buildid=30)

--- a/newsfragments/test-result-sets-all.feature
+++ b/newsfragments/test-result-sets-all.feature
@@ -1,0 +1,2 @@
+Added a way to return all test result sets from `getTestResultSets()`
+and from data API via new /test_result_sets path.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [automatic] I have updated the appropriate documentation
