### PR TITLE
steps/git: Move final resolution of repourl after renderables

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -168,6 +168,7 @@ class Git(Source, GitStepMixin):
 
     @defer.inlineCallbacks
     def run_vc(self, branch, revision, patch):
+        self.setup_repourl()
         self.branch = branch or 'HEAD'
         self.revision = revision
 
@@ -668,6 +669,7 @@ class GitPush(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
 
     @defer.inlineCallbacks
     def run(self):
+        self.setup_repourl()
         self.stdio_log = yield self.addLog("stdio")
 
         auth_workdir = self._get_auth_data_workdir()

--- a/master/buildbot/steps/source/gitlab.py
+++ b/master/buildbot/steps/source/gitlab.py
@@ -26,9 +26,15 @@ class GitLab(Git):
     """
 
     def run_vc(self, branch, revision, patch):
+        self.setup_repourl()
         # If this is a merge request:
         if self.build.hasProperty("target_branch"):
             target_repourl = self.build.getProperty("target_git_ssh_url", None)
+
+            # repourl always includes ssh://
+            if not target_repourl.startswith('ssh://'):
+                target_repourl = 'ssh://' + target_repourl
+
             if self.repourl != target_repourl:
                 log.msg(
                     "GitLab.run_vc: note: GitLab step for merge requests"

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -21,6 +21,7 @@ from twisted.trial import unittest
 from buildbot import config as bbconfig
 from buildbot.interfaces import WorkerSetupError
 from buildbot.process import remotetransfer
+from buildbot.process.properties import Interpolate
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import RETRY
@@ -120,7 +121,17 @@ class TestGit(
 
     @parameterized.expand([
         ('url', 'ssh://github.com/test/test.git', 'ssh://github.com/test/test.git'),
+        (
+            'url_renderable',
+            Interpolate('ssh://github.com/test/test.git'),
+            'ssh://github.com/test/test.git',
+        ),
         ('ssh_host_and_path', 'host:path/to/git', 'ssh://host:22/path/to/git'),
+        (
+            'ssh_host_and_path_renderable',
+            Interpolate('host:path/to/git'),
+            'ssh://host:22/path/to/git',
+        ),
     ])
     def test_mode_full_clean(self, name, url, pull_url):
         self.setup_step(self.stepClass(repourl=url, mode='full', method='clean'))
@@ -4183,7 +4194,13 @@ class TestGitPush(
 
     @parameterized.expand([
         ('url', 'ssh://github.com/test/test.git', 'ssh://github.com/test/test.git'),
+        (
+            'url_renderable',
+            Interpolate('ssh://github.com/test/test.git'),
+            'ssh://github.com/test/test.git',
+        ),
         ('host_path', 'host:path/to/git', 'ssh://host:22/path/to/git'),
+        ('host_path_renderable', Interpolate('host:path/to/git'), 'ssh://host:22/path/to/git'),
     ])
     def test_push_simple(self, name, url, push_url):
         self.setup_step(self.stepClass(workdir='wkdir', repourl=url, branch='testbranch'))

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -78,7 +78,7 @@ class TestGitLab(
                     'fetch',
                     '-f',
                     '--progress',
-                    'git@gitlab.example.com:build/awesome_project.git',
+                    'ssh://git@gitlab.example.com:22/build/awesome_project.git',
                     'ms-viewport',
                 ],
             ).exit(0),

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -184,6 +184,7 @@ class GitStepMixin(GitMixin):
         if not hasattr(self, '_git_auth'):
             self._git_auth = GitStepAuth(self)
 
+    def setup_repourl(self):
         # Use standard URL syntax to enable the use of a dedicated SSH port
         self.repourl = scp_style_to_url_syntax(self.repourl, self.port)
 

--- a/newsfragments/renderable-git-repourl.bugfix
+++ b/newsfragments/renderable-git-repourl.bugfix
@@ -1,0 +1,1 @@
+Fixed regression introduced in Buildbot 4.2.0 that broke support for renderable Git step repourl parameter.


### PR DESCRIPTION
This fixes exceptions such as the following in scp_style_to_url_syntax:

builtins.TypeError: argument of type 'Interpolate' is not iterable

Fixes https://github.com/buildbot/buildbot/issues/8274.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
