### PR TITLE
DockerLatentWorker: Handle NotFound exception when stopping

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -116,3 +116,6 @@ class APIClient(Client):
 class errors:
     class APIError(Exception):
         pass
+
+    class NotFound(Exception):
+        pass

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -527,6 +527,28 @@ class TestDockerLatentWorker(ConfigErrorsMixin, TestReactorMixin, unittest.TestC
         )
         self.assertEqual((yield bs.check_instance()), (False, expected_logs))
 
+    @defer.inlineCallbacks
+    def test_stop_instance_stop_NotFound(self):
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
+        yield bs.start_instance(self.build)
+
+        def stop(_, params):
+            raise docker.errors.NotFound
+
+        self.patch(docker.Client, "stop", stop)
+        yield bs.stop_instance(self.build)
+
+    @defer.inlineCallbacks
+    def test_stop_instance_remove_container_NotFound(self):
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
+        yield bs.start_instance(self.build)
+
+        def remove_container(_, params, v=False, force=False):
+            raise docker.errors.NotFound
+
+        self.patch(docker.Client, "remove_container", remove_container)
+        yield bs.stop_instance(self.build)
+
 
 class testDockerPyStreamLogs(unittest.TestCase):
     def compare(self, result, log):

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -457,10 +457,18 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin, DockerBaseWorker):
     def _thd_stop_instance(self, instance, curr_client_args, fast):
         docker_client = self._getDockerClient(curr_client_args)
         log.msg(f"Stopping container {instance['Id'][:6]}...")
-        docker_client.stop(instance['Id'])
+        try:
+            docker_client.stop(instance['Id'])
+        except docker.errors.NotFound as not_found_err:
+            log.msg('Cannot stop container {}: {}'.format(instance['Id'][:6], not_found_err))
+            # don't try to wait for it.
+            fast = True
         if not fast:
             docker_client.wait(instance['Id'])
-        docker_client.remove_container(instance['Id'], v=True, force=True)
+        try:
+            docker_client.remove_container(instance['Id'], v=True, force=True)
+        except docker.errors.NotFound as not_found_err:
+            log.msg('Cannot remove container {}: {}'.format(instance['Id'][:6], not_found_err))
         if self.image is None:
             try:
                 docker_client.remove_image(image=instance['image'])

--- a/newsfragments/docker-stop.bugfix
+++ b/newsfragments/docker-stop.bugfix
@@ -1,0 +1,1 @@
+:py:class:`DockerLatentWorker`: Handle not found exception better when stopping container.


### PR DESCRIPTION
This PR builds on solution of @cmouse to handle `NotFound` exceptions when stopping `DockerLatentWorker`. It is needed to avoid substantiation getting stuck on preparing worker if there is e.g. connectivity problem to the docker host.
Thanks to @cmouse  for contribution. I completed his PR by adding the requested tests.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation