### PR TITLE
Allow configuring database `engine` via `db` config key

### DIFF
--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -150,7 +150,7 @@ def basicData(master):
             'distro': get_distro(),
         },
         'plugins': plugins_uses,
-        'db': master.config.db['db_url'].split("://")[0],
+        'db': master.config.db.db_url.split("://")[0],
         'mq': master.config.mq['type'],
         'www_plugins': list(master.config.www['plugins'].keys()),
     }

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import ProgrammingError
 
+from buildbot.config.master import DBConfig as MasterDBConfig
 from buildbot.config.master import MasterConfig
 from buildbot.db import enginestrategy
 from buildbot.db import model
@@ -57,18 +58,20 @@ class FakePool:
 
 
 class DbConfig:
+    db_config: MasterDBConfig
+
     def __init__(self, BuildmasterConfig, basedir, name="config"):
-        self.db_url = MasterConfig.getDbUrlFromConfig(BuildmasterConfig, throwErrors=False)
+        self.db_config = MasterConfig.get_dbconfig_from_config(BuildmasterConfig, throwErrors=False)
         self.basedir = basedir
         self.name = name
 
     def getDb(self):
         try:
             db = FakeDBConnector(
-                engine=enginestrategy.create_engine(self.db_url, basedir=self.basedir)
+                engine=enginestrategy.create_engine(self.db_config.db_url, basedir=self.basedir)
             )
         except Exception:
-            # db_url is probably trash. Just ignore, config.py db part will
+            # db_config.db_url is probably trash. Just ignore, config.py db part will
             # create proper message
             return None
 

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 async def doCleanupDatabase(config, master_cfg) -> None:
     if not config['quiet']:
-        print(f"cleaning database ({master_cfg.db['db_url']})")
+        print(f"cleaning database ({master_cfg.db.db_url})")
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg

--- a/master/buildbot/scripts/copydb.py
+++ b/master/buildbot/scripts/copydb.py
@@ -70,9 +70,9 @@ def _copy_database_in_reactor(config):
     if not master_src_cfg or not master_dst_cfg:
         return 1
 
-    master_dst_cfg.db["db_url"] = config["destination_url"]
+    master_dst_cfg.db.db_url = config["destination_url"]
 
-    print_log(f"Copying database ({master_src_cfg.db['db_url']}) to ({config['destination_url']})")
+    print_log(f"Copying database ({master_src_cfg.db.db_url}) to ({config['destination_url']})")
 
     if not master_src_cfg or not master_dst_cfg:
         return 1

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -78,13 +78,13 @@ def createDB(config):
     # create a master with the default configuration, but with db_url
     # overridden
     master_cfg = config_master.MasterConfig()
-    master_cfg.db['db_url'] = config['db']
+    master_cfg.db.db_url = config['db']
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
     db = master.db
     yield db.setup(check_version=False, verbose=not config['quiet'])
     if not config['quiet']:
-        print(f"creating database ({master_cfg.db['db_url']})")
+        print(f"creating database ({master_cfg.db.db_url})")
     yield db.model.upgrade()
 
 

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -77,7 +77,7 @@ def upgradeFiles(config):
 @defer.inlineCallbacks
 def upgradeDatabase(config, master_cfg):
     if not config['quiet']:
-        db_url_cfg = master_cfg.db['db_url']
+        db_url_cfg = master_cfg.db.db_url
         if IRenderable.providedBy(db_url_cfg):
             # if it's a renderable, assume the password is rendered
             # so no need to try and strip it.

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -23,6 +23,7 @@ from unittest import mock
 from twisted.internet import defer
 from twisted.internet import reactor
 
+from buildbot.config.master import DBConfig as MasterDBConfig
 from buildbot.config.master import MasterConfig
 from buildbot.secrets.manager import SecretManager
 from buildbot.test import fakedb
@@ -207,7 +208,7 @@ async def make_master(
             # affect further tests
             testcase.addCleanup(master.test_shutdown)
 
-        master.db.configured_url = resolve_test_db_url(db_url, sqlite_memory)
+        master.db.configured_db_config = MasterDBConfig(resolve_test_db_url(db_url, sqlite_memory))
         if not os.path.exists(master.basedir):
             os.makedirs(master.basedir)
         await master.db.set_master(master)

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -245,7 +245,7 @@ class MasterConfigTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         cfg = config.master.MasterConfig()
         expected = {
             # validation,
-            "db": {"db_url": 'sqlite:///state.sqlite'},
+            "db": config.master.DBConfig(db_url='sqlite:///state.sqlite'),
             "mq": {"type": 'simple'},
             "metrics": None,
             "caches": {"Changes": 10, "Builds": 15},
@@ -322,7 +322,7 @@ class MasterConfigTests(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         # make sure all of the loaders and checkers are called
         self.assertTrue(rv.load_global.called)
         self.assertTrue(rv.load_validation.called)
-        self.assertTrue(rv.load_db.called)
+        self.assertTrue(rv.load_dbconfig.called)
         self.assertTrue(rv.load_metrics.called)
         self.assertTrue(rv.load_caches.called)
         self.assertTrue(rv.load_schedulers.called)
@@ -574,20 +574,22 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertIn('revision', self.cfg.validation)
 
     def test_load_db_defaults(self):
-        self.cfg.load_db(self.filename, {})
-        self.assertResults(db={"db_url": 'sqlite:///state.sqlite'})
+        self.cfg.load_dbconfig(self.filename, {})
+        self.assertResults(
+            db=config.master.DBConfig(db_url='sqlite:///state.sqlite', engine_kwargs={})
+        )
 
     def test_load_db_db_url(self):
-        self.cfg.load_db(self.filename, {"db_url": 'abcd'})
-        self.assertResults(db={"db_url": 'abcd'})
+        self.cfg.load_dbconfig(self.filename, {"db_url": 'abcd'})
+        self.assertResults(db=config.master.DBConfig(db_url='abcd'))
 
     def test_load_db_dict(self):
-        self.cfg.load_db(self.filename, {'db': {'db_url': 'abcd'}})
-        self.assertResults(db={"db_url": 'abcd'})
+        self.cfg.load_dbconfig(self.filename, {'db': {'db_url': 'abcd'}})
+        self.assertResults(db=config.master.DBConfig(db_url='abcd'))
 
     def test_load_db_unk_keys(self):
         with capture_config_errors() as errors:
-            self.cfg.load_db(self.filename, {'db': {'db_url': 'abcd', 'bar': 'bar'}})
+            self.cfg.load_dbconfig(self.filename, {'db': {'db_url': 'abcd', 'bar': 'bar'}})
 
         self.assertConfigError(errors, "unrecognized keys in")
 

--- a/master/buildbot/test/unit/db/test_connector.py
+++ b/master/buildbot/test/unit/db/test_connector.py
@@ -39,7 +39,7 @@ class TestDBConnector(TestReactorMixin, unittest.TestCase):
             self, wantDb=True, auto_upgrade=False, check_version=False
         )
         self.master.config = MasterConfig()
-        self.db_url = self.master.db.configured_url
+        self.db_url = self.master.db.configured_db_config.db_url
         yield self.master.db._shutdown()
         self.db = connector.DBConnector(os.path.abspath('basedir'))
         yield self.db.set_master(self.master)
@@ -53,7 +53,7 @@ class TestDBConnector(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def startService(self, check_version=False):
-        self.master.config.db['db_url'] = self.db_url
+        self.master.config.db.db_url = self.db_url
         yield self.db.setup(check_version=check_version)
         yield self.db.startService()
         yield self.db.reconfigServiceWithBuildbotConfig(self.master.config)

--- a/master/buildbot/test/unit/scripts/test_cleanupdb.py
+++ b/master/buildbot/test/unit/scripts/test_cleanupdb.py
@@ -145,7 +145,7 @@ class TestCleanupDbRealDb(
         logid = await self.master.db.logs.addLog(102, "x", "x", "s")
         await self.master.db.logs.appendLog(logid, LOGDATA)
 
-        db_url = self.master.db.configured_url
+        db_url = self.master.db.configured_db_config.db_url
 
         # test all methods
         lengths = {}

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -76,7 +76,7 @@ class TestedMaster:
 
         # TODO: Allow BuildMaster to transparently upgrade the database, at least
         # for tests.
-        self.master.config.db['db_url'] = config_dict['db_url']
+        self.master.config.db.db_url = config_dict['db_url']
         await self.master.db.setup(check_version=False)
         await self.master.db.model.upgrade()
         self.master.db.setup = lambda: None

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -151,10 +151,11 @@ class MasterService(AsyncMultiService):
     def master(self):
         return self
 
-    def get_db_url(self, new_config) -> defer.Deferred:
+    def get_db_config(self, new_config) -> defer.Deferred:
         p = Properties()
         p.master = self
-        return p.render(new_config.db['db_url'])
+
+        return p.render(new_config.db)
 
 
 class SharedService(AsyncMultiService):

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -50,6 +50,21 @@ documented at http://www.sqlalchemy.org/docs/dialects/, but is generally of the 
 This parameter can be specified directly in the configuration dictionary, as ``c['db_url']``,
 although this method is deprecated.
 
+Buildbot also accepts a dictionary at ``c['db']['engine_kwargs']``, this dictionary eventually ends
+up being passed to SQLAlchemy's ``create_engine`` function, see
+https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine for details. As an
+example, one may configure the amount of connections opened to PostgreSQL like so:
+
+.. code-block:: python
+
+    c['db'] = {
+        'db_url': "postgresql://username:password@hostname/dbname",
+        'engine_kwargs': {
+	    'pool_size': 512,
+            'max_overflow': 0,
+	},
+    }
+
 The following sections give additional information for particular database backends:
 
 .. index:: SQLite

--- a/newsfragments/allow-configuring-database-engine.feature
+++ b/newsfragments/allow-configuring-database-engine.feature
@@ -1,0 +1,1 @@
+Allow configuring the database engine, with the ``db.engine_kwargs`` configuration key


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

## _

So I'm not sure if this is the way to do it, `config['db']` goes from only having `db_url` as the only allowed key to allowing anything and passing all of it except for `db_url` to the backing DB engine. If this approach is fine ill write up the docs, newsfragments and all the rest.