### PR TITLE
Convert schedulers to full BuildbotService life cycle

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -27,6 +27,7 @@ from buildbot.changes import changes
 from buildbot.process.properties import Properties
 from buildbot.util.service import ClusteredBuildbotService
 from buildbot.util.state import StateMixin
+from buildbot.warnings import warn_deprecated
 
 
 @implementer(interfaces.IScheduler)
@@ -41,6 +42,11 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
     )
 
     def __init__(self, name, builderNames, properties=None, codebases=None, priority=None):
+        warn_deprecated(
+            '4.3.0',
+            'BaseScheduler has been deprecated, use ReconfigurableBaseScheduler',
+        )
+
         super().__init__(name=name)
         if codebases is None:
             codebases = self.DEFAULT_CODEBASES.copy()

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -468,3 +468,453 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
             **kw,
         )
         return (bsid, brids)
+
+
+@implementer(interfaces.IScheduler)
+class ReconfigurableBaseScheduler(ClusteredBuildbotService, StateMixin):
+    DEFAULT_CODEBASES: dict[str, dict[str, str]] = {'': {}}
+
+    compare_attrs: ClassVar[Sequence[str]] = (
+        *ClusteredBuildbotService.compare_attrs,
+        'builderNames',
+        'properties',
+        'codebases',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.enabled = True
+        self._enable_consumer = None
+        self._change_consumer = None
+        self._change_consumption_lock = defer.DeferredLock()
+
+    def checkConfig(self, builderNames, properties=None, codebases=None, priority=None):
+        ok = True
+        if interfaces.IRenderable.providedBy(builderNames):
+            pass
+        elif isinstance(builderNames, (list, tuple)):
+            for b in builderNames:
+                if not isinstance(b, str) and not interfaces.IRenderable.providedBy(b):
+                    ok = False
+        else:
+            ok = False
+        if not ok:
+            config.error(
+                "The builderNames argument to a scheduler must be a list "
+                "of Builder names or an IRenderable object that will render"
+                "to a list of builder names."
+            )
+
+        self.builderNames = builderNames
+
+        # Set the codebases that are necessary to process the changes
+        # These codebases will always result in a sourcestamp with or without
+        # changes
+        known_keys = set(['branch', 'repository', 'revision'])
+
+        if codebases is None:
+            codebases = self.DEFAULT_CODEBASES.copy()
+
+        if codebases is None:
+            config.error("Codebases cannot be None")
+        elif isinstance(codebases, list):
+            pass
+        elif not isinstance(codebases, dict):
+            config.error("Codebases must be a dict of dicts, or list of strings")
+        else:
+            for codebase, attrs in codebases.items():
+                if not isinstance(attrs, dict):
+                    config.error("Codebases must be a dict of dicts")
+                else:
+                    unk = set(attrs) - known_keys
+                    if unk:
+                        config.error(
+                            f"Unknown codebase keys {', '.join(unk)} for codebase {codebase}"
+                        )
+
+        if priority and not isinstance(priority, int) and not callable(priority):
+            config.error(
+                f"Invalid type for priority: {type(priority)}. "
+                "It must either be an integer or a function"
+            )
+
+    @defer.inlineCallbacks
+    def reconfigService(self, builderNames, properties=None, codebases=None, priority=None):
+        yield super().reconfigService()
+
+        if codebases is None:
+            codebases = self.DEFAULT_CODEBASES.copy()
+
+        self.builderNames = builderNames
+
+        if properties is None:
+            properties = {}
+        self.properties = Properties()
+        self.properties.update(properties, "Scheduler")
+        self.properties.setProperty("scheduler", self.name, "Scheduler")
+
+        if isinstance(codebases, list):
+            codebases = {codebase: {} for codebase in codebases}
+        self.codebases = codebases
+
+        self.priority = priority
+
+    def __repr__(self):
+        """
+        Provide a meaningful string representation of scheduler.
+        """
+        return (
+            f'<{self.__class__.__name__}({self.name}, {self.builderNames}, enabled={self.enabled})>'
+        )
+
+    # activity handling
+    @defer.inlineCallbacks
+    def activate(self):
+        if not self.enabled:
+            return None
+
+        # even if we aren't called via _activityPoll(), at this point we
+        # need to ensure the service id is set correctly
+        if self.serviceid is None:
+            self.serviceid = yield self._getServiceId()
+            assert self.serviceid is not None
+
+        schedulerData = yield self._getScheduler(self.serviceid)
+
+        if schedulerData:
+            self.enabled = schedulerData.enabled
+
+        if not self._enable_consumer:
+            yield self.startConsumingEnableEvents()
+        return None
+
+    def _enabledCallback(self, key, msg):
+        if msg['enabled']:
+            self.enabled = True
+            d = self.activate()
+        else:
+            d = self.deactivate()
+
+            def fn(x):
+                self.enabled = False
+
+            d.addCallback(fn)
+        return d
+
+    @defer.inlineCallbacks
+    def deactivate(self):
+        if not self.enabled:
+            return None
+        yield self._stopConsumingChanges()
+        return None
+
+    # service handling
+
+    def _getServiceId(self):
+        return self.master.data.updates.findSchedulerId(self.name)
+
+    def _getScheduler(self, sid):
+        return self.master.db.schedulers.getScheduler(sid)
+
+    def _claimService(self):
+        return self.master.data.updates.trySetSchedulerMaster(self.serviceid, self.master.masterid)
+
+    def _unclaimService(self):
+        return self.master.data.updates.trySetSchedulerMaster(self.serviceid, None)
+
+    # status queries
+
+    # deprecated: these aren't compatible with distributed schedulers
+
+    def listBuilderNames(self):
+        return self.builderNames
+
+    # change handling
+
+    @defer.inlineCallbacks
+    def startConsumingChanges(self, fileIsImportant=None, change_filter=None, onlyImportant=False):
+        assert fileIsImportant is None or callable(fileIsImportant)
+
+        # register for changes with the data API
+        assert not self._change_consumer
+        self._change_consumer = yield self.master.mq.startConsuming(
+            lambda k, m: self._changeCallback(k, m, fileIsImportant, change_filter, onlyImportant),
+            ('changes', None, 'new'),
+        )
+
+    @defer.inlineCallbacks
+    def startConsumingEnableEvents(self):
+        assert not self._enable_consumer
+        self._enable_consumer = yield self.master.mq.startConsuming(
+            self._enabledCallback, ('schedulers', str(self.serviceid), 'updated')
+        )
+
+    @defer.inlineCallbacks
+    def _changeCallback(self, key, msg, fileIsImportant, change_filter, onlyImportant):
+        # ignore changes delivered while we're not running
+        if not self._change_consumer:
+            return
+
+        # get a change object, since the API requires it
+        chdict = yield self.master.db.changes.getChange(msg['changeid'])
+        change = yield changes.Change.fromChdict(self.master, chdict)
+
+        # filter it
+        if change_filter and not change_filter.filter_change(change):
+            return
+
+        if change.codebase not in self.codebases:
+            log.msg(
+                format='change contains codebase %(codebase)s that is '
+                'not processed by scheduler %(name)s',
+                codebase=change.codebase,
+                name=self.name,
+            )
+            return
+
+        if fileIsImportant:
+            try:
+                important = fileIsImportant(change)
+                if not important and onlyImportant:
+                    return
+            except Exception as e:
+                log.err(e, f'in fileIsImportant check for {change}')
+                return
+        else:
+            important = True
+
+        # use change_consumption_lock to ensure the service does not stop
+        # while this change is being processed
+        d = self._change_consumption_lock.run(self.gotChange, change, important)
+        d.addErrback(log.err, 'while processing change')
+
+    def _stopConsumingChanges(self):
+        # (note: called automatically in deactivate)
+
+        # acquire the lock change consumption lock to ensure that any change
+        # consumption is complete before we are done stopping consumption
+        def stop():
+            if self._change_consumer:
+                self._change_consumer.stopConsuming()
+                self._change_consumer = None
+
+        return self._change_consumption_lock.run(stop)
+
+    def gotChange(self, change, important):
+        raise NotImplementedError
+
+    # starting builds
+
+    @defer.inlineCallbacks
+    def addBuildsetForSourceStampsWithDefaults(
+        self,
+        reason,
+        sourcestamps=None,
+        waited_for=False,
+        properties=None,
+        builderNames=None,
+        priority=None,
+        **kw,
+    ):
+        if sourcestamps is None:
+            sourcestamps = []
+
+        # convert sourcestamps to a dictionary keyed by codebase
+        stampsByCodebase = {}
+        for ss in sourcestamps:
+            cb = ss['codebase']
+            if cb in stampsByCodebase:
+                raise RuntimeError("multiple sourcestamps with same codebase")
+            stampsByCodebase[cb] = ss
+
+        # Merge codebases with the passed list of sourcestamps
+        # This results in a new sourcestamp for each codebase
+        stampsWithDefaults = []
+        for codebase in self.codebases:
+            cb = yield self.getCodebaseDict(codebase)
+            ss = {
+                'codebase': codebase,
+                'repository': cb.get('repository', ''),
+                'branch': cb.get('branch', None),
+                'revision': cb.get('revision', None),
+                'project': '',
+            }
+            # apply info from passed sourcestamps onto the configured default
+            # sourcestamp attributes for this codebase.
+            ss.update(stampsByCodebase.get(codebase, {}))
+            stampsWithDefaults.append(ss)
+
+        # fill in any supplied sourcestamps that aren't for a codebase in the
+        # scheduler's codebase dictionary
+        for codebase in set(stampsByCodebase) - set(self.codebases):
+            cb = stampsByCodebase[codebase]
+            ss = {
+                'codebase': codebase,
+                'repository': cb.get('repository', ''),
+                'branch': cb.get('branch', None),
+                'revision': cb.get('revision', None),
+                'project': '',
+            }
+            stampsWithDefaults.append(ss)
+
+        rv = yield self.addBuildsetForSourceStamps(
+            sourcestamps=stampsWithDefaults,
+            reason=reason,
+            waited_for=waited_for,
+            properties=properties,
+            builderNames=builderNames,
+            priority=priority,
+            **kw,
+        )
+        return rv
+
+    def getCodebaseDict(self, codebase):
+        # Hook for subclasses to change codebase parameters when a codebase does
+        # not have a change associated with it.
+        try:
+            return defer.succeed(self.codebases[codebase])
+        except KeyError:
+            return defer.fail()
+
+    @defer.inlineCallbacks
+    def addBuildsetForChanges(
+        self,
+        waited_for=False,
+        reason='',
+        external_idstring=None,
+        changeids=None,
+        builderNames=None,
+        properties=None,
+        priority=None,
+        **kw,
+    ):
+        if changeids is None:
+            changeids = []
+        changesByCodebase = {}
+
+        def get_last_change_for_codebase(codebase):
+            return max(changesByCodebase[codebase], key=lambda change: change.changeid)
+
+        # Changes are retrieved from database and grouped by their codebase
+        for changeid in changeids:
+            chdict = yield self.master.db.changes.getChange(changeid)
+            changesByCodebase.setdefault(chdict.codebase, []).append(chdict)
+
+        sourcestamps = []
+        for codebase in sorted(self.codebases):
+            if codebase not in changesByCodebase:
+                # codebase has no changes
+                # create a sourcestamp that has no changes
+                cb = yield self.getCodebaseDict(codebase)
+
+                ss = {
+                    'codebase': codebase,
+                    'repository': cb.get('repository', ''),
+                    'branch': cb.get('branch', None),
+                    'revision': cb.get('revision', None),
+                    'project': '',
+                }
+            else:
+                lastChange = get_last_change_for_codebase(codebase)
+                ss = lastChange.sourcestampid
+            sourcestamps.append(ss)
+
+        if priority is None:
+            priority = self.priority
+
+        if callable(priority):
+            priority = priority(builderNames or self.builderNames, changesByCodebase)
+        elif priority is None:
+            priority = 0
+
+        # add one buildset, using the calculated sourcestamps
+        bsid, brids = yield self.addBuildsetForSourceStamps(
+            waited_for,
+            sourcestamps=sourcestamps,
+            reason=reason,
+            external_idstring=external_idstring,
+            builderNames=builderNames,
+            properties=properties,
+            priority=priority,
+            **kw,
+        )
+
+        return (bsid, brids)
+
+    @defer.inlineCallbacks
+    def addBuildsetForSourceStamps(
+        self,
+        waited_for=False,
+        sourcestamps=None,
+        reason='',
+        external_idstring=None,
+        properties=None,
+        builderNames=None,
+        priority=None,
+        **kw,
+    ):
+        if sourcestamps is None:
+            sourcestamps = []
+        # combine properties
+        if properties:
+            properties.updateFromProperties(self.properties)
+        else:
+            properties = self.properties
+
+        # make a fresh copy that we actually can modify safely
+        properties = Properties.fromDict(properties.asDict())
+
+        # make extra info available from properties.render()
+        properties.master = self.master
+        properties.sourcestamps = []
+        properties.changes = []
+        for ss in sourcestamps:
+            if isinstance(ss, int):
+                # fetch actual sourcestamp and changes from data API
+                properties.sourcestamps.append((yield self.master.data.get(('sourcestamps', ss))))
+                properties.changes.extend(
+                    (yield self.master.data.get(('sourcestamps', ss, 'changes')))
+                )
+            else:
+                # sourcestamp with no change, see addBuildsetForChanges
+                properties.sourcestamps.append(ss)
+
+        for c in properties.changes:
+            properties.updateFromProperties(Properties.fromDict(c['properties']))
+
+        # apply the default builderNames
+        if not builderNames:
+            builderNames = self.builderNames
+
+        # dynamically get the builder list to schedule
+        builderNames = yield properties.render(builderNames)
+
+        # Get the builder ids
+        # Note that there is a data.updates.findBuilderId(name)
+        # but that would merely only optimize the single builder case, while
+        # probably the multiple builder case will be severely impacted by the
+        # several db requests needed.
+        builderids = []
+        for bldr in (yield self.master.data.get(('builders',))):
+            if bldr['name'] in builderNames:
+                builderids.append(bldr['builderid'])
+
+        # translate properties object into a dict as required by the
+        # addBuildset method
+        properties_dict = yield properties.render(properties.asDict())
+
+        if priority is None:
+            priority = 0
+
+        bsid, brids = yield self.master.data.updates.addBuildset(
+            scheduler=self.name,
+            sourcestamps=sourcestamps,
+            reason=reason,
+            waited_for=waited_for,
+            properties=properties_dict,
+            builderids=builderids,
+            external_idstring=external_idstring,
+            priority=priority,
+            **kw,
+        )
+        return (bsid, brids)

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from typing import Any
 from typing import ClassVar
 from typing import Sequence
 
@@ -27,13 +28,28 @@ from buildbot.util import debounce
 
 
 @implementer(ITriggerableScheduler)
-class Triggerable(base.BaseScheduler):
-    compare_attrs: ClassVar[Sequence[str]] = (*base.BaseScheduler.compare_attrs, 'reason')
+class Triggerable(base.ReconfigurableBaseScheduler):
+    compare_attrs: ClassVar[Sequence[str]] = (
+        *base.ReconfigurableBaseScheduler.compare_attrs,
+        'reason',
+    )
 
-    def __init__(self, name, builderNames, reason=None, **kwargs):
-        super().__init__(name, builderNames, **kwargs)
+    def __init__(self, name, builderNames, *args, **kwargs):
+        super().__init__(*args, name=name, builderNames=builderNames, **kwargs)
         self._waiters = {}
         self._buildset_complete_consumer = None
+
+    def checkConfig(self, builderNames, reason=None, **kwargs: Any):  # type: ignore[override]
+        super().checkConfig(builderNames=builderNames, **kwargs)
+
+    @defer.inlineCallbacks
+    def reconfigService(  # type: ignore[override]
+        self,
+        builderNames,
+        reason=None,
+        **kwargs: Any,
+    ):
+        yield super().reconfigService(builderNames=builderNames, **kwargs)
         self.reason = reason
 
     def trigger(

--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -79,6 +79,7 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.schedulers.timed.Timed',
             'buildbot.schedulers.trysched.TryBase',
             'buildbot.schedulers.base.BaseScheduler',
+            'buildbot.schedulers.base.ReconfigurableBaseScheduler',
             'buildbot.schedulers.timed.NightlyBase',
             'buildbot.schedulers.basic.Scheduler',
         }

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -151,7 +151,9 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
 
     @defer.inlineCallbacks
     def test_userpass_no_wait(self):
-        yield self.startMaster(trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))
+        yield self.startMaster(
+            trysched.Try_Userpass(name='try', builderNames=['a'], port=0, userpass=[('u', b'p')])
+        )
         yield self.runClient({
             'connect': 'pb',
             'master': f'127.0.0.1:{self.serverPort}',
@@ -173,7 +175,9 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
 
     @defer.inlineCallbacks
     def test_userpass_wait(self):
-        yield self.startMaster(trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))
+        yield self.startMaster(
+            trysched.Try_Userpass(name='try', builderNames=['a'], port=0, userpass=[('u', b'p')])
+        )
         yield self.runClient({
             'connect': 'pb',
             'master': f'127.0.0.1:{self.serverPort}',
@@ -199,7 +203,9 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
     def test_userpass_wait_bytes(self):
         self.sourcestamp = tryclient.SourceStamp(branch=b'br', revision=b'rr', patch=(0, b'++--'))
 
-        yield self.startMaster(trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))
+        yield self.startMaster(
+            trysched.Try_Userpass(name='try', builderNames=['a'], port=0, userpass=[('u', b'p')])
+        )
         yield self.runClient({
             'connect': 'pb',
             'master': f'127.0.0.1:{self.serverPort}',
@@ -223,7 +229,9 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
 
     @defer.inlineCallbacks
     def test_userpass_wait_dryrun(self):
-        yield self.startMaster(trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))
+        yield self.startMaster(
+            trysched.Try_Userpass(name='try', builderNames=['a'], port=0, userpass=[('u', b'p')])
+        )
         yield self.runClient({
             'connect': 'pb',
             'master': f'127.0.0.1:{self.serverPort}',
@@ -253,7 +261,9 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
 
     @defer.inlineCallbacks
     def test_userpass_list_builders(self):
-        yield self.startMaster(trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))
+        yield self.startMaster(
+            trysched.Try_Userpass(name='try', builderNames=['a'], port=0, userpass=[('u', b'p')])
+        )
         yield self.runClient({
             'connect': 'pb',
             'get-builder-names': True,
@@ -275,7 +285,7 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
     @defer.inlineCallbacks
     def test_jobdir_no_wait(self):
         jobdir = self.setupJobdir()
-        yield self.startMaster(trysched.Try_Jobdir('try', ['a'], jobdir))
+        yield self.startMaster(trysched.Try_Jobdir(name='try', builderNames=['a'], jobdir=jobdir))
         yield self.runClient({
             'connect': 'ssh',
             'master': '127.0.0.1',
@@ -298,7 +308,7 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
     @defer.inlineCallbacks
     def test_jobdir_wait(self):
         jobdir = self.setupJobdir()
-        yield self.startMaster(trysched.Try_Jobdir('try', ['a'], jobdir))
+        yield self.startMaster(trysched.Try_Jobdir(name='try', builderNames=['a'], jobdir=jobdir))
         yield self.runClient({
             'connect': 'ssh',
             'wait': True,

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -699,7 +699,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.assertConfigError(errors, "scheduler name 'sch' used multiple times")
 
     def test_load_schedulers(self):
-        sch = schedulers_base.BaseScheduler('sch', [""])
+        sch = schedulers_base.ReconfigurableBaseScheduler(name='sch', builderNames=["a"])
         self.cfg.load_schedulers(self.filename, {"schedulers": [sch]})
         self.assertResults(schedulers={"sch": sch})
 

--- a/master/buildbot/test/unit/data/test_forceschedulers.py
+++ b/master/buildbot/test/unit/data/test_forceschedulers.py
@@ -193,6 +193,9 @@ class ForceschedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         yield self.setUpEndpoint()
         scheds = [ForceScheduler(name="defaultforce", builderNames=["builder"])]
         self.master.allSchedulers = lambda: scheds
+        for sched in scheds:
+            yield sched.setServiceParent(self.master)
+        yield self.master.startService()
 
     @defer.inlineCallbacks
     def test_get_existing(self):
@@ -216,6 +219,9 @@ class ForceSchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         yield self.setUpEndpoint()
         scheds = [ForceScheduler(name="defaultforce", builderNames=["builder"])]
         self.master.allSchedulers = lambda: scheds
+        for sched in scheds:
+            yield sched.setServiceParent(self.master)
+        yield self.master.startService()
 
     @defer.inlineCallbacks
     def test_get_existing(self):

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -29,6 +29,852 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
 
 
+class TestReconfigurableBaseScheduler(
+    scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase
+):
+    OBJECTID = 19
+    SCHEDULERID = 9
+    exp_bsid_brids = (123, {'b': 456})
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setup_test_reactor()
+        yield self.setUpScheduler()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        if self.master.running:
+            yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def makeScheduler(self, name='testsched', builderNames=None, properties=None, codebases=None):
+        if builderNames is None:
+            builderNames = ['a', 'b']
+        if properties is None:
+            properties = {}
+        if codebases is None:
+            codebases = {'': {}}
+
+        if isinstance(builderNames, list):
+            dbBuilder = []
+            builderid = 0
+            for builderName in builderNames:
+                if isinstance(builderName, str):
+                    builderid += 1
+                    dbBuilder.append(fakedb.Builder(id=builderid, name=builderName))
+
+            yield self.master.db.insert_test_data(dbBuilder)
+
+        sched = yield self.attachScheduler(
+            base.ReconfigurableBaseScheduler(
+                name=name, builderNames=builderNames, properties=properties, codebases=codebases
+            ),
+            self.OBJECTID,
+            self.SCHEDULERID,
+        )
+        self.master.data.updates.addBuildset = mock.Mock(
+            name='data.addBuildset',
+            side_effect=lambda *args, **kwargs: defer.succeed(self.exp_bsid_brids),
+        )
+
+        return sched
+
+    # tests
+
+    @defer.inlineCallbacks
+    def test_constructor_builderNames(self):
+        with self.assertRaises(config.ConfigErrors):
+            yield self.makeScheduler(builderNames='xxx')
+
+    @defer.inlineCallbacks
+    def test_constructor_builderNames_unicode(self):
+        yield self.makeScheduler(builderNames=['a'])
+
+    @defer.inlineCallbacks
+    def test_constructor_builderNames_renderable(self):
+        @properties.renderer
+        def names(props):
+            return ['a']
+
+        yield self.makeScheduler(builderNames=names)
+
+    @defer.inlineCallbacks
+    def test_constructor_codebases_valid(self):
+        codebases = {"codebase1": {"repository": "", "branch": "", "revision": ""}}
+        yield self.makeScheduler(codebases=codebases)
+
+    @defer.inlineCallbacks
+    def test_constructor_codebases_valid_list(self):
+        codebases = ['codebase1']
+        yield self.makeScheduler(codebases=codebases)
+
+    @defer.inlineCallbacks
+    def test_constructor_codebases_invalid(self):
+        # scheduler only accepts codebases with at least repository set
+        codebases = {"codebase1": {"dictionary": "", "that": "", "fails": ""}}
+        with self.assertRaises(config.ConfigErrors):
+            yield self.makeScheduler(codebases=codebases)
+
+    @defer.inlineCallbacks
+    def test_getCodebaseDict(self):
+        sched = yield self.makeScheduler(codebases={'lib': {'repository': 'librepo'}})
+        yield self.master.startService()
+        cbd = yield sched.getCodebaseDict('lib')
+        self.assertEqual(cbd, {'repository': 'librepo'})
+
+    @defer.inlineCallbacks
+    def test_getCodebaseDict_constructedFromList(self):
+        sched = yield self.makeScheduler(codebases=['lib', 'lib2'])
+        yield self.master.startService()
+        cbd = yield sched.getCodebaseDict('lib')
+        self.assertEqual(cbd, {})
+
+    @defer.inlineCallbacks
+    def test_getCodebaseDict_not_found(self):
+        sched = yield self.makeScheduler(codebases={'lib': {'repository': 'librepo'}})
+        yield self.master.startService()
+        with self.assertRaises(KeyError):
+            yield sched.getCodebaseDict('app')
+
+    @defer.inlineCallbacks
+    def test_listBuilderNames(self):
+        sched = yield self.makeScheduler(builderNames=['x', 'y'])
+        yield self.master.startService()
+        self.assertEqual(sched.listBuilderNames(), ['x', 'y'])
+
+    @defer.inlineCallbacks
+    def test_startConsumingChanges_fileIsImportant_check(self):
+        sched = yield self.makeScheduler()
+        try:
+            yield sched.startConsumingChanges(fileIsImportant="maybe")
+        except AssertionError:
+            pass
+        else:
+            self.fail("didn't assert")
+
+    @defer.inlineCallbacks
+    def test_enabled_callback(self):
+        sched = yield self.makeScheduler()
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+
+    @defer.inlineCallbacks
+    def do_test_change_consumption(self, kwargs, expected_result, change_kwargs=None):
+        if change_kwargs is None:
+            change_kwargs = {}
+
+        # (expected_result should be True (important), False (unimportant), or
+        # None (ignore the change))
+        sched = yield self.makeScheduler()
+        sched.startService()
+        self.addCleanup(sched.stopService)
+
+        # set up a change message, a changedict, a change, and convince
+        # getChange and fromChdict to convert one to the other
+        msg = {"changeid": 12934}
+
+        chdict = {"changeid": 12934, "is_chdict": True}
+
+        def getChange(changeid):
+            assert changeid == 12934
+            return defer.succeed(chdict)
+
+        self.db.changes.getChange = getChange
+
+        change = self.makeFakeChange(**change_kwargs)
+        change.number = 12934
+
+        def fromChdict(cls, master, chdict):
+            assert chdict['changeid'] == 12934 and chdict['is_chdict']
+            return defer.succeed(change)
+
+        self.patch(changes.Change, 'fromChdict', classmethod(fromChdict))
+
+        change_received = [None]
+
+        def gotChange(got_change, got_important):
+            # check that we got the expected change object
+            self.assertIdentical(got_change, change)
+            change_received[0] = got_important
+            return defer.succeed(None)
+
+        sched.gotChange = gotChange
+
+        yield sched.startConsumingChanges(**kwargs)
+
+        # check that it registered callbacks
+        self.assertEqual(len(self.mq.qrefs), 2)
+
+        qref = self.mq.qrefs[1]
+        self.assertEqual(qref.filter, ('changes', None, 'new'))
+
+        # invoke the callback with the change, and check the result
+        qref.callback('change.12934.new', msg)
+        self.assertEqual(change_received[0], expected_result)
+
+    def test_change_consumption_defaults(self):
+        # all changes are important by default
+        return self.do_test_change_consumption({}, True)
+
+    def test_change_consumption_fileIsImportant_True(self):
+        return self.do_test_change_consumption({"fileIsImportant": lambda c: True}, True)
+
+    def test_change_consumption_fileIsImportant_False(self):
+        return self.do_test_change_consumption({"fileIsImportant": lambda c: False}, False)
+
+    @defer.inlineCallbacks
+    def test_change_consumption_fileIsImportant_exception(self):
+        yield self.do_test_change_consumption({"fileIsImportant": lambda c: 1 / 0}, None)
+
+        self.assertEqual(1, len(self.flushLoggedErrors(ZeroDivisionError)))
+
+    def test_change_consumption_change_filter_True(self):
+        cf = mock.Mock()
+        cf.filter_change = lambda c: True
+        return self.do_test_change_consumption({"change_filter": cf}, True)
+
+    def test_change_consumption_change_filter_False(self):
+        cf = mock.Mock()
+        cf.filter_change = lambda c: False
+        return self.do_test_change_consumption({"change_filter": cf}, None)
+
+    def test_change_consumption_change_filter_gerrit_ref_updates(self):
+        cf = mock.Mock()
+        cf.filter_change = lambda c: False
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            None,
+            change_kwargs={'category': 'ref-updated', 'branch': 'master'},
+        )
+
+    def test_change_consumption_change_filter_gerrit_ref_updates_with_refs(self):
+        cf = mock.Mock()
+        cf.filter_change = lambda c: False
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            None,
+            change_kwargs={'category': 'ref-updated', 'branch': 'refs/changes/123'},
+        )
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_new(self):
+        cf = filter.ChangeFilter(branch='master')
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            True,
+            change_kwargs={'category': 'ref-updated', 'branch': 'master'},
+        )
+
+    def test_change_consumption_change_filter_gerrit_filters_branch_new_not_match(self):
+        cf = filter.ChangeFilter(branch='other')
+        return self.do_test_change_consumption(
+            {'change_filter': cf},
+            None,
+            change_kwargs={'category': 'ref-updated', 'branch': 'master'},
+        )
+
+    def test_change_consumption_fileIsImportant_False_onlyImportant(self):
+        return self.do_test_change_consumption(
+            {"fileIsImportant": lambda c: False, "onlyImportant": True}, None
+        )
+
+    def test_change_consumption_fileIsImportant_True_onlyImportant(self):
+        return self.do_test_change_consumption(
+            {"fileIsImportant": lambda c: True, "onlyImportant": True}, True
+        )
+
+    @defer.inlineCallbacks
+    def test_activation(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['a'])
+        sched.activate = mock.Mock(return_value=defer.succeed(None))
+        sched.deactivate = mock.Mock(return_value=defer.succeed(None))
+
+        # set the schedulerid, and claim the scheduler on another master
+        yield self.setSchedulerToMaster(self.OTHER_MASTER_ID)
+
+        yield self.master.startService()
+        self.reactor.advance(sched.POLL_INTERVAL_SEC / 2)
+        self.reactor.advance(sched.POLL_INTERVAL_SEC / 5)
+        self.reactor.advance(sched.POLL_INTERVAL_SEC / 5)
+        self.assertFalse(sched.activate.called)
+        self.assertFalse(sched.deactivate.called)
+        self.assertFalse(sched.isActive())
+        # objectid is attached by the test helper
+        self.assertEqual(sched.serviceid, self.SCHEDULERID)
+
+        # clear that masterid
+        yield sched.stopService()
+        self.setSchedulerToMaster(None)
+        yield sched.startService()
+        self.reactor.advance(sched.POLL_INTERVAL_SEC)
+        self.assertTrue(sched.activate.called)
+        self.assertFalse(sched.deactivate.called)
+        self.assertTrue(sched.isActive())
+
+        # stop the service and see that deactivate is called
+        yield self.master.stopService()
+        self.assertTrue(sched.activate.called)
+        self.assertTrue(sched.deactivate.called)
+        self.assertFalse(sched.isActive())
+
+    @defer.inlineCallbacks
+    def test_activation_claim_raises(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['a'])
+
+        # set the schedulerid, and claim the scheduler on another master
+        self.setSchedulerToMaster(RuntimeError())
+
+        sched.startService()
+        self.assertEqual(1, len(self.flushLoggedErrors(RuntimeError)))
+        self.assertFalse(sched.isActive())
+
+    @defer.inlineCallbacks
+    def test_activation_activate_fails(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['a'])
+
+        def activate():
+            raise RuntimeError('oh noes')
+
+        sched.activate = activate
+
+        yield self.master.startService()
+        self.assertEqual(1, len(self.flushLoggedErrors(RuntimeError)))
+
+    @defer.inlineCallbacks
+    def do_addBuildsetForSourceStampsWithDefaults(self, codebases, sourcestamps, exp_sourcestamps):
+        sched = yield self.makeScheduler(name='n', builderNames=['b'], codebases=codebases)
+        yield self.master.startService()
+
+        bsid, brids = yield sched.addBuildsetForSourceStampsWithDefaults(
+            reason='power', sourcestamps=sourcestamps, waited_for=False
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        call = self.master.data.updates.addBuildset.mock_calls[0]
+
+        def sourceStampKey(sourceStamp):
+            repository = sourceStamp.get('repository', '')
+            if repository is None:
+                repository = ''
+            branch = sourceStamp.get('branch', '') if not None else ''
+            if branch is None:
+                branch = ''
+            return (repository, branch)
+
+        self.assertEqual(
+            sorted(call[2]['sourcestamps'], key=sourceStampKey),
+            sorted(exp_sourcestamps, key=sourceStampKey),
+        )
+
+    def test_addBuildsetForSourceStampsWithDefaults(self):
+        codebases = {
+            'cbA': {"repository": 'svn://A..', "branch": 'stable', "revision": '13579'},
+            'cbB': {"repository": 'svn://B..', "branch": 'stable', "revision": '24680'},
+        }
+        sourcestamps = [
+            {'codebase': 'cbA', 'branch': 'AA'},
+            {'codebase': 'cbB', 'revision': 'BB'},
+        ]
+        exp_sourcestamps = [
+            {
+                'repository': 'svn://B..',
+                'branch': 'stable',
+                'revision': 'BB',
+                'codebase': 'cbB',
+                'project': '',
+            },
+            {
+                'repository': 'svn://A..',
+                'branch': 'AA',
+                'project': '',
+                'revision': '13579',
+                'codebase': 'cbA',
+            },
+        ]
+        return self.do_addBuildsetForSourceStampsWithDefaults(
+            codebases, sourcestamps, exp_sourcestamps
+        )
+
+    def test_addBuildsetForSourceStampsWithDefaults_fill_in_codebases(self):
+        codebases = {
+            'cbA': {"repository": 'svn://A..', "branch": 'stable', "revision": '13579'},
+            'cbB': {"repository": 'svn://B..', "branch": 'stable', "revision": '24680'},
+        }
+        sourcestamps = [
+            {'codebase': 'cbA', 'branch': 'AA'},
+        ]
+        exp_sourcestamps = [
+            {
+                'repository': 'svn://B..',
+                'branch': 'stable',
+                'revision': '24680',
+                'codebase': 'cbB',
+                'project': '',
+            },
+            {
+                'repository': 'svn://A..',
+                'branch': 'AA',
+                'project': '',
+                'revision': '13579',
+                'codebase': 'cbA',
+            },
+        ]
+        return self.do_addBuildsetForSourceStampsWithDefaults(
+            codebases, sourcestamps, exp_sourcestamps
+        )
+
+    def test_addBuildsetForSourceStampsWithDefaults_no_repository(self):
+        exp_sourcestamps = [
+            {'repository': '', 'branch': None, 'revision': None, 'codebase': '', 'project': ''},
+        ]
+        return self.do_addBuildsetForSourceStampsWithDefaults({'': {}}, [], exp_sourcestamps)
+
+    def test_addBuildsetForSourceStamps_unknown_codbases(self):
+        codebases = {}
+        sourcestamps = [
+            {'codebase': 'cbA', 'branch': 'AA'},
+            {'codebase': 'cbB', 'revision': 'BB'},
+        ]
+        exp_sourcestamps = [
+            {'branch': None, 'revision': 'BB', 'codebase': 'cbB', 'project': '', 'repository': ''},
+            {'branch': 'AA', 'revision': None, 'codebase': 'cbA', 'project': '', 'repository': ''},
+        ]
+        return self.do_addBuildsetForSourceStampsWithDefaults(
+            codebases, sourcestamps, exp_sourcestamps
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForChanges_one_change(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['b'])
+        yield self.master.startService()
+
+        yield self.db.insert_test_data([
+            fakedb.SourceStamp(id=234),
+            fakedb.Change(changeid=13, sourcestampid=234),
+        ])
+        bsid, brids = yield sched.addBuildsetForChanges(
+            reason='power', waited_for=False, changeids=[13]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1],
+            external_idstring=None,
+            properties={
+                'scheduler': ('n', 'Scheduler'),
+            },
+            reason='power',
+            scheduler='n',
+            sourcestamps=[234],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForChanges_properties(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['c'])
+        yield self.master.startService()
+
+        yield self.db.insert_test_data([
+            fakedb.SourceStamp(id=234),
+            fakedb.Change(changeid=14, sourcestampid=234),
+        ])
+        bsid, brids = yield sched.addBuildsetForChanges(
+            reason='downstream', waited_for=False, changeids=[14]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1],
+            external_idstring=None,
+            properties={
+                'scheduler': ('n', 'Scheduler'),
+            },
+            reason='downstream',
+            scheduler='n',
+            sourcestamps=[234],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForChanges_properties_with_virtual_builders(self):
+        sched = yield self.makeScheduler(
+            name='n',
+            builderNames=['c'],
+            properties={'virtual_builder_name': Interpolate("myproject-%(src::branch)s")},
+        )
+        yield self.master.startService()
+
+        yield self.db.insert_test_data([
+            fakedb.SourceStamp(id=234, branch='dev1', project="linux"),
+            fakedb.Change(changeid=14, sourcestampid=234, branch="dev1"),
+        ])
+        bsid, brids = yield sched.addBuildsetForChanges(
+            reason='downstream', waited_for=False, changeids=[14]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1],
+            external_idstring=None,
+            properties={
+                'virtual_builder_name': ("myproject-dev1", "Scheduler"),
+                'scheduler': ('n', 'Scheduler'),
+            },
+            reason='downstream',
+            scheduler='n',
+            sourcestamps=[234],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForChanges_multiple_changes_same_codebase(self):
+        # This is a test for backwards compatibility
+        # Changes from different repositories come together in one build
+        sched = yield self.makeScheduler(
+            name='n', builderNames=['b', 'c'], codebases={'cb': {'repository': 'http://repo'}}
+        )
+        yield self.master.startService()
+
+        # No codebaseGenerator means all changes have codebase == ''
+        yield self.db.insert_test_data([
+            fakedb.SourceStamp(id=10),
+            fakedb.SourceStamp(id=11),
+            fakedb.SourceStamp(id=12),
+            fakedb.Change(changeid=13, codebase='cb', sourcestampid=12),
+            fakedb.Change(changeid=14, codebase='cb', sourcestampid=11),
+            fakedb.Change(changeid=15, codebase='cb', sourcestampid=10),
+        ])
+
+        # note that the changeids are given out of order here; it should still
+        # use the most recent
+        bsid, brids = yield sched.addBuildsetForChanges(
+            reason='power', waited_for=False, changeids=[14, 15, 13]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1, 2],
+            external_idstring=None,
+            properties={
+                'scheduler': ('n', 'Scheduler'),
+            },
+            reason='power',
+            scheduler='n',
+            sourcestamps=[10],  # sourcestampid from greatest changeid
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForChanges_codebases_set_multiple_codebases(self):
+        codebases = {
+            'cbA': {"repository": 'svn://A..', "branch": 'stable', "revision": '13579'},
+            'cbB': {"repository": 'svn://B..', "branch": 'stable', "revision": '24680'},
+            'cbC': {"repository": 'svn://C..', "branch": 'stable', "revision": '12345'},
+            'cbD': {"repository": 'svn://D..'},
+        }
+        # Scheduler gets codebases that can be used to create extra sourcestamps
+        # for repositories that have no changes
+        sched = yield self.makeScheduler(name='n', builderNames=['b', 'c'], codebases=codebases)
+        yield self.master.startService()
+
+        yield self.db.insert_test_data([
+            fakedb.SourceStamp(id=912),
+            fakedb.SourceStamp(id=913),
+            fakedb.SourceStamp(id=914),
+            fakedb.SourceStamp(id=915),
+            fakedb.SourceStamp(id=916),
+            fakedb.SourceStamp(id=917),
+            fakedb.Change(changeid=12, codebase='cbA', sourcestampid=912),
+            fakedb.Change(changeid=13, codebase='cbA', sourcestampid=913),
+            fakedb.Change(changeid=14, codebase='cbA', sourcestampid=914),
+            fakedb.Change(changeid=15, codebase='cbB', sourcestampid=915),
+            fakedb.Change(changeid=16, codebase='cbB', sourcestampid=916),
+            fakedb.Change(changeid=17, codebase='cbB', sourcestampid=917),
+            # note: no changes for cbC or cbD
+        ])
+
+        # note that the changeids are given out of order here; it should still
+        # use the most recent for each codebase
+        bsid, brids = yield sched.addBuildsetForChanges(
+            reason='power', waited_for=True, changeids=[14, 12, 17, 16, 13, 15]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=True,
+            builderids=[1, 2],
+            external_idstring=None,
+            reason='power',
+            scheduler='n',
+            properties={
+                'scheduler': ('n', 'Scheduler'),
+            },
+            sourcestamps=[
+                914,
+                917,
+                {
+                    "branch": 'stable',
+                    "repository": 'svn://C..',
+                    "codebase": 'cbC',
+                    "project": '',
+                    "revision": '12345',
+                },
+                {
+                    "branch": None,
+                    "repository": 'svn://D..',
+                    "codebase": 'cbD',
+                    "project": '',
+                    "revision": None,
+                },
+            ],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamp(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['b'])
+        yield self.master.startService()
+
+        sourcestamps = [91, {'sourcestamp': True}]
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='whynot', waited_for=False, sourcestamps=sourcestamps
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1],
+            external_idstring=None,
+            reason='whynot',
+            scheduler='n',
+            properties={
+                'scheduler': ('n', 'Scheduler'),
+            },
+            sourcestamps=[91, {'sourcestamp': True}],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamp_explicit_builderNames(self):
+        sched = yield self.makeScheduler(name='n', builderNames=['b', 'x', 'y'])
+        yield self.master.startService()
+
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='whynot',
+            waited_for=True,
+            sourcestamps=[91, {'sourcestamp': True}],
+            builderNames=['x', 'y'],
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=True,
+            builderids=[2, 3],
+            external_idstring=None,
+            reason='whynot',
+            scheduler='n',
+            properties={
+                'scheduler': ('n', 'Scheduler'),
+            },
+            sourcestamps=[91, {'sourcestamp': True}],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamp_properties(self):
+        props = properties.Properties(xxx="yyy")
+        sched = yield self.makeScheduler(name='n', builderNames=['b'])
+        yield self.master.startService()
+
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='whynot', waited_for=False, sourcestamps=[91], properties=props
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1],
+            external_idstring=None,
+            properties={'xxx': ('yyy', 'TEST'), 'scheduler': ('n', 'Scheduler')},
+            reason='whynot',
+            scheduler='n',
+            sourcestamps=[91],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamp_combine_change_properties(self):
+        sched = yield self.makeScheduler()
+        yield self.master.startService()
+
+        yield self.master.db.insert_test_data([
+            fakedb.SourceStamp(id=98, branch='stable'),
+            fakedb.Change(changeid=25, sourcestampid=98, branch='stable'),
+            fakedb.ChangeProperty(
+                changeid=25, property_name='color', property_value='["pink","Change"]'
+            ),
+        ])
+
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='whynot', waited_for=False, sourcestamps=[98]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1, 2],
+            external_idstring=None,
+            properties={'scheduler': ('testsched', 'Scheduler'), 'color': ('pink', 'Change')},
+            reason='whynot',
+            scheduler='testsched',
+            sourcestamps=[98],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamp_renderable_builderNames(self):
+        @properties.renderer
+        def names(props):
+            if props.changes[0]['branch'] == 'stable':
+                return ['c']
+            elif props.changes[0]['branch'] == 'unstable':
+                return ['a', 'b']
+            return None
+
+        sched = yield self.makeScheduler(name='n', builderNames=names)
+        yield self.master.startService()
+
+        yield self.master.db.insert_test_data([
+            fakedb.Builder(id=1, name='a'),
+            fakedb.Builder(id=2, name='b'),
+            fakedb.Builder(id=3, name='c'),
+            fakedb.SourceStamp(id=98, branch='stable'),
+            fakedb.SourceStamp(id=99, branch='unstable'),
+            fakedb.Change(changeid=25, sourcestampid=98, branch='stable'),
+            fakedb.Change(changeid=26, sourcestampid=99, branch='unstable'),
+        ])
+
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='whynot', waited_for=False, sourcestamps=[98]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[3],
+            external_idstring=None,
+            properties={'scheduler': ('n', 'Scheduler')},
+            reason='whynot',
+            scheduler='n',
+            sourcestamps=[98],
+            priority=0,
+        )
+
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='because', waited_for=False, sourcestamps=[99]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1, 2],
+            external_idstring=None,
+            properties={'scheduler': ('n', 'Scheduler')},
+            reason='because',
+            scheduler='n',
+            sourcestamps=[99],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamp_list_of_renderable_builderNames(self):
+        names = ['a', 'b', properties.Interpolate('%(prop:extra_builder)s')]
+        sched = yield self.makeScheduler(name='n', builderNames=names)
+        yield self.master.startService()
+
+        yield self.master.db.insert_test_data([
+            fakedb.Builder(id=3, name='c'),
+            fakedb.SourceStamp(id=98, branch='stable'),
+            fakedb.Change(changeid=25, sourcestampid=98, branch='stable'),
+            fakedb.ChangeProperty(
+                changeid=25, property_name='extra_builder', property_value='["c","Change"]'
+            ),
+        ])
+
+        bsid, brids = yield sched.addBuildsetForSourceStamps(
+            reason='whynot', waited_for=False, sourcestamps=[98]
+        )
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            waited_for=False,
+            builderids=[1, 2, 3],
+            external_idstring=None,
+            properties={'scheduler': ('n', 'Scheduler'), 'extra_builder': ('c', 'Change')},
+            reason='whynot',
+            scheduler='n',
+            sourcestamps=[98],
+            priority=0,
+        )
+
+    @defer.inlineCallbacks
+    def test_signature_addBuildsetForChanges(self):
+        sched = yield self.makeScheduler(builderNames=['xxx'])
+
+        @self.assertArgSpecMatches(
+            sched.addBuildsetForChanges,  # Real
+            self.fake_addBuildsetForChanges,  # Real
+        )
+        def addBuildsetForChanges(
+            self,
+            waited_for=False,
+            reason='',
+            external_idstring=None,
+            changeids=None,
+            builderNames=None,
+            properties=None,
+            priority=None,
+            **kw,
+        ):
+            pass
+
+    @defer.inlineCallbacks
+    def test_signature_addBuildsetForSourceStamps(self):
+        sched = yield self.makeScheduler(builderNames=['xxx'])
+
+        @self.assertArgSpecMatches(
+            sched.addBuildsetForSourceStamps,  # Real
+            self.fake_addBuildsetForSourceStamps,  # Fake
+        )
+        def addBuildsetForSourceStamps(
+            self,
+            waited_for=False,
+            sourcestamps=None,
+            reason='',
+            external_idstring=None,
+            properties=None,
+            builderNames=None,
+            priority=None,
+            **kw,
+        ):
+            pass
+
+    @defer.inlineCallbacks
+    def test_signature_addBuildsetForSourceStampsWithDefaults(self):
+        sched = yield self.makeScheduler(builderNames=['xxx'])
+
+        @self.assertArgSpecMatches(
+            sched.addBuildsetForSourceStampsWithDefaults,  # Real
+            self.fake_addBuildsetForSourceStampsWithDefaults,  # Fake
+        )
+        def addBuildsetForSourceStampsWithDefaults(
+            self,
+            reason,
+            sourcestamps=None,
+            waited_for=False,
+            properties=None,
+            builderNames=None,
+            priority=None,
+            **kw,
+        ):
+            pass
+
+
 class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     OBJECTID = 19
     SCHEDULERID = 9

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -28,6 +28,8 @@ from buildbot.test import fakedb
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
 from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestReconfigurableBaseScheduler(
@@ -926,10 +928,15 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
 
             yield self.master.db.insert_test_data(dbBuilder)
 
-        sched = yield self.attachScheduler(
-            base.BaseScheduler(
+        with assertProducesWarnings(
+            DeprecatedApiWarning,
+            message_pattern="",
+        ):
+            sched = base.BaseScheduler(
                 name=name, builderNames=builderNames, properties=properties, codebases=codebases
-            ),
+            )
+        sched = yield self.attachScheduler(
+            sched,
             self.OBJECTID,
             self.SCHEDULERID,
         )

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -27,10 +27,11 @@ from buildbot.schedulers import base
 from buildbot.test import fakedb
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import scheduler
+from buildbot.test.util.config import ConfigErrorsMixin
 
 
 class TestReconfigurableBaseScheduler(
-    scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase
+    scheduler.SchedulerMixin, ConfigErrorsMixin, TestReactorMixin, unittest.TestCase
 ):
     OBJECTID = 19
     SCHEDULERID = 9
@@ -97,6 +98,27 @@ class TestReconfigurableBaseScheduler(
             return ['a']
 
         yield self.makeScheduler(builderNames=names)
+
+    @defer.inlineCallbacks
+    def test_integer_builderNames(self):
+        with self.assertRaisesConfigError(
+            "builderNames argument to a scheduler must be a list of Builder names"
+        ):
+            yield self.makeScheduler(builderNames=1234)
+
+    @defer.inlineCallbacks
+    def test_listofints_builderNames(self):
+        with self.assertRaisesConfigError(
+            "builderNames argument to a scheduler must be a list of Builder names"
+        ):
+            yield self.makeScheduler(builderNames=[1234])
+
+    @defer.inlineCallbacks
+    def test_listofmixed_builderNames(self):
+        with self.assertRaisesConfigError(
+            "builderNames argument to a scheduler must be a list of Builder names"
+        ):
+            yield self.makeScheduler(builderNames=['test', 1234])
 
     @defer.inlineCallbacks
     def test_constructor_codebases_valid(self):

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -77,7 +77,7 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
     @defer.inlineCallbacks
     def test_activate(self):
         sched = yield self.makeScheduler()
-        sched.activate()
+        yield self.master.startService()
 
         self.assertEqual(
             sorted([q.filter for q in sched.master.mq.qrefs]),
@@ -139,8 +139,8 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
             fakedb.Object(id=OBJECTID),
         ])
 
-        sched = yield self.makeScheduler()
-        sched.activate()
+        yield self.makeScheduler()
+        yield self.master.startService()
 
         # announce a buildset with a matching name..
         yield self.db.insert_test_data([

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -44,9 +44,9 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
     @defer.inlineCallbacks
     def makeScheduler(self, upstream=None):
         # build a fake upstream scheduler
-        class Upstream(base.BaseScheduler):
+        class Upstream(base.ReconfigurableBaseScheduler):
             def __init__(self, name):
-                self.name = name
+                super().__init__(name=name, builderNames=['a'])
 
         if not upstream:
             upstream = Upstream(UPSTREAM_NAME)

--- a/master/buildbot/test/unit/schedulers/test_forcesched.py
+++ b/master/buildbot/test/unit/schedulers/test_forcesched.py
@@ -169,6 +169,7 @@ class TestForceScheduler(
     @defer.inlineCallbacks
     def test_basicForce(self):
         sched = yield self.makeScheduler()
+        yield self.master.startService()
 
         res = yield sched.force(
             'user',
@@ -214,6 +215,7 @@ class TestForceScheduler(
     def test_basicForce_reasonString(self):
         """Same as above, but with a reasonString"""
         sched = yield self.makeScheduler(reasonString='%(owner)s wants it %(reason)s')
+        yield self.master.startService()
 
         res = yield sched.force(
             'user',
@@ -260,6 +262,7 @@ class TestForceScheduler(
     @defer.inlineCallbacks
     def test_force_allBuilders(self):
         sched = yield self.makeScheduler()
+        yield self.master.startService()
 
         res = yield sched.force(
             'user',
@@ -301,6 +304,7 @@ class TestForceScheduler(
     @defer.inlineCallbacks
     def test_force_someBuilders(self):
         sched = yield self.makeScheduler(builderNames=['a', 'b', 'c'])
+        yield self.master.startService()
 
         res = yield sched.force(
             'user',
@@ -380,6 +384,7 @@ class TestForceScheduler(
     @defer.inlineCallbacks
     def test_good_codebases(self):
         sched = yield self.makeScheduler(codebases=['foo', CodebaseParameter('bar')])
+        yield self.master.startService()
         yield sched.force(
             'user',
             builderNames=['a'],
@@ -435,6 +440,7 @@ class TestForceScheduler(
         sched = yield self.makeScheduler(
             codebases=['foo', CodebaseParameter('bar', patch=PatchParameter())]
         )
+        yield self.master.startService()
         yield sched.force(
             'user',
             builderNames=['a'],
@@ -550,6 +556,7 @@ class TestForceScheduler(
             self.assertEqual(gotSpec, expectSpec)
 
         sched = yield self.makeScheduler(properties=[prop])
+        yield self.master.startService()
 
         if not req:
             req = {name: value, 'reason': 'because'}
@@ -920,10 +927,6 @@ class TestForceScheduler(
         ):
             ForceScheduler(name='testsched', builderNames=[], codebases=['bar'], username="foo")
 
-    def test_notstring_name(self):
-        with self.assertRaisesConfigError("ForceScheduler name must be a unicode string:"):
-            ForceScheduler(name=1234, builderNames=[], codebases=['bar'], username="foo")
-
     def test_notidentifier_name(self):
         # FIXME: this test should be removed eventually when bug 3460 gets a
         # real fix
@@ -936,29 +939,6 @@ class TestForceScheduler(
         with self.assertRaisesConfigError("ForceScheduler name must not be empty:"):
             ForceScheduler(name='', builderNames=[], codebases=['bar'], username="foo")
 
-    def test_integer_builderNames(self):
-        with self.assertRaisesConfigError(
-            "ForceScheduler 'testsched': builderNames must be a list of strings:"
-        ):
-            ForceScheduler(name='testsched', builderNames=1234, codebases=['bar'], username="foo")
-
-    def test_listofints_builderNames(self):
-        with self.assertRaisesConfigError(
-            "ForceScheduler 'testsched': builderNames must be a list of strings:"
-        ):
-            ForceScheduler(name='testsched', builderNames=[1234], codebases=['bar'], username="foo")
-
-    def test_listofunicode_builderNames(self):
-        ForceScheduler(name='testsched', builderNames=['a', 'b'])
-
-    def test_listofmixed_builderNames(self):
-        with self.assertRaisesConfigError(
-            "ForceScheduler 'testsched': builderNames must be a list of strings:"
-        ):
-            ForceScheduler(
-                name='testsched', builderNames=['test', 1234], codebases=['bar'], username="foo"
-            )
-
     def test_integer_properties(self):
         with self.assertRaisesConfigError(
             "ForceScheduler 'testsched': properties must be a list of BaseParameters:"
@@ -966,8 +946,6 @@ class TestForceScheduler(
             ForceScheduler(
                 name='testsched',
                 builderNames=[],
-                codebases=['bar'],
-                username="foo",
                 properties=1234,
             )
 
@@ -978,8 +956,6 @@ class TestForceScheduler(
             ForceScheduler(
                 name='testsched',
                 builderNames=[],
-                codebases=['bar'],
-                username="foo",
                 properties=[1234, 2345],
             )
 
@@ -990,8 +966,6 @@ class TestForceScheduler(
             ForceScheduler(
                 name='testsched',
                 builderNames=[],
-                codebases=['bar'],
-                username="foo",
                 properties=[
                     BaseParameter(
                         name="test",

--- a/master/buildbot/test/unit/schedulers/test_manager.py
+++ b/master/buildbot/test/unit/schedulers/test_manager.py
@@ -23,6 +23,8 @@ from twisted.trial import unittest
 from buildbot.db.schedulers import SchedulerModel
 from buildbot.schedulers import base
 from buildbot.schedulers import manager
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class SchedulerManager(unittest.TestCase):
@@ -176,7 +178,10 @@ class SchedulerManager(unittest.TestCase):
         sch1_new = self.makeSched(self.Sched, 'sch1', attr='alpha')
         self.new_config.schedulers = {"sch1": sch1_new}
 
-        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
+        with assertProducesWarnings(
+            DeprecatedApiWarning, message_pattern='.*raising NotImplementedError.*'
+        ):
+            yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         # sch1 had parameter change but is not reconfigurable, so sch1_new is now the active
         # instance

--- a/master/buildbot/test/unit/schedulers/test_manager.py
+++ b/master/buildbot/test/unit/schedulers/test_manager.py
@@ -23,7 +23,7 @@ from twisted.trial import unittest
 from buildbot.db.schedulers import SchedulerModel
 from buildbot.schedulers import base
 from buildbot.schedulers import manager
-from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 
 
@@ -103,7 +103,10 @@ class SchedulerManager(unittest.TestCase):
         pass
 
     def makeSched(self, cls, name, attr='alpha'):
-        sch = cls(name=name, builderNames=['x'], properties={})
+        with assertProducesWarnings(
+            DeprecatedApiWarning, message_pattern='.*BaseScheduler has been deprecated.*'
+        ):
+            sch = cls(name=name, builderNames=['x'], properties={})
         sch.attr = attr
         return sch
 

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyBase.py
@@ -52,6 +52,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_hourly(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'])
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 0, 0), (2011, 1, 1, 4, 0, 0)),
@@ -67,6 +68,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     def test_getNextBuildTime_minutes_single(self):
         # basically the same as .._hourly
         sched = yield self.makeScheduler(name='test', builderNames=['test'], minute=4)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 0, 0), (2011, 1, 1, 3, 4, 0)),
@@ -76,6 +78,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_minutes_multiple(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], minute=[4, 34])
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 0, 0), (2011, 1, 1, 3, 4, 0)),
@@ -87,6 +90,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_minutes_star(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], minute='*')
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 11, 30), (2011, 1, 1, 3, 12, 0)),
@@ -97,6 +101,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_hours_single(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], hour=4)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 0), (2011, 1, 1, 4, 0)),
@@ -106,6 +111,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_hours_multiple(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], hour=[7, 19])
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 0), (2011, 1, 1, 7, 0)),
@@ -117,6 +123,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_hours_minutes(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], hour=13, minute=19)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 1, 3, 11), (2011, 1, 1, 13, 19)),
@@ -127,6 +134,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_month_single(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], month=3)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 2, 27, 3, 11), (2011, 3, 1, 0, 0)),
@@ -137,6 +145,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_month_multiple(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], month=[4, 6])
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 3, 30, 3, 11), (2011, 4, 1, 0, 0)),
@@ -150,6 +159,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], month=[3, 6], dayOfMonth=[15]
         )
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 2, 12, 3, 11), (2011, 3, 15, 0, 0)),
@@ -159,6 +169,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
     @defer.inlineCallbacks
     def test_getNextBuildTime_dayOfMonth_single(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], dayOfMonth=10)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 9, 3, 0), (2011, 1, 10, 0, 0)),
@@ -173,6 +184,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfMonth=[10, 20, 30]
         )
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 9, 22, 0), (2011, 1, 10, 0, 0)),
@@ -187,6 +199,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfMonth=15, hour=20, minute=30
         )
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 13, 22, 19), (2011, 1, 15, 20, 30)),
@@ -199,6 +212,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfWeek=1
         )  # Tuesday (2011-1-1 was a Saturday)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 3, 22, 19), (2011, 1, 4, 0, 0)),
@@ -211,6 +225,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfWeek="1"
         )  # Tuesday (2011-1-1 was a Saturday)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 3, 22, 19), (2011, 1, 4, 0, 0)),
@@ -223,6 +238,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfWeek="tue,3"
         )  # Tuesday, Thursday (2011-1-1 was a Saturday)
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             ((2011, 1, 3, 22, 19), (2011, 1, 4, 0, 0)),
@@ -239,6 +255,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfWeek=[1, 3], hour=1
         )
+        yield self.master.startService()
 
         yield self.do_getNextBuildTime_test(
             sched,
@@ -251,6 +268,7 @@ class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase)
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], dayOfWeek=[1, 4], dayOfMonth=5, hour=1
         )
+        yield self.master.startService()
         yield self.do_getNextBuildTime_test(
             sched,
             # Tues

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -80,6 +80,7 @@ class NightlyTriggerable(
     @defer.inlineCallbacks
     def test_constructor_no_reason(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'])
+        yield sched.configureService()
         self.assertEqual(
             sched.reason, "The NightlyTriggerable scheduler named 'test' triggered this build"
         )
@@ -89,18 +90,20 @@ class NightlyTriggerable(
         sched = yield self.makeScheduler(
             name='test', builderNames=['test'], reason="hourlytriggerable"
         )
+        yield sched.configureService()
         self.assertEqual(sched.reason, "hourlytriggerable")
 
     @defer.inlineCallbacks
     def test_constructor_month(self):
         sched = yield self.makeScheduler(name='test', builderNames=['test'], month='1')
+        yield sched.configureService()
         self.assertEqual(sched.month, "1")
 
     @defer.inlineCallbacks
     def test_timer_noBuilds(self):
-        sched = yield self.makeScheduler(name='test', builderNames=['test'], minute=[5])
+        yield self.makeScheduler(name='test', builderNames=['test'], minute=[5])
+        yield self.master.startService()
 
-        sched.activate()
         self.reactor.advance(60 * 60)  # Run for 1h
 
         self.assertEqual(self.addBuildsetCalls, [])
@@ -113,8 +116,7 @@ class NightlyTriggerable(
             minute=[5],
             codebases={'cb': {'repository': 'annoying'}},
         )
-
-        sched.activate()
+        yield self.master.startService()
 
         sched.trigger(
             False,
@@ -153,7 +155,7 @@ class NightlyTriggerable(
             codebases={'cb': {'repository': 'annoying'}},
         )
 
-        sched.activate()
+        yield self.master.startService()
 
         sched.trigger(
             False,
@@ -206,7 +208,7 @@ class NightlyTriggerable(
             codebases={'cb': {'repository': 'annoying'}},
         )
 
-        sched.activate()
+        yield self.master.startService()
 
         sched.trigger(
             False,
@@ -250,7 +252,7 @@ class NightlyTriggerable(
             codebases={'cb': {'repository': 'annoying'}},
         )
 
-        sched.activate()
+        yield self.master.startService()
 
         sched.trigger(
             False,
@@ -310,7 +312,7 @@ class NightlyTriggerable(
 
     @defer.inlineCallbacks
     def test_savedTrigger(self):
-        sched = yield self.makeScheduler(
+        yield self.makeScheduler(
             name='test',
             builderNames=['test'],
             minute=[5],
@@ -329,7 +331,7 @@ class NightlyTriggerable(
             ),
         ])
 
-        sched.activate()
+        yield self.master.startService()
 
         self.reactor.advance(60 * 60)  # Run for 1h
 
@@ -347,7 +349,7 @@ class NightlyTriggerable(
 
     @defer.inlineCallbacks
     def test_savedTrigger_dict(self):
-        sched = yield self.makeScheduler(
+        yield self.makeScheduler(
             name='test',
             builderNames=['test'],
             minute=[5],
@@ -365,7 +367,7 @@ class NightlyTriggerable(
             ),
         ])
 
-        sched.activate()
+        yield self.master.startService()
 
         self.reactor.advance(60 * 60)  # Run for 1h
 
@@ -393,7 +395,7 @@ class NightlyTriggerable(
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
         ])
 
-        sched.activate()
+        yield self.master.startService()
 
         _, d = sched.trigger(
             False,
@@ -440,7 +442,7 @@ class NightlyTriggerable(
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
         ])
 
-        sched.activate()
+        yield self.master.startService()
 
         _, d = sched.trigger(
             False,
@@ -473,7 +475,7 @@ class NightlyTriggerable(
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
         ])
 
-        sched.activate()
+        yield self.master.startService()
 
         sched.trigger(
             False,
@@ -524,7 +526,7 @@ class NightlyTriggerable(
 
     @defer.inlineCallbacks
     def test_savedProperties(self):
-        sched = yield self.makeScheduler(
+        yield self.makeScheduler(
             name='test',
             builderNames=['test'],
             minute=[5],
@@ -543,7 +545,7 @@ class NightlyTriggerable(
             ),
         ])
 
-        sched.activate()
+        yield self.master.startService()
 
         self.reactor.advance(60 * 60)  # Run for 1h
 

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -60,6 +60,7 @@ class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         sched = yield self.makeScheduler(
             name='tsched', builderNames=['a'], port='tcp:9999', userpass=[('fred', 'derf')]
         )
+        yield sched.configureService()
         expectedValue = not sched.enabled
         yield sched._enabledCallback(None, {'enabled': not sched.enabled})
         self.assertEqual(sched.enabled, expectedValue)
@@ -456,10 +457,13 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
+    @defer.inlineCallbacks
     def test_parseJob_v3_no_builders(self):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['buildera', 'builderb'], jobdir='foo'
         )
+        yield sched.setServiceParent(self.master)
+        yield self.master.startService()
         jobstr = self.makeNetstring(
             '3',
             'extid',
@@ -474,10 +478,13 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
+    @defer.inlineCallbacks
     def test_parseJob_v3_no_properties(self):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['buildera', 'builderb'], jobdir='foo'
         )
+        yield sched.setServiceParent(self.master)
+        yield self.master.startService()
         jobstr = self.makeNetstring(
             '3',
             'extid',
@@ -715,6 +722,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             overrideBuildsetMethods=True,
             createBuilderDB=True,
         )
+        yield self.master.startService()
         fakefile = mock.Mock()
 
         def parseJob_(f):

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -32,6 +32,7 @@ from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
+from buildbot.warnings import warn_deprecated
 
 
 class ReconfigurableServiceMixin:
@@ -549,6 +550,12 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin, Reconfig
                 # so we implement switch of child when the service raises NotImplementedError
                 # Note this means that self will stop, and sibling will take ownership
                 # means that we have a small time where the service is unavailable.
+                warn_deprecated(
+                    '4.3.0',
+                    'raising NotImplementedError from '
+                    'reconfigServiceWithSibling() or reconfigService() has been deprecated',
+                )
+
                 yield svc.disownServiceParent()
                 config_sibling.objectid = svc.objectid
                 yield config_sibling.setServiceParent(self)

--- a/master/docs/developer/cls-basescheduler.rst
+++ b/master/docs/developer/cls-basescheduler.rst
@@ -3,7 +3,7 @@ BaseScheduler
 
 .. py:module:: buildbot.schedulers.base
 
-.. py:class:: BaseScheduler
+.. py:class:: ReconfigurableBaseScheduler
 
     This is the base class for all Buildbot schedulers.
     See :ref:`Writing-Schedulers` for information on writing new schedulers.
@@ -170,3 +170,9 @@ BaseScheduler
         :returns: Deferred
 
         This calls through to :py:meth:`buildbot.db.state.StateConnectorComponent.setState`, using the scheduler's objectid.
+
+
+.. py:class:: BaseScheduler
+
+    This class is legacy counterpart of ``ReconfigurableBaseScheduler``. It does not support
+    reconfiguration.

--- a/master/docs/developer/config.rst
+++ b/master/docs/developer/config.rst
@@ -455,7 +455,7 @@ For backward compatibility, schedulers that do not support reconfiguration will 
 During a reconfiguration, if a new and old scheduler's fully qualified class names differ, then the old class will be stopped, and the new class will be started.
 This supports the case when a user changes, for example, a :bb:sched:`Nightly` scheduler to a :bb:sched:`Periodic` scheduler without changing the name.
 
-Because Buildbot uses :py:class:`~buildbot.schedulers.base.BaseScheduler` instances directly in the configuration file, a reconfigured scheduler must extract its new configuration information from another instance of itself.
+Because Buildbot uses :py:class:`~buildbot.schedulers.base.ReconfigurableBaseScheduler` instances directly in the configuration file, a reconfigured scheduler must extract its new configuration information from another instance of itself.
 
 Custom Subclasses
 ~~~~~~~~~~~~~~~~~

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -26,6 +26,13 @@ The ``build_files``, ``worker_env`` and ``worker_version`` arguments of
 ``TestBuildStepMixin.setup_step()`` have been removed. As a replacement, call
 ``TestBuildStepMixin.setup_build()`` before ``setup_step``.
 
+Non-reconfigurable services
+===========================
+
+Raising ``NotImplementedError`` from ``reconfigServiceWithSibling`` or ``reconfigService`` service
+functions has been deprecated. Use ``canReconfigWithSibling()`` that returns ``False`` as a
+replacement.
+
 HTTP service
 ============
 

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -84,6 +84,9 @@ Schedulers
 Old location of ``Dependent`` scheduler has been removed. Instead of
 ``buildbot.schedulers.basic.Dependent`` use ``buildbot.plugins.schedulers.Dependent``.
 
+``buildbot.schedulers.base.BaseScheduler`` has been deprecated. Replace uses of it with
+``buildbot.schedulers.base.ReconfigurableBaseScheduler``.
+
 Reporters
 =========
 

--- a/newsfragments/reconfig-service-with-sibling-not-implemented.removal
+++ b/newsfragments/reconfig-service-with-sibling-not-implemented.removal
@@ -1,0 +1,3 @@
+Raising ``NotImplementedError`` from ``reconfigServiceWithSibling`` or
+``reconfigService`` has been deprecated. Use ``canReconfigWithSibling()`` that returns ``False`` as
+a replacement.

--- a/newsfragments/schedulers-base-scheduler.removal
+++ b/newsfragments/schedulers-base-scheduler.removal
@@ -1,0 +1,2 @@
+``buildbot.schedulers.base.BaseScheduler`` has been deprecated. Replace uses of it with
+``ReconfigurableBaseScheduler``.


### PR DESCRIPTION
Schedulers were using a compatibility path that does not require them to implement `reconfigService` and `checkConfig`. This has been fixed in this PR. Since schedulers were the only user of the compatibility path, it has been deprecated as well.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
