### PR TITLE
test: Remove database method signature tests

### DIFF
--- a/master/buildbot/test/unit/db/test_build_data.py
+++ b/master/buildbot/test/unit/db/test_build_data.py
@@ -21,10 +21,9 @@ from buildbot.db import build_data
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     common_data = [
         fakedb.Worker(id=47, name='linux'),
         fakedb.Buildset(id=20),
@@ -44,26 +43,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_add_build_data(self):
-        @self.assertArgSpecMatches(self.db.build_data.setBuildData)
-        def setBuildData(self, buildid, name, value, source):
-            pass
-
-    def test_signature_get_build_data(self):
-        @self.assertArgSpecMatches(self.db.build_data.getBuildData)
-        def getBuildData(self, buildid, name):
-            pass
-
-    def test_signature_get_build_data_no_value(self):
-        @self.assertArgSpecMatches(self.db.build_data.getBuildDataNoValue)
-        def getBuildDataNoValue(self, buildid, name):
-            pass
-
-    def test_signature_get_all_build_data_no_values(self):
-        @self.assertArgSpecMatches(self.db.build_data.getAllBuildDataNoValues)
-        def getAllBuildDataNoValues(self, buildid):
-            pass
 
     @defer.inlineCallbacks
     def test_add_data_get_data(self):

--- a/master/buildbot/test/unit/db/test_builders.py
+++ b/master/buildbot/test/unit/db/test_builders.py
@@ -22,7 +22,6 @@ from buildbot.db import builders
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util.twisted import async_to_deferred
 
 
@@ -30,7 +29,7 @@ def builderKey(builder: builders.BuilderModel) -> int:
     return builder.id
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # common sample data
 
     builder_row = [
@@ -42,38 +41,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_findBuilderId(self):
-        @self.assertArgSpecMatches(self.db.builders.findBuilderId)
-        def findBuilderId(self, name, autoCreate=True):
-            pass
-
-    def test_signature_addBuilderMaster(self):
-        @self.assertArgSpecMatches(self.db.builders.addBuilderMaster)
-        def addBuilderMaster(self, builderid=None, masterid=None):
-            pass
-
-    def test_signature_removeBuilderMaster(self):
-        @self.assertArgSpecMatches(self.db.builders.removeBuilderMaster)
-        def removeBuilderMaster(self, builderid=None, masterid=None):
-            pass
-
-    def test_signature_getBuilder(self):
-        @self.assertArgSpecMatches(self.db.builders.getBuilder)
-        def getBuilder(self, builderid):
-            pass
-
-    def test_signature_getBuilders(self):
-        @self.assertArgSpecMatches(self.db.builders.getBuilders)
-        def getBuilders(self, masterid=None, projectid=None, workerid=None):
-            pass
-
-    def test_signature_updateBuilderInfo(self):
-        @self.assertArgSpecMatches(self.db.builders.updateBuilderInfo)
-        def updateBuilderInfo(
-            self, builderid, description, description_format, description_html, projectid, tags
-        ):
-            pass
 
     @defer.inlineCallbacks
     def test_updateBuilderInfo(self):

--- a/master/buildbot/test/unit/db/test_buildrequests.py
+++ b/master/buildbot/test/unit/db/test_buildrequests.py
@@ -23,12 +23,11 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import db
-from buildbot.test.util import interfaces
 from buildbot.util import UTC
 from buildbot.util import epoch2datetime
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # test that the datetime translations are done correctly by specifying
     # the epoch timestamp and datetime objects explicitly.  These should
     # pass regardless of the local timezone used while running tests!

--- a/master/buildbot/test/unit/db/test_builds.py
+++ b/master/buildbot/test/unit/db/test_builds.py
@@ -21,7 +21,6 @@ from buildbot.db import builds
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import epoch2datetime
 
 TIME1 = 1304262222
@@ -31,7 +30,7 @@ TIME4 = 1304262235
 CREATED_AT = 927845299
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # common sample data
 
     backgroundData = [
@@ -130,57 +129,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
 
-    # signature tests
-
-    def test_signature_getBuild(self):
-        @self.assertArgSpecMatches(self.db.builds.getBuild)
-        def getBuild(self, buildid):
-            pass
-
-    def test_signature_getBuildByNumber(self):
-        @self.assertArgSpecMatches(self.db.builds.getBuildByNumber)
-        def getBuild(self, builderid, number):
-            pass
-
-    def test_signature_getBuilds(self):
-        @self.assertArgSpecMatches(self.db.builds.getBuilds)
-        def getBuilds(
-            self, builderid=None, buildrequestid=None, workerid=None, complete=None, resultSpec=None
-        ):
-            pass
-
-    def test_signature_addBuild(self):
-        @self.assertArgSpecMatches(self.db.builds.addBuild)
-        def addBuild(self, builderid, buildrequestid, workerid, masterid, state_string):
-            pass
-
-    def test_signature_setBuildStateString(self):
-        @self.assertArgSpecMatches(self.db.builds.setBuildStateString)
-        def setBuildStateString(self, buildid, state_string):
-            pass
-
-    def test_signature_add_build_locks_duration(self):
-        @self.assertArgSpecMatches(self.db.builds.add_build_locks_duration)
-        def setBuildStateString(self, buildid, duration_s):
-            pass
-
-    def test_signature_finishBuild(self):
-        @self.assertArgSpecMatches(self.db.builds.finishBuild)
-        def finishBuild(self, buildid, results):
-            pass
-
-    def test_signature_getBuildProperties(self):
-        @self.assertArgSpecMatches(self.db.builds.getBuildProperties)
-        def getBuildProperties(self, bid, resultSpec=None):
-            pass
-
-    def test_signature_setBuildProperty(self):
-        @self.assertArgSpecMatches(self.db.builds.setBuildProperty)
-        def setBuildProperty(self, bid, name, value, source):
-            pass
-
-    # method tests
-
     @defer.inlineCallbacks
     def test_getBuild(self):
         yield self.db.insert_test_data([*self.backgroundData, self.threeBuilds[0]])
@@ -253,11 +201,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(
             sorted(bdicts, key=lambda bd: bd.id), [self.threeBdicts[50], self.threeBdicts[51]]
         )
-
-    def test_signature_getBuildsForChange(self):
-        @self.assertArgSpecMatches(self.db.builds.getBuildsForChange)
-        def getBuildsForChange(self, changeid):
-            pass
 
     @defer.inlineCallbacks
     def do_test_getBuildsForChange(self, rows, changeid, expected):

--- a/master/buildbot/test/unit/db/test_buildsets.py
+++ b/master/buildbot/test/unit/db/test_buildsets.py
@@ -25,13 +25,12 @@ from buildbot.db import buildsets
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import UTC
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
@@ -47,49 +46,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
             fakedb.Builder(id=1, name='bldr1'),
             fakedb.Builder(id=2, name='bldr2'),
         ])
-
-    def test_signature_addBuildset(self):
-        @self.assertArgSpecMatches(self.db.buildsets.addBuildset)
-        def addBuildset(
-            self,
-            sourcestamps,
-            reason,
-            properties,
-            builderids,
-            waited_for,
-            external_idstring=None,
-            submitted_at=None,
-            rebuilt_buildid=None,
-            parent_buildid=None,
-            parent_relationship=None,
-            priority=0,
-        ):
-            pass
-
-    def test_signature_completeBuildset(self):
-        @self.assertArgSpecMatches(self.db.buildsets.completeBuildset)
-        def completeBuildset(self, bsid, results, complete_at=None):
-            pass
-
-    def test_signature_getBuildset(self):
-        @self.assertArgSpecMatches(self.db.buildsets.getBuildset)
-        def getBuildset(self, bsid):
-            pass
-
-    def test_signature_getBuildsets(self):
-        @self.assertArgSpecMatches(self.db.buildsets.getBuildsets)
-        def getBuildsets(self, complete=None, resultSpec=None):
-            pass
-
-    def test_signature_getRecentBuildsets(self):
-        @self.assertArgSpecMatches(self.db.buildsets.getRecentBuildsets)
-        def getBuildsets(self, count=None, branch=None, repository=None, complete=None):
-            pass
-
-    def test_signature_getBuildsetProperties(self):
-        @self.assertArgSpecMatches(self.db.buildsets.getBuildsetProperties)
-        def getBuildsetProperties(self, key, no_cache=False):
-            pass
 
     @defer.inlineCallbacks
     def test_addBuildset_getBuildset(self):

--- a/master/buildbot/test/unit/db/test_changes.py
+++ b/master/buildbot/test/unit/db/test_changes.py
@@ -24,14 +24,13 @@ from buildbot.db import sourcestamps
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import epoch2datetime
 
 SOMETIME = 20398573
 OTHERTIME = 937239287
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # common sample data
 
     change13_rows = [
@@ -102,33 +101,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_addChange(self):
-        @self.assertArgSpecMatches(self.db.changes.addChange)
-        def addChange(
-            self,
-            author=None,
-            committer=None,
-            files=None,
-            comments=None,
-            is_dir=None,
-            revision=None,
-            when_timestamp=None,
-            branch=None,
-            category=None,
-            revlink='',
-            properties=None,
-            repository='',
-            codebase='',
-            project='',
-            uid=None,
-        ):
-            pass
-
-    def test_signature_getChange(self):
-        @self.assertArgSpecMatches(self.db.changes.getChange)
-        def getChange(self, key, no_cache=False):
-            pass
 
     @defer.inlineCallbacks
     def test_addChange_getChange(self):
@@ -253,11 +225,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
         self.assertTrue(chdict is None)
 
-    def test_signature_getChangeUids(self):
-        @self.assertArgSpecMatches(self.db.changes.getChangeUids)
-        def getChangeUids(self, changeid):
-            pass
-
     @defer.inlineCallbacks
     def test_getChangeUids_missing(self):
         res = yield self.db.changes.getChangeUids(1)
@@ -293,11 +260,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         res = yield self.db.changes.getChangeUids(14)
 
         self.assertEqual(sorted(res), [1, 2])
-
-    def test_signature_getChanges(self):
-        @self.assertArgSpecMatches(self.db.changes.getChanges)
-        def getChanges(self, resultSpec=None):
-            pass
 
     def insert7Changes(self):
         return self.db.insert_test_data([
@@ -374,11 +336,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         changes = yield self.db.changes.getChanges()
         check(changes)
 
-    def test_signature_getLatestChangeid(self):
-        @self.assertArgSpecMatches(self.db.changes.getLatestChangeid)
-        def getLatestChangeid(self):
-            pass
-
     @defer.inlineCallbacks
     def test_getLatestChangeid(self):
         yield self.db.insert_test_data(self.change13_rows)
@@ -392,11 +349,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         changeid = yield self.db.changes.getLatestChangeid()
 
         self.assertEqual(changeid, None)
-
-    def test_signature_getParentChangeIds(self):
-        @self.assertArgSpecMatches(self.db.changes.getParentChangeIds)
-        def getParentChangeIds(self, branch, repository, project, codebase):
-            pass
 
     @defer.inlineCallbacks
     def test_getParentChangeIds(self):

--- a/master/buildbot/test/unit/db/test_changesources.py
+++ b/master/buildbot/test/unit/db/test_changesources.py
@@ -22,14 +22,13 @@ from buildbot.db import changesources
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 
 
 def changeSourceKey(changeSource: changesources.ChangeSourceModel):
     return changeSource.id
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # test data
 
     cs42 = fakedb.ChangeSource(id=42, name='cool_source')
@@ -47,13 +46,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
 
-    def test_signature_findChangeSourceId(self):
-        """The signature of findChangeSourceId is correct"""
-
-        @self.assertArgSpecMatches(self.db.changesources.findChangeSourceId)
-        def findChangeSourceId(self, name):
-            pass
-
     @defer.inlineCallbacks
     def test_findChangeSourceId_new(self):
         """findChangeSourceId for a new changesource creates it"""
@@ -67,13 +59,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         id1 = yield self.db.changesources.findChangeSourceId('csname')
         id2 = yield self.db.changesources.findChangeSourceId('csname')
         self.assertEqual(id1, id2)
-
-    def test_signature_setChangeSourceMaster(self):
-        """setChangeSourceMaster has the right signature"""
-
-        @self.assertArgSpecMatches(self.db.changesources.setChangeSourceMaster)
-        def setChangeSourceMaster(self, changesourceid, masterid):
-            pass
 
     @defer.inlineCallbacks
     def test_setChangeSourceMaster_fresh(self):
@@ -126,13 +111,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         cs = yield self.db.changesources.getChangeSource(87)
         self.assertEqual(cs.masterid, None)
 
-    def test_signature_getChangeSource(self):
-        """getChangeSource has the right signature"""
-
-        @self.assertArgSpecMatches(self.db.changesources.getChangeSource)
-        def getChangeSource(self, changesourceid):
-            pass
-
     @defer.inlineCallbacks
     def test_getChangeSource(self):
         """getChangeSource for a changesource that exists"""
@@ -167,13 +145,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
             cs, changesources.ChangeSourceModel(id=87, name='lame_source', masterid=14)
         )
         # row exists, but marked inactive
-
-    def test_signature_getChangeSources(self):
-        """getChangeSources has right signature"""
-
-        @self.assertArgSpecMatches(self.db.changesources.getChangeSources)
-        def getChangeSources(self, active=None, masterid=None):
-            pass
 
     @defer.inlineCallbacks
     def test_getChangeSources(self):

--- a/master/buildbot/test/unit/db/test_logs.py
+++ b/master/buildbot/test/unit/db/test_logs.py
@@ -29,7 +29,6 @@ from buildbot.db import logs
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.util.twisted import async_to_deferred
@@ -54,7 +53,7 @@ class FakeUnavailableCompressor(compression.CompressorInterface):
         return data[len(FakeUnavailableCompressor.HEADER) :]
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     TIMESTAMP_STEP101 = 100000
     TIMESTAMP_STEP102 = 200000
     backgroundData = [
@@ -152,55 +151,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
                 self.assertEqual(got_lines, _join_lines(expLines[first_line : last_line + 1]))
         # check overflow
         self.assertEqual((yield self.db.logs.getLogLines(201, 5, 20)), _join_lines(expLines[5:7]))
-
-    # signature tests
-
-    def test_signature_getLog(self):
-        @self.assertArgSpecMatches(self.db.logs.getLog)
-        def getLog(self, logid):
-            pass
-
-    def test_signature_getLogBySlug(self):
-        @self.assertArgSpecMatches(self.db.logs.getLogBySlug)
-        def getLogBySlug(self, stepid, slug):
-            pass
-
-    def test_signature_getLogs(self):
-        @self.assertArgSpecMatches(self.db.logs.getLogs)
-        def getLogs(self, stepid=None):
-            pass
-
-    def test_signature_getLogLines(self):
-        @self.assertArgSpecMatches(self.db.logs.getLogLines)
-        def getLogLines(self, logid, first_line, last_line):
-            pass
-
-    def test_signature_addLog(self):
-        @self.assertArgSpecMatches(self.db.logs.addLog)
-        def addLog(self, stepid, name, slug, type):
-            pass
-
-    def test_signature_appendLog(self):
-        @self.assertArgSpecMatches(self.db.logs.appendLog)
-        def appendLog(self, logid, content):
-            pass
-
-    def test_signature_finishLog(self):
-        @self.assertArgSpecMatches(self.db.logs.finishLog)
-        def finishLog(self, logid):
-            pass
-
-    def test_signature_compressLog(self):
-        @self.assertArgSpecMatches(self.db.logs.compressLog)
-        def compressLog(self, logid, force=False):
-            pass
-
-    def test_signature_deleteOldLogChunks(self):
-        @self.assertArgSpecMatches(self.db.logs.deleteOldLogChunks)
-        def deleteOldLogChunks(self, older_than_timestamp):
-            pass
-
-    # method tests
 
     @defer.inlineCallbacks
     def test_getLog(self):

--- a/master/buildbot/test/unit/db/test_masters.py
+++ b/master/buildbot/test/unit/db/test_masters.py
@@ -20,7 +20,6 @@ from buildbot.db import masters
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import epoch2datetime
 
 SOMETIME = 1348971992
@@ -29,7 +28,7 @@ OTHERTIME = 1008971992
 OTHERTIME_DT = epoch2datetime(OTHERTIME)
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # common sample data
 
     master_row = [
@@ -42,26 +41,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.reactor.advance(SOMETIME)
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_findMasterId(self):
-        @self.assertArgSpecMatches(self.db.masters.findMasterId)
-        def findMasterId(self, name):
-            pass
-
-    def test_signature_setMasterState(self):
-        @self.assertArgSpecMatches(self.db.masters.setMasterState)
-        def setMasterState(self, masterid, active):
-            pass
-
-    def test_signature_getMaster(self):
-        @self.assertArgSpecMatches(self.db.masters.getMaster)
-        def getMaster(self, masterid):
-            pass
-
-    def test_signature_getMasters(self):
-        @self.assertArgSpecMatches(self.db.masters.getMasters)
-        def getMasters(self):
-            pass
 
     @defer.inlineCallbacks
     def test_findMasterId_new(self):

--- a/master/buildbot/test/unit/db/test_projects.py
+++ b/master/buildbot/test/unit/db/test_projects.py
@@ -20,46 +20,18 @@ from buildbot.db import projects
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 
 
 def project_key(builder):
     return builder.id
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_find_project_id(self):
-        @self.assertArgSpecMatches(self.db.projects.find_project_id)
-        def find_project_id(self, name, auto_create=True):
-            pass
-
-    def test_signature_get_project(self):
-        @self.assertArgSpecMatches(self.db.projects.get_project)
-        def get_project(self, projectid):
-            pass
-
-    def test_signature_get_projects(self):
-        @self.assertArgSpecMatches(self.db.projects.get_projects)
-        def get_projects(self):
-            pass
-
-    def test_signature_update_project_info(self):
-        @self.assertArgSpecMatches(self.db.projects.update_project_info)
-        def update_project_info(
-            self,
-            projectid,
-            slug,
-            description,
-            description_format,
-            description_html,
-        ):
-            pass
 
     @defer.inlineCallbacks
     def test_update_project_info(self):

--- a/master/buildbot/test/unit/db/test_schedulers.py
+++ b/master/buildbot/test/unit/db/test_schedulers.py
@@ -21,10 +21,9 @@ from buildbot.db import schedulers
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # test data
 
     ss92 = fakedb.SourceStamp(id=92)
@@ -46,11 +45,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_enable(self):
-        @self.assertArgSpecMatches(self.db.schedulers.enable)
-        def enable(self, schedulerid, v):
-            pass
 
     @defer.inlineCallbacks
     def test_enable(self):
@@ -74,11 +68,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(
             sch, schedulers.SchedulerModel(id=24, name='schname', enabled=True, masterid=13)
         )
-
-    def test_signature_classifyChanges(self):
-        @self.assertArgSpecMatches(self.db.schedulers.classifyChanges)
-        def classifyChanges(self, schedulerid, classifications):
-            pass
 
     @defer.inlineCallbacks
     def test_classifyChanges(self):
@@ -104,11 +93,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         yield self.db.schedulers.classifyChanges(24, {3: True, 4: False, 5: True, 6: False})
         res = yield self.db.schedulers.getChangeClassifications(24)
         self.assertEqual(res, {3: True, 4: False, 5: True, 6: False})
-
-    def test_signature_flushChangeClassifications(self):
-        @self.assertArgSpecMatches(self.db.schedulers.flushChangeClassifications)
-        def flushChangeClassifications(self, schedulerid, less_than=None):
-            pass
 
     @defer.inlineCallbacks
     def test_flushChangeClassifications(self):
@@ -140,13 +124,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         res = yield self.db.schedulers.getChangeClassifications(24)
         self.assertEqual(res, {5: True})
 
-    def test_signature_getChangeClassifications(self):
-        @self.assertArgSpecMatches(self.db.schedulers.getChangeClassifications)
-        def getChangeClassifications(
-            self, schedulerid, branch=-1, repository=-1, project=-1, codebase=-1
-        ):
-            pass
-
     @defer.inlineCallbacks
     def test_getChangeClassifications(self):
         yield self.db.insert_test_data([
@@ -175,11 +152,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         res = yield self.db.schedulers.getChangeClassifications(24, branch='sql')
         self.assertEqual(res, {6: True})
 
-    def test_signature_findSchedulerId(self):
-        @self.assertArgSpecMatches(self.db.schedulers.findSchedulerId)
-        def findSchedulerId(self, name):
-            pass
-
     @defer.inlineCallbacks
     def test_findSchedulerId_new(self):
         id = yield self.db.schedulers.findSchedulerId('schname')
@@ -191,11 +163,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         id = yield self.db.schedulers.findSchedulerId('schname')
         id2 = yield self.db.schedulers.findSchedulerId('schname')
         self.assertEqual(id, id2)
-
-    def test_signature_setSchedulerMaster(self):
-        @self.assertArgSpecMatches(self.db.schedulers.setSchedulerMaster)
-        def setSchedulerMaster(self, schedulerid, masterid):
-            pass
 
     @defer.inlineCallbacks
     def test_setSchedulerMaster_fresh(self):
@@ -252,11 +219,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         sch = yield self.db.schedulers.getScheduler(25)
         self.assertEqual(sch.masterid, None)
 
-    def test_signature_getScheduler(self):
-        @self.assertArgSpecMatches(self.db.schedulers.getScheduler)
-        def getScheduler(self, schedulerid):
-            pass
-
     @defer.inlineCallbacks
     def test_getScheduler(self):
         yield self.db.insert_test_data([self.scheduler24])
@@ -288,11 +250,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.assertEqual(
             sch, schedulers.SchedulerModel(id=25, name='schname2', enabled=True, masterid=14)
         )  # row exists, but marked inactive
-
-    def test_signature_getSchedulers(self):
-        @self.assertArgSpecMatches(self.db.schedulers.getSchedulers)
-        def getSchedulers(self, active=None, masterid=None):
-            pass
 
     @defer.inlineCallbacks
     def test_getSchedulers(self):

--- a/master/buildbot/test/unit/db/test_sourcestamps.py
+++ b/master/buildbot/test/unit/db/test_sourcestamps.py
@@ -25,7 +25,6 @@ from buildbot.db import sourcestamps
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import epoch2datetime
 
 if TYPE_CHECKING:
@@ -38,7 +37,7 @@ def sourceStampKey(sourceStamp: sourcestamps.SourceStampModel):
     return (sourceStamp.repository, sourceStamp.branch, sourceStamp.created_at)
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     db: FakeDBConnector
 
     @defer.inlineCallbacks
@@ -46,43 +45,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_findSourceStampId(self):
-        @self.assertArgSpecMatches(self.db.sourcestamps.findSourceStampId)
-        def findSourceStampId(
-            self,
-            branch=None,
-            revision=None,
-            repository=None,
-            project=None,
-            codebase=None,
-            patch_body=None,
-            patch_level=None,
-            patch_author=None,
-            patch_comment=None,
-            patch_subdir=None,
-        ):
-            pass
-
-    def test_signature_getSourceStamp(self):
-        @self.assertArgSpecMatches(self.db.sourcestamps.getSourceStamp)
-        def getSourceStamp(self, key, no_cache=False):
-            pass
-
-    def test_signature_getSourceStamps(self):
-        @self.assertArgSpecMatches(self.db.sourcestamps.getSourceStamps)
-        def getSourceStamps(self):
-            pass
-
-    def test_signature_getSourceStampsForBuild(self):
-        @self.assertArgSpecMatches(self.db.sourcestamps.getSourceStampsForBuild)
-        def getSourceStampsForBuild(self, buildid):
-            pass
-
-    def test_signature_get_sourcestamps_for_buildset(self):
-        @self.assertArgSpecMatches(self.db.sourcestamps.get_sourcestamps_for_buildset)
-        def get_sourcestamps_for_buildset(self, buildsetid):
-            pass
 
     @defer.inlineCallbacks
     def test_findSourceStampId_simple(self):

--- a/master/buildbot/test/unit/db/test_steps.py
+++ b/master/buildbot/test/unit/db/test_steps.py
@@ -23,7 +23,6 @@ from buildbot.db import steps
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.util import epoch2datetime
 
 TIME1 = 1304262222
@@ -33,7 +32,7 @@ TIME4 = 1304262235
 TIME5 = 1304262236
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     # common sample data
 
     backgroundData = [
@@ -120,38 +119,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_getStep(self):
-        @self.assertArgSpecMatches(self.db.steps.getStep)
-        def getStep(self, stepid=None, buildid=None, number=None, name=None):
-            pass
-
-    def test_signature_getSteps(self):
-        @self.assertArgSpecMatches(self.db.steps.getSteps)
-        def getSteps(self, buildid):
-            pass
-
-    def test_signature_addStep(self):
-        @self.assertArgSpecMatches(self.db.steps.addStep)
-        def addStep(self, buildid, name, state_string):
-            pass
-
-    def test_signature_startStep(self):
-        @self.assertArgSpecMatches(self.db.steps.startStep)
-        def addStep(self, stepid, started_at, locks_acquired):
-            pass
-
-    def test_signature_setStepStateString(self):
-        @self.assertArgSpecMatches(self.db.steps.setStepStateString)
-        def setStepStateString(self, stepid, state_string):
-            pass
-
-    def test_signature_finishStep(self):
-        @self.assertArgSpecMatches(self.db.steps.finishStep)
-        def finishStep(self, stepid, results, hidden):
-            pass
-
-    # method tests
 
     @defer.inlineCallbacks
     def test_getStep(self):

--- a/master/buildbot/test/unit/db/test_test_result_sets.py
+++ b/master/buildbot/test/unit/db/test_test_result_sets.py
@@ -20,10 +20,9 @@ from buildbot.db import test_result_sets
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     common_data = [
         fakedb.Worker(id=47, name='linux'),
         fakedb.Buildset(id=20),
@@ -74,28 +73,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_add_test_result_set(self):
-        @self.assertArgSpecMatches(self.db.test_result_sets.addTestResultSet)
-        def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
-            pass
-
-    def test_signature_get_test_result_set(self):
-        @self.assertArgSpecMatches(self.db.test_result_sets.getTestResultSet)
-        def getTestResultSet(self, test_result_setid):
-            pass
-
-    def test_signature_get_test_result_sets(self):
-        @self.assertArgSpecMatches(self.db.test_result_sets.getTestResultSets)
-        def getTestResultSets(
-            self, builderid=None, buildid=None, stepid=None, complete=None, result_spec=None
-        ):
-            pass
-
-    def test_signature_complete_test_result_set(self):
-        @self.assertArgSpecMatches(self.db.test_result_sets.completeTestResultSet)
-        def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
-            pass
 
     @defer.inlineCallbacks
     def test_add_set_get_set(self):

--- a/master/buildbot/test/unit/db/test_test_results.py
+++ b/master/buildbot/test/unit/db/test_test_results.py
@@ -20,10 +20,9 @@ from buildbot.db import test_results
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 
 
-class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
+class Tests(TestReactorMixin, unittest.TestCase):
     common_data = [
         fakedb.Worker(id=47, name='linux'),
         fakedb.Buildset(id=20),
@@ -49,31 +48,6 @@ class Tests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_get_test_code_paths(self):
-        @self.assertArgSpecMatches(self.db.test_results.getTestCodePaths)
-        def getTestCodePaths(self, builderid, path_prefix=None, result_spec=None):
-            pass
-
-    def test_signature_get_test_names(self):
-        @self.assertArgSpecMatches(self.db.test_results.getTestNames)
-        def getTestNames(self, builderid, name_prefix=None, result_spec=None):
-            pass
-
-    def test_signature_add_test_results(self):
-        @self.assertArgSpecMatches(self.db.test_results.addTestResults)
-        def addTestResults(self, builderid, test_result_setid, result_values):
-            pass
-
-    def test_signature_get_test_result(self):
-        @self.assertArgSpecMatches(self.db.test_results.getTestResult)
-        def getTestResult(self, test_resultid):
-            pass
-
-    def test_signature_get_test_results(self):
-        @self.assertArgSpecMatches(self.db.test_results.getTestResults)
-        def getTestResults(self, builderid, test_result_setid, result_spec=None):
-            pass
 
     @defer.inlineCallbacks
     def test_add_set_results(self):

--- a/master/buildbot/test/unit/db/test_workers.py
+++ b/master/buildbot/test/unit/db/test_workers.py
@@ -21,7 +21,6 @@ from buildbot.db import workers
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
-from buildbot.test.util import interfaces
 from buildbot.test.util import querylog
 
 
@@ -33,9 +32,7 @@ def configuredOnKey(worker: workers.BuilderMasterModel):
     return (worker.builderid, worker.masterid)
 
 
-class Tests(
-    interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase, querylog.SqliteMaxVariableMixin
-):
+class Tests(TestReactorMixin, unittest.TestCase, querylog.SqliteMaxVariableMixin):
     # common sample data
 
     baseRows = [
@@ -86,51 +83,6 @@ class Tests(
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
-
-    def test_signature_findWorkerId(self):
-        @self.assertArgSpecMatches(self.db.workers.findWorkerId)
-        def findWorkerId(self, name):
-            pass
-
-    def test_signature_getWorker(self):
-        @self.assertArgSpecMatches(self.db.workers.getWorker)
-        def getWorker(self, workerid=None, name=None, masterid=None, builderid=None):
-            pass
-
-    def test_signature_getWorkers(self):
-        @self.assertArgSpecMatches(self.db.workers.getWorkers)
-        def getWorkers(self, masterid=None, builderid=None, paused=None, graceful=None):
-            pass
-
-    def test_signature_workerConnected(self):
-        @self.assertArgSpecMatches(self.db.workers.workerConnected)
-        def workerConnected(self, workerid, masterid, workerinfo):
-            pass
-
-    def test_signature_workerDisconnected(self):
-        @self.assertArgSpecMatches(self.db.workers.workerDisconnected)
-        def workerDisconnected(self, workerid, masterid):
-            pass
-
-    def test_signature_workerConfigured(self):
-        @self.assertArgSpecMatches(self.db.workers.workerConfigured)
-        def workerConfigured(self, workerid, masterid, builderids):
-            pass
-
-    def test_signature_deconfigureAllWorkersForMaster(self):
-        @self.assertArgSpecMatches(self.db.workers.deconfigureAllWorkersForMaster)
-        def deconfigureAllWorkersForMaster(self, masterid):
-            pass
-
-    def test_signature_set_worker_paused(self):
-        @self.assertArgSpecMatches(self.db.workers.set_worker_paused)
-        def set_worker_paused(self, workerid, paused, pause_reason=None):
-            pass
-
-    def test_signature_set_worker_graceful(self):
-        @self.assertArgSpecMatches(self.db.workers.set_worker_graceful)
-        def set_worker_graceful(self, workerid, graceful):
-            pass
 
     @defer.inlineCallbacks
     def test_findWorkerId_insert(self):


### PR DESCRIPTION
The purpose of signature tests was to verify signatures between real and fake database API implementations. As fakedb has been removed this is no longer necessary.
