### PR TITLE
scripts: Add information about running time of `cleanupdb` script

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -747,6 +747,8 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
     This command uses the database specified in
     the master configuration file.  If you wish to use a database other than
     the default (sqlite), be sure to set that parameter before upgrading.
+    This command runs for as long as it takes to finish the job including the
+    time needed to check the master configuration file.
     """)
 
 


### PR DESCRIPTION
This PR adds information about running time of `cleanupdb` script to command's `--help` output.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
