### PR TITLE
Prefer TestCase.addCleanup() to the same functionality in tearDown()

### DIFF
--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -32,9 +32,6 @@ class RealConfigs(dirs.DirsMixin, unittest.TestCase):
         self.basedir = os.path.abspath('basedir')
         self.filename = os.path.abspath("test.cfg")
 
-    def tearDown(self):
-        self.tearDownDirs()
-
     def test_sample_config(self):
         filename = util.sibpath(runner.__file__, 'sample.cfg')
         with assertNotProducesWarnings(DeprecatedApiWarning):

--- a/master/buildbot/test/integration/test_graphql.py
+++ b/master/buildbot/test/integration/test_graphql.py
@@ -93,12 +93,9 @@ class GraphQL(unittest.TestCase, TestReactorMixin):
         self.master.allSchedulers = lambda: scheds
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
         yield self.insert_initial_data()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.master.stopService()
 
     @defer.inlineCallbacks
     def insert_initial_data(self):

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -154,12 +154,14 @@ class TelegramBot(www.RequiresWwwMixin, dirs.DirsMixin, unittest.TestCase):
 
         tb.bot.send_message = send_message
 
-    @defer.inlineCallbacks
-    def tearDown(self):
-        if self.master:
-            yield self.master.www.stopService()
-            yield self.master.mq.stopService()
-            yield self.master.test_shutdown()
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.master:
+                yield self.master.www.stopService()
+                yield self.master.mq.stopService()
+                yield self.master.test_shutdown()
+
+        self.addCleanup(cleanup)
 
     @defer.inlineCallbacks
     def testWebhook(self):

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -156,7 +156,6 @@ class TelegramBot(www.RequiresWwwMixin, dirs.DirsMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownDirs()
         if self.master:
             yield self.master.www.stopService()
             yield self.master.mq.stopService()

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -90,9 +90,7 @@ class UpgradeTestMixin(TestReactorMixin):
         )
 
         self._sql_log_handler = querylog.start_log_queries()
-
-    def tearDownUpgradeTest(self):
-        querylog.stop_log_queries(self._sql_log_handler)
+        self.addCleanup(lambda: querylog.stop_log_queries(self._sql_log_handler))
 
     # save subclasses the trouble of calling our setUp and tearDown methods
 
@@ -102,7 +100,6 @@ class UpgradeTestMixin(TestReactorMixin):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownUpgradeTest()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -95,12 +95,8 @@ class UpgradeTestMixin(TestReactorMixin):
     # save subclasses the trouble of calling our setUp and tearDown methods
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpUpgradeTest()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def assertModelMatches(self):

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -103,22 +103,18 @@ class Www(www.RequiresWwwMixin, unittest.TestCase):
 
         self.master = master
 
+        self.addCleanup(self.master.test_shutdown)
+        self.addCleanup(self.master.www.stopService)
+
         # build an HTTP agent, using an explicit connection pool if Twisted
         # supports it (Twisted 13.0.0 and up)
         if hasattr(client, 'HTTPConnectionPool'):
             self.pool = client.HTTPConnectionPool(reactor)
             self.agent = client.Agent(reactor, pool=self.pool)
+            self.addCleanup(self.pool.closeCachedConnections)
         else:
             self.pool = None
             self.agent = client.Agent(reactor)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        if self.pool:
-            yield self.pool.closeCachedConnections()
-        if self.master:
-            yield self.master.www.stopService()
-        yield self.master.test_shutdown()
 
     @defer.inlineCallbacks
     def apiGet(self, url, expect200=True):

--- a/master/buildbot/test/integration/worker/test_comm.py
+++ b/master/buildbot/test/integration/worker/test_comm.py
@@ -161,7 +161,7 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
 
         # set the worker port to a loopback address with unspecified
@@ -215,10 +215,6 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
             yield defer.gatherResults(deferreds, consumeErrors=True)
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def addWorker(self, **kwargs):

--- a/master/buildbot/test/integration/worker/test_proxy.py
+++ b/master/buildbot/test/integration/worker/test_proxy.py
@@ -147,19 +147,21 @@ class RunMasterBehindProxy(RunMasterBase):
         self.target_port = self.queue.get()
         write_to_log(f"got target_port {self.target_port}\n")
 
-    def tearDown(self):
-        write_to_log("tearDown\n")
-        self.proxy_process.terminate()
-        self.proxy_process.join()
-        if self.enable_debug:
-            print("---- stdout ----")
-            with open(get_log_path(), encoding='utf-8') as file:
-                print(file.read())
-            print("---- ------ ----")
-            with open(self.queue.get(), encoding='utf-8') as file:
-                print(file.read())
-            print("---- ------ ----")
-            os.unlink(get_log_path())
+        def cleanup():
+            write_to_log("cleanup\n")
+            self.proxy_process.terminate()
+            self.proxy_process.join()
+            if self.enable_debug:
+                print("---- stdout ----")
+                with open(get_log_path(), encoding='utf-8') as file:
+                    print(file.read())
+                print("---- ------ ----")
+                with open(self.queue.get(), encoding='utf-8') as file:
+                    print(file.read())
+                print("---- ------ ----")
+                os.unlink(get_log_path())
+
+        self.addCleanup(cleanup)
 
     @defer.inlineCallbacks
     def setup_master(self, config_dict, startWorker=True):

--- a/master/buildbot/test/integration/worker/test_workerside.py
+++ b/master/buildbot/test/integration/worker/test_workerside.py
@@ -111,7 +111,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         # set the worker port to a loopback address with unspecified
         # port
@@ -156,10 +156,6 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
                 yield self.buildworker.waitForCompleteShutdown()
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def addMasterSideWorker(

--- a/master/buildbot/test/integration/worker/test_workerside.py
+++ b/master/buildbot/test/integration/worker/test_workerside.py
@@ -142,18 +142,23 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
         self.tmpdirs = set()
 
+        @defer.inlineCallbacks
+        def cleanup():
+            for tmp in self.tmpdirs:
+                if os.path.exists(tmp):
+                    shutil.rmtree(tmp)
+            yield self.pbmanager.stopService()
+            yield self.botmaster.stopService()
+            yield self.workers.stopService()
+
+            # if the worker is still attached, wait for it to detach, too
+            if self.buildworker:
+                yield self.buildworker.waitForCompleteShutdown()
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        for tmp in self.tmpdirs:
-            if os.path.exists(tmp):
-                shutil.rmtree(tmp)
-        yield self.pbmanager.stopService()
-        yield self.botmaster.stopService()
-        yield self.workers.stopService()
-
-        # if the worker is still attached, wait for it to detach, too
-        if self.buildworker:
-            yield self.buildworker.waitForCompleteShutdown()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/reactor.py
+++ b/master/buildbot/test/reactor.py
@@ -23,6 +23,7 @@ from buildbot.test.fake.reactor import NonThreadPool
 from buildbot.test.fake.reactor import TestReactor
 from buildbot.util import twisted
 from buildbot.util.eventual import _setReactor
+from buildbot.warnings import warn_deprecated
 
 
 class TestReactorMixin:
@@ -32,6 +33,9 @@ class TestReactorMixin:
     """
 
     def setup_test_reactor(self, use_asyncio=False, auto_tear_down=True):
+        if not auto_tear_down:
+            warn_deprecated('4.2.0', 'auto_tear_down=False is deprecated')
+
         self.patch(threadpool, 'ThreadPool', NonThreadPool)
         self.patch(twisted, 'ThreadPool', NonThreadPool)
         self.reactor = TestReactor()

--- a/master/buildbot/test/regressions/test_bad_change_properties_rows.py
+++ b/master/buildbot/test/regressions/test_bad_change_properties_rows.py
@@ -30,13 +30,9 @@ class TestBadRows(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_bogus_row_no_source(self):

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -704,8 +704,12 @@ class TestBuildStepMixin:
         self._exp_result_summaries: list[str] = []
         self._exp_build_result_summaries: list[str] = []
 
-    def tear_down_test_build_step(self):
-        pass
+    def tear_down_test_build_step(self):  # pragma: no cover
+        warn_deprecated(
+            '4.2.0',
+            'tear_down_test_build_step() no longer needs to be called, '
+            + 'test tear down is run automatically',
+        )
 
     def _setup_fake_build(self, worker_version, worker_env, build_files):
         if worker_version is None:

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -32,12 +32,8 @@ class TestChangeSource(changesource.ChangeSourceMixin, TestReactorMixin, unittes
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_activation(self):
@@ -83,15 +79,11 @@ class TestReconfigurablePollingChangeSource(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         yield self.setUpChangeSource()
 
         yield self.attachChangeSource(self.Subclass(name="DummyCS"))
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def runClockFor(self, secs):

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -37,7 +37,6 @@ class TestChangeSource(changesource.ChangeSourceMixin, TestReactorMixin, unittes
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -92,7 +91,6 @@ class TestReconfigurablePollingChangeSource(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -306,7 +306,6 @@ class TestBitbucketPullrequestPoller(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     def _fakeGetPage(self, result):

--- a/master/buildbot/test/unit/changes/test_bitbucket.py
+++ b/master/buildbot/test/unit/changes/test_bitbucket.py
@@ -274,7 +274,7 @@ class TestBitbucketPullrequestPoller(
     changesource.ChangeSourceMixin, TestReactorMixin, LoggingMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpLogging()
 
         # create pull requests
@@ -303,10 +303,6 @@ class TestBitbucketPullrequestPoller(
         )
 
         return self.setUpChangeSource()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def _fakeGetPage(self, result):
         # Install a fake getPage that puts the requested URL in self.getPage_got_url

--- a/master/buildbot/test/unit/changes/test_changes.py
+++ b/master/buildbot/test/unit/changes/test_changes.py
@@ -54,7 +54,7 @@ class Change(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.change23 = changes.Change(**{  # using **dict(..) forces kwargs
             "category": 'devel',
@@ -106,10 +106,6 @@ class Change(unittest.TestCase, TestReactorMixin):
             "revision": 'deadbeef',
         })
         self.change25.number = 25
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_fromChdict(self):

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -99,14 +99,10 @@ class TestGerritChangeSource(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         self._got_events = []
         yield self.setUpChangeSource()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def create_gerrit(self, host, user, *args, **kwargs):
@@ -1050,14 +1046,10 @@ class TestGerritEventLogPoller(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def newChangeSource(self, **kwargs):

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -97,17 +97,22 @@ class TestGerritChangeSource(
     TestReactorMixin,
     unittest.TestCase,
 ):
+    @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor(auto_tear_down=False)
         self.setup_master_run_process()
         self._got_events = []
-        return self.setUpChangeSource()
+        yield self.setUpChangeSource()
+
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.master.running:
+                yield self.stopChangeSource()
+
+        self.addCleanup(cleanup)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.master.running:
-            yield self.stopChangeSource()
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1059,7 +1064,6 @@ class TestGerritEventLogPoller(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -1053,10 +1053,10 @@ class TestGerritEventLogPoller(
         self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpChangeSource()
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -104,13 +104,6 @@ class TestGerritChangeSource(
         self._got_events = []
         yield self.setUpChangeSource()
 
-        @defer.inlineCallbacks
-        def cleanup():
-            if self.master.running:
-                yield self.stopChangeSource()
-
-        self.addCleanup(cleanup)
-
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.tear_down_test_reactor()

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -190,12 +190,12 @@ class TestGitHubPullrequestPoller(
         yield secret_service.setServiceParent(self.master)
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
         fake_storage_service.reconfigService(secretdict={"token": "1234"})
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -180,7 +180,7 @@ class TestGitHubPullrequestPoller(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
 
         fake_storage_service = FakeSecretStorage()
@@ -193,10 +193,6 @@ class TestGitHubPullrequestPoller(
         self.addCleanup(self.master.stopService)
 
         fake_storage_service.reconfigService(secretdict={"token": "1234"})
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def newChangeSource(self, owner, repo, endpoint='https://api.github.com', **kwargs):

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -196,7 +196,6 @@ class TestGitHubPullrequestPoller(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -67,12 +67,12 @@ class TestGitPollerBase(
         self.setup_master_run_process()
         yield self.setUpChangeSource()
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
         self.poller = yield self.attachChangeSource(self.createPoller())
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @async_to_deferred
@@ -2423,10 +2423,10 @@ class TestGitPollerConstructor(
         self.setup_test_reactor(auto_tear_down=False)
         yield self.setUpChangeSource()
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -2580,6 +2580,7 @@ class TestGitPollerBareRepository(
 
         yield self.setUpChangeSource(want_real_reactor=True)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
         self.poller_workdir = tempfile.mkdtemp(
             prefix="TestGitPollerBareRepository_",
@@ -2596,10 +2597,7 @@ class TestGitPollerBareRepository(
             )
         )
 
-    @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
-
         def _delete_repository(repo_path: Path):
             # on Win, git will mark objects as read-only
             git_objects_path = repo_path / "objects"

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -63,17 +63,13 @@ class TestGitPollerBase(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
 
         self.poller = yield self.attachChangeSource(self.createPoller())
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @async_to_deferred
     async def set_last_rev(self, state: dict[str, str]) -> None:
@@ -2420,14 +2416,10 @@ class TestGitPollerConstructor(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpChangeSource()
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_deprecatedFetchRefspec(self):

--- a/master/buildbot/test/unit/changes/test_gitpoller.py
+++ b/master/buildbot/test/unit/changes/test_gitpoller.py
@@ -73,7 +73,6 @@ class TestGitPollerBase(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @async_to_deferred
@@ -2428,7 +2427,6 @@ class TestGitPollerConstructor(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -2601,7 +2599,6 @@ class TestGitPollerBareRepository(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
-        yield self.tearDownChangeSource()
 
         def _delete_repository(repo_path: Path):
             # on Win, git will mark objects as read-only

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -61,10 +61,10 @@ class TestHgPollerBase(
         self.poller._isRepositoryReady = _isRepositoryReady
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -38,7 +38,7 @@ class TestHgPollerBase(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
 
@@ -62,10 +62,6 @@ class TestHgPollerBase(
 
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def check_current_rev(self, wished, branch='default'):

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -65,7 +65,6 @@ class TestHgPollerBase(
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.master.stopService()
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -271,9 +270,6 @@ class TestHgPollerBookmarks(TestHgPollerBase):
 
 
 class TestHgPoller(TestHgPollerBase):
-    def tearDown(self):
-        return self.tearDownChangeSource()
-
     def gpoFullcommandPattern(self, commandName, *expected_args):
         """Match if the command is commandName and arg list start as expected.
 

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -54,7 +54,6 @@ class TestMaildirSource(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownDirs()
         yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -54,7 +54,6 @@ class TestMaildirSource(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     # tests

--- a/master/buildbot/test/unit/changes/test_mail.py
+++ b/master/buildbot/test/unit/changes/test_mail.py
@@ -29,7 +29,7 @@ class TestMaildirSource(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.maildir = os.path.abspath("maildir")
 
         yield self.setUpChangeSource()
@@ -51,10 +51,6 @@ class TestMaildirSource(
     def assertMailProcessed(self):
         self.assertFalse(os.path.exists(os.path.join(self.maildir, "new", "newmsg")))
         self.assertTrue(os.path.exists(os.path.join(self.maildir, "cur", "newmsg")))
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # tests
 

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -28,7 +28,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestChangeManager(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
         self.cm = manager.ChangeManager()
 
@@ -37,10 +37,6 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
 
         yield self.cm.setServiceParent(self.master)
         self.new_config = mock.Mock()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def make_sources(self, n, klass=base.ChangeSource, **kwargs):
         for i in range(n):

--- a/master/buildbot/test/unit/changes/test_manager.py
+++ b/master/buildbot/test/unit/changes/test_manager.py
@@ -31,13 +31,15 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
         self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True)
         self.cm = manager.ChangeManager()
+
         self.master.startService()
+        self.addCleanup(self.master.stopService)
+
         yield self.cm.setServiceParent(self.master)
         self.new_config = mock.Mock()
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def make_sources(self, n, klass=base.ChangeSource, **kwargs):

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -115,7 +115,6 @@ class TestP4Poller(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     def add_p4_describe_result(self, number, result):

--- a/master/buildbot/test/unit/changes/test_p4poller.py
+++ b/master/buildbot/test/unit/changes/test_p4poller.py
@@ -109,13 +109,9 @@ class TestP4Poller(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         yield self.setUpChangeSource()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def add_p4_describe_result(self, number, result):
         self.expect_commands(

--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -48,7 +48,6 @@ class TestPBChangeSource(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     def test_registration_no_workerport(self):

--- a/master/buildbot/test/unit/changes/test_pb.py
+++ b/master/buildbot/test/unit/changes/test_pb.py
@@ -40,15 +40,11 @@ class TestPBChangeSource(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpPBChangeSource()
         yield self.setUpChangeSource()
 
         self.master.pbmanager = self.pbmanager
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_registration_no_workerport(self):
         return self._test_registration(None, exp_ConfigErrors=True, user='alice', passwd='sekrit')
@@ -216,12 +212,8 @@ class TestPBChangeSource(
 class TestChangePerspective(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
-
-        @defer.inlineCallbacks
-        def tearDown(self):
-            yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_addChange_noprefix(self):

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -265,7 +265,6 @@ class TestSVNPoller(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownChangeSource()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/changes/test_svnpoller.py
+++ b/master/buildbot/test/unit/changes/test_svnpoller.py
@@ -259,13 +259,9 @@ class TestSVNPoller(
     MasterRunProcessMixin, changesource.ChangeSourceMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         return self.setUpChangeSource()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def attachSVNPoller(self, *args, **kwargs):

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -113,9 +113,6 @@ class ConfigLoaderTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.SynchronousT
 
         return self.setUpDirs('basedir')
 
-    def tearDown(self):
-        return self.tearDownDirs()
-
     def install_config_file(self, config_file, other_files=None):
         if other_files is None:
             other_files = {}
@@ -206,9 +203,6 @@ class MasterConfigTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         self.basedir = os.path.abspath('basedir')
         self.filename = os.path.join(self.basedir, 'test.cfg')
         return self.setUpDirs('basedir')
-
-    def tearDown(self):
-        return self.tearDownDirs()
 
     # utils
 

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -26,11 +26,7 @@ from buildbot.test.util import endpoint
 
 class ResourceType(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     def makeResourceTypeSubclass(self, **attributes):
         attributes.setdefault('name', 'thing')

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -106,9 +106,6 @@ class Endpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         yield self.setUpEndpoint()
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     def test_sets_master(self):
         self.assertIdentical(self.master, self.ep.master)
 

--- a/master/buildbot/test/unit/data/test_build_data.py
+++ b/master/buildbot/test/unit/data/test_build_data.py
@@ -323,7 +323,7 @@ class TestBuildDatasNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestBuildData(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = build_data.BuildData(self.master)
         yield self.master.db.insert_test_data([
@@ -334,10 +334,6 @@ class TestBuildData(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCa
             fakedb.Master(id=88),
             fakedb.Build(id=2, buildrequestid=41, masterid=88, builderid=88, workerid=47),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_set_build_data(self):
         @self.assertArgSpecMatches(self.master.data.updates.setBuildData, self.rtype.setBuildData)

--- a/master/buildbot/test/unit/data/test_build_data.py
+++ b/master/buildbot/test/unit/data/test_build_data.py
@@ -45,9 +45,6 @@ class TestBuildDataNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildData(id=91, buildid=30, name='name1', value=b'value1', source='source1'),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing_build_data_by_build_id(self):
         result = yield self.callGet(('builds', 30, 'data', 'name1'))
@@ -152,9 +149,6 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             ),
             fakedb.BuildData(id=91, buildid=30, name='name1', value=b'value1', source='source1'),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     def validateData(self, data):
         self.assertIsInstance(data['raw'], bytes)
@@ -285,9 +279,6 @@ class TestBuildDatasNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildData(id=92, buildid=30, name='name2', value=b'value2', source='source2'),
             fakedb.BuildData(id=93, buildid=31, name='name3', value=b'value3', source='source3'),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @parameterized.expand([
         ('multiple_values', 7, ['name1', 'name2']),

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -215,17 +215,13 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = builders.Builder(self.master)
         yield self.master.db.insert_test_data([
             fakedb.Master(id=13),
             fakedb.Master(id=14),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findBuilderId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -44,9 +44,6 @@ class BuilderEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuilderMaster(id=1, builderid=2, masterid=13),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         builder = yield self.callGet(('builders', 2))
@@ -129,9 +126,6 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.ConnectedWorker(id=1, workerid=1, masterid=13),
             fakedb.ConfiguredWorker(id=1, workerid=1, buildermasterid=1),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -268,13 +268,9 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin, unittest.Tes
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = buildrequests.BuildRequest(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def doTestCallthrough(

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -66,9 +66,6 @@ class TestBuildRequestEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             ),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def testGetExisting(self):
         self.db.buildrequests.claimBuildRequests([44], claimed_at=self.CLAIMED_AT)
@@ -150,9 +147,6 @@ class TestBuildRequestsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.SourceStamp(id=100),
             fakedb.BuildsetSourceStamp(buildsetid=8822, sourcestampid=100),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def testGetAll(self):

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -337,7 +337,7 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = builds.Build(self.master)
 
@@ -352,10 +352,6 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
                 id=99, builderid=10, masterid=824, workerid=20, buildrequestid=499, number=42
             ),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_callthrough(

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -56,9 +56,6 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             ),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         build = yield self.callGet(('builds', 14))
@@ -180,9 +177,6 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
                 buildid=13, name='reason', value='"force build"', source="Force Build Form"
             ),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get_all(self):

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -120,7 +120,7 @@ class BuildsetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Buildset(TestReactorMixin, util_interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = buildsets.Buildset(self.master)
         yield self.master.db.insert_test_data([
@@ -138,10 +138,6 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests, unittest.TestCa
             fakedb.Buildset(id=199, complete=False),
             fakedb.BuildRequest(id=999, buildsetid=199, builderid=42),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     SS234_DATA = {
         'branch': 'br',

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -49,9 +49,6 @@ class BuildsetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Buildset(id=14, reason='no sourcestamps'),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         buildset = yield self.callGet(('buildsets', 13))
@@ -87,9 +84,6 @@ class BuildsetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildsetSourceStamp(buildsetid=13, sourcestampid=92),
             fakedb.BuildsetSourceStamp(buildsetid=14, sourcestampid=92),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -51,9 +51,6 @@ class ChangeEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             ),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         change = yield self.callGet(('changes', '13'))
@@ -105,9 +102,6 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildRequest(id=1, builderid=1, buildsetid=8822),
             fakedb.Build(buildrequestid=1, masterid=1, workerid=1, builderid=1, number=1),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -195,17 +195,13 @@ class Change(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = changes.Change(self.master)
 
         yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=99),  # force minimum ID in tests below
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_addChange(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_changesources.py
+++ b/master/buildbot/test/unit/data/test_changesources.py
@@ -47,9 +47,6 @@ class ChangeSourceEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.ChangeSourceMaster(changesourceid=15, masterid=33),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         """get an existing changesource by id"""
@@ -114,9 +111,6 @@ class ChangeSourcesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.ChangeSource(id=16, name='wholenother:changesource'),
             fakedb.ChangeSourceMaster(changesourceid=16, masterid=33),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_changesources.py
+++ b/master/buildbot/test/unit/data/test_changesources.py
@@ -140,13 +140,9 @@ class ChangeSourcesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class ChangeSource(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = changesources.ChangeSource(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findChangeSourceId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -112,26 +112,18 @@ class Tests(interfaces.InterfaceTests):
 class TestFakeData(TestReactorMixin, unittest.TestCase, Tests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.data = self.master.data
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestDataConnector(TestReactorMixin, unittest.TestCase, Tests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True)
         self.data = connector.DataConnector()
         yield self.data.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class DataConnector(TestReactorMixin, unittest.TestCase):
@@ -139,16 +131,12 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         # don't load by default
         self.patch(connector.DataConnector, 'submodules', [])
         self.data = connector.DataConnector()
         yield self.data.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def patchFooPattern(self):
         cls = type('FooEndpoint', (base.Endpoint,), {})

--- a/master/buildbot/test/unit/data/test_forceschedulers.py
+++ b/master/buildbot/test/unit/data/test_forceschedulers.py
@@ -194,9 +194,6 @@ class ForceschedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         scheds = [ForceScheduler(name="defaultforce", builderNames=["builder"])]
         self.master.allSchedulers = lambda: scheds
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         res = yield self.callGet(('forceschedulers', "defaultforce"))
@@ -219,9 +216,6 @@ class ForceSchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         yield self.setUpEndpoint()
         scheds = [ForceScheduler(name="defaultforce", builderNames=["builder"])]
         self.master.allSchedulers = lambda: scheds
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get_existing(self):

--- a/master/buildbot/test/unit/data/test_logchunks.py
+++ b/master/buildbot/test/unit/data/test_logchunks.py
@@ -95,9 +95,6 @@ class LogChunkEndpointBase(endpoint.EndpointMixin, unittest.TestCase):
             ]
         )
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def do_test_chunks(self, path, logid, expLines):
         # get the whole thing in one go

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -48,9 +48,6 @@ class LogEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Log(id=61, stepid=50, name='errors', slug='errors', type='t'),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         log = yield self.callGet(('logs', 60))
@@ -137,9 +134,6 @@ class LogsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Log(id=71, stepid=51, name='results_html', type='h'),
             fakedb.Step(id=52, buildid=13, number=11, name='nothing'),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get_stepid(self):

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -194,13 +194,9 @@ class LogsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Log(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = logs.Log(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_callthrough(

--- a/master/buildbot/test/unit/data/test_masters.py
+++ b/master/buildbot/test/unit/data/test_masters.py
@@ -49,9 +49,6 @@ class MasterEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Builder(id=24, name='bldr2'),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         master = yield self.callGet(('masters', 14))
@@ -99,9 +96,6 @@ class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Builder(id=22),
             fakedb.BuilderMaster(masterid=13, builderid=22),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_masters.py
+++ b/master/buildbot/test/unit/data/test_masters.py
@@ -125,13 +125,9 @@ class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Master(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = masters.Master(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_masterActive(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_patches.py
+++ b/master/buildbot/test/unit/data/test_patches.py
@@ -24,12 +24,8 @@ from buildbot.test.reactor import TestReactorMixin
 class Patch(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = patches.Patch(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # no update methods -> nothing to test

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -41,9 +41,6 @@ class ProjectEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Project(id=2, name='project2'),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing_id(self):
         project = yield self.callGet(('projects', 2))
@@ -87,9 +84,6 @@ class ProjectsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Builder(id=201, projectid=3),
             fakedb.BuilderMaster(id=300, builderid=200, masterid=100),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @parameterized.expand([
         ('no_filter', None, [1, 2, 3]),

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -109,16 +109,12 @@ class ProjectsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Project(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = projects.Project(self.master)
         yield self.master.db.insert_test_data([
             fakedb.Project(id=13, name="fake_project"),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_find_project_id(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -45,9 +45,6 @@ class BuildsetPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildsetProperty(buildsetid=14),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_properties(self):
         props = yield self.callGet(('buildsets', 14, 'properties'))
@@ -72,9 +69,6 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildProperty(buildid=786, name="year", value=1651, source="Wikipedia"),
             fakedb.BuildProperty(buildid=786, name="island_name", value="despair", source="Book"),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get_properties(self):

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -85,13 +85,9 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Properties(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=False, wantDb=True, wantData=True)
         self.rtype = properties.Properties(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_callthrough(

--- a/master/buildbot/test/unit/data/test_root.py
+++ b/master/buildbot/test/unit/data/test_root.py
@@ -32,9 +32,6 @@ class RootEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             {'name': 'abc'},
         ]
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get(self):
         rootlinks = yield self.callGet(('',))
@@ -61,9 +58,6 @@ class SpecEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.master.data.disownServiceParent()
         self.master.data = connector.DataConnector()
         yield self.master.data.setServiceParent(self.master)
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_schedulers.py
+++ b/master/buildbot/test/unit/data/test_schedulers.py
@@ -45,9 +45,6 @@ class SchedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.SchedulerMaster(schedulerid=15, masterid=33),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         scheduler = yield self.callGet(('schedulers', 14))
@@ -111,9 +108,6 @@ class SchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Scheduler(id=16, name='wholenother:scheduler'),
             fakedb.SchedulerMaster(schedulerid=16, masterid=33),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_schedulers.py
+++ b/master/buildbot/test/unit/data/test_schedulers.py
@@ -137,13 +137,9 @@ class SchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Scheduler(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = schedulers.Scheduler(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_schedulerEnable(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_sourcestamps.py
+++ b/master/buildbot/test/unit/data/test_sourcestamps.py
@@ -41,9 +41,6 @@ class SourceStampEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.SourceStamp(id=14, patchid=99, branch='poplar'),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         sourcestamp = yield self.callGet(('sourcestamps', 13))
@@ -92,9 +89,6 @@ class SourceStampsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.BuildsetSourceStamp(sourcestampid=13, buildsetid=30),
             fakedb.BuildsetSourceStamp(sourcestampid=14, buildsetid=30),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/data/test_steps.py
+++ b/master/buildbot/test/unit/data/test_steps.py
@@ -73,9 +73,6 @@ class StepEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Step(id=72, number=2, name='three', buildid=30, started_at=TIME4, hidden=True),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         step = yield self.callGet(('steps', 72))
@@ -182,9 +179,6 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.Step(id=72, number=2, name='three', buildid=30, started_at=TIME4),
             fakedb.Step(id=73, number=0, name='otherbuild', buildid=31, started_at=TIME3),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get_buildid(self):

--- a/master/buildbot/test/unit/data/test_steps.py
+++ b/master/buildbot/test/unit/data/test_steps.py
@@ -211,7 +211,7 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = steps.Step(self.master)
 
@@ -225,10 +225,6 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
                 id=10, builderid=77, number=7, masterid=88, buildrequestid=82, workerid=47
             ),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_addStep(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -55,9 +55,6 @@ class TestResultSetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             ),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing_result_set(self):
         result = yield self.callGet(('test_result_sets', 13))
@@ -122,9 +119,6 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
                 complete=1,
             ),
         ])
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get_result_sets_all(self):

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -159,7 +159,7 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestResultSet(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         yield self.master.db.insert_test_data([
             fakedb.Master(id=1),
@@ -187,10 +187,6 @@ class TestResultSet(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCa
             ),
         ])
         self.rtype = test_result_sets.TestResultSet(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_add_test_result_set(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -79,9 +79,6 @@ class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             ),
         ])
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing_results(self):
         results = yield self.callGet(('test_result_sets', 13, 'results'))

--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -95,7 +95,7 @@ class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = test_results.TestResult(self.master)
         yield self.master.db.insert_test_data([
@@ -110,10 +110,6 @@ class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase)
             fakedb.Step(id=131, number=132, name='step132', buildid=30),
             fakedb.TestResultSet(id=13, builderid=88, buildid=30, stepid=131),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_add_test_results(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -288,17 +288,13 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 class Worker(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.rtype = workers.Worker(self.master)
         yield self.master.db.insert_test_data([
             fakedb.Master(id=13),
             fakedb.Master(id=14),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findWorkerId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -127,9 +127,6 @@ class WorkerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         yield self.setUpEndpoint()
         yield self.db.insert_test_data(testData)
 
-    def tearDown(self):
-        self.tearDownEndpoint()
-
     @defer.inlineCallbacks
     def test_get_existing(self):
         worker = yield self.callGet(('workers', 2))
@@ -213,9 +210,6 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         yield self.setUpEndpoint()
         yield self.db.insert_test_data(testData)
-
-    def tearDown(self):
-        self.tearDownEndpoint()
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/db/test_base.py
+++ b/master/buildbot/test/unit/db/test_base.py
@@ -73,13 +73,9 @@ class TestBase(unittest.TestCase):
 class TestBaseAsConnectorComponent(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_findSomethingId_race(self):

--- a/master/buildbot/test/unit/db/test_build_data.py
+++ b/master/buildbot/test/unit/db/test_build_data.py
@@ -41,13 +41,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_add_build_data(self):
         @self.assertArgSpecMatches(self.db.build_data.setBuildData)

--- a/master/buildbot/test/unit/db/test_builders.py
+++ b/master/buildbot/test/unit/db/test_builders.py
@@ -39,13 +39,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findBuilderId(self):
         @self.assertArgSpecMatches(self.db.builders.findBuilderId)

--- a/master/buildbot/test/unit/db/test_buildrequests.py
+++ b/master/buildbot/test/unit/db/test_buildrequests.py
@@ -47,7 +47,7 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
 
         # set up a sourcestamp and buildset for use below
@@ -66,10 +66,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
             fakedb.Builder(id=self.BLDRID3, name="builder3"),
             fakedb.BuildsetSourceStamp(buildsetid=self.BSID, sourcestampid=234),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getBuildRequest(self):

--- a/master/buildbot/test/unit/db/test_builds.py
+++ b/master/buildbot/test/unit/db/test_builds.py
@@ -126,13 +126,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # signature tests
 

--- a/master/buildbot/test/unit/db/test_buildsets.py
+++ b/master/buildbot/test/unit/db/test_buildsets.py
@@ -34,7 +34,7 @@ from buildbot.util import epoch2datetime
 class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
 
@@ -47,10 +47,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
             fakedb.Builder(id=1, name='bldr1'),
             fakedb.Builder(id=2, name='bldr2'),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_addBuildset(self):
         @self.assertArgSpecMatches(self.db.buildsets.addBuildset)

--- a/master/buildbot/test/unit/db/test_changes.py
+++ b/master/buildbot/test/unit/db/test_changes.py
@@ -99,13 +99,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_addChange(self):
         @self.assertArgSpecMatches(self.db.changes.addChange)

--- a/master/buildbot/test/unit/db/test_changesources.py
+++ b/master/buildbot/test/unit/db/test_changesources.py
@@ -43,13 +43,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findChangeSourceId(self):
         """The signature of findChangeSourceId is correct"""

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -44,10 +44,15 @@ class TestDBConnector(TestReactorMixin, unittest.TestCase):
         self.db = connector.DBConnector(os.path.abspath('basedir'))
         yield self.db.set_master(self.master)
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.db.pool is not None:
+                yield self.db.pool.stop()
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.db.pool is not None:
-            yield self.db.pool.stop()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -33,7 +33,7 @@ class TestDBConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.master = yield fakemaster.make_master(
             self, wantDb=True, auto_upgrade=False, check_version=False
@@ -50,10 +50,6 @@ class TestDBConnector(TestReactorMixin, unittest.TestCase):
                 yield self.db.pool.stop()
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def startService(self, check_version=False):

--- a/master/buildbot/test/unit/db/test_logs.py
+++ b/master/buildbot/test/unit/db/test_logs.py
@@ -127,13 +127,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def checkTestLogLines(self):

--- a/master/buildbot/test/unit/db/test_masters.py
+++ b/master/buildbot/test/unit/db/test_masters.py
@@ -38,14 +38,10 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.reactor.advance(SOMETIME)
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findMasterId(self):
         @self.assertArgSpecMatches(self.db.masters.findMasterId)

--- a/master/buildbot/test/unit/db/test_pool.py
+++ b/master/buildbot/test/unit/db/test_pool.py
@@ -41,10 +41,7 @@ class Basic(unittest.TestCase):
         self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
         self.pool.start()
         yield self.pool.do(thd_clean_database)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.pool.stop()
+        self.addCleanup(self.pool.stop)
 
     @defer.inlineCallbacks
     def test_do(self):
@@ -163,10 +160,9 @@ class Stress(unittest.TestCase):
         self.engine.optimal_thread_pool_size = 2
         self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
         self.pool.start()
+        self.addCleanup(self.pool.stop)
 
-    @defer.inlineCallbacks
     def tearDown(self):
-        yield self.pool.stop()
         os.unlink("test.sqlite")
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/db/test_projects.py
+++ b/master/buildbot/test/unit/db/test_projects.py
@@ -30,13 +30,9 @@ def project_key(builder):
 class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_find_project_id(self):
         @self.assertArgSpecMatches(self.db.projects.find_project_id)

--- a/master/buildbot/test/unit/db/test_schedulers.py
+++ b/master/buildbot/test/unit/db/test_schedulers.py
@@ -43,13 +43,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_enable(self):
         @self.assertArgSpecMatches(self.db.schedulers.enable)

--- a/master/buildbot/test/unit/db/test_sourcestamps.py
+++ b/master/buildbot/test/unit/db/test_sourcestamps.py
@@ -43,13 +43,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findSourceStampId(self):
         @self.assertArgSpecMatches(self.db.sourcestamps.findSourceStampId)

--- a/master/buildbot/test/unit/db/test_state.py
+++ b/master/buildbot/test/unit/db/test_state.py
@@ -25,13 +25,9 @@ from buildbot.test.reactor import TestReactorMixin
 class TestStateConnectorComponent(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getObjectId_new(self):

--- a/master/buildbot/test/unit/db/test_steps.py
+++ b/master/buildbot/test/unit/db/test_steps.py
@@ -117,13 +117,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_getStep(self):
         @self.assertArgSpecMatches(self.db.steps.getStep)

--- a/master/buildbot/test/unit/db/test_test_result_sets.py
+++ b/master/buildbot/test/unit/db/test_test_result_sets.py
@@ -71,13 +71,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_add_test_result_set(self):
         @self.assertArgSpecMatches(self.db.test_result_sets.addTestResultSet)

--- a/master/buildbot/test/unit/db/test_test_results.py
+++ b/master/buildbot/test/unit/db/test_test_results.py
@@ -46,13 +46,9 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_get_test_code_paths(self):
         @self.assertArgSpecMatches(self.db.test_results.getTestCodePaths)

--- a/master/buildbot/test/unit/db/test_users.py
+++ b/master/buildbot/test/unit/db/test_users.py
@@ -26,13 +26,9 @@ from buildbot.test.reactor import TestReactorMixin
 class TestUsersConnectorComponent(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # sample user data
 

--- a/master/buildbot/test/unit/db/test_workers.py
+++ b/master/buildbot/test/unit/db/test_workers.py
@@ -83,13 +83,9 @@ class Tests(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_signature_findWorkerId(self):
         @self.assertArgSpecMatches(self.db.workers.findWorkerId)

--- a/master/buildbot/test/unit/db_migrate/test_versions_060_add_builder_projects.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_060_add_builder_projects.py
@@ -26,9 +26,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/db_migrate/test_versions_061_add_builder_description_format.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_061_add_builder_description_format.py
@@ -26,9 +26,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/db_migrate/test_versions_062_add_project_description_format.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_062_add_project_description_format.py
@@ -26,9 +26,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/db_migrate/test_versions_063_add_steps_locks_acquired_at.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_063_add_steps_locks_acquired_at.py
@@ -24,9 +24,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/db_migrate/test_versions_064_add_worker_pause_reason.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_064_add_worker_pause_reason.py
@@ -25,9 +25,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/db_migrate/test_versions_065_add_buildsets_rebuilt_buildid.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_065_add_buildsets_rebuilt_buildid.py
@@ -25,9 +25,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/db_migrate/test_versions_066_add_build_locks_duration_s.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_066_add_build_locks_duration_s.py
@@ -24,9 +24,6 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def setUp(self):
         return self.setUpMigrateTest()
 
-    def tearDown(self):
-        return self.tearDownMigrateTest()
-
     def create_tables_thd(self, conn):
         metadata = sa.MetaData()
         metadata.bind = conn

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -164,10 +164,10 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
         yield self.botmaster.setServiceParent(self.master)
         self.new_config = mock.Mock()
         self.botmaster.startService()
+        self.addCleanup(self.botmaster.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.botmaster.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -30,15 +30,11 @@ from buildbot.test.reactor import TestReactorMixin
 class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
         self.botmaster = BotMaster()
         yield self.botmaster.setServiceParent(self.master)
         self.botmaster.startService()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertReactorStopped(self, _=None):
         self.assertTrue(self.reactor.stop_called)
@@ -156,7 +152,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 class TestBotMaster(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.master.botmaster.disownServiceParent()
@@ -165,10 +161,6 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
         self.new_config = mock.Mock()
         self.botmaster.startService()
         self.addCleanup(self.botmaster.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -182,7 +182,7 @@ def makeControllableStepFactory():
 class TestBuild(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         r = FakeRequest()
         r.sources = [FakeSource()]
         r.sources[0].changes = [FakeChange()]
@@ -206,10 +206,6 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.build.workerforbuilder = self.workerforbuilder
         self.build.text = []
         self.build.buildid = 666
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertWorkerPreparationFailure(self, reason):
         states = "".join(self.master.data.updates.stepStateString.values())
@@ -897,7 +893,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 class TestMultipleSourceStamps(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.builder = FakeBuilder(self.master)
 
@@ -920,10 +916,6 @@ class TestMultipleSourceStamps(TestReactorMixin, unittest.TestCase):
         r.sources.extend([s1, s2, s3])
 
         self.build = Build([r], self.builder)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_buildReturnSourceStamp(self):
         """
@@ -948,7 +940,7 @@ class TestMultipleSourceStamps(TestReactorMixin, unittest.TestCase):
 class TestBuildBlameList(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.builder = FakeBuilder(self.master)
 
@@ -972,10 +964,6 @@ class TestBuildBlameList(TestReactorMixin, unittest.TestCase):
         self.patchSource.changes = []
         self.patchSource.revision = "67890"
         self.patchSource.patch_info = ("jeff", "jeff's new feature")
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_blamelist_for_changes(self):
         r = FakeRequest()
@@ -1001,7 +989,7 @@ class TestSetupProperties_MultipleSources(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.props = {}
         self.r = FakeRequest()
         self.r.sources = []
@@ -1021,10 +1009,6 @@ class TestSetupProperties_MultipleSources(TestReactorMixin, unittest.TestCase):
         self.build.setStepFactories([])
         # record properties that will be set
         self.build.properties.setProperty = self.setProperty
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def setProperty(self, n, v, s, runtime=False):
         if s not in self.props:
@@ -1050,7 +1034,7 @@ class TestSetupProperties_SingleSource(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.props = {}
         self.r = FakeRequest()
         self.r.sources = []
@@ -1065,10 +1049,6 @@ class TestSetupProperties_SingleSource(TestReactorMixin, unittest.TestCase):
         self.build.setStepFactories([])
         # record properties that will be set
         self.build.properties.setProperty = self.setProperty
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def setProperty(self, n, v, s, runtime=False):
         if s not in self.props:

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -108,7 +108,7 @@ class FakeLatentWorker(AbstractLatentWorker):
 class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         # a collection of rows that would otherwise clutter up every test
         yield self.setUpBuilderMixin()
         self.base_rows = [
@@ -117,10 +117,6 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
             fakedb.Buildset(id=11, reason='because'),
             fakedb.BuildsetSourceStamp(buildsetid=11, sourcestampid=21),
         ]
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeBuilder(self, patch_random=False, startBuildsForSucceeds=True, **config_kwargs):
@@ -485,12 +481,8 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
 class TestGetBuilderId(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpBuilderMixin()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getBuilderId(self):
@@ -512,7 +504,7 @@ class TestGetBuilderId(TestReactorMixin, BuilderMixin, unittest.TestCase):
 class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -534,10 +526,6 @@ class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase
             fakedb.BuildRequest(id=555, submitted_at=2800, builderid=182, buildsetid=11),
         ]
         yield self.db.insert_test_data(self.base_rows)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_gort_unclaimed(self):
@@ -562,7 +550,7 @@ class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase
 class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -589,10 +577,6 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
         yield self.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
-
-    @defer.inlineCallbacks
     def test_gnct_completed(self):
         yield self.makeBuilder(name='bldr1')
         rqtime = yield self.bldr.getNewestCompleteTime()
@@ -608,7 +592,7 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
 class TestGetHighestPriority(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpBuilderMixin()
 
         # a collection of rows that would otherwise clutter up every test
@@ -633,10 +617,6 @@ class TestGetHighestPriority(TestReactorMixin, BuilderMixin, unittest.TestCase):
         yield self.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
-
-    @defer.inlineCallbacks
     def test_ghp_unclaimed(self):
         yield self.makeBuilder(name='bldr1')
         priority = yield self.bldr.get_highest_priority()
@@ -654,17 +634,13 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpBuilderMixin()
 
         yield self.db.insert_test_data([
             fakedb.Project(id=301, name='old_project'),
             fakedb.Project(id=302, name='new_project'),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfig(self):

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -30,7 +30,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True)
         self.master.botmaster = mock.Mock(name='botmaster')
         self.master.botmaster.builders = {}
@@ -52,10 +52,6 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         bldr.getCollapseRequestsFn = lambda: False
 
         return bldr
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_request_collapse(self, brids, exp):
@@ -509,11 +505,7 @@ class TestSourceStamp(unittest.TestCase):
 
 class TestBuildRequest(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_fromBrdict(self):

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -65,6 +65,13 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
         self.brd.parent = self.botmaster
         self.brd.startService()
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.brd.running:
+                yield self.brd.stopService()
+
+        self.addCleanup(cleanup)
+
         # a collection of rows that would otherwise clutter up every test
         self.base_rows = [
             fakedb.Master(id=fakedb.FakeDBConnector.MASTER_ID),
@@ -76,8 +83,6 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.brd.running:
-            yield self.brd.stopService()
         yield self.tear_down_test_reactor()
 
     def make_workers(self, worker_count):

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -47,7 +47,7 @@ def nth_worker(n):
 class TestBRDBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.botmaster = mock.Mock(name='botmaster')
         self.botmaster.builders = {}
         self.builders = {}
@@ -80,10 +80,6 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
             fakedb.Buildset(id=11, reason='because'),
             fakedb.BuildsetSourceStamp(sourcestampid=21, buildsetid=11),
         ]
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def make_workers(self, worker_count):
         rows = self.base_rows[:]

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -115,12 +115,8 @@ class TestBuildStep(
             return SUCCESS
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # support
 
@@ -1090,13 +1086,9 @@ class InterfaceTests(interfaces.InterfaceTests):
 class TestFakeItfc(unittest.TestCase, TestBuildStepMixin, TestReactorMixin, InterfaceTests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setup_test_build_step()
         self.setup_step(buildstep.BuildStep())
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestRealItfc(unittest.TestCase, InterfaceTests):
@@ -1118,13 +1110,9 @@ class CommandMixinExample(buildstep.CommandMixin, buildstep.BuildStep):
 class TestCommandMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setup_test_build_step()
         self.setup_step(CommandMixinExample())
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_runRmdir(self):
@@ -1236,12 +1224,8 @@ class TestShellMixin(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setup_test_build_step(with_secrets={"s3cr3t": "really_safe_string"})
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_setupShellMixin_bad_arg(self):
         mixin = SimpleShellCommand()

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -120,7 +120,6 @@ class TestBuildStep(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     # support
@@ -1125,7 +1124,6 @@ class TestCommandMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1243,7 +1241,6 @@ class TestShellMixin(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_setupShellMixin_bad_arg(self):

--- a/master/buildbot/test/unit/process/test_debug.py
+++ b/master/buildbot/test/unit/process/test_debug.py
@@ -32,13 +32,9 @@ class FakeManhole(service.AsyncService):
 
 class TestDebugServices(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = mock.Mock(name='master')
         self.config = MasterConfig()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfigService_manhole(self):

--- a/master/buildbot/test/unit/process/test_log.py
+++ b/master/buildbot/test/unit/process/test_log.py
@@ -29,12 +29,8 @@ from buildbot.test.util import interfaces
 class Tests(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeLog(self, type, logEncoding='utf-8'):

--- a/master/buildbot/test/unit/process/test_logobserver.py
+++ b/master/buildbot/test/unit/process/test_logobserver.py
@@ -45,12 +45,8 @@ class MyLogObserver(logobserver.LogObserver):
 class TestLogObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -100,12 +96,8 @@ class MyLogLineObserver(logobserver.LogLineObserver):
 class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_sequence(self, consumer):
@@ -177,12 +169,8 @@ class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
 class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -221,12 +209,8 @@ class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
 class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -245,12 +229,8 @@ class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
 class TestBufferObserver(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_sequence(self, lo):

--- a/master/buildbot/test/unit/process/test_metrics.py
+++ b/master/buildbot/test/unit/process/test_metrics.py
@@ -36,10 +36,15 @@ class TestMetricBase(TestReactorMixin, unittest.TestCase):
         self.observer.startService()
         self.observer.reconfigServiceWithBuildbotConfig(self.master.config)
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.observer.running:
+                yield self.observer.stopService()
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.observer.running:
-            yield self.observer.stopService()
         yield self.tear_down_test_reactor()
 
 

--- a/master/buildbot/test/unit/process/test_metrics.py
+++ b/master/buildbot/test/unit/process/test_metrics.py
@@ -28,7 +28,7 @@ from buildbot.test.reactor import TestReactorMixin
 class TestMetricBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.observer = metrics.MetricLogObserver()
         self.observer.parent = self.master = yield fakemaster.make_master(self)
         self.master.config.metrics = {"log_interval": 0, "periodic_interval": 0}
@@ -42,10 +42,6 @@ class TestMetricBase(TestReactorMixin, unittest.TestCase):
                 yield self.observer.stopService()
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestMetricCountEvent(TestMetricBase):

--- a/master/buildbot/test/unit/process/test_users_manager.py
+++ b/master/buildbot/test/unit/process/test_users_manager.py
@@ -32,11 +32,9 @@ class TestUserManager(unittest.TestCase):
         self.master = mock.Mock()
         self.umm = manager.UserManagerManager(self.master)
         self.umm.startService()
+        self.addCleanup(self.umm.stopService)
 
         self.config = MasterConfig()
-
-    def tearDown(self):
-        self.umm.stopService()
 
     @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):

--- a/master/buildbot/test/unit/process/test_users_manual.py
+++ b/master/buildbot/test/unit/process/test_users_manual.py
@@ -47,12 +47,8 @@ class TestUsersBase(unittest.TestCase):
 
 class TestCommandlineUserManagerPerspective(TestReactorMixin, unittest.TestCase, ManualUsersMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpManualUsers()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def call_perspective_commandline(self, *args):
         persp = manual.CommandlineUserManagerPerspective(self.master)
@@ -250,16 +246,12 @@ class TestCommandlineUserManagerPerspective(TestReactorMixin, unittest.TestCase,
 class TestCommandlineUserManager(TestReactorMixin, unittest.TestCase, ManualUsersMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpManualUsers()
         self.manual_component = manual.CommandlineUserManager(
             username="user", passwd="userpw", port="9990"
         )
         yield self.manual_component.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_userpass(self):

--- a/master/buildbot/test/unit/process/test_users_users.py
+++ b/master/buildbot/test/unit/process/test_users_users.py
@@ -28,14 +28,10 @@ from buildbot.test.reactor import TestReactorMixin
 class UsersTests(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.test_sha = users.encrypt("cancer")
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def verify_users(self, users):

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -40,14 +40,10 @@ class TestReporterBase(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.setUpLogging()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupNotifier(self, generators):

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -38,7 +38,7 @@ class TestBitbucketStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
@@ -59,10 +59,6 @@ class TestBitbucketStatusPush(
         yield self.bsp.setServiceParent(self.master)
         yield self.bsp.startService()
         self.addCleanup(self.bsp.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):
@@ -272,7 +268,7 @@ class TestBitbucketStatusPushProperties(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
@@ -308,10 +304,6 @@ class TestBitbucketStatusPushProperties(
         yield self.bsp.setServiceParent(self.master)
         yield self.bsp.startService()
         self.addCleanup(self.bsp.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_properties(self):
@@ -377,17 +369,13 @@ class TestBitbucketStatusPushConfig(ConfigErrorsMixin, unittest.TestCase):
 class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         self.bsp = BitbucketStatusPush(Interpolate('key'), Interpolate('secret'))
         yield self.bsp.setServiceParent(self.master)
         yield self.bsp.startService()
         self.addCleanup(self.bsp.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def parse(self, repourl):
         return tuple(self.bsp.get_owner_and_repo(repourl))

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -58,10 +58,10 @@ class TestBitbucketStatusPush(
         self.bsp = BitbucketStatusPush(Interpolate('key'), Interpolate('secret'))
         yield self.bsp.setServiceParent(self.master)
         yield self.bsp.startService()
+        self.addCleanup(self.bsp.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.bsp.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -307,10 +307,10 @@ class TestBitbucketStatusPushProperties(
         )
         yield self.bsp.setServiceParent(self.master)
         yield self.bsp.startService()
+        self.addCleanup(self.bsp.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.bsp.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -383,10 +383,10 @@ class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):
         self.bsp = BitbucketStatusPush(Interpolate('key'), Interpolate('secret'))
         yield self.bsp.setServiceParent(self.master)
         yield self.bsp.startService()
+        self.addCleanup(self.bsp.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.bsp.stopService()
         yield self.tear_down_test_reactor()
 
     def parse(self, repourl):

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -54,7 +54,7 @@ class TestBitbucketServerStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -69,10 +69,6 @@ class TestBitbucketServerStatusPush(
         )
         yield self.sp.setServiceParent(self.master)
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_start_and_finish_build(self, build):
@@ -220,7 +216,7 @@ class TestBitbucketServerCoreAPIStatusPush(
 ):
     @defer.inlineCallbacks
     def setupReporter(self, token=None, **kwargs):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
@@ -256,11 +252,6 @@ class TestBitbucketServerCoreAPIStatusPush(
 
     def setUp(self):
         self.master = None
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        if self.master:
-            yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_start_and_finish_build(self, build, parentPlan=False, epoch=False):
@@ -636,7 +627,7 @@ class TestBitbucketServerPRCommentPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -671,10 +662,6 @@ class TestBitbucketServerPRCommentPush(
             **kwargs,
         )
         yield self.cp.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults, set_pr=True):

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -68,10 +68,10 @@ class TestBitbucketServerStatusPush(
             "serv", Interpolate("username"), Interpolate("passwd"), **kwargs
         )
         yield self.sp.setServiceParent(self.master)
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -247,14 +247,19 @@ class TestBitbucketServerCoreAPIStatusPush(
         yield self.sp.setServiceParent(self.master)
         yield self.master.startService()
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.master.running:
+                yield self.master.stopService()
+
+        self.addCleanup(cleanup)
+
     def setUp(self):
         self.master = None
 
     @defer.inlineCallbacks
     def tearDown(self):
         if self.master:
-            if self.master.running:
-                yield self.master.stopService()
             yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -635,6 +640,7 @@ class TestBitbucketServerPRCommentPush(
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def setupReporter(self, verbose=True, generator_class=BuildStatusGenerator, **kwargs):
@@ -668,7 +674,6 @@ class TestBitbucketServerPRCommentPush(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -35,13 +35,9 @@ from buildbot.warnings import DeprecatedApiWarning
 class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(
@@ -301,13 +297,9 @@ class TestBuildStartEndGenerator(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(

--- a/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildrequest.py
@@ -36,17 +36,13 @@ class TestBuildRequestGenerator(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         builder = Mock(spec=Builder)
         builder.master = self.master
         self.master.botmaster.getBuilderById = Mock(return_value=builder)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @parameterized.expand([
         ('tags', 'tag'),

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -34,13 +34,9 @@ class TestBuildSetGeneratorBase(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_generators_utils.py
+++ b/master/buildbot/test/unit/reporters/test_generators_utils.py
@@ -36,13 +36,9 @@ from buildbot.test.util.reporter import ReporterTestMixin
 class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_build_finished_get_props(self, results, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_generators_worker.py
+++ b/master/buildbot/test/unit/reporters/test_generators_worker.py
@@ -26,12 +26,8 @@ from buildbot.test.util.config import ConfigErrorsMixin
 class TestWorkerMissingGenerator(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def _get_worker_dict(self, worker_name):
         return {

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -122,13 +122,9 @@ def sampleSummaryCBDeferred(buildInfoList, results, master, arg):
 class TestGerritStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupGerritStatusPushSimple(self, *args, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -46,6 +46,7 @@ class TestGerritVerifyStatusPush(
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def createGerritStatus(self, **kwargs):
@@ -59,7 +60,6 @@ class TestGerritVerifyStatusPush(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -39,7 +39,7 @@ class TestGerritVerifyStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.reporter_test_props = {'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]}
 
@@ -57,10 +57,6 @@ class TestGerritVerifyStatusPush(
         )
         self.sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)
         yield self.sp.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -44,6 +44,8 @@ class TestGitHubStatusPush(
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
+
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master,
             self,
@@ -60,7 +62,6 @@ class TestGitHubStatusPush(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -312,6 +313,8 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
+
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master,
             self,
@@ -328,7 +331,6 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -35,7 +35,7 @@ class TestGitHubStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         # project must be in the form <owner>/<project>
@@ -59,10 +59,6 @@ class TestGitHubStatusPush(
 
     def createService(self):
         return GitHubStatusPush(Interpolate('XXYYZZ'))
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):
@@ -303,7 +299,7 @@ class TestGitHubStatusPush(
 class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         # project must be in the form <owner>/<project>
@@ -328,10 +324,6 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase, ReporterTestM
 
     def createService(self):
         return GitHubStatusPush('XXYYZZ')
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_ssh(self):

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -47,6 +47,8 @@ class TestGitLabStatusPush(
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
+
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master,
             self,
@@ -70,7 +72,6 @@ class TestGitLabStatusPush(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -38,7 +38,7 @@ class TestGitLabStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
         # repository must be in the form http://gitlab/<owner>/<project>
@@ -69,10 +69,6 @@ class TestGitLabStatusPush(
         builder.name = "Builder0"
         builder.setup_properties = setup_properties
         self.master.botmaster.getBuilderById = mock.Mock(return_value=builder)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_buildrequest(self):

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -34,6 +34,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin,
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def createReporter(self, auth=("username", "passwd"), headers=None, **kwargs):
@@ -52,7 +53,6 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin,
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -30,7 +30,7 @@ from buildbot.test.util.reporter import ReporterTestMixin
 class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin, ConfigErrorsMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         yield self.master.startService()
@@ -50,10 +50,6 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin,
 
         self.sp = HttpStatusPush("serv", auth=interpolated_auth, headers=headers, **kwargs)
         yield self.sp.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -41,13 +41,9 @@ from buildbot.util import ssl
 class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupMailNotifier(self, *args, **kwargs):

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -160,12 +160,8 @@ class TestMessageFormatting(unittest.TestCase):
 class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_db(self, results1, results2, with_steps=False, extra_build_properties=None):

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -34,12 +34,8 @@ from buildbot.util import httpclientservice
 class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # returns a Deferred
     def setupFakeHttp(self, base_url='https://api.pushjet.io'):

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -34,12 +34,8 @@ from buildbot.util import httpclientservice
 class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # returns a Deferred
     def setupFakeHttp(self):

--- a/master/buildbot/test/unit/reporters/test_telegram.py
+++ b/master/buildbot/test/unit/reporters/test_telegram.py
@@ -560,14 +560,10 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.patch(reactor, 'callLater', self.reactor.callLater)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
         self.http = None
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_http_service(self):

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -42,12 +42,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True, wantMq=True)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupDb(self):
@@ -630,12 +626,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 class TestURLUtils(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_UrlForBuild(self):
         self.assertEqual(

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -48,7 +48,7 @@ class ContactMixin(TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self) -> Generator[Any, None, None]:
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.patch(reactor, 'callLater', self.reactor.callLater)
         self.patch(reactor, 'seconds', self.reactor.seconds)
         self.patch(reactor, 'stop', self.reactor.stop)
@@ -94,10 +94,6 @@ class ContactMixin(TestReactorMixin):
         yield self.contact.channel.setServiceParent(self.master)
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def patch_send(self):
         self.sent = []

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -93,10 +93,10 @@ class ContactMixin(TestReactorMixin):
         self.contact = self.contactClass(user=self.USER, channel=self.bot.getChannel(self.CHANNEL))
         yield self.contact.channel.setServiceParent(self.master)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def patch_send(self):

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -36,10 +36,15 @@ class TestZulipStatusPush(
             testcase=self, wantData=True, wantDb=True, wantMq=True
         )
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.master.running:
+                yield self.master.stopService()
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.master.running:
-            yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -30,7 +30,7 @@ class TestZulipStatusPush(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_reporter_test()
         self.master = yield fakemaster.make_master(
             testcase=self, wantData=True, wantDb=True, wantMq=True
@@ -42,10 +42,6 @@ class TestZulipStatusPush(
                 yield self.master.stopService()
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupZulipStatusPush(self, endpoint="http://example.com", token="123", stream=None):

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -42,7 +42,6 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -37,12 +37,8 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, name='testsched', builderNames=None, properties=None, codebases=None):

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -102,12 +102,8 @@ class BaseBasicScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def mkch(self, **kwargs):
@@ -379,12 +375,8 @@ class SingleBranchScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_constructor_no_reason(self):
@@ -622,12 +614,8 @@ class AnyBranchScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_constructor_branch_forbidden(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -107,7 +107,6 @@ class BaseBasicScheduler(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -385,7 +384,6 @@ class SingleBranchScheduler(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -629,7 +627,6 @@ class AnyBranchScheduler(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     def test_constructor_branch_forbidden(self):

--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -49,7 +49,7 @@ class TestFilterSet(unittest.TestCase):
 
 class TestOldBuildrequestTracker(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         filter = _OldBuildFilterSet()
 
         ss_filter = SourceStampFilter(
@@ -60,10 +60,6 @@ class TestOldBuildrequestTracker(unittest.TestCase, TestReactorMixin):
         self.tracker = _OldBuildrequestTracker(
             self.reactor, filter, lambda ss: ss['branch'], self.on_cancel
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def on_cancel(self, brid):
         self.cancellations.append(brid)
@@ -388,7 +384,7 @@ class TestOldBuildCancellerUtils(ConfigErrorsMixin, unittest.TestCase):
 class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.master.mq.verifyMessages = False
 
@@ -397,10 +393,6 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def create_ss_dict(self, project, codebase, repository, branch):
         # Changes have the same structure for the attributes that we're using, so we reuse this

--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -396,10 +396,10 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
         self._cancelled_build_ids = []
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def create_ss_dict(self, project, codebase, repository, branch):

--- a/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
@@ -36,10 +36,10 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
         self._cancelled_build_ids = []
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller_buildset.py
@@ -28,7 +28,7 @@ from buildbot.util.ssfilter import SourceStampFilter
 class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
         self.master.mq.verifyMessages = False
 
@@ -37,10 +37,6 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def insert_test_data(self):

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -38,12 +38,8 @@ UPSTREAM_NAME = 'uppy'
 class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, upstream=None):

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -43,7 +43,6 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -53,7 +53,6 @@ class TestForceScheduler(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -48,12 +48,8 @@ class TestForceScheduler(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, name='testsched', builderNames=None, **kw):

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -124,7 +124,6 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unitte
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     def assertConsumingChanges(self, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -119,12 +119,8 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unitte
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertConsumingChanges(self, **kwargs):
         self.assertEqual(self.consumingChanges, kwargs)

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -31,12 +31,8 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):
         return self.attachScheduler(timed.NightlyBase(**kwargs), self.OBJECTID, self.SCHEDULERID)

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -36,7 +36,6 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -53,7 +53,6 @@ class NightlyTriggerable(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     # utilities

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -48,12 +48,8 @@ class NightlyTriggerable(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # utilities
 

--- a/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
@@ -33,12 +33,8 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, firstBuildDuration=0, firstBuildError=False, exp_branch=None, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Periodic.py
@@ -38,7 +38,6 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/schedulers/test_timed_Timed.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Timed.py
@@ -27,12 +27,8 @@ class Timed(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     class Subclass(timed.Timed):
         def getNextBuildTime(self, lastActuation):

--- a/master/buildbot/test/unit/schedulers/test_timed_Timed.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Timed.py
@@ -32,7 +32,6 @@ class Timed(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     class Subclass(timed.Timed):

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -38,16 +38,12 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         # Necessary to get an assertable submitted_at time.
         self.reactor.advance(946684799)
 
         yield self.setUpScheduler()
         self.subscription = None
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, overrideBuildsetMethods=False, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_triggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_triggerable.py
@@ -47,7 +47,6 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -101,9 +101,6 @@ class JobdirService(dirs.DirsMixin, unittest.TestCase):
         self.tmpdir = os.path.join(self.jobdir, 'tmp')
         self.setUpDirs(self.jobdir, self.newdir, self.curdir, self.tmpdir)
 
-    def tearDown(self):
-        self.tearDownDirs()
-
     def test_messageReceived(self):
         # stub out svc.scheduler.handleJobFile and .jobdir
         scheduler = mock.Mock()

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -35,12 +35,8 @@ class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeScheduler(self, **kwargs):
         return self.attachScheduler(
@@ -128,15 +124,13 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
         self.jobdir = None
 
-    @defer.inlineCallbacks
     def tearDown(self):
         if self.jobdir:
             shutil.rmtree(self.jobdir)
-        yield self.tear_down_test_reactor()
 
     # tests
 
@@ -876,12 +870,8 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin, unitt
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeScheduler(self, **kwargs):
         return self.attachScheduler(
@@ -1054,12 +1044,8 @@ class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpScheduler()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def makeScheduler(self, **kwargs):

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -40,7 +40,6 @@ class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     def makeScheduler(self, **kwargs):
@@ -135,7 +134,6 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         if self.jobdir:
             shutil.rmtree(self.jobdir)
         yield self.tear_down_test_reactor()
@@ -883,7 +881,6 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin, unitt
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     def makeScheduler(self, **kwargs):
@@ -1062,7 +1059,6 @@ class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownScheduler()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/scripts/test_base.py
+++ b/master/buildbot/test/unit/scripts/test_base.py
@@ -187,9 +187,6 @@ class TestLoadOptionsFile(dirs.DirsMixin, misc.StdoutAssertionsMixin, unittest.T
         self.home = os.path.abspath('home')
         self.setUpStdoutAssertions()
 
-    def tearDown(self):
-        self.tearDownDirs()
-
     def do_loadOptionsFile(self, _here, exp):
         # only patch these os.path functions briefly, to
         # avoid breaking other parts of the test system
@@ -282,9 +279,6 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin, unittest.TestCa
     def setUp(self):
         self.setUpDirs('test')
         self.setUpStdoutAssertions()
-
-    def tearDown(self):
-        self.tearDownDirs()
 
     def activeBasedir(self, extra_lines=()):
         with open(os.path.join('test', 'buildbot.tac'), "w", encoding='utf-8') as f:

--- a/master/buildbot/test/unit/scripts/test_checkconfig.py
+++ b/master/buildbot/test/unit/scripts/test_checkconfig.py
@@ -33,9 +33,6 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
         self.configdir = self.mktemp()
         return self.setUpDirs(self.configdir)
 
-    def tearDown(self):
-        return self.tearDownDirs()
-
     # tests
 
     def do_test_load(self, config='', other_files=None, stdout_re=None, stderr_re=None):

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -94,7 +94,6 @@ class TestCleanupDb(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     def createMasterCfg(self, extraconfig=""):
@@ -139,7 +138,6 @@ class TestCleanupDbRealDb(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     def createMasterCfg(self, db_url, extraconfig=""):

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -87,14 +87,10 @@ class TestCleanupDb(
     misc.StdoutAssertionsMixin, dirs.DirsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpDirs('basedir')
         write_buildbot_tac(os.path.join('basedir', 'buildbot.tac'))
         self.setUpStdoutAssertions()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def createMasterCfg(self, extraconfig=""):
         write_master_cfg(os.path.join('basedir', 'master.cfg'), 'sqlite://', extraconfig)
@@ -127,7 +123,7 @@ class TestCleanupDbRealDb(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpDirs('basedir')
         write_buildbot_tac(os.path.join('basedir', 'buildbot.tac'))
         self.setUpStdoutAssertions()
@@ -135,10 +131,6 @@ class TestCleanupDbRealDb(
         self.master = yield fakemaster.make_master(
             self, wantDb=True, wantRealReactor=True, sqlite_memory=False
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def createMasterCfg(self, db_url, extraconfig=""):
         write_master_cfg(os.path.join('basedir', 'master.cfg'), db_url, extraconfig)

--- a/master/buildbot/test/unit/scripts/test_copydb.py
+++ b/master/buildbot/test/unit/scripts/test_copydb.py
@@ -64,7 +64,6 @@ class TestCopyDb(misc.StdoutAssertionsMixin, dirs.DirsMixin, TestReactorMixin, u
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     def create_master_cfg(self, db_url='sqlite://', extraconfig=""):
@@ -112,9 +111,6 @@ class TestCopyDbRealDb(misc.StdoutAssertionsMixin, RunMasterBase, dirs.DirsMixin
         self.setUpDirs('basedir')
         self.setUpStdoutAssertions()  # comment out to see stdout from script
         write_buildbot_tac(os.path.join('basedir', 'buildbot.tac'))
-
-    def tearDown(self):
-        self.tearDownDirs()
 
     @defer.inlineCallbacks
     def create_master_config(self):

--- a/master/buildbot/test/unit/scripts/test_copydb.py
+++ b/master/buildbot/test/unit/scripts/test_copydb.py
@@ -57,14 +57,10 @@ def write_buildbot_tac(path):
 
 class TestCopyDb(misc.StdoutAssertionsMixin, dirs.DirsMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpDirs('basedir')
         write_buildbot_tac(os.path.join('basedir', 'buildbot.tac'))
         self.setUpStdoutAssertions()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def create_master_cfg(self, db_url='sqlite://', extraconfig=""):
         with open(os.path.join('basedir', 'master.cfg'), "w", encoding='utf-8') as f:

--- a/master/buildbot/test/unit/scripts/test_create_master.py
+++ b/master/buildbot/test/unit/scripts/test_create_master.py
@@ -91,14 +91,10 @@ class TestCreateMasterFunctions(
     unittest.TestCase,
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertInTacFile(self, str):
         with open(os.path.join('test', 'buildbot.tac'), encoding='utf-8') as f:

--- a/master/buildbot/test/unit/scripts/test_create_master.py
+++ b/master/buildbot/test/unit/scripts/test_create_master.py
@@ -98,7 +98,6 @@ class TestCreateMasterFunctions(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     def assertInTacFile(self, str):

--- a/master/buildbot/test/unit/scripts/test_logwatcher.py
+++ b/master/buildbot/test/unit/scripts/test_logwatcher.py
@@ -46,7 +46,6 @@ class TestLogWatcher(unittest.TestCase, dirs.DirsMixin, TestReactorMixin):
 
     def setUp(self):
         self.setUpDirs('workdir')
-        self.addCleanup(self.tearDownDirs)
 
         self.setup_test_reactor(auto_tear_down=False)
         self.spawned_process = mock.Mock()

--- a/master/buildbot/test/unit/scripts/test_logwatcher.py
+++ b/master/buildbot/test/unit/scripts/test_logwatcher.py
@@ -47,13 +47,9 @@ class TestLogWatcher(unittest.TestCase, dirs.DirsMixin, TestReactorMixin):
     def setUp(self):
         self.setUpDirs('workdir')
 
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.spawned_process = mock.Mock()
         self.reactor.spawnProcess = mock.Mock(return_value=self.spawned_process)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_start(self):
         lw = MockedLogWatcher('workdir/test.log', _reactor=self.reactor)

--- a/master/buildbot/test/unit/scripts/test_restart.py
+++ b/master/buildbot/test/unit/scripts/test_restart.py
@@ -37,9 +37,6 @@ class TestStop(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
             f.write("Application('buildmaster')")
         self.setUpStdoutAssertions()
 
-    def tearDown(self):
-        self.tearDownDirs()
-
     # tests
 
     def test_restart_not_basedir(self):

--- a/master/buildbot/test/unit/scripts/test_start.py
+++ b/master/buildbot/test/unit/scripts/test_start.py
@@ -65,9 +65,6 @@ class TestStart(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
             f.write(fake_master_tac)
         self.setUpStdoutAssertions()
 
-    def tearDown(self):
-        self.tearDownDirs()
-
     # tests
 
     def test_start_not_basedir(self):

--- a/master/buildbot/test/unit/scripts/test_stop.py
+++ b/master/buildbot/test/unit/scripts/test_stop.py
@@ -37,9 +37,6 @@ class TestStop(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
         self.setUpDirs('basedir')
         self.setUpStdoutAssertions()
 
-    def tearDown(self):
-        self.tearDownDirs()
-
     # tests
 
     def do_test_stop(self, config, kill_sequence, is_running=True, **kwargs):

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -121,7 +121,6 @@ class TestUpgradeMasterFunctions(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     def writeFile(self, path, contents):

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -114,14 +114,10 @@ class TestUpgradeMasterFunctions(
     unittest.TestCase,
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def writeFile(self, path, contents):
         with open(path, "w", encoding='utf-8') as f:

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -33,7 +33,6 @@ class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def expect_and_run_command(self, *params):

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -28,12 +28,8 @@ from buildbot.test.steps import TestBuildStepMixin
 class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def expect_and_run_command(self, *params):
         command = [CMake.DEFAULT_CMAKE, *list(params)]

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -33,7 +33,6 @@ class Cppcheck(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_success(self):

--- a/master/buildbot/test/unit/steps/test_cppcheck.py
+++ b/master/buildbot/test/unit/steps/test_cppcheck.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.properties import WithProperties
@@ -28,12 +27,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class Cppcheck(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(cppcheck.Cppcheck(enable=['all'], inconclusive=True))

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -88,7 +88,6 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             yield self.site.stopFactory()
             yield self.site.close_connections()
         finally:
-            yield self.tear_down_test_build_step()
             yield self.tear_down_test_reactor()
 
     def get_connection_string(self):

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -66,7 +66,7 @@ class TestPage(Resource):
 
 class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         if txrequests is None:
             raise unittest.SkipTest("Need to install txrequests to test http steps")
 
@@ -85,10 +85,6 @@ class TestHTTPStep(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
         self.port = self.listener.getHost().port
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def get_connection_string(self):
         return f"http://127.0.0.1:{self.port}"

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -49,7 +49,6 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
                 os.environ[_COMSPEC_ENV] = self.comspec
             else:
                 del os.environ[_COMSPEC_ENV]
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_constr_args(self):
@@ -175,7 +174,6 @@ class TestSetProperty(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_simple(self):
@@ -199,7 +197,6 @@ class TestLogRenderable(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_simple(self):
@@ -222,7 +219,6 @@ class TestsSetProperties(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def doOneTest(self, **kwargs):
@@ -255,7 +251,6 @@ class TestAssert(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_eq_pass(self):

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -36,20 +36,18 @@ _COMSPEC_ENV = 'COMSPEC'
 
 class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         if runtime.platformType == 'win32':
             self.comspec = os.environ.get(_COMSPEC_ENV)
             os.environ[_COMSPEC_ENV] = r'C:\WINDOWS\system32\cmd.exe'
         return self.setup_test_build_step()
 
-    @defer.inlineCallbacks
     def tearDown(self):
         if runtime.platformType == 'win32':
             if self.comspec:
                 os.environ[_COMSPEC_ENV] = self.comspec
             else:
                 del os.environ[_COMSPEC_ENV]
-        yield self.tear_down_test_reactor()
 
     def test_constr_args(self):
         self.setup_step(
@@ -169,12 +167,8 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class TestSetProperty(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_simple(self):
         self.setup_step(
@@ -192,12 +186,8 @@ class TestSetProperty(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestLogRenderable(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_simple(self):
         self.setup_step(
@@ -214,12 +204,8 @@ class TestLogRenderable(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestsSetProperties(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def doOneTest(self, **kwargs):
         # all three tests should create a 'a' property with 'b' value, all with different
@@ -246,12 +232,8 @@ class TestsSetProperties(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
 class TestAssert(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_eq_pass(self):
         self.setup_step(master.Assert(Property("test_prop") == "foo"))

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -27,12 +26,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestShellCommandExecution(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_testdir_required(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_maxq.py
+++ b/master/buildbot/test/unit/steps/test_maxq.py
@@ -32,7 +32,6 @@ class TestShellCommandExecution(TestBuildStepMixin, TestReactorMixin, unittest.T
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_testdir_required(self):

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -40,7 +40,6 @@ class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def _run_simple_test(

--- a/master/buildbot/test/unit/steps/test_mswin.py
+++ b/master/buildbot/test/unit/steps/test_mswin.py
@@ -35,12 +35,8 @@ class TestRobocopySimple(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
     """
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def _run_simple_test(
         self,

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -26,12 +25,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestDebLintian(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_fileloc(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_deb_lintian.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_lintian.py
@@ -31,7 +31,6 @@ class TestDebLintian(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_fileloc(self):

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -15,7 +15,6 @@
 
 import time
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -31,12 +30,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_new(self):
         self.setup_step(pbuilder.DebPbuilder())
@@ -490,12 +485,8 @@ class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_new(self):
         self.setup_step(pbuilder.DebCowbuilder())
@@ -642,12 +633,8 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_distribution(self):
         with self.assertRaises(config.ConfigErrors):
@@ -695,12 +682,8 @@ class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestUbuCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_distribution(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/steps/test_package_deb_pbuilder.py
@@ -36,7 +36,6 @@ class TestDebPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_new(self):
@@ -496,7 +495,6 @@ class TestDebCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_new(self):
@@ -649,7 +647,6 @@ class TestUbuPbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_distribution(self):
@@ -703,7 +700,6 @@ class TestUbuCowbuilder(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_distribution(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -28,7 +27,7 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
 
     def test_no_root(self):
@@ -106,12 +105,8 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_spec(self):
         with self.assertRaises(config.ConfigErrors):
@@ -148,12 +143,8 @@ class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestMockRebuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_srpm(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_mock.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_mock.py
@@ -31,9 +31,6 @@ class TestMock(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor(auto_tear_down=False)
         return self.setup_test_build_step()
 
-    def tearDown(self):
-        return self.tear_down_test_build_step()
-
     def test_no_root(self):
         with self.assertRaises(config.ConfigErrors):
             mock.Mock()
@@ -114,7 +111,6 @@ class TestMockBuildSRPM(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_spec(self):
@@ -157,7 +153,6 @@ class TestMockRebuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_srpm(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -30,12 +30,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class RpmBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_specfile(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmbuild.py
@@ -35,7 +35,6 @@ class RpmBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_specfile(self):

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS
@@ -25,12 +24,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestRpmLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(rpmlint.RpmLint())

--- a/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/steps/test_package_rpm_rpmlint.py
@@ -30,7 +30,6 @@ class TestRpmLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_success(self):

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -125,12 +125,8 @@ Warning: Unable to extract the base list for
 
 class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_sample(self):
         self.setup_step(python.BuildEPYDoc())
@@ -143,12 +139,8 @@ class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @parameterized.expand([('no_results', True), ('with_results', False)])
     def test_success(self, name, store_results):
@@ -441,12 +433,8 @@ class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(python.PyFlakes())
@@ -528,12 +516,8 @@ class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_builddir_required(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -130,7 +130,6 @@ class BuildEPYDoc(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_sample(self):
@@ -149,7 +148,6 @@ class PyLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @parameterized.expand([('no_results', True), ('with_results', False)])
@@ -448,7 +446,6 @@ class PyFlakes(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_success(self):
@@ -536,7 +533,6 @@ class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_builddir_required(self):

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -99,7 +99,6 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_run_env(self):
@@ -405,7 +404,6 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_run_ok(self):
@@ -476,7 +474,6 @@ class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_run_ok(self):

--- a/master/buildbot/test/unit/steps/test_python_twisted.py
+++ b/master/buildbot/test/unit/steps/test_python_twisted.py
@@ -15,7 +15,6 @@
 
 import textwrap
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.properties import Property
@@ -94,12 +93,8 @@ FAILED (failures=8)
 
 class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_run_env(self):
         self.setup_step(
@@ -399,12 +394,8 @@ class Trial(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_run_ok(self):
         self.setup_build(build_files=['foo.xhtml'])
@@ -469,12 +460,8 @@ class HLint(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class RemovePYCs(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_run_ok(self):
         self.setup_step(python_twisted.RemovePYCs())

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.buildstep import BuildStep
@@ -33,12 +32,8 @@ class TestBuildStepNameIsRenderable(
     TestBuildStepMixin, unittest.TestCase, TestReactorMixin, configmixin.ConfigErrorsMixin
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_name_is_renderable(self):
         step = TestBuildStep(name=Interpolate('%(kw:foo)s', foo='bar'))

--- a/master/buildbot/test/unit/steps/test_renderable.py
+++ b/master/buildbot/test/unit/steps/test_renderable.py
@@ -38,7 +38,6 @@ class TestBuildStepNameIsRenderable(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_name_is_renderable(self):

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -45,7 +45,6 @@ class TestShellCommandExecution(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_doStepIf_False(self):
@@ -187,7 +186,6 @@ class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_run_success(self):
@@ -225,7 +223,6 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_constructor_conflict(self):
@@ -360,7 +357,6 @@ class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_new_version_success(self):
@@ -475,7 +471,6 @@ class Configure(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_class_attrs(self):
@@ -499,7 +494,6 @@ class WarningCountingShellCommand(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_no_warnings(self):
@@ -829,7 +823,6 @@ class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_class_args(self):
@@ -851,7 +844,6 @@ class Test(TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, 
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_setTestResults(self):

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -40,12 +40,8 @@ class TestShellCommandExecution(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_doStepIf_False(self):
         self.setup_step(shell.ShellCommand(command="echo hello", doStepIf=False))
@@ -181,12 +177,8 @@ class TestShellCommandExecution(
 
 class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_run_success(self):
         self.setup_step(shell.TreeSize())
@@ -218,12 +210,8 @@ class TreeSize(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_constructor_conflict(self):
         with self.assertRaises(config.ConfigErrors):
@@ -352,12 +340,8 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_new_version_success(self):
         self.setup_step(shell.PerlModuleTest(command="cmd"))
@@ -466,12 +450,8 @@ class PerlModuleTest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class Configure(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_class_attrs(self):
         step = shell.Configure()
@@ -489,12 +469,8 @@ class WarningCountingShellCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_warnings(self):
         self.setup_step(shell.WarningCountingShellCommand(workdir='w', command=['make']))
@@ -818,12 +794,8 @@ class WarningCountingShellCommand(
 
 class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_class_args(self):
         # since this step is just a pre-configured WarningCountingShellCommand,
@@ -839,12 +811,8 @@ class Compile(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class Test(TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_setTestResults(self):
         step = self.setup_step(shell.Test())

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -38,11 +38,8 @@ class TestOneShellCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor(auto_tear_down=True)
         return self.setup_test_build_step()
-
-    def tearDown(self):
-        return self.tear_down_test_build_step()
 
     def testShellArgInput(self):
         with self.assertRaisesConfigError("the 'command' parameter of ShellArg must not be None"):

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -38,7 +38,7 @@ class TestOneShellCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=True)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
 
     def testShellArgInput(self):

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -32,12 +32,8 @@ class OldStyleSourceStep(Source):
 
 class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def setup_deferred_mock(self):
         m = mock.Mock()
@@ -169,12 +165,8 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCas
 
 class TestSourceDescription(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_constructor_args_strings(self):
         step = Source(
@@ -206,12 +198,8 @@ class AttrGroup(Source):
 
 class TestSourceAttrGroup(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_attrgroup_hasattr(self):
         step = AttrGroup()

--- a/master/buildbot/test/unit/steps/test_source_base_Source.py
+++ b/master/buildbot/test/unit/steps/test_source_base_Source.py
@@ -37,7 +37,6 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def setup_deferred_mock(self):
@@ -175,7 +174,6 @@ class TestSourceDescription(TestBuildStepMixin, TestReactorMixin, unittest.TestC
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_constructor_args_strings(self):
@@ -213,7 +211,6 @@ class TestSourceAttrGroup(sourcesteps.SourceStepMixin, TestReactorMixin, unittes
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_attrgroup_hasattr(self):

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -43,7 +43,6 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def test_mode_full(self):

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -16,7 +16,6 @@
 
 import os
 
-from twisted.internet import defer
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
@@ -38,12 +37,8 @@ from buildbot.test.util import sourcesteps
 
 class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_mode_full(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -43,7 +43,6 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def setup_step(self, step, *args, **kwargs):

--- a/master/buildbot/test/unit/steps/test_source_cvs.py
+++ b/master/buildbot/test/unit/steps/test_source_cvs.py
@@ -15,7 +15,6 @@
 
 import time
 
-from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
@@ -38,12 +37,8 @@ from buildbot.test.util import sourcesteps
 
 class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def setup_step(self, step, *args, **kwargs):
         super().setup_step(step, *args, **kwargs)

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
@@ -34,12 +33,8 @@ from buildbot.test.util import sourcesteps
 
 class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_no_empty_step_config(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/steps/test_source_darcs.py
+++ b/master/buildbot/test/unit/steps/test_source_darcs.py
@@ -39,7 +39,6 @@ class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def test_no_empty_step_config(self):

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS
@@ -30,12 +29,8 @@ class TestGerrit(
     sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_mode_full_clean(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -35,7 +35,6 @@ class TestGerrit(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def test_mode_full_clean(self):

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -4183,11 +4183,8 @@ class TestGitPush(
     stepClass = git.GitPush
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor(auto_tear_down=True)
         return self.setup_test_build_step()
-
-    def tearDown(self):
-        return self.tear_down_test_build_step()
 
     @parameterized.expand([
         ('url', 'ssh://github.com/test/test.git', 'ssh://github.com/test/test.git'),
@@ -4664,11 +4661,8 @@ class TestGitTag(TestBuildStepMixin, config.ConfigErrorsMixin, TestReactorMixin,
     stepClass = git.GitTag
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor(auto_tear_down=True)
         return self.setup_test_build_step()
-
-    def tearDown(self):
-        return self.tear_down_test_build_step()
 
     def test_tag_annotated(self):
         messages = ['msg1', 'msg2']
@@ -4768,7 +4762,6 @@ class TestGitCommit(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_add_fail(self):

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -54,7 +54,6 @@ class TestGit(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def test_mode_full_filters_2_26(self):

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -48,13 +48,9 @@ class TestGit(
     stepClass = git.Git
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_mode_full_filters_2_26(self):
         self.setup_step(
@@ -4753,15 +4749,11 @@ class TestGitCommit(
     stepClass = git.GitCommit
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.message_list = ['my commit', '42']
         self.path_list = ['file1.txt', 'file2.txt']
 
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_add_fail(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -4178,7 +4178,7 @@ class TestGitPush(
     stepClass = git.GitPush
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=True)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
 
     @parameterized.expand([
@@ -4656,7 +4656,7 @@ class TestGitTag(TestBuildStepMixin, config.ConfigErrorsMixin, TestReactorMixin,
     stepClass = git.GitTag
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=True)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
 
     def test_tag_annotated(self):

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS
@@ -32,7 +31,7 @@ class TestGitLab(
     stepClass = gitlab.GitLab
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 
@@ -53,10 +52,6 @@ class TestGitLab(
         )
         step.build.properties.setProperty("target_project_id", 239, "gitlab target project ID")
         return step
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_with_merge_branch(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -56,7 +56,6 @@ class TestGitLab(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def test_with_merge_branch(self):

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
@@ -35,12 +34,8 @@ from buildbot.test.util import sourcesteps
 
 class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def patch_workerVersionIsOlderThan(self, result):
         self.patch(mercurial.Mercurial, 'workerVersionIsOlderThan', lambda x, y, z: result)

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -40,7 +40,6 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.Test
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def patch_workerVersionIsOlderThan(self, result):

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -47,7 +47,6 @@ class TestMonotone(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def test_mode_full_clean(self):

--- a/master/buildbot/test/unit/steps/test_source_mtn.py
+++ b/master/buildbot/test/unit/steps/test_source_mtn.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
@@ -42,12 +41,8 @@ class TestMonotone(
     MTN_VER = 'monotone 1.0 (base revision: UNKNOWN_REV)'
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_mode_full_clean(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -42,7 +42,6 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin, u
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def setup_step(self, step, args=None, patch=None, **kwargs):

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -17,7 +17,6 @@
 import platform
 import textwrap
 
-from twisted.internet import defer
 from twisted.internet import error
 from twisted.python import reflect
 from twisted.trial import unittest
@@ -37,12 +36,8 @@ _is_windows = platform.system() == 'Windows'
 
 class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def setup_step(self, step, args=None, patch=None, **kwargs):
         if args is None:

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -68,7 +68,6 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def shouldLogEnviron(self):

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.changes.changes import Change
@@ -61,14 +60,10 @@ class RepoURL(unittest.TestCase):
 
 class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.shouldRetry = False
         self.logEnviron = True
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def shouldLogEnviron(self):
         r = self.logEnviron

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -126,7 +126,6 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tearDownSourceStep()
         yield self.tear_down_test_reactor()
 
     def patch_workerVersionIsOlderThan(self, result):

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -121,12 +121,8 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
                             </info>"""
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setUpSourceStep()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def patch_workerVersionIsOlderThan(self, result):
         self.patch(svn.SVN, 'workerVersionIsOlderThan', lambda x, y, z: result)

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -61,7 +61,6 @@ class TestSubUnit(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_empty(self):

--- a/master/buildbot/test/unit/steps/test_subunit.py
+++ b/master/buildbot/test/unit/steps/test_subunit.py
@@ -17,7 +17,6 @@ import io
 import re
 import sys
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import FAILURE
@@ -56,12 +55,8 @@ class TestSubUnit(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         if TestProtocolClient is None:
             raise unittest.SkipTest("Need to install python-subunit to test subunit step")
 
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_empty(self):
         self.setup_step(subunit.SubunitShellCommand(command='test'))

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -53,7 +53,6 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def testConstructorModeType(self):
@@ -323,7 +322,6 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def testBasic(self):
@@ -509,7 +507,6 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def testEmpty(self):
@@ -953,7 +950,6 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
 
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_init_workerdest_keyword(self):
@@ -1060,7 +1056,6 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     # check that ConfigErrors is raised on invalid 'mode' argument
@@ -1170,7 +1165,6 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1273,7 +1267,6 @@ class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -43,17 +43,15 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
         return self.setup_test_build_step()
 
-    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-        yield self.tear_down_test_reactor()
 
     def testConstructorModeType(self):
         with self.assertRaises(config.ConfigErrors):
@@ -310,19 +308,16 @@ class TestFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
         return self.setup_test_build_step()
 
-    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
-
-        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_step(transfer.DirectoryUpload(workersrc="srcdir", masterdest=self.destdir))
@@ -495,19 +490,16 @@ class TestDirectoryUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
 class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
 
         return self.setup_test_build_step()
 
-    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
-
-        yield self.tear_down_test_reactor()
 
     def testEmpty(self):
         self.setup_step(transfer.MultipleFileUpload(workersrcs=[], masterdest=self.destdir))
@@ -939,18 +931,15 @@ class TestMultipleFileUpload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class TestFileDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
         return self.setup_test_build_step()
 
-    @defer.inlineCallbacks
     def tearDown(self):
         if os.path.exists(self.destfile):
             os.unlink(self.destfile)
-
-        yield self.tear_down_test_reactor()
 
     def test_init_workerdest_keyword(self):
         step = transfer.FileDownload(mastersrc='srcfile', workerdest='dstfile')
@@ -1051,12 +1040,8 @@ class TestFileDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # check that ConfigErrors is raised on invalid 'mode' argument
 
@@ -1160,12 +1145,8 @@ class TestStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 
 class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testBasic(self):
@@ -1262,12 +1243,8 @@ class TestJSONStringDownload(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
 class TestJSONPropertiesDownload(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testBasic(self):

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -105,7 +105,6 @@ class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/steps/test_trigger.py
+++ b/master/buildbot/test/unit/steps/test_trigger.py
@@ -100,12 +100,8 @@ def BRID_TO_BUILD_NUMBER(brid):
 
 class TestTrigger(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_step(self, step, sourcestampsInBuild=None, gotRevisionsInBuild=None, *args, **kwargs):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -233,7 +233,6 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_default_config(self):
@@ -356,7 +355,6 @@ class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
@@ -456,7 +454,6 @@ class TestVC7(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
@@ -593,7 +590,6 @@ class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_args(self):
@@ -656,7 +652,6 @@ class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, 
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_args(self):
@@ -715,7 +710,6 @@ class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_installdir(self):
@@ -738,7 +732,6 @@ class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unitte
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_installdir(self):
@@ -761,7 +754,6 @@ class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unitte
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_installdir(self):
@@ -784,7 +776,6 @@ class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -888,7 +879,6 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1010,7 +1000,6 @@ class TestMsBuild16(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_version_range_is_correct(self):
@@ -1039,7 +1028,6 @@ class TestMsBuild17(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_version_range_is_correct(self):

--- a/master/buildbot/test/unit/steps/test_vstudio.py
+++ b/master/buildbot/test/unit/steps/test_vstudio.py
@@ -228,12 +228,8 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     """
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_default_config(self):
         vs = vstudio.VisualStudio()
@@ -350,12 +346,8 @@ class VisualStudio(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
         include = [
@@ -449,12 +441,8 @@ class TestVC6(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestVC7(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def getExpectedEnv(self, installdir, LIB=None, p=None, i=None):
         include = [
@@ -585,12 +573,8 @@ class VC8ExpectedEnvMixin:
 
 class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_args(self):
         self.setup_step(vstudio.VC8(projectfile='pf', config='cfg', project='pj', arch='arch'))
@@ -647,12 +631,8 @@ class TestVC8(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
 
 class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_args(self):
         self.setup_step(vstudio.VCExpress9(projectfile='pf', config='cfg', project='pj'))
@@ -705,12 +685,8 @@ class TestVCExpress9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, 
 
 class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC9(projectfile='pf', config='cfg', project='pj'))
@@ -727,12 +703,8 @@ class TestVC9(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittes
 
 class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC10(projectfile='pf', config='cfg', project='pj'))
@@ -749,12 +721,8 @@ class TestVC10(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unitte
 
 class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_installdir(self):
         self.setup_step(vstudio.VC11(projectfile='pf', config='cfg', project='pj'))
@@ -771,12 +739,8 @@ class TestVC11(VC8ExpectedEnvMixin, TestBuildStepMixin, TestReactorMixin, unitte
 
 class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_platform(self):
@@ -874,12 +838,8 @@ class TestMsBuild(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_platform(self):
@@ -995,12 +955,8 @@ class TestMsBuild141(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMsBuild16(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_version_range_is_correct(self):
         self.setup_step(
@@ -1023,12 +979,8 @@ class TestMsBuild16(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestMsBuild17(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_version_range_is_correct(self):
         self.setup_step(

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -42,12 +42,8 @@ from buildbot.test.steps import TestBuildStepMixin
 
 class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_simple(self):
         self.setup_step(
@@ -82,12 +78,8 @@ class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin, unittest.Te
 
 class TestFileExists(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_found(self):
         self.setup_step(worker.FileExists(file="x"))
@@ -125,12 +117,8 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
 class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(worker.CopyDirectory(src="s", dest="d"))
@@ -169,12 +157,8 @@ class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
 class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(worker.RemoveDirectory(dir="d"))
@@ -198,12 +182,8 @@ class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
 class TestMakeDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_success(self):
         self.setup_step(worker.MakeDirectory(dir="d"))
@@ -240,12 +220,8 @@ class CompositeUser(buildstep.BuildStep, worker.CompositeStepMixin):
 
 class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_runRemoteCommand(self):
         cmd_args = ('foo', {'bar': False})

--- a/master/buildbot/test/unit/steps/test_worker.py
+++ b/master/buildbot/test/unit/steps/test_worker.py
@@ -47,7 +47,6 @@ class TestSetPropertiesFromEnv(TestBuildStepMixin, TestReactorMixin, unittest.Te
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_simple(self):
@@ -88,7 +87,6 @@ class TestFileExists(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_found(self):
@@ -132,7 +130,6 @@ class TestCopyDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_success(self):
@@ -177,7 +174,6 @@ class TestRemoveDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_success(self):
@@ -207,7 +203,6 @@ class TestMakeDirectory(TestBuildStepMixin, TestReactorMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_success(self):
@@ -250,7 +245,6 @@ class TestCompositeStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_runRemoteCommand(self):

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -17,7 +17,6 @@
 import os
 import stat
 
-from twisted.internet import defer
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
@@ -38,15 +37,11 @@ class TestDownloadFileSecretToWorkerCommand(
     TestBuildStepMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_step(
@@ -81,15 +76,11 @@ class TestDownloadFileSecretToWorkerCommand(
 
 class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_build(worker_version={'*': '3.0'})
@@ -122,15 +113,11 @@ class TestRemoveFileSecretToWorkerCommand(
     TestBuildStepMixin, configmixin.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def testBasic(self):
         self.setup_step(

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -46,7 +46,6 @@ class TestDownloadFileSecretToWorkerCommand(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def testBasic(self):
@@ -90,7 +89,6 @@ class TestRemoveWorkerFileSecretCommand30(TestBuildStepMixin, TestReactorMixin, 
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def testBasic(self):
@@ -132,7 +130,6 @@ class TestRemoveFileSecretToWorkerCommand(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def testBasic(self):

--- a/master/buildbot/test/unit/test_fake_httpclientservice.py
+++ b/master/buildbot/test/unit/test_fake_httpclientservice.py
@@ -43,7 +43,7 @@ class myTestedService(service.BuildbotService):
 class Test(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        yield self.setup_test_reactor(auto_tear_down=False)
+        yield self.setup_test_reactor()
 
         baseurl = 'http://127.0.0.1:8080'
         master = yield fakemaster.make_master(self)
@@ -53,10 +53,6 @@ class Test(unittest.TestCase, TestReactorMixin):
 
         yield self.tested.setServiceParent(master)
         yield master.startService()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_root(self):

--- a/master/buildbot/test/unit/test_fake_secrets_manager.py
+++ b/master/buildbot/test/unit/test_fake_secrets_manager.py
@@ -11,15 +11,11 @@ from buildbot.test.reactor import TestReactorMixin
 class TestSecretsManager(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.master.config.secretsProviders = [
             FakeSecretStorage(secretdict={"foo": "bar", "other": "value"})
         ]
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testGetManagerService(self):

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -19,7 +19,7 @@ class FakeBuildWithMaster(FakeBuild):
 class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase, ConfigErrorsMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"foo": "bar", "other": "value"})
@@ -27,10 +27,6 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase, ConfigErrorsMi
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
         self.build = FakeBuildWithMaster(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret(self):
@@ -48,13 +44,9 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase, ConfigErrorsMi
 class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase, ConfigErrorsMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.build = FakeBuildWithMaster(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret(self):
@@ -66,7 +58,7 @@ class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase, Confi
 class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         password = "bar"
@@ -77,10 +69,6 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
         self.build = FakeBuildWithMaster(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret(self):

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -74,7 +74,6 @@ class LogChunksJanitorTests(
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -68,13 +68,9 @@ class LogChunksJanitorTests(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setup_test_build_step()
         self.patch(janitor, "now", lambda: datetime.datetime(year=2017, month=1, day=1))
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/test_machine_generic.py
+++ b/master/buildbot/test/unit/test_machine_generic.py
@@ -55,12 +55,8 @@ class TestActions(
     MasterRunProcessMixin, config.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_local_wake_action(self):
@@ -263,15 +259,11 @@ class TestActions(
 class TestHttpAction(config.ConfigErrorsMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, "http://localhost/request"
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_http_wrong_method(self):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -79,7 +79,7 @@ class InitTests(unittest.SynchronousTestCase):
 class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpLogging()
         self.basedir = os.path.abspath('basedir')
         yield self.setUpDirs(self.basedir)
@@ -114,10 +114,6 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
         yield self.mq.setServiceParent(self.master)
         self.data = self.master.data = fakedata.FakeDataConnector(self.master, self)
         yield self.data.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # tests
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -111,7 +111,6 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
     def tearDown(self):
         if self.db.pool is not None:
             yield self.db.pool.stop()
-        yield self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     # tests

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -133,24 +133,16 @@ class RealTests(tuplematching.TupleMatchingMixin, Tests):
 class TestFakeMQ(TestReactorMixin, unittest.TestCase, Tests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True)
         self.mq = self.master.mq
         self.mq.verifyMessages = False
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestSimpleMQ(TestReactorMixin, unittest.TestCase, RealTests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         yield self.mq.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -42,15 +42,11 @@ class FakeMQ(service.ReconfigurableServiceMixin, base.MQBase):
 class MQConnector(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.mqconfig = self.master.config.mq = {}
         self.conn = connector.MQConnector()
         yield self.conn.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def patchFakeMQ(self, name='fake'):
         self.patch(

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -32,10 +32,15 @@ class SimpleMQ(TestReactorMixin, unittest.TestCase):
         self.mq.setServiceParent(self.master)
         yield self.mq.startService()
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.mq.running:
+                yield self.mq.stopService()
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.mq.running:
-            yield self.mq.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -26,7 +26,7 @@ from buildbot.test.reactor import TestReactorMixin
 class SimpleMQ(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         self.mq.setServiceParent(self.master)
@@ -38,10 +38,6 @@ class SimpleMQ(TestReactorMixin, unittest.TestCase):
                 yield self.mq.stopService()
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_forward_data(self):

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -126,7 +126,7 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.master.wamp = FakeWampConnector()
         self.mq = wamp.WampMQ()
@@ -139,10 +139,6 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
                 yield self.mq.stopService()
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_startConsuming_basic(self):
@@ -254,7 +250,7 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         if "WAMP_ROUTER_URL" not in os.environ:
             raise unittest.SkipTest(self.HOW_TO_RUN)
         self.master = yield fakemaster.make_master(self)
@@ -269,10 +265,6 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
         config = FakeConfig()
         config.mq['router_url'] = os.environ["WAMP_ROUTER_URL"]
         yield self.connector.reconfigServiceWithBuildbotConfig(config)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_forward_data(self):

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -133,10 +133,15 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
         yield self.mq.setServiceParent(self.master)
         yield self.mq.startService()
 
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.mq.running:
+                yield self.mq.stopService()
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.mq.running:
-            yield self.mq.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -257,14 +262,16 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
         yield self.mq.setServiceParent(self.master)
         self.connector = self.master.wamp = connector.WampConnector()
         yield self.connector.setServiceParent(self.master)
+
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
+
         config = FakeConfig()
         config.mq['router_url'] = os.environ["WAMP_ROUTER_URL"]
         yield self.connector.reconfigServiceWithBuildbotConfig(config)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -42,10 +42,7 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         self.filepath = self.createFileTemp(self.tmp_dir, "tempfile.txt", text="key value\n")
         self.srvfile = SecretInAFile(self.tmp_dir)
         yield self.srvfile.startService()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.srvfile.stopService()
+        self.addCleanup(self.srvfile.stopService)
 
     def testCheckConfigSecretInAFileService(self):
         self.assertEqual(self.srvfile.name, "SecretInAFile")

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -33,7 +33,7 @@ class TestSecretInPass(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         self.master = yield fakemaster.make_master(self)
         with mock.patch.object(Path, "is_file", return_value=True):
@@ -42,10 +42,6 @@ class TestSecretInPass(
             yield self.srvpass.setServiceParent(self.master)
             yield self.master.startService()
             self.addCleanup(self.srvpass.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def create_temp_dir(self, dirname):
         tempdir = FilePath(self.mktemp())

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -41,10 +41,10 @@ class TestSecretInPass(
             self.srvpass = SecretInPass("password", self.tmp_dir)
             yield self.srvpass.setServiceParent(self.master)
             yield self.master.startService()
+            self.addCleanup(self.srvpass.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.srvpass.stopService()
         yield self.tear_down_test_reactor()
 
     def create_temp_dir(self, dirname):

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -25,7 +25,7 @@ class FakeServiceUsingSecrets(BuildbotService):
 class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage(secretdict={"foo": "bar", "other": "value"})
         self.secretsrv = SecretManager()
@@ -35,10 +35,6 @@ class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
         yield self.srvtest.setServiceParent(self.master)
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_secret_rendered(self):

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -34,10 +34,10 @@ class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
         self.srvtest = FakeServiceUsingSecrets()
         yield self.srvtest.setServiceParent(self.master)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -45,7 +45,7 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True, wantDb=True)
 
         yield self.master.db.insert_test_data(
@@ -64,10 +64,6 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
         yield self.stats_service.setServiceParent(self.master)
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestStatsServicesConfiguration(TestStatsServicesBase):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -63,10 +63,10 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
         )
         yield self.stats_service.setServiceParent(self.master)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
 

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -38,7 +38,6 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     def test_merge_base_failure(self):

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process import results
@@ -33,12 +32,8 @@ class TestDiffInfo(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         skip = 'unidiff is required for GitDiffInfo tests'
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_merge_base_failure(self):
         self.setup_step(gitdiffinfo.GitDiffInfo())

--- a/master/buildbot/test/unit/test_steps_mixin.py
+++ b/master/buildbot/test/unit/test_steps_mixin.py
@@ -48,12 +48,8 @@ class TestStep(buildstep.ShellMixin, buildstep.BuildStep):
 
 class TestTestBuildStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         return self.setup_test_build_step()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_setup_build(self):

--- a/master/buildbot/test/unit/test_steps_mixin.py
+++ b/master/buildbot/test/unit/test_steps_mixin.py
@@ -53,7 +53,6 @@ class TestTestBuildStepMixin(TestBuildStepMixin, TestReactorMixin, unittest.Test
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.tear_down_test_build_step()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -59,7 +59,7 @@ class TestedWampConnector(connector.WampConnector):
 class WampConnector(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         master = yield fakemaster.make_master(self)
         self.connector = TestedWampConnector()
 
@@ -68,10 +68,6 @@ class WampConnector(TestReactorMixin, unittest.TestCase):
         yield self.connector.setServiceParent(master)
         yield master.startService()
         yield self.connector.reconfigServiceWithBuildbotConfig(config)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfig_same_config(self):

--- a/master/buildbot/test/unit/util/test_backoff.py
+++ b/master/buildbot/test/unit/util/test_backoff.py
@@ -28,11 +28,7 @@ class TestException(Exception):
 
 class ExponentialBackoffEngineAsyncTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     def test_construct_asserts(self):
         with self.assertRaises(ValueError):

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -42,14 +42,10 @@ class TestAbsoluteSourceStampsMixin(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.db = self.master.db
         self.object = FakeObject(self.master, self.codebases)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def mkch(self, **kwargs):

--- a/master/buildbot/test/unit/util/test_deferwaiter.py
+++ b/master/buildbot/test/unit/util/test_deferwaiter.py
@@ -76,11 +76,7 @@ class WaiterTests(unittest.TestCase):
 
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_does_not_add_action_on_start(self):
@@ -432,11 +428,7 @@ class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
 
 class NonRepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_does_not_add_action_on_start(self):

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -106,17 +106,13 @@ class KubeClientServiceTestKubeHardcodedConfig(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, "http://localhost:8001"
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_basic(self):
         self.config = kubeclientservice.KubeHardcodedConfig(

--- a/master/buildbot/test/unit/util/test_kubeclientservice.py
+++ b/master/buildbot/test/unit/util/test_kubeclientservice.py
@@ -112,10 +112,10 @@ class KubeClientServiceTestKubeHardcodedConfig(
             self.master, self, "http://localhost:8001"
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def test_basic(self):
@@ -206,13 +206,16 @@ class KubeClientServiceTest(unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.parent = service.BuildbotService(name="parent")
+
+        @defer.inlineCallbacks
+        def cleanup():
+            if self.parent.running:
+                yield self.parent.stopService()
+
+        self.addCleanup(cleanup)
+
         self.client = kubeclientservice.KubeClientService()
         yield self.client.setServiceParent(self.parent)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        if self.parent.running:
-            yield self.parent.stopService()
 
     @defer.inlineCallbacks
     def test_stopped(self):

--- a/master/buildbot/test/unit/util/test_maildir.py
+++ b/master/buildbot/test/unit/util/test_maildir.py
@@ -36,7 +36,6 @@ class TestMaildirService(dirs.DirsMixin, unittest.TestCase):
     def tearDown(self):
         if self.svc and self.svc.running:
             self.svc.stopService()
-        self.tearDownDirs()
 
     # tests
 

--- a/master/buildbot/test/unit/util/test_misc.py
+++ b/master/buildbot/test/unit/util/test_misc.py
@@ -86,12 +86,8 @@ class deferredLocked(unittest.TestCase):
 
 class TestCancelAfter(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.d = defer.Deferred()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_succeeds(self):
         d = misc.cancelAfter(10, self.d, self.reactor)

--- a/master/buildbot/test/unit/util/test_poll.py
+++ b/master/buildbot/test/unit/util/test_poll.py
@@ -39,10 +39,14 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
         self.calls = 0
         self.fail_after_running = False
 
+        def cleanup():
+            poll.reset_poll_methods()
+            self.assertEqual(self.reactor.getDelayedCalls(), [])
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        poll.reset_poll_methods()
-        self.assertEqual(self.reactor.getDelayedCalls(), [])
         yield self.tear_down_test_reactor()
 
     def test_call_not_started_does_nothing(self):
@@ -202,9 +206,10 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.duration = 1
         self.fail_after_running = False
 
+        self.addCleanup(poll.reset_poll_methods)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        poll.reset_poll_methods()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/util/test_poll.py
+++ b/master/buildbot/test/unit/util/test_poll.py
@@ -31,7 +31,7 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
             raise RuntimeError('oh noes')
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = mock.Mock()
         self.master.reactor = self.reactor
 
@@ -44,10 +44,6 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
             self.assertEqual(self.reactor.getDelayedCalls(), [])
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_call_not_started_does_nothing(self):
         self.reactor.advance(100)
@@ -196,7 +192,7 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
             raise RuntimeError('oh noes')
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = mock.Mock()
         self.master.reactor = self.reactor
 
@@ -207,10 +203,6 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.fail_after_running = False
 
         self.addCleanup(poll.reset_poll_methods)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_call_when_started_forces_run(self):

--- a/master/buildbot/test/unit/util/test_runprocess.py
+++ b/master/buildbot/test/unit/util/test_runprocess.py
@@ -37,14 +37,10 @@ class TestRunProcess(TestReactorMixin, LoggingMixin, unittest.TestCase):
     FAKE_PID = 1234
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpLogging()
         self.process = None
         self.reactor.spawnProcess = self.fake_spawn_process
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def fake_spawn_process(self, pp, command, args, env, workdir, usePTY=False):
         self.assertIsNone(self.process)

--- a/master/buildbot/test/unit/util/test_service.py
+++ b/master/buildbot/test/unit/util/test_service.py
@@ -103,13 +103,9 @@ class ClusteredBuildbotService(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.svc = self.makeService()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeService(self, attach_to_master=True, name=SVC_NAME, serviceid=SVC_ID):
         svc = self.DummyService(name=name)

--- a/master/buildbot/test/unit/util/test_state.py
+++ b/master/buildbot/test/unit/util/test_state.py
@@ -34,13 +34,9 @@ class TestStateMixin(TestReactorMixin, StateTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.object = FakeObject(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getState(self):

--- a/master/buildbot/test/unit/util/test_test_result_submitter.py
+++ b/master/buildbot/test/unit/util/test_test_result_submitter.py
@@ -28,6 +28,7 @@ class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor(auto_tear_down=False)
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True)
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
         yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
@@ -43,7 +44,6 @@ class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/util/test_test_result_submitter.py
+++ b/master/buildbot/test/unit/util/test_test_result_submitter.py
@@ -25,7 +25,7 @@ from buildbot.util.test_result_submitter import TestResultSubmitter
 class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantData=True, wantDb=True)
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
@@ -41,10 +41,6 @@ class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
             ),
             fakedb.Step(id=131, number=132, name='step132', buildid=30),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_complete_empty(self):

--- a/master/buildbot/test/unit/util/test_watchdog.py
+++ b/master/buildbot/test/unit/util/test_watchdog.py
@@ -15,7 +15,6 @@
 
 from unittest import mock
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.reactor import TestReactorMixin
@@ -24,11 +23,7 @@ from buildbot.util.watchdog import Watchdog
 
 class TestWatchdog(TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     def test_not_started_no_calls(self):
         m = mock.Mock()

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -115,12 +115,8 @@ class WorkerInterfaceTests(interfaces.InterfaceTests):
 
 class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.wrk = ConcreteWorker('wrk', 'pa')
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def callAttached(self):
@@ -137,13 +133,9 @@ class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
 class FakeWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.wrk = worker.FakeWorker(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def callAttached(self):
         self.conn = fakeprotocol.FakeConnection(self.wrk)
@@ -153,17 +145,13 @@ class FakeWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
 class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setUpLogging()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
         yield self.workers.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def createWorker(self, name='bot', password='pass', attached=False, configured=True, **kwargs):
@@ -929,16 +917,12 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
 class TestAbstractLatentWorker(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
         yield self.workers.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_reconfigService(self, old, new, existingRegistration=True):

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -47,7 +47,7 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         return self._client
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.patch(dockerworker, 'docker', docker)
 
@@ -60,10 +60,6 @@ class TestDockerLatentWorker(ConfigErrorsMixin, unittest.TestCase, TestReactorMi
         self.build2 = Properties(image='busybox:latest', builder='docker_worker2', distro='wheezy')
         docker.Client.containerCreated = False
         docker.Client.start_exception = None
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_constructor_noimage_nodockerfile(self):

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -63,7 +63,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
     worker = None
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, config=None, **kwargs):
@@ -85,10 +85,6 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
         self.assertTrue(config.running)
         self.addCleanup(self.master.stopService)
         return worker
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def get_expected_metadata(self):
         return {"name": "buildbot-worker-87de7e"}

--- a/master/buildbot/test/unit/worker/test_libvirt.py
+++ b/master/buildbot/test/unit/worker/test_libvirt.py
@@ -67,15 +67,11 @@ class TestException(Exception):
 
 class TestLibVirtWorker(TestReactorMixin, MasterRunProcessMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setup_master_run_process()
         self.connections = {}
         self.patch(libvirtworker, "libvirt", libvirtfake)
         self.threadpool = TestServerThreadPool(self)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def libvirt_open(self, uri):
         if uri not in self.connections:

--- a/master/buildbot/test/unit/worker/test_local.py
+++ b/master/buildbot/test/unit/worker/test_local.py
@@ -32,14 +32,10 @@ class TestLocalWorker(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         self.workers = self.master.workers
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def createWorker(self, name='bot', attached=False, configured=True, **kwargs):
         worker = local.LocalWorker(name, **kwargs)

--- a/master/buildbot/test/unit/worker/test_manager.py
+++ b/master/buildbot/test/unit/worker/test_manager.py
@@ -60,10 +60,10 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
 
         self.new_config = mock.Mock()
         self.workers.startService()
+        self.addCleanup(self.workers.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.workers.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/worker/test_manager.py
+++ b/master/buildbot/test/unit/worker/test_manager.py
@@ -47,7 +47,7 @@ class FakeWorker2(FakeWorker):
 class TestWorkerManager(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.workers = workermanager.WorkerManager(self.master)
@@ -61,10 +61,6 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
         self.new_config = mock.Mock()
         self.workers.startService()
         self.addCleanup(self.workers.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_reconfigServiceWorkers_add_remove(self):

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -34,14 +34,18 @@ class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
         self.worker = None
         self.master = None
 
+        def cleanup():
+            if self.worker is not None:
+
+                class FakeResult:
+                    code = 200
+
+                self._http.delete = lambda _: defer.succeed(FakeResult())
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.worker is not None:
-
-            class FakeResult:
-                code = 200
-
-            self._http.delete = lambda _: defer.succeed(FakeResult())
         self.flushLoggedErrors(LatentWorkerSubstantiatiationCancelled)
         yield self.tear_down_test_reactor()
 

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -29,7 +29,7 @@ from buildbot.worker.marathon import MarathonLatentWorker
 
 class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.build = Properties(image="busybox:latest", builder="docker_worker")
         self.worker = None
         self.master = None
@@ -44,10 +44,8 @@ class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
 
         self.addCleanup(cleanup)
 
-    @defer.inlineCallbacks
     def tearDown(self):
         self.flushLoggedErrors(LatentWorkerSubstantiatiationCancelled)
-        yield self.tear_down_test_reactor()
 
     def test_constructor_normal(self):
         worker = MarathonLatentWorker('bot', 'tcp://marathon.local', 'foo', 'bar', 'debian:wheezy')

--- a/master/buildbot/test/unit/worker/test_openstack.py
+++ b/master/buildbot/test/unit/worker/test_openstack.py
@@ -43,7 +43,7 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
     bs_image_args = {"flavor": 1, "image": '28a65eb4-f354-4420-97dc-253b826547f7', **os_auth}
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.patch(openstack, "client", novaclient)
         self.patch(openstack, "loading", novaclient)
         self.patch(openstack, "session", novaclient)
@@ -54,10 +54,6 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
             meta_value='value',
         )
         self.masterhash = hashlib.sha1(b'fake:/master').hexdigest()[:6]
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):

--- a/master/buildbot/test/unit/worker/test_protocols_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_base.py
@@ -15,7 +15,6 @@
 
 from unittest import mock
 
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakeprotocol
@@ -26,24 +25,16 @@ from buildbot.worker.protocols import base
 
 class TestFakeConnection(protocols.ConnectionInterfaceTest, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.worker = mock.Mock()
         self.conn = fakeprotocol.FakeConnection(self.worker)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestConnection(protocols.ConnectionInterfaceTest, TestReactorMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.worker = mock.Mock()
         self.conn = base.Connection(self.worker.workername)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_notify(self):
         cb = mock.Mock()

--- a/master/buildbot/test/unit/worker/test_protocols_manager_pbmanager.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_pbmanager.py
@@ -42,11 +42,11 @@ class TestPBManager(unittest.TestCase):
     def setUp(self):
         self.pbm = PBManager()
         yield self.pbm.setServiceParent(FakeMaster())
-        self.pbm.startService()
-        self.connections = []
 
-    def tearDown(self):
-        return self.pbm.stopService()
+        self.pbm.startService()
+        self.addCleanup(self.pbm.stopService)
+
+        self.connections = []
 
     def perspectiveFactory(self, mind, username):
         persp = mock.Mock()

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -32,12 +32,8 @@ from buildbot.worker.protocols import msgpack
 class TestListener(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_constructor(self):
         listener = msgpack.Listener(self.master)
@@ -88,28 +84,20 @@ class TestConnectionApi(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.conn = msgpack.Connection(self.master, mock.Mock(), mock.Mock())
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestConnection(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.protocol = mock.Mock()
         self.worker = mock.Mock()
         self.worker.workername = 'test_worker'
         self.conn = msgpack.Connection(self.master, self.worker, self.protocol)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_constructor(self):
         self.assertEqual(self.conn.protocol, self.protocol)

--- a/master/buildbot/test/unit/worker/test_protocols_pb.py
+++ b/master/buildbot/test/unit/worker/test_protocols_pb.py
@@ -30,12 +30,8 @@ from buildbot.worker.protocols import pb
 class TestListener(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeListener(self):
         listener = pb.Listener(self.master)
@@ -89,26 +85,18 @@ class TestConnectionApi(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.conn = pb.Connection(self.master, mock.Mock(), mock.Mock())
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
 
 class TestConnection(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self)
         self.mind = mock.Mock()
         self.worker = mock.Mock()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_constructor(self):
         conn = pb.Connection(self.master, self.worker, self.mind)

--- a/master/buildbot/test/unit/worker/test_upcloud.py
+++ b/master/buildbot/test/unit/worker/test_upcloud.py
@@ -86,8 +86,6 @@ class TestUpcloudWorker(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        if self.master is not None:
-            yield self.master.test_shutdown()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -95,7 +93,7 @@ class TestUpcloudWorker(TestReactorMixin, unittest.TestCase):
         worker = upcloud.UpcloudLatentWorker(
             *args, api_username='test-api-user', api_password='test-api-password', **kwargs
         )
-        self.master = yield fakemaster.make_master(self, wantData=True, auto_shutdown=False)
+        self.master = yield fakemaster.make_master(self, wantData=True)
         self._http = worker.client = yield fakehttpclientservice.HTTPClientService.getService(
             self.master,
             self,

--- a/master/buildbot/test/unit/worker/test_upcloud.py
+++ b/master/buildbot/test/unit/worker/test_upcloud.py
@@ -82,11 +82,7 @@ class TestUpcloudWorker(TestReactorMixin, unittest.TestCase):
     master = None
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):

--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -42,13 +42,9 @@ class AuthResourceMixin:
 class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpAuthResource()
         self.rsrc = auth.AuthRootResource(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_getChild_login(self):
         glr = mock.Mock(name='glr')
@@ -66,15 +62,11 @@ class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, un
 class AuthBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.auth = auth.AuthBase()
         self.master = yield self.make_master(url='h:/a/b/')
         self.auth.master = self.master
         self.req = self.make_request(b'/')
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin(self):
@@ -111,14 +103,10 @@ class NoAuth(unittest.TestCase):
 class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         yield self.make_master()
         self.request = self.make_request(b'/')
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin(self):
@@ -155,14 +143,10 @@ class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         self.auth = auth.NoAuth()
         yield self.make_master()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_requestAvatar(self):
         realm = auth.AuthRealm(self.master, self.auth)
@@ -173,7 +157,7 @@ class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 class TwistedICredAuthBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
     # twisted.web makes it difficult to simulate the authentication process, so
     # this only tests the mechanics of the getLoginResource method.
@@ -208,11 +192,7 @@ class CustomAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             return us == 'fellow' and ps == 'correct'
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_callable(self):
@@ -228,12 +208,8 @@ class CustomAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class LoginResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpAuthResource()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -251,13 +227,9 @@ class PreAuthenticatedLoginResource(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpAuthResource()
         self.rsrc = auth.PreAuthenticatedLoginResource(self.master, 'him')
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -280,13 +252,9 @@ class PreAuthenticatedLoginResource(
 class LogoutResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         yield self.setUpAuthResource()
         self.rsrc = auth.LogoutResource(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):

--- a/master/buildbot/test/unit/www/test_authz.py
+++ b/master/buildbot/test/unit/www/test_authz.py
@@ -36,7 +36,7 @@ from buildbot.www.authz.roles import RolesFromOwner
 class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         authzcfg = authz.Authz(
             # simple matcher with '*' glob character
             stringsMatcher=authz.fnmatchStrMatcher,
@@ -106,10 +106,6 @@ class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
                 id=15, builderid=77, masterid=88, workerid=13, buildrequestid=82, number=5
             ),
         ])
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def setAllowRules(self, allow_rules):
         # we should add links to authz and master instances in each new rule

--- a/master/buildbot/test/unit/www/test_avatar.py
+++ b/master/buildbot/test/unit/www/test_avatar.py
@@ -32,11 +32,7 @@ class TestAvatar(avatar.AvatarBase):
 
 class AvatarResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_default(self):
@@ -526,7 +522,7 @@ github_commit_search_not_found_reply = {"total_count": 0, "incomplete_results": 
 class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         master = yield self.make_master(
             url='http://a/b/',
@@ -551,10 +547,6 @@ class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_username(self):
@@ -726,7 +718,7 @@ class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class GitHubAvatarBasicAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         avatar_method = avatar.AvatarGitHub(client_id="oauth_id", client_secret="oauth_secret")
         master = yield self.make_master(
@@ -751,10 +743,6 @@ class GitHubAvatarBasicAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCas
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_incomplete_credentials(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/test/unit/www/test_avatar.py
+++ b/master/buildbot/test/unit/www/test_avatar.py
@@ -550,10 +550,10 @@ class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -750,10 +750,10 @@ class GitHubAvatarBasicAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCas
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def test_incomplete_credentials(self):

--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -51,11 +51,7 @@ class Utils(unittest.TestCase):
 
 class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -88,11 +84,7 @@ class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 class IndexResourceTest(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     def get_react_base_path(self):
         path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/master/buildbot/test/unit/www/test_endpointmatchers.py
+++ b/master/buildbot/test/unit/www/test_endpointmatchers.py
@@ -27,16 +27,12 @@ from buildbot.www.authz import endpointmatchers
 class EndpointBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url='h:/a/b/')
         self.db = self.master.db
         self.matcher = self.makeMatcher()
         self.matcher.setAuthz(self.master.authz)
         yield self.insertData()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeMatcher(self):
         raise NotImplementedError()

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -225,14 +225,10 @@ class DisabledV3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCa
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url="http://server/path/")
         self.rsrc = graphql.V3RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_basic_disabled(self):

--- a/master/buildbot/test/unit/www/test_hooks_base.py
+++ b/master/buildbot/test/unit/www/test_hooks_base.py
@@ -39,12 +39,8 @@ def _prepare_request(payload, headers=None):
 class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.changeHook = yield _prepare_base_change_hook(self)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_base_with_change(self, payload):
@@ -102,7 +98,7 @@ class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCustomBase(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         class CustomBase(BaseHookHandler):
             def getChanges(self, request):
@@ -116,10 +112,6 @@ class TestChangeHookConfiguredWithCustomBase(unittest.TestCase, TestReactorMixin
                 return ([chdict], None)
 
         self.changeHook = yield _prepare_base_change_hook(self, custom_class=CustomBase)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_base_with_change(self, payload):

--- a/master/buildbot/test/unit/www/test_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucket.py
@@ -139,15 +139,11 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase, TestReactor
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         master = yield fakeMasterForHooks(self)
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucket': True}, master=master
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def testGitWithChange(self):

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketcloud.py
@@ -684,7 +684,7 @@ def _prepare_request(payload, headers=None, change_dict=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         master = yield fakeMasterForHooks(self)
         self.change_hook = change_hook.ChangeHookResource(
             dialects={
@@ -694,10 +694,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
             },
             master=master,
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}

--- a/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/www/test_hooks_bitbucketserver.py
@@ -709,7 +709,7 @@ def _prepare_request(payload, headers=None, change_dict=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         master = yield fakeMasterForHooks(self)
         self.change_hook = change_hook.ChangeHookResource(
             dialects={
@@ -719,10 +719,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
             },
             master=master,
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -624,10 +624,10 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
@@ -902,10 +902,10 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -952,10 +952,10 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1009,12 +1009,12 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
         yield secret_service.setServiceParent(self.master)
 
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
         fake_storage.reconfigService(secretdict={self.secret_name: self.secret_value})
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1053,10 +1053,10 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReac
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1146,10 +1146,10 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
@@ -1264,10 +1264,10 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMi
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
@@ -1308,10 +1308,10 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase, TestR
             verify=True,
         )
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -609,7 +609,7 @@ def _prepare_request(event, payload, _secret=None, headers=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"]
         )
@@ -625,10 +625,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin)
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}
@@ -887,7 +883,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"], pullrequest_ref="head"
         )
@@ -903,10 +899,6 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_git_pull_request_with_custom_ref(self):
@@ -929,7 +921,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
 ):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
             self,
@@ -955,10 +947,6 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
         self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
-
-    @defer.inlineCallbacks
     def test_git_pull_request_with_custom_ref(self):
         commit = deepcopy([gitJsonPayloadPullRequest])
 
@@ -980,7 +968,7 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         self.changeHook = yield _prepare_github_change_hook(
             self,
@@ -1014,10 +1002,6 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
         fake_storage.reconfigService(secretdict={self.secret_name: self.secret_value})
 
     @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
-
-    @defer.inlineCallbacks
     def test_git_pull_request(self):
         commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
         files_endpoint = '/repos/defunkt/github/pulls/50/files'
@@ -1034,7 +1018,7 @@ class TestChangeHookRefWithAuth(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, skips=[r'\[ *bb *skip *\]'], token=_token
@@ -1054,10 +1038,6 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReac
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_push_with_skip_message(self, payload):
@@ -1126,7 +1106,7 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase, TestReac
 class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
@@ -1147,10 +1127,6 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertDictSubset(self, expected_dict, response_dict):
         expected = {}
@@ -1249,7 +1225,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.changeHook = yield _prepare_github_change_hook(
             self, strict=False, github_api_endpoint='https://black.magic.io'
         )
@@ -1265,10 +1241,6 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMi
         )
         yield self.master.startService()
         self.addCleanup(self.master.stopService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_pull_request(self, payload):
@@ -1288,7 +1260,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase, TestReactorMi
 class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = yield _prepare_github_change_hook(
@@ -1311,10 +1283,6 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase, TestR
         self.addCleanup(self.master.stopService)
 
     @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
-
-    @defer.inlineCallbacks
     def _check_pull_request(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
@@ -1334,7 +1302,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"secret_key": self._SECRET})
@@ -1346,10 +1314,6 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
             self, strict=True, secret=util.Secret("secret_key")
         )
         self.changeHook.master.addService(secretService)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_signature_ok(self):
@@ -1442,12 +1406,8 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
 class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.changeHook = yield _prepare_github_change_hook(self, codebase='foobar')
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_git_with_change(self, payload):
@@ -1471,12 +1431,8 @@ def _codebase_function(payload):
 class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.changeHook = yield _prepare_github_change_hook(self, codebase=_codebase_function)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def _check_git_with_change(self, payload):
@@ -1496,7 +1452,7 @@ class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase, TestReacto
 class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         class CustomGitHubEventHandler(GitHubEventHandler):
             def handle_ping(self, _, __):
@@ -1506,10 +1462,6 @@ class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase, TestReac
         self.changeHook = yield _prepare_github_change_hook(
             self, **{'class': CustomGitHubEventHandler}
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_ping(self):

--- a/master/buildbot/test/unit/www/test_hooks_gitlab.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitlab.py
@@ -1019,13 +1019,9 @@ def FakeRequestMR(content):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         master = yield fakeMasterForHooks(self)
         self.changeHook = change_hook.ChangeHookResource(dialects={'gitlab': True}, master=master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def check_changes_tag_event(self, r, project='', codebase=None):
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
@@ -1252,7 +1248,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakeMasterForHooks(self)
 
         fakeStorageService = FakeSecretStorage()
@@ -1265,10 +1261,6 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase, TestReactorMixin):
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitlab': {'secret': util.Secret("secret_key")}}, master=self.master
         )
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_missing_secret(self):

--- a/master/buildbot/test/unit/www/test_hooks_gitorious.py
+++ b/master/buildbot/test/unit/www/test_hooks_gitorious.py
@@ -64,14 +64,10 @@ gitJsonPayload = b"""
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         dialects = {'gitorious': True}
         master = yield fakeMasterForHooks(self)
         self.changeHook = change_hook.ChangeHookResource(dialects=dialects, master=master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     # Test 'base' hook with attributes. We should get a json string
     # representing a Change object as a dictionary. All values show be set.

--- a/master/buildbot/test/unit/www/test_hooks_poller.py
+++ b/master/buildbot/test/unit/www/test_hooks_poller.py
@@ -48,6 +48,8 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
         )
         master.www = www
         yield self.master.startService()
+        self.addCleanup(self.master.stopService)
+
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'poller': options}, master=master
         )
@@ -68,7 +70,6 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/www/test_hooks_poller.py
+++ b/master/buildbot/test/unit/www/test_hooks_poller.py
@@ -35,7 +35,7 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
             self.called = True
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def setUpRequest(self, args, options=True, activate=True):
@@ -67,10 +67,6 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
 
         yield self.request.test_render(self.changeHook)
         yield util.asyncSleep(0.1)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_no_args(self):

--- a/master/buildbot/test/unit/www/test_ldapuserinfo.py
+++ b/master/buildbot/test/unit/www/test_ldapuserinfo.py
@@ -186,7 +186,7 @@ class LdapAvatar(CommonTestCase, TestReactorMixin, WwwTestMixin):
     @defer.inlineCallbacks
     def setUp(self):
         CommonTestCase.setUp(self)
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         master = yield self.make_master(url='http://a/b/', avatar_methods=[self.userInfoProvider])
 
@@ -194,10 +194,6 @@ class LdapAvatar(CommonTestCase, TestReactorMixin, WwwTestMixin):
         self.rsrc.reconfigResource(master.config)
 
         yield self.master.startService()
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeUserInfoProvider(self):
         self.userInfoProvider = ldapuserinfo.LdapUserInfo(

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -59,7 +59,7 @@ class FakeResponse:
 
 class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
 
@@ -146,10 +146,6 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin, unittest
         master = yield self.make_master(url='h:/a/b/', auth=auth)
         auth.reconfigAuth(master, master.config)
         return auth
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_getGoogleLoginURL(self):
@@ -630,7 +626,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
 
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
@@ -661,7 +657,6 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
         for reader in reactor.getReaders():
             if isinstance(reader, Server):
                 reader.connectionLost(f)
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_E2E(self):

--- a/master/buildbot/test/unit/www/test_resource.py
+++ b/master/buildbot/test/unit/www/test_resource.py
@@ -28,11 +28,7 @@ class ResourceSubclass(resource.Resource):
 
 class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_base_url(self):
@@ -49,11 +45,7 @@ class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 class RedirectResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
+        self.setup_test_reactor()
 
     @defer.inlineCallbacks
     def test_redirect(self):

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -37,12 +37,8 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     maxVersion = 3
 
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         _ = graphql  # used for import side effect
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -75,15 +71,11 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class V2RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url='http://server/path/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertSimpleError(self, message, responseCode):
         content = json.dumps({'error': message})
@@ -148,7 +140,7 @@ class V2RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url='h:/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
@@ -160,10 +152,6 @@ class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
             return defer.succeed(None)
 
         self.rsrc.renderRest = renderRest
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertOk(self, expectHeaders=True, content=b'ok', origin=b'h://good'):
         hdrs = (
@@ -272,7 +260,7 @@ class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
 class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url='h:/')
         self.master.config.www['debug'] = True
         self.master.data._scanModule(endpoint)
@@ -288,10 +276,6 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
         endpoint.TestsEndpoint.rtype = mock.MagicMock()
         endpoint.Test.kind = EndpointKind.COLLECTION
         endpoint.Test.rtype = endpoint.Test
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertRestCollection(
         self, typeName, items, total=None, contentType=None, orderSignificant=False
@@ -769,7 +753,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
 class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url='h:/')
 
         def allow(*args, **kw):
@@ -780,10 +764,6 @@ class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin, unittest.TestC
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def assertJsonRpcError(self, message, responseCode=400, jsonrpccode=None):
         got = {}

--- a/master/buildbot/test/unit/www/test_service.py
+++ b/master/buildbot/test/unit/www/test_service.py
@@ -59,14 +59,10 @@ class NeedsReconfigResource(resource.Resource):
 class Test(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield self.make_master(url='h:/a/b/')
         self.svc = self.master.www = service.WWWService()
         yield self.svc.setServiceParent(self.master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def makeConfig(self, **kwargs):
         w = {"port": None, "auth": auth.NoAuth(), "logfileName": 'l'}

--- a/master/buildbot/test/unit/www/test_sse.py
+++ b/master/buildbot/test/unit/www/test_sse.py
@@ -32,13 +32,9 @@ from buildbot.www import sse
 class EventResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = master = yield self.make_master(url=b'h:/a/b/')
         self.sse = sse.EventResource(master)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     def test_simpleapi(self):
         self.render_resource(self.sse, b'/changes/*/*')

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -42,15 +42,15 @@ class ChangeSourceMixin:
         )
         assert not hasattr(self.master, 'addChange')  # just checking..
 
-    @defer.inlineCallbacks
-    def tearDownChangeSource(self):
-        "Tear down the mixin - returns a deferred."
-        if not self.started:
-            return
-        if self.changesource.running:
-            yield self.changesource.stopService()
-        yield self.changesource.disownServiceParent()
-        return
+        @defer.inlineCallbacks
+        def cleanup():
+            if not self.started:
+                return
+            if self.changesource.running:
+                yield self.changesource.stopService()
+            yield self.changesource.disownServiceParent()
+
+        self.addCleanup(cleanup)
 
     @defer.inlineCallbacks
     def attachChangeSource(self, cs):

--- a/master/buildbot/test/util/dirs.py
+++ b/master/buildbot/test/util/dirs.py
@@ -31,12 +31,13 @@ class DirsMixin:
             if os.path.exists(dir):
                 shutil.rmtree(dir)
             os.makedirs(dir)
-        # return a deferred to make chaining easier
-        return defer.succeed(None)
 
-    def tearDownDirs(self):
-        for dir in self._dirs:
-            if os.path.exists(dir):
-                shutil.rmtree(dir)
+        def cleanup():
+            for dir in self._dirs:
+                if os.path.exists(dir):
+                    shutil.rmtree(dir)
+
+        self.addCleanup(cleanup)
+
         # return a deferred to make chaining easier
         return defer.succeed(None)

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -38,7 +38,7 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def setUpEndpoint(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
         self.db = self.master.db
         self.mq = self.master.mq
@@ -67,10 +67,6 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
             for pp in pathPatterns
             if pp is not None
         ]
-
-    @defer.inlineCallbacks
-    def tearDownEndpoint(self):
-        yield self.tear_down_test_reactor()
 
     def validateData(self, object):
         validation.verifyData(self, self.rtype.entityType, {}, object)

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -176,17 +176,13 @@ async def print_build(build, master: BuildMaster, out=sys.stdout, with_logs=Fals
 
 class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
     def setUp(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.setupDebugIntegrationLogs()
 
         def cleanup():
             self.assertFalse(self.master.running, "master is still running!")
 
         self.addCleanup(cleanup)
-
-    @defer.inlineCallbacks
-    def tearDown(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def setup_master(self, config_dict):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -179,9 +179,13 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin, DebugIntegratio
         self.setup_test_reactor(auto_tear_down=False)
         self.setupDebugIntegrationLogs()
 
+        def cleanup():
+            self.assertFalse(self.master.running, "master is still running!")
+
+        self.addCleanup(cleanup)
+
     @defer.inlineCallbacks
     def tearDown(self):
-        self.assertFalse(self.master.running, "master is still running!")
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 class MigrateTestMixin(TestReactorMixin, dirs.DirsMixin):
     @defer.inlineCallbacks
     def setUpMigrateTest(self):
-        self.setup_test_reactor(auto_tear_down=False)
+        self.setup_test_reactor()
         self.basedir = os.path.abspath("basedir")
         self.setUpDirs('basedir')
 
@@ -52,10 +52,6 @@ class MigrateTestMixin(TestReactorMixin, dirs.DirsMixin):
             self, wantDb=True, auto_upgrade=False, check_version=False
         )
         self.db = self.master.db
-
-    @defer.inlineCallbacks
-    def tearDownMigrateTest(self):
-        yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks
     def do_test_migration(self, base_revision, target_revision, setup_thd_cb, verify_thd_cb):

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -55,7 +55,6 @@ class MigrateTestMixin(TestReactorMixin, dirs.DirsMixin):
 
     @defer.inlineCallbacks
     def tearDownMigrateTest(self):
-        self.tearDownDirs()
         yield self.tear_down_test_reactor()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -46,9 +46,6 @@ class SchedulerMixin(interfaces.InterfaceTests):
     def setUpScheduler(self):
         self.master = yield fakemaster.make_master(self, wantDb=True, wantMq=True, wantData=True)
 
-    def tearDownScheduler(self):
-        pass
-
     @defer.inlineCallbacks
     def attachScheduler(
         self, scheduler, objectid, schedulerid, overrideBuildsetMethods=False, createBuilderDB=False

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -36,7 +36,7 @@ class SourceStepMixin(TestBuildStepMixin):
         return super().setup_test_build_step()
 
     def tearDownSourceStep(self):
-        return super().tear_down_test_build_step()
+        return None
 
     # utilities
 

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -35,9 +35,6 @@ class SourceStepMixin(TestBuildStepMixin):
     def setUpSourceStep(self):
         return super().setup_test_build_step()
 
-    def tearDownSourceStep(self):
-        return None
-
     # utilities
 
     def setup_step(self, step, args=None, patch=None, **kwargs):

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -26,7 +26,7 @@ class SourceStepMixin(TestBuildStepMixin):
 
      - fake sourcestamps
 
-    The following instance variables are available after C{setupSourceStep}, in
+    The following instance variables are available after C{setup_step}, in
     addition to those made available by L{TestBuildStepMixin}:
 
     @ivar sourcestamp: fake SourceStamp for the build

--- a/master/docs/manual/configuration/tests/reactor.rst
+++ b/master/docs/manual/configuration/tests/reactor.rst
@@ -18,14 +18,12 @@ TestReactorMixin
     .. py:method:: setup_test_reactor(use_asyncio=False, auto_tear_down=True)
 
         :param bool use_asyncio: Whether to enable asyncio integration.
-        :param bool auto_tear_down: Whether to automatically tear down the test reactor. This
-            option is deprecated in favor of ``tear_down_test_reactor()`` as the automatic tear
-            down can only run before ``tearDown()`` and thus in many tests the test reactor is
-            shut down prematurely.
+        :param bool auto_tear_down: Whether to automatically tear down the test reactor.
+                                    Setting it to ``False`` is deprecated.
 
         Call this function in the ``setUp()`` of the test case to setup fake reactor.
 
     .. py:method:: tear_down_test_reactor()
 
         Call this function in the ``tearDown()`` of the test case to tear down fake reactor.
-        The function returns a ``Deferred``.
+        This function is deprecated. The function returns a ``Deferred``.

--- a/master/docs/manual/configuration/tests/steps.rst
+++ b/master/docs/manual/configuration/tests/steps.rst
@@ -23,7 +23,6 @@ TestBuildStepMixin
 
             @defer.inlineCallbacks
             def tearDown(self):
-                yield self.tear_down_test_build_step()
                 yield self.tear_down_test_reactor()
 
             @defer.inlineCallbacks
@@ -59,10 +58,6 @@ TestBuildStepMixin
     .. py:method:: setup_test_build_step()
 
         Call this function in the ``setUp()`` method of the test case to setup step testing machinery.
-
-    .. py:method:: tear_down_test_build_step()
-
-        Call this function in the ``tearDown()`` of the test case to destroy step testing machinery.
 
     .. py:method:: setup_build(worker_env=None, build_files=None)
 

--- a/master/docs/manual/configuration/tests/steps.rst
+++ b/master/docs/manual/configuration/tests/steps.rst
@@ -18,12 +18,8 @@ TestBuildStepMixin
 
             @defer.inlineCallbacks
             def setUp(self):
-                yield self.setup_test_reactor(auto_tear_down=False)
+                yield self.setup_test_reactor()
                 yield self.setup_test_build_step()
-
-            @defer.inlineCallbacks
-            def tearDown(self):
-                yield self.tear_down_test_reactor()
 
             @defer.inlineCallbacks
             def test_run_ok(self):

--- a/newsfragments/tests_teardown.removal
+++ b/newsfragments/tests_teardown.removal
@@ -1,0 +1,6 @@
+The following test tear down functions have been deprecated:
+
+ - ``TestBuildStepMixin.tear_down_test_build_step()``
+
+The tear down is now run automatically. Any additional test tear down should be run using
+``twisted.trial.TestCase.addCleanup`` to better control tear down ordering.

--- a/newsfragments/tests_teardown.removal
+++ b/newsfragments/tests_teardown.removal
@@ -1,6 +1,7 @@
 The following test tear down functions have been deprecated:
 
  - ``TestBuildStepMixin.tear_down_test_build_step()``
+ - ``TestReactorMixin.tear_down_test_reactor()``
 
 The tear down is now run automatically. Any additional test tear down should be run using
 ``twisted.trial.TestCase.addCleanup`` to better control tear down ordering.

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -59,13 +59,11 @@ VERSION_ID="1"
         self.real_bot = pb.BotPbLike(self.basedir, False)
         self.real_bot.setOsReleaseFile(f"{self.basedir}/test-release-file")
         self.real_bot.startService()
+        self.addCleanup(self.real_bot.stopService)
 
         self.bot = FakeRemote(self.real_bot)
 
-    @defer.inlineCallbacks
     def tearDown(self):
-        if self.real_bot and self.real_bot.running:
-            yield self.real_bot.stopService()
         if os.path.exists(self.basedir):
             shutil.rmtree(self.basedir)
 
@@ -214,6 +212,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
 
         self.bot = FakeBot(self.basedir, False)
         self.bot.startService()
+        self.addCleanup(self.bot.stopService)
 
         # get a WorkerForBuilder object from the bot and wrap it as a fake
         # remote
@@ -222,10 +221,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
 
         self.setUpCommand()
 
-    @defer.inlineCallbacks
     def tearDown(self):
-        if self.bot and self.bot.running:
-            yield self.bot.stopService()
         if os.path.exists(self.basedir):
             shutil.rmtree(self.basedir)
 

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -224,8 +224,6 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        self.tearDownCommand()
-
         if self.bot and self.bot.running:
             yield self.bot.stopService()
         if os.path.exists(self.basedir):

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -86,8 +86,6 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
     def tearDown(self):
         if self.realm:
             yield self.realm.shutdown()
-        if self.worker and self.worker.running:
-            yield self.worker.stopService()
         if self.listeningport:
             yield self.listeningport.stopListening()
         if os.path.exists(self.basedir):
@@ -209,6 +207,7 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
             protocol='pb',
         )
         self.worker.startService()
+        self.addCleanup(self.worker.stopService)
 
         # and wait for the result of the print
         return d
@@ -290,6 +289,7 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
         )
 
         self.worker.startService()
+        self.addCleanup(self.worker.stopService)
 
         def check(ign):
             self.assertEqual(called, [('shutdown',)])

--- a/worker/buildbot_worker/test/unit/test_commands_base.py
+++ b/worker/buildbot_worker/test/unit/test_commands_base.py
@@ -61,9 +61,6 @@ class TestDummyCommand(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     def assertState(self, setup_done, running, started, interrupted, msg=None):
         self.assertEqual(
             {

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -34,9 +34,6 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_simple_real(self):
         file_path = os.path.join(self.basedir, 'workdir')
@@ -176,9 +173,6 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_simple(self):
         from_path = os.path.join(self.basedir, 'workdir')
@@ -214,9 +208,6 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
 class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
-
-    def tearDown(self):
-        self.tearDownCommand()
 
     @defer.inlineCallbacks
     def test_empty_paths(self):
@@ -270,9 +261,6 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_non_existent(self):
         path = os.path.join(self.basedir, 'no-such-file')
@@ -321,9 +309,6 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_non_existent(self):
         self.make_command(fs.GlobPath, {'path': os.path.join(self.basedir, 'no-*-file')}, True)
@@ -371,9 +356,6 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_non_existent(self):
         path = os.path.join(self.basedir, 'no-such-dir')
@@ -414,9 +396,6 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
 class TestRemoveFile(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
-
-    def tearDown(self):
-        self.tearDownCommand()
 
     @defer.inlineCallbacks
     def test_simple(self):

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -27,9 +27,6 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
     def setUp(self):
         self.setUpCommand()
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_simple(self):
         workdir = os.path.join(self.basedir, 'workdir')

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -123,8 +123,6 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             f.write(b"this is some data\n" * 10)
 
     def tearDown(self):
-        self.tearDownCommand()
-
         if os.path.exists(self.datadir):
             shutil.rmtree(self.datadir)
 
@@ -317,8 +315,6 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
             f.write(b"and a little b" * 17)
 
     def tearDown(self):
-        self.tearDownCommand()
-
         if os.path.exists(self.datadir):
             shutil.rmtree(self.datadir)
 
@@ -400,9 +396,6 @@ class TestWorkerDirectoryUploadNoDir(CommandTestMixin, unittest.TestCase):
         self.setUpCommand()
         self.fakemaster = FakeMasterMethods(self.add_update)
 
-    def tearDown(self):
-        self.tearDownCommand()
-
     @defer.inlineCallbacks
     def test_directory_not_available(self):
         path = os.path.join(self.basedir, 'workdir', os.path.expanduser('data'))
@@ -443,8 +436,6 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
         os.makedirs(self.basedir)
 
     def tearDown(self):
-        self.tearDownCommand()
-
         if os.path.exists(self.basedir):
             shutil.rmtree(self.basedir)
 

--- a/worker/buildbot_worker/test/util/command.py
+++ b/worker/buildbot_worker/test/util/command.py
@@ -44,18 +44,20 @@ class CommandTestMixin:
         if os.path.exists(self.basedir):
             shutil.rmtree(self.basedir)
 
-    def tearDownCommand(self):
-        """
-        Call this from the tearDown method to clean up any leftover workdirs and do
-        any additional cleanup required.
-        """
-        # clean up the basedir unconditionally
-        if os.path.exists(self.basedir):
-            shutil.rmtree(self.basedir)
+        def cleanup():
+            """
+            Call this from the tearDown method to clean up any leftover workdirs and do
+            any additional cleanup required.
+            """
+            # clean up the basedir unconditionally
+            if os.path.exists(self.basedir):
+                shutil.rmtree(self.basedir)
 
-        # finish up the runprocess
-        if hasattr(self, 'runprocess_patched') and self.runprocess_patched:
-            runprocess.FakeRunProcess.test_done()
+            # finish up the runprocess
+            if hasattr(self, 'runprocess_patched') and self.runprocess_patched:
+                runprocess.FakeRunProcess.test_done()
+
+        self.addCleanup(cleanup)
 
     def make_command(self, cmdclass, args, makedirs=False):
         """


### PR DESCRIPTION
Twisted runs addCleanup() before tearDown. This makes it hard to run test cleanups in tearDown(), because anything added via addCleanup() has already run by that time. The solution is to use addCleanup() as much as possible for all cleanups.

The old `tear_down_xyz` methods have been either removed or deprecated depending on whether they were exposed as a public API.