### PR TITLE
util: Fix exception during thread pool shutdown

### DIFF
--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -65,11 +65,20 @@ class ThreadPool(threadpool.ThreadPool):
             return
 
         super().start()
-        self._stop_event = reactor.addSystemEventTrigger('during', 'shutdown', self.stop)
+        self._stop_event = reactor.addSystemEventTrigger(
+            'during', 'shutdown', self._stop_on_shutdown
+        )
+
+    def _stop_on_shutdown(self):
+        self._stop_impl(remove_trigger=False)
 
     def stop(self):
+        self._stop_impl(remove_trigger=True)
+
+    def _stop_impl(self, remove_trigger):
         if not self._stop_event:
             return
         super().stop()
-        reactor.removeSystemEventTrigger(self._stop_event)
+        if remove_trigger:
+            reactor.removeSystemEventTrigger(self._stop_event)
         self._stop_event = None


### PR DESCRIPTION
If thread pool is shutdown thrrough reactor shutdown system event trigger, then removeSystemEventTrigger() call is not needed. Otherwise exception is observed.

Fixes 6d376310dbff778624e682bb58f65570bb8a7a06.
