### PR TITLE
Fix service reconfig priority

### DIFF
--- a/master/buildbot/machine/manager.py
+++ b/master/buildbot/machine/manager.py
@@ -16,11 +16,9 @@
 from __future__ import annotations
 
 from buildbot.util import service
-from buildbot.worker.manager import WorkerManager
 
 
 class MachineManager(service.BuildbotServiceManager):
-    reconfig_priority = WorkerManager.reconfig_priority + 1
     name: str | None = 'MachineManager'  # type: ignore[assignment]
     managed_services_name = 'machines'
     config_attr = 'machines'

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -162,6 +162,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.machine_manager = MachineManager()
         yield self.machine_manager.setServiceParent(self)
+        self.machine_manager.reconfig_priority = self.workers.reconfig_priority + 1
 
         self.scheduler_manager = SchedulerManager()
         yield self.scheduler_manager.setServiceParent(self)

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -159,6 +159,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.botmaster = BotMaster()
         yield self.botmaster.setServiceParent(self)
+        # must be configured first so that projects and codebases are registered
+        self.botmaster.reconfig_priority = 1001
 
         self.machine_manager = MachineManager()
         yield self.machine_manager.setServiceParent(self)

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -152,6 +152,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.workers = workermanager.WorkerManager(self)
         yield self.workers.setServiceParent(self)
+        self.workers.reconfig_priority = 127
 
         self.change_svc = ChangeManager()
         yield self.change_svc.setServiceParent(self)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -55,9 +55,6 @@ def enforceChosenWorker(bldr, workerforbuilder, breq):
 
 
 class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
-    # reconfigure builders before workers
-    reconfig_priority = 196
-
     master: BuildMaster | None = None
 
     @property

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -45,9 +45,6 @@ class AbstractWorker(service.BuildbotService):
     running builds.  I am instantiated by the configuration file, and can be
     subclassed to add extra functionality."""
 
-    # reconfig workers after builders
-    reconfig_priority = 64
-
     quarantine_timer: DelayedCall | None = None
     quarantine_timeout = quarantine_initial_timeout = 10
     quarantine_max_timeout = 60 * 60

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -76,7 +76,6 @@ class WorkerManager(MeasuredBuildbotServiceManager):
 
     config_attr = "workers"
     PING_TIMEOUT = 10
-    reconfig_priority = 127
 
     def __init__(self, master):
         super().__init__()


### PR DESCRIPTION
With the addition of Codebases, the requirements of service reconfiguration priority have changed. BotMaster now should be among the very first services to start so that it correctly saves things to the database.

Newsfragment is not needed because change applies to the not released code.