### PR TITLE
www: Fix indexing of non-first log chunks

### DIFF
--- a/newsfragments/fix-ANSI-garbage-output-in-builds-steps-logs.bugfix
+++ b/newsfragments/fix-ANSI-garbage-output-in-builds-steps-logs.bugfix
@@ -1,0 +1,1 @@
+Fix garbage output of ANSI escape codes sequences in builds steps logs (:bug:`7852`)

--- a/www/base/src/util/LogChunkParsing.test.ts
+++ b/www/base/src/util/LogChunkParsing.test.ts
@@ -76,19 +76,19 @@ describe('LogChunkParsing', () => {
 
     const chunkCssClasses = parseCssClassesForChunk(chunk, 20, 23);
     expect(chunkCssClasses).toEqual({
-      20: ["DEBUG [plugin]: Loading plugin karma-jasmine.",
+      0: ["DEBUG [plugin]: Loading plugin karma-jasmine.",
         [
           {cssClasses: "ansi36", firstPos: 0, lastPos: 16},
           {cssClasses: "", firstPos: 16, lastPos: 45},
         ],
       ],
-      21: [".F",
+      1: [".F",
         [
           {cssClasses: "ansi32", firstPos: 0, lastPos: 1},
           {cssClasses: "ansi31", firstPos: 1, lastPos: 2},
         ],
       ],
-      22: ["..",
+      2: ["..",
         [
           {cssClasses: "ansi32", firstPos: 0, lastPos: 1},
           {cssClasses: "ansi32", firstPos: 1, lastPos: 2},

--- a/www/base/src/util/LogChunkParsing.tsx
+++ b/www/base/src/util/LogChunkParsing.tsx
@@ -210,10 +210,10 @@ export function mergeChunks(chunk1: ParsedLogChunk, chunk2: ParsedLogChunk): Par
 export type ChunkCssClasses = {[globalLine: number]: [string, LineCssClasses[]]};
 
 // Parses ansi escape code information for a span of lines in a particular chunk. Returns a map
-// containing key-value pairs, where each key-value pair represents a line with at least on escape
-// code. The key is line number and value is a tuple containing the line text with escape
-// sequences removed and a list of CSS classes to style the line. The line text and the
-// text positions in the list exclude any trailing newlines.
+// containing key-value pairs, where each key-value pair represents a line with at least one escape
+// code. The key is line index relative to beginning of a specific chunk and value is a tuple
+// containing the line text with escape sequences removed and a list of CSS classes to style the
+// line. The line text and the text positions in the list exclude any trailing newlines.
 export function parseCssClassesForChunk(chunk: ParsedLogChunk,
                                         firstLine: number, lastLine: number) {
   const cssClasses: ChunkCssClasses = {};
@@ -257,7 +257,7 @@ export function parseCssClassesForChunk(chunk: ParsedLogChunk,
 
       const [strippedLine, lineCssClasses] = parseEscapeCodesToClasses(chunkLine);
       if (lineCssClasses !== null) {
-        cssClasses[lineI] = [strippedLine, lineCssClasses!];
+        cssClasses[chunkLineI] = [strippedLine, lineCssClasses!];
       }
     }
   }

--- a/www/base/src/util/LogChunkParsing.tsx
+++ b/www/base/src/util/LogChunkParsing.tsx
@@ -227,11 +227,11 @@ export function parseCssClassesForChunk(chunk: ParsedLogChunk,
   if (lastLine > chunk.lastLine) {
     lastLine = chunk.lastLine;
   }
+  const chunkFirstLine = firstLine - chunk.firstLine;
+  const chunkLastLine = lastLine - chunk.firstLine;
 
   if (chunk.linesWithEscapes !== null) {
     // small number of escaped lines
-    const chunkFirstLine = firstLine - chunk.firstLine;
-    const chunkLastLine = lastLine - chunk.firstLine;
     for (const chunkLineI of chunk.linesWithEscapes) {
       if (chunkLineI < chunkFirstLine) {
         // It probably makes sense to use binary search in this loop
@@ -250,14 +250,13 @@ export function parseCssClassesForChunk(chunk: ParsedLogChunk,
     }
   } else {
     // large number of escape sequences
-    for (let lineI = firstLine; lineI < lastLine; ++lineI) {
-      const chunkLineI = lineI - chunk.firstLine;
+    for (let lineI = chunkFirstLine; lineI < chunkLastLine; ++lineI) {
       const chunkLine = chunk.text.slice(
-        chunk.textLineBounds[chunkLineI], chunk.textLineBounds[chunkLineI + 1] - 1);
+        chunk.textLineBounds[lineI], chunk.textLineBounds[lineI + 1] - 1);
 
       const [strippedLine, lineCssClasses] = parseEscapeCodesToClasses(chunkLine);
       if (lineCssClasses !== null) {
-        cssClasses[chunkLineI] = [strippedLine, lineCssClasses!];
+        cssClasses[lineI] = [strippedLine, lineCssClasses!];
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/7852.
Currently, cssClass keys represent indexes of log lines from log beginning to its end. However, code later expects log chunk to start with index 0. As a result, user sees garbage output where ANSI escape sequences are in non-first log chunks.

## Contributor Checklist:
* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
