### PR TITLE
www: Implement bold text style in builds steps logs

### DIFF
--- a/newsfragments/implement-bold-text-style-in-builds-steps-logs.bugfix
+++ b/newsfragments/implement-bold-text-style-in-builds-steps-logs.bugfix
@@ -1,0 +1,1 @@
+Implement bold text style in builds steps logs (:issue:`7853`)

--- a/www/base/src/components/LogViewer/LogViewerText.scss
+++ b/www/base/src/components/LogViewer/LogViewerText.scss
@@ -31,6 +31,7 @@
   }
   // bright colors
   .ansi1 {
+    font-weight: bold;
     &.ansi30 {
       color: #ffffff;
     }
@@ -76,6 +77,7 @@
   }
   // bright colors
   .ansi1 {
+    font-weight: bold;
     &.ansi40 {
       background-color: #ffffff;
     }

--- a/www/base/src/util/AnsiEscapeCodes.test.tsx
+++ b/www/base/src/util/AnsiEscapeCodes.test.tsx
@@ -146,6 +146,15 @@ describe('AnsiEscapeCodes', () => {
       ]);
     });
 
+    it('bold', () => {
+      const ret = parseEscapeCodesToSimple(
+        "\x1b[1;36mDEBUG [plugin]: \x1b[39mLoading plugin karma-jasmine.");
+      expect(ret).toEqual([
+        {class: "ansi1 ansi36", text: "DEBUG [plugin]: "},
+        {class: "", text: "Loading plugin karma-jasmine."},
+      ]);
+    });
+
     it('256 colors reset only fg last instruction', () => {
       const ret = parseEscapeCodesToSimple(
         "\x1b[48;5;71mDEBUG \x1b[38;5;72m[plugin]: \x1b[39mLoading plugin karma-jasmine.");


### PR DESCRIPTION
This PR implements bold text style in builds steps logs.
Fixes https://github.com/buildbot/buildbot/issues/7853.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
