### PR TITLE
docs: Clarify `cleanupdb` script documentation

### DIFF
--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -163,6 +163,8 @@ This command is frontend for various database maintenance jobs:
 - optimiselogs: This optimization groups logs into bigger chunks
   to apply higher level of compression.
 
+This script runs for as long as it takes to finish the job including the time needed to check master.cfg file.
+
 copy-db
 +++++++
 


### PR DESCRIPTION
This PR clarifies `cleanupdb` script documentation.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
