### PR TITLE
Don't apply monkey patches on generic start

### DIFF
--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -72,8 +72,9 @@ def patch_config_for_unit_tests():
     set_is_in_unit_tests(True)
 
 
-def patch_all():
+def patch_all(for_tests=False):
+    if for_tests:
+        patch_testcase_timeout()
+        patch_config_for_unit_tests()
     patch_servicechecks()
-    patch_testcase_timeout()
     patch_decorators()
-    patch_config_for_unit_tests()

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -26,7 +26,7 @@ from buildbot.warnings import DeprecatedApiWarning  # noqa: F401
 _ = mock
 
 # apply the same patches the buildmaster does when it starts
-monkeypatches.patch_all()
+monkeypatches.patch_all(for_tests=True)
 
 # enable deprecation warnings
 warnings.filterwarnings('always', category=DeprecationWarning)

--- a/newsfragments/fix-deprecation-warnings.bugfix
+++ b/newsfragments/fix-deprecation-warnings.bugfix
@@ -1,0 +1,1 @@
+Fixed deprecation warnings being raised as errors


### PR DESCRIPTION
Since commit d6b698e, the monkey patches were applied on every installs.

This implies that set_is_in_unit_tests(True) was called even when not it in unit tests.

Because it believes being in tests, db.logs._async_iter_on_pool is importing NonThreadPool
from a submodule in the test module.
This runs the test __init__ code which sets up warnings as error by default.

As a consequence, any Deprecation warning will trigger an exception 
instead of just being shown in logs.

This is causing troubles in current v4.2.0 with out of tree modules (which use deprecated code, granted).
A backport would be great.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
