### PR TITLE
reporters: words: fix build status reporting

### DIFF
--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -390,7 +390,7 @@ class Channel(service.AsyncService):
                 f"Build [#{buildNumber}]({url}) of `{builderName}` "
                 f"{self.bot.format_build_status(build)}"
             )
-        s = build.get('status_string')
+        s = build.get('status_string') or build.get('state_string')
         if build['results'] != SUCCESS and s is not None:
             r += ": " + s
         else:

--- a/newsfragments/words-status.bugfix
+++ b/newsfragments/words-status.bugfix
@@ -1,0 +1,1 @@
+Fix build status reporting to use state_string as fallback when status_string is None. This makes IRC build failure messages more informative by showing the failure reason instead of just "failed". 


### PR DESCRIPTION
I've noticed, that on web interface, build failure status is more verbose, then on IRC, where it basically just says "failed" and one has to click on the build to see the reason.

```
 < bot> Build [#24](https://url/images/#/builders/44/builds/24) of `build` failed.
```

This patch fixes that by using build.get('state_string') as a fallback instead of build.get('status_string') in case of build failure.

```
  <bot> Build [#27](https://url/images/#/builders/119/builds/27) of `build` failed:  failed Images built and installed (failure) (timed out)
```

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
