### PR TITLE
Fix setting `dataModuliRoot` instead of `moduliRoot` in `_BaseManhole`

### DIFF
--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -186,9 +186,10 @@ class _BaseManhole(service.AsyncMultiService):
             assert OpenSSHFactory is not None, "cryptography required for ssh mahole."
             openSSHFactory = OpenSSHFactory()
             openSSHFactory.dataRoot = self.ssh_hostkey_dir
-            openSSHFactory.dataModuliRoot = self.ssh_hostkey_dir
+            openSSHFactory.moduliRoot = self.ssh_hostkey_dir
             f.publicKeys = openSSHFactory.getPublicKeys()
             f.privateKeys = openSSHFactory.getPrivateKeys()
+            f.primes = openSSHFactory.getPrimes()
         else:
             self.using_ssh = False
             r = _TelnetRealm(makeNamespace)

--- a/newsfragments/fix-authorized-keys-manhole.bugfix
+++ b/newsfragments/fix-authorized-keys-manhole.bugfix
@@ -1,0 +1,1 @@
+Fix ``AuthorizedKeysManhole`` not picking up the given ``ssh_host_keydir``


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

At some point it must have changed in Twisted