### PR TITLE
bbtravis: Use /scratch directory for temporary sqlite DB

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -62,7 +62,7 @@ matrix:
     # (by default in other tests in-memory SQLite database is used which is
     # recreated for each test).
     # Helps to detect issues with incorrect database setup/cleanup in tests.
-    - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=sqlite:////tmp/test_db{TEST_ID}.sqlite
+    - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=sqlite:////scratch/test_db{TEST_ID}.sqlite
     # Configuration that runs tests with real MySQL database
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest{TEST_ID}
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest{TEST_ID}?storage_engine=InnoDB


### PR DESCRIPTION
/tmp is not necessarily mounted on a memory filesystem, however /scratch is explicitly mounted there for mysql and postgres database tests. Use the same directory for sqlite to reduce filesystem writes and slowdown of other tests.
