### PR TITLE
newsfragments: Removed obsolete line

### DIFF
--- a/newsfragments/README.txt
+++ b/newsfragments/README.txt
@@ -14,6 +14,5 @@ towncrier has a few standard types of news fragments, signified by the file exte
 The core of the filename can be the fixed issue number or any unique text relative to your work.
 Buildbot project does not require a tracking ticket to be made for each contribution even if this is appreciated.
 
-Please point to the trac bug using syntax: (:bug:`NNN`)
 Please point to the github bug using syntax: (:issue:`NNN`)
 please point to classes using syntax: `HttpStatusPush`.


### PR DESCRIPTION
PR removes obsolete line from a newsfragments file as trac.buildbot.org is not active anymore.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
