### PR TITLE
Add Options to Control Log and Patch Attachments in MailNotifier

### DIFF
--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -109,6 +109,8 @@ class MailNotifier(ReporterBase):
         smtpPort=25,
         dumpMailsToLog=False,
         generators=None,
+        attach_logs=True,  # Add attach_logs option
+        attach_patches=True  # Add attach_patches option
     ):
         if ESMTPSenderFactory is None:
             config.error("twisted-mail is not installed - cannot send mail")
@@ -139,6 +141,9 @@ class MailNotifier(ReporterBase):
         if useSmtps:
             ssl.ensureHasSSL(self.__class__.__name__)
 
+        self.attach_logs = attach_logs
+        self.attach_patches = attach_patches
+
     @defer.inlineCallbacks
     def reconfigService(
         self,
@@ -155,6 +160,8 @@ class MailNotifier(ReporterBase):
         smtpPort=25,
         dumpMailsToLog=False,
         generators=None,
+        attach_logs=True,  # Add attach_logs option
+        attach_patches=True  # Add attach_patches option
     ):
         if generators is None:
             generators = self._create_default_generators()
@@ -178,6 +185,8 @@ class MailNotifier(ReporterBase):
         self.smtpPassword = smtpPassword
         self.smtpPort = smtpPort
         self.dumpMailsToLog = dumpMailsToLog
+        self.attach_logs = attach_logs
+        self.attach_patches = attach_patches
 
     def _create_default_generators(self):
         return [
@@ -222,11 +231,11 @@ class MailNotifier(ReporterBase):
         m['From'] = self.fromaddr
         # m['To'] is added later
 
-        if patches:
+        if patches and self.attach_patches:
             for i, patch in enumerate(patches):
                 a = self.patch_to_attachment(patch, i)
                 m.attach(a)
-        if logs:
+        if logs and self.attach_logs:
             for log in logs:
                 # Use distinct filenames for the e-mail summary
                 name = f"{log['stepname']}.{log['name']}"


### PR DESCRIPTION
**This pull request introduces two new configuration options, attach_logs and attach_patches, to the MailNotifier class. These options allow users to control whether logs and patches should be attached to email notifications. This change aims to address issue #8279, where the deprecation of add_logs caused all logs to be attached to email notifications, leading to large email sizes.**

Changes:
Added attach_logs and attach_patches options to the MailNotifier class.
Updated the createEmail method to conditionally attach logs and patches based on the new options.
Ensured backward compatibility by setting default values for the new options to True.
How the System Will Work After This Update:
After this update, the MailNotifier will have two new configuration options:

attach_logs: Controls whether logs should be attached to email notifications. Default is True.
attach_patches: Controls whether patches should be attached to email notifications. Default is True.
Users can configure these options when setting up the MailNotifier. If attach_logs is set to False, logs will not be attached to the emails, reducing the email size. Similarly, if attach_patches is set to False, patches will not be attached to the emails.