### PR TITLE
tests: Remove some duplicated members in tests 

### DIFF
--- a/master/buildbot/test/regressions/test_bad_change_properties_rows.py
+++ b/master/buildbot/test/regressions/test_bad_change_properties_rows.py
@@ -32,28 +32,27 @@ class TestBadRows(TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
 
     @defer.inlineCallbacks
     def test_bogus_row_no_source(self):
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=10),
             fakedb.ChangeProperty(changeid=13, property_name='devel', property_value='"no source"'),
             fakedb.Change(changeid=13, sourcestampid=10),
         ])
 
-        c = yield self.db.changes.getChange(13)
+        c = yield self.master.db.changes.getChange(13)
 
         self.assertEqual(c.properties, {"devel": ('no source', 'Change')})
 
     @defer.inlineCallbacks
     def test_bogus_row_jsoned_list(self):
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=10),
             fakedb.ChangeProperty(changeid=13, property_name='devel', property_value='[1, 2]'),
             fakedb.Change(changeid=13, sourcestampid=10),
         ])
 
-        c = yield self.db.changes.getChange(13)
+        c = yield self.master.db.changes.getChange(13)
 
         self.assertEqual(c.properties, {"devel": ([1, 2], 'Change')})

--- a/master/buildbot/test/unit/data/test_build_data.py
+++ b/master/buildbot/test/unit/data/test_build_data.py
@@ -33,7 +33,7 @@ class TestBuildDataNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Buildset(id=20),
             fakedb.Builder(id=88, name='b1'),
@@ -138,7 +138,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Buildset(id=20),
             fakedb.Builder(id=88, name='b1'),
@@ -258,7 +258,7 @@ class TestBuildDatasNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Buildset(id=20),
             fakedb.Builder(id=88, name='b1'),

--- a/master/buildbot/test/unit/data/test_builders.py
+++ b/master/buildbot/test/unit/data/test_builders.py
@@ -36,7 +36,7 @@ class BuilderEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=1, name='buildera'),
             fakedb.Builder(id=2, name='builderb'),
             fakedb.Builder(id=3, name='builder unicode \N{SNOWMAN}'),
@@ -106,7 +106,7 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Project(id=201, name='project201'),
             fakedb.Project(id=202, name='project202'),
             fakedb.Builder(id=1, name='buildera'),

--- a/master/buildbot/test/unit/data/test_buildrequests.py
+++ b/master/buildbot/test/unit/data/test_buildrequests.py
@@ -45,7 +45,7 @@ class TestBuildRequestEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=77, name='bbb'),
             fakedb.Master(id=fakedb.FakeDBConnector.MASTER_ID),
             fakedb.Worker(id=13, name='wrk'),
@@ -68,8 +68,8 @@ class TestBuildRequestEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def testGetExisting(self):
-        self.db.buildrequests.claimBuildRequests([44], claimed_at=self.CLAIMED_AT)
-        self.db.buildrequests.completeBuildRequests([44], 75, complete_at=self.COMPLETE_AT)
+        self.master.db.buildrequests.claimBuildRequests([44], claimed_at=self.CLAIMED_AT)
+        self.master.db.buildrequests.completeBuildRequests([44], 75, complete_at=self.COMPLETE_AT)
         buildrequest = yield self.callGet(('buildrequests', 44))
         self.validateData(buildrequest)
         # check data formatting:
@@ -127,7 +127,7 @@ class TestBuildRequestsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=77, name='bbb'),
             fakedb.Builder(id=78, name='ccc'),
             fakedb.Builder(id=79, name='ddd'),

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -36,7 +36,7 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
             fakedb.Worker(id=13, name='wrk'),
@@ -138,7 +138,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=77, name='builder77'),
             fakedb.Builder(id=78, name='builder78'),
             fakedb.Builder(id=79, name='builder79'),

--- a/master/buildbot/test/unit/data/test_buildsets.py
+++ b/master/buildbot/test/unit/data/test_buildsets.py
@@ -40,7 +40,7 @@ class BuildsetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Buildset(id=13, reason='because I said so'),
             fakedb.SourceStamp(id=92),
             fakedb.SourceStamp(id=93),
@@ -77,7 +77,7 @@ class BuildsetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=92),
             fakedb.Buildset(id=13, complete=True),
             fakedb.Buildset(id=14, complete=False),

--- a/master/buildbot/test/unit/data/test_changes.py
+++ b/master/buildbot/test/unit/data/test_changes.py
@@ -38,7 +38,7 @@ class ChangeEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234),
             fakedb.Change(
                 changeid=13,
@@ -72,7 +72,7 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=1),
             fakedb.Worker(id=1, name='wrk'),
             fakedb.SourceStamp(id=133),
@@ -115,12 +115,12 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getChanges_from_build(self):
-        fake_change = yield self.db.changes.getChangeFromSSid(144)
+        fake_change = yield self.master.db.changes.getChangeFromSSid(144)
 
         mockGetChangeById = mock.Mock(
-            spec=self.db.changes.getChangesForBuild, return_value=[fake_change]
+            spec=self.master.db.changes.getChangesForBuild, return_value=[fake_change]
         )
-        self.patch(self.db.changes, 'getChangesForBuild', mockGetChangeById)
+        self.patch(self.master.db.changes, 'getChangesForBuild', mockGetChangeById)
 
         changes = yield self.callGet(('builds', '1', 'changes'))
 
@@ -129,11 +129,11 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getChanges_from_builder(self):
-        fake_change = yield self.db.changes.getChangeFromSSid(144)
+        fake_change = yield self.master.db.changes.getChangeFromSSid(144)
         mockGetChangeById = mock.Mock(
-            spec=self.db.changes.getChangesForBuild, return_value=[fake_change]
+            spec=self.master.db.changes.getChangesForBuild, return_value=[fake_change]
         )
-        self.patch(self.db.changes, 'getChangesForBuild', mockGetChangeById)
+        self.patch(self.master.db.changes, 'getChangesForBuild', mockGetChangeById)
 
         changes = yield self.callGet(('builders', '1', 'builds', '1', 'changes'))
         self.validateData(changes[0])

--- a/master/buildbot/test/unit/data/test_changesources.py
+++ b/master/buildbot/test/unit/data/test_changesources.py
@@ -37,7 +37,7 @@ class ChangeSourceEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         yield self.setUpEndpoint()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=22, active=0),
             fakedb.Master(id=33, active=1),
             fakedb.ChangeSource(id=13, name='some:changesource'),
@@ -100,7 +100,7 @@ class ChangeSourcesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=22, active=0),
             fakedb.Master(id=33, active=1),
             fakedb.ChangeSource(id=13, name='some:changesource'),

--- a/master/buildbot/test/unit/data/test_codebase_branches.py
+++ b/master/buildbot/test/unit/data/test_codebase_branches.py
@@ -39,7 +39,7 @@ class CodebaseBranchEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1'),
             fakedb.CodebaseCommit(id=110, codebaseid=13),
@@ -75,7 +75,7 @@ class CodebaseBranchesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1'),
             fakedb.CodebaseCommit(id=110, codebaseid=13),

--- a/master/buildbot/test/unit/data/test_codebase_commits.py
+++ b/master/buildbot/test/unit/data/test_codebase_commits.py
@@ -39,7 +39,7 @@ class CodebaseCommitEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1'),
             fakedb.CodebaseCommit(id=110, codebaseid=13),
@@ -77,7 +77,7 @@ class CodebaseCommitsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1'),
             fakedb.CodebaseCommit(id=106, codebaseid=13),
@@ -117,7 +117,7 @@ class CodebaseCommitsGraphEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1'),
             fakedb.CodebaseCommit(id=106, codebaseid=13),

--- a/master/buildbot/test/unit/data/test_codebases.py
+++ b/master/buildbot/test/unit/data/test_codebases.py
@@ -39,7 +39,7 @@ class CodebaseEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1', slug='slug_codebase1'),
         ])
@@ -67,7 +67,7 @@ class CodebasesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @async_to_deferred
     async def setUp(self) -> None:  # type: ignore[override]
         await self.setUpEndpoint()
-        await self.db.insert_test_data([
+        await self.master.db.insert_test_data([
             fakedb.Project(id=7, name='fake_project7'),
             fakedb.Project(id=8, name='fake_project8'),
             fakedb.Codebase(id=13, projectid=7, name='codebase1', slug='slug_codebase1'),

--- a/master/buildbot/test/unit/data/test_logchunks.py
+++ b/master/buildbot/test/unit/data/test_logchunks.py
@@ -44,7 +44,7 @@ class LogChunkEndpointBase(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data(
+        yield self.master.db.insert_test_data(
             [
                 fakedb.Builder(id=77),
                 fakedb.Worker(id=13, name='wrk'),

--- a/master/buildbot/test/unit/data/test_logs.py
+++ b/master/buildbot/test/unit/data/test_logs.py
@@ -34,7 +34,7 @@ class LogEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
             fakedb.Worker(id=13, name='wrk'),
@@ -117,7 +117,7 @@ class LogsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=77),
             fakedb.Master(id=88),
             fakedb.Worker(id=13, name='wrk'),

--- a/master/buildbot/test/unit/data/test_masters.py
+++ b/master/buildbot/test/unit/data/test_masters.py
@@ -41,7 +41,7 @@ class MasterEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         yield self.setUpEndpoint()
         self.master.name = "myname"
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=13, active=False, last_active=SOMETIME),
             fakedb.Master(id=14, active=False, last_active=SOMETIME),
             fakedb.Builder(id=23, name='bldr1'),
@@ -90,7 +90,7 @@ class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         yield self.setUpEndpoint()
         self.master.name = "myname"
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=13, active=False, last_active=SOMETIME),
             fakedb.Master(id=14, active=True, last_active=OTHERTIME),
             fakedb.Builder(id=22),

--- a/master/buildbot/test/unit/data/test_projects.py
+++ b/master/buildbot/test/unit/data/test_projects.py
@@ -36,7 +36,7 @@ class ProjectEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Project(id=1, name='project1'),
             fakedb.Project(id=2, name='project2'),
         ])
@@ -75,7 +75,7 @@ class ProjectsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Project(id=1, name='project1'),
             fakedb.Project(id=2, name='project2'),
             fakedb.Project(id=3, name='project3'),

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -35,7 +35,7 @@ class BuildsetPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Buildset(id=13, reason='because I said so'),
             fakedb.SourceStamp(id=92),
             fakedb.SourceStamp(id=93),
@@ -59,7 +59,7 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=1),
             fakedb.Buildset(id=28),
             fakedb.BuildRequest(id=5, buildsetid=28, builderid=1),

--- a/master/buildbot/test/unit/data/test_schedulers.py
+++ b/master/buildbot/test/unit/data/test_schedulers.py
@@ -35,7 +35,7 @@ class SchedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=22, active=0),
             fakedb.Master(id=33, active=1),
             fakedb.Scheduler(id=13, name='some:scheduler'),
@@ -97,7 +97,7 @@ class SchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=22, active=0),
             fakedb.Master(id=33, active=1),
             fakedb.Scheduler(id=13, name='some:scheduler'),

--- a/master/buildbot/test/unit/data/test_sourcestamps.py
+++ b/master/buildbot/test/unit/data/test_sourcestamps.py
@@ -28,7 +28,7 @@ class SourceStampEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=13, branch='oak'),
             fakedb.Patch(
                 id=99,
@@ -81,7 +81,7 @@ class SourceStampsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Buildset(id=30, reason="foo", submitted_at=1300305712, results=-1),
             fakedb.SourceStamp(id=13),
             fakedb.SourceStamp(id=14),

--- a/master/buildbot/test/unit/data/test_steps.py
+++ b/master/buildbot/test/unit/data/test_steps.py
@@ -40,7 +40,7 @@ class StepEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
@@ -143,7 +143,7 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -33,7 +33,7 @@ class TestResultSetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Buildset(id=20),
             fakedb.Builder(id=88, name='b1'),
@@ -88,7 +88,7 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Buildset(id=20),
             fakedb.Builder(id=88, name='b1'),

--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -33,7 +33,7 @@ class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Worker(id=47, name='linux'),
             fakedb.Buildset(id=20),
             fakedb.Builder(id=88, name='b1'),

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -125,7 +125,7 @@ class WorkerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data(testData)
+        yield self.master.db.insert_test_data(testData)
 
     @defer.inlineCallbacks
     def test_get_existing(self):
@@ -209,7 +209,7 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         yield self.setUpEndpoint()
-        yield self.db.insert_test_data(testData)
+        yield self.master.db.insert_test_data(testData)
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -39,7 +39,6 @@ class BuilderMixin:
     def setUpBuilderMixin(self):
         self.factory = factory.BuildFactory()
         self.master = yield fakemaster.make_master(self, wantData=True)
-        self.mq = self.master.mq
 
     # returns a Deferred that returns None
     def makeBuilder(self, name="bldr", patch_random=False, noReconfig=False, **config_kwargs):

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -40,7 +40,6 @@ class BuilderMixin:
         self.factory = factory.BuildFactory()
         self.master = yield fakemaster.make_master(self, wantData=True)
         self.mq = self.master.mq
-        self.db = self.master.db
 
     # returns a Deferred that returns None
     def makeBuilder(self, name="bldr", patch_random=False, noReconfig=False, **config_kwargs):
@@ -525,7 +524,7 @@ class TestGetOldestRequestTime(TestReactorMixin, BuilderMixin, unittest.TestCase
             fakedb.BuildRequestClaim(brid=444, masterid=master_id, claimed_at=2501),
             fakedb.BuildRequest(id=555, submitted_at=2800, builderid=182, buildsetid=11),
         ]
-        yield self.db.insert_test_data(self.base_rows)
+        yield self.master.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
     def test_gort_unclaimed(self):
@@ -574,7 +573,7 @@ class TestGetNewestCompleteTime(TestReactorMixin, BuilderMixin, unittest.TestCas
             fakedb.BuildRequest(id=444, submitted_at=2500, builderid=78, buildsetid=11),
             fakedb.BuildRequestClaim(brid=444, masterid=master_id, claimed_at=2501),
         ]
-        yield self.db.insert_test_data(self.base_rows)
+        yield self.master.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
     def test_gnct_completed(self):
@@ -614,7 +613,7 @@ class TestGetHighestPriority(TestReactorMixin, BuilderMixin, unittest.TestCase):
             fakedb.BuildRequest(id=555, submitted_at=2500, builderid=78, buildsetid=11),
             fakedb.BuildRequestClaim(brid=555, masterid=master_id, claimed_at=2501),
         ]
-        yield self.db.insert_test_data(self.base_rows)
+        yield self.master.db.insert_test_data(self.base_rows)
 
     @defer.inlineCallbacks
     def test_ghp_unclaimed(self):
@@ -637,7 +636,7 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
         self.setup_test_reactor()
         yield self.setUpBuilderMixin()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Project(id=301, name='old_project'),
             fakedb.Project(id=302, name='new_project'),
         ])

--- a/master/buildbot/test/unit/process/test_users_users.py
+++ b/master/buildbot/test/unit/process/test_users_users.py
@@ -30,7 +30,6 @@ class UsersTests(TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
         self.test_sha = users.encrypt("cancer")
 
     @defer.inlineCallbacks
@@ -39,23 +38,23 @@ class UsersTests(TestReactorMixin, unittest.TestCase):
         for user in users_no_attrs:
             user.attributes = None
 
-        got_users = yield self.db.users.getUsers()
+        got_users = yield self.master.db.users.getUsers()
         self.assertEqual(got_users, users_no_attrs)
 
         for user in users:
-            got_user = yield self.db.users.getUser(user.uid)
+            got_user = yield self.master.db.users.getUser(user.uid)
             self.assertEqual(got_user, user)
 
     @defer.inlineCallbacks
     def test_createUserObject_no_src(self):
         yield users.createUserObject(self.master, "Tyler Durden", None)
-        got_users = yield self.db.users.getUsers()
+        got_users = yield self.master.db.users.getUsers()
         self.assertEqual(got_users, [])
 
     @defer.inlineCallbacks
     def test_createUserObject_unrecognized_src(self):
         yield users.createUserObject(self.master, "Tyler Durden", 'blah')
-        got_users = yield self.db.users.getUsers()
+        got_users = yield self.master.db.users.getUsers()
         self.assertEqual(got_users, [])
 
     @defer.inlineCallbacks
@@ -143,7 +142,7 @@ class UsersTests(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getUserContact_found(self):
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.User(uid=1, identifier='tdurden'),
             fakedb.UserInfo(uid=1, attr_type='svn', attr_data='tdurden'),
             fakedb.UserInfo(uid=1, attr_type='email', attr_data='tyler@mayhem.net'),
@@ -154,7 +153,7 @@ class UsersTests(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getUserContact_key_not_found(self):
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.User(uid=1, identifier='tdurden'),
             fakedb.UserInfo(uid=1, attr_type='svn', attr_data='tdurden'),
             fakedb.UserInfo(uid=1, attr_type='email', attr_data='tyler@mayhem.net'),

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -687,7 +687,7 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixi
     @defer.inlineCallbacks
     def test_extract_project_revision_no_build(self):
         yield self.insert_test_data([], SUCCESS)
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.BuildsetProperty(
                 buildsetid=98, property_name="event.change.id", property_value='["12345", "fakedb"]'
             ),

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -168,8 +168,7 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
         if extra_build_properties is None:
             extra_build_properties = {}
 
-        self.db = self.master.db
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=92),
             fakedb.Worker(id=13, name='wrkr'),
             fakedb.Buildset(id=98, results=results1, reason="testReason1"),
@@ -200,18 +199,18 @@ class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
             ),
         ])
         for build_id in (20, 21):
-            yield self.db.insert_test_data([
+            yield self.master.db.insert_test_data([
                 fakedb.BuildProperty(buildid=build_id, name="workername", value="wrkr"),
                 fakedb.BuildProperty(buildid=build_id, name="reason", value="because"),
             ])
 
             for name, value in extra_build_properties.items():
-                yield self.db.insert_test_data([
+                yield self.master.db.insert_test_data([
                     fakedb.BuildProperty(buildid=build_id, name=name, value=value),
                 ])
 
         if with_steps:
-            yield self.db.insert_test_data([
+            yield self.master.db.insert_test_data([
                 fakedb.Step(id=151, buildid=21, number=1, results=SUCCESS, name='first step'),
                 fakedb.Step(id=152, buildid=21, number=2, results=results2, name='second step'),
                 fakedb.Step(id=153, buildid=21, number=3, results=SUCCESS, name='third step'),

--- a/master/buildbot/test/unit/reporters/test_utils.py
+++ b/master/buildbot/test/unit/reporters/test_utils.py
@@ -47,8 +47,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 
     @defer.inlineCallbacks
     def setupDb(self):
-        self.db = self.master.db
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=92),
             fakedb.Worker(id=13, name='wrk'),
             fakedb.Buildset(id=97, results=SUCCESS, reason="testReason0"),
@@ -129,7 +128,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
             fakedb.SourceStamp(id=235, patchid=99),
         ])
         for _id in (20, 21):
-            yield self.db.insert_test_data([
+            yield self.master.db.insert_test_data([
                 fakedb.BuildProperty(buildid=_id, name="workername", value="wrk"),
                 fakedb.BuildProperty(buildid=_id, name="reason", value="because"),
                 fakedb.BuildProperty(buildid=_id, name="owner", value="him"),
@@ -573,7 +572,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     def test_getResponsibleUsersForBuildWithBadOwner(self):
         self.setUpLogging()
         yield self.setupDb()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.BuildProperty(buildid=20, name="owner", value=["him"]),
         ])
         res = yield utils.getResponsibleUsersForBuild(self.master, 20)
@@ -583,7 +582,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     @defer.inlineCallbacks
     def test_getResponsibleUsersForBuildWithOwners(self):
         yield self.setupDb()
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.BuildProperty(buildid=20, name="owners", value=["him", "her"]),
         ])
         res = yield utils.getResponsibleUsersForBuild(self.master, 20)
@@ -593,7 +592,7 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
     def test_get_responsible_users_for_buildset_with_owner(self):
         yield self.setupDb()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.BuildsetProperty(
                 buildsetid=98, property_name="owner", property_value='["buildset_owner", "fakedb"]'
             ),

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -233,9 +233,9 @@ class TestReconfigurableBaseScheduler(
         yield sched.startConsumingChanges(**kwargs)
 
         # check that it registered callbacks
-        self.assertEqual(len(self.mq.qrefs), 2)
+        self.assertEqual(len(self.master.mq.qrefs), 2)
 
-        qref = self.mq.qrefs[1]
+        qref = self.master.mq.qrefs[1]
         self.assertEqual(qref.filter, ('changes', None, 'new'))
 
         # invoke the callback with the change, and check the result
@@ -1072,9 +1072,9 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
         yield sched.startConsumingChanges(**kwargs)
 
         # check that it registered callbacks
-        self.assertEqual(len(self.mq.qrefs), 2)
+        self.assertEqual(len(self.master.mq.qrefs), 2)
 
-        qref = self.mq.qrefs[1]
+        qref = self.master.mq.qrefs[1]
         self.assertEqual(qref.filter, ('changes', None, 'new'))
 
         # invoke the callback with the change, and check the result

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -209,7 +209,7 @@ class TestReconfigurableBaseScheduler(
             assert changeid == 12934
             return defer.succeed(chdict)
 
-        self.db.changes.getChange = getChange
+        self.master.db.changes.getChange = getChange
 
         change = self.makeFakeChange(**change_kwargs)
         change.number = 12934
@@ -475,7 +475,7 @@ class TestReconfigurableBaseScheduler(
         sched = yield self.makeScheduler(name='n', builderNames=['b'])
         yield self.master.startService()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234),
             fakedb.Change(changeid=13, sourcestampid=234),
         ])
@@ -501,7 +501,7 @@ class TestReconfigurableBaseScheduler(
         sched = yield self.makeScheduler(name='n', builderNames=['c'])
         yield self.master.startService()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234),
             fakedb.Change(changeid=14, sourcestampid=234),
         ])
@@ -531,7 +531,7 @@ class TestReconfigurableBaseScheduler(
         )
         yield self.master.startService()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234, branch='dev1', project="linux"),
             fakedb.Change(changeid=14, sourcestampid=234, branch="dev1"),
         ])
@@ -563,7 +563,7 @@ class TestReconfigurableBaseScheduler(
         yield self.master.startService()
 
         # No codebaseGenerator means all changes have codebase == ''
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=10),
             fakedb.SourceStamp(id=11),
             fakedb.SourceStamp(id=12),
@@ -604,7 +604,7 @@ class TestReconfigurableBaseScheduler(
         sched = yield self.makeScheduler(name='n', builderNames=['b', 'c'], codebases=codebases)
         yield self.master.startService()
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=912),
             fakedb.SourceStamp(id=913),
             fakedb.SourceStamp(id=914),
@@ -1048,7 +1048,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
             assert changeid == 12934
             return defer.succeed(chdict)
 
-        self.db.changes.getChange = getChange
+        self.master.db.changes.getChange = getChange
 
         change = self.makeFakeChange(**change_kwargs)
         change.number = 12934
@@ -1310,7 +1310,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
     @defer.inlineCallbacks
     def test_addBuildsetForChanges_one_change(self):
         sched = yield self.makeScheduler(name='n', builderNames=['b'])
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234),
             fakedb.Change(changeid=13, sourcestampid=234),
         ])
@@ -1334,7 +1334,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
     @defer.inlineCallbacks
     def test_addBuildsetForChanges_properties(self):
         sched = yield self.makeScheduler(name='n', builderNames=['c'])
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234),
             fakedb.Change(changeid=14, sourcestampid=234),
         ])
@@ -1362,7 +1362,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
             builderNames=['c'],
             properties={'virtual_builder_name': Interpolate("myproject-%(src::branch)s")},
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=234, branch='dev1', project="linux"),
             fakedb.Change(changeid=14, sourcestampid=234, branch="dev1"),
         ])
@@ -1392,7 +1392,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
             name='n', builderNames=['b', 'c'], codebases={'cb': {'repository': 'http://repo'}}
         )
         # No codebaseGenerator means all changes have codebase == ''
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=10),
             fakedb.SourceStamp(id=11),
             fakedb.SourceStamp(id=12),
@@ -1431,7 +1431,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
         # Scheduler gets codebases that can be used to create extra sourcestamps
         # for repositories that have no changes
         sched = yield self.makeScheduler(name='n', builderNames=['b', 'c'], codebases=codebases)
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=912),
             fakedb.SourceStamp(id=913),
             fakedb.SourceStamp(id=914),

--- a/master/buildbot/test/unit/schedulers/test_basic.py
+++ b/master/buildbot/test/unit/schedulers/test_basic.py
@@ -111,7 +111,7 @@ class BaseBasicScheduler(
         chd['changeid'] = chd['number']
         sourcestampid = chd['number'] + 100
         del chd['number']
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Change(sourcestampid=sourcestampid, **chd),
             fakedb.SourceStamp(id=sourcestampid),
         ])
@@ -136,7 +136,7 @@ class BaseBasicScheduler(
             fakedb.Change(changeid=20),
         ])
 
-        yield self.db.schedulers.classifyChanges(self.SCHEDULERID, {20: True})
+        yield self.master.db.schedulers.classifyChanges(self.SCHEDULERID, {20: True})
 
         yield self.master.startService()
 
@@ -154,7 +154,7 @@ class BaseBasicScheduler(
             fakedb.SourceStamp(id=92),
             fakedb.Change(changeid=20),
         ])
-        yield self.db.schedulers.classifyChanges(self.SCHEDULERID, {20: True})
+        yield self.master.db.schedulers.classifyChanges(self.SCHEDULERID, {20: True})
 
         yield self.master.startService()
 
@@ -339,7 +339,7 @@ class SingleBranchScheduler(
         chd['changeid'] = chd['number']
         sourcestampid = chd['number'] + 100
         del chd['number']
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Change(sourcestampid=sourcestampid, **chd),
             fakedb.SourceStamp(id=sourcestampid),
         ])
@@ -432,7 +432,7 @@ class SingleBranchScheduler(
             codebases=self.codebases,
             createAbsoluteSourceStamps=True,
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.OBJECTID, name='test', class_name='SingleBranchScheduler')
         ])
         yield self.master.startService()
@@ -473,7 +473,7 @@ class SingleBranchScheduler(
             codebases=self.codebases,
             createAbsoluteSourceStamps=True,
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.OBJECTID, name='test', class_name='SingleBranchScheduler'),
             fakedb.ObjectState(
                 objectid=self.OBJECTID,
@@ -547,7 +547,7 @@ class SingleBranchScheduler(
         sched = yield self.makeFullScheduler(
             name='test', builderNames=['test'], branch='master', priority=8
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.OBJECTID, name='test', class_name='SingleBranchScheduler')
         ])
 

--- a/master/buildbot/test/unit/schedulers/test_dependent.py
+++ b/master/buildbot/test/unit/schedulers/test_dependent.py
@@ -143,7 +143,7 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
         yield self.master.startService()
 
         # announce a buildset with a matching name..
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(
                 id=93,
                 revision='555',
@@ -173,7 +173,7 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
             yield self.assertBuildsetSubscriptions([])
 
         # pretend that the buildset is finished
-        yield self.db.buildsets.completeBuildset(bsid=44, results=results)
+        yield self.master.db.buildsets.completeBuildset(bsid=44, results=results)
         self.sendBuildsetMessage(results=results, complete=True)
 
         # and check whether a buildset was added in response
@@ -213,7 +213,7 @@ class Dependent(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unit
         sched = yield self.makeScheduler()
 
         # insert some state, with more bsids than exist
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.SourceStamp(id=1234),
             fakedb.Buildset(id=11),
             fakedb.Buildset(id=13),

--- a/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_Nightly.py
@@ -109,7 +109,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unitte
         # fakedb.Change requires changeid instead of number
         chd['changeid'] = chd['number']
         del chd['number']
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Change(**chd),
             fakedb.SourceStamp(id=92),
         ])
@@ -234,7 +234,7 @@ class Nightly(scheduler.SchedulerMixin, TestReactorMixin, StateTestMixin, unitte
         yield self.mkch(number=19)
 
         # add a change classification
-        yield self.db.schedulers.classifyChanges(self.SCHEDULERID, {19: True})
+        yield self.master.db.schedulers.classifyChanges(self.SCHEDULERID, {19: True})
 
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/schedulers/test_timed_NightlyTriggerable.py
@@ -324,7 +324,7 @@ class NightlyTriggerable(
             '"branch": "br", "revision": "myrev"} ], {}, null, null ]'
         )
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
             fakedb.ObjectState(
                 objectid=self.SCHEDULERID, name='lastTrigger', value_json=value_json
@@ -360,7 +360,7 @@ class NightlyTriggerable(
             '[ { "cb": {"codebase": "cb", "project": "p", "repository": "r", '
             '"branch": "br", "revision": "myrev"} }, {}, null, null ]'
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
             fakedb.ObjectState(
                 objectid=self.SCHEDULERID, name='lastTrigger', value_json=value_json
@@ -391,7 +391,7 @@ class NightlyTriggerable(
             minute=[5],
             codebases={'cb': {'repository': 'annoying'}},
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
         ])
 
@@ -438,7 +438,7 @@ class NightlyTriggerable(
             minute=[5],
             codebases={'cb': {'repository': 'annoying'}},
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
         ])
 
@@ -471,7 +471,7 @@ class NightlyTriggerable(
             minute=[5],
             codebases={'cb': {'repository': 'annoying'}},
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
         ])
 
@@ -538,7 +538,7 @@ class NightlyTriggerable(
             '"branch": "br", "revision": "myrev"} ], '
             '{"testprop": ["test", "TEST"]}, null, null ]'
         )
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Object(id=self.SCHEDULERID, name='test', class_name='NightlyTriggerable'),
             fakedb.ObjectState(
                 objectid=self.SCHEDULERID, name='lastTrigger', value_json=value_json

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -905,7 +905,7 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin, unitt
         def getBuildset(bsid):
             return {"bsid": bsid}
 
-        self.db.buildsets.getBuildset = getBuildset
+        self.master.db.buildsets.getBuildset = getBuildset
 
         rbss = yield persp.perspective_try(*args, **kwargs)
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -100,13 +100,13 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
         self.master.caches = fakemaster.FakeCaches()
         self.secrets_manager = self.master.secrets_manager = SecretManager()
         yield self.secrets_manager.setServiceParent(self.master)
-        self.db = self.master.db = fakedb.FakeDBConnector(self.basedir, self, auto_upgrade=True)
-        yield self.db.set_master(self.master)
+        self.master.db = fakedb.FakeDBConnector(self.basedir, self, auto_upgrade=True)
+        yield self.master.db.set_master(self.master)
 
         @defer.inlineCallbacks
         def cleanup():
-            if self.db.pool is not None:
-                yield self.db.pool.stop()
+            if self.master.db.pool is not None:
+                yield self.master.db.pool.stop()
 
         self.addCleanup(cleanup)
 
@@ -137,7 +137,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
             log.msg("GOT HERE")
             raise exceptions.DatabaseNotReadyError()
 
-        self.db.setup = db_setup
+        self.master.db.setup = db_setup
 
         yield self.master.startService()
 
@@ -150,7 +150,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
         def db_setup():
             raise RuntimeError("oh noes")
 
-        self.db.setup = db_setup
+        self.master.db.setup = db_setup
 
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -110,8 +110,8 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, TestReactorMixin,
 
         self.addCleanup(cleanup)
 
-        self.mq = self.master.mq = fakemq.FakeMQConnector(self)
-        yield self.mq.setServiceParent(self.master)
+        self.master.mq = fakemq.FakeMQConnector(self)
+        yield self.master.mq.setServiceParent(self.master)
         self.data = self.master.data = fakedata.FakeDataConnector(self.master, self)
         yield self.data.setServiceParent(self.master)
 

--- a/master/buildbot/test/unit/util/test_codebase.py
+++ b/master/buildbot/test/unit/util/test_codebase.py
@@ -44,7 +44,6 @@ class TestAbsoluteSourceStampsMixin(
     def setUp(self):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantDb=True, wantData=True)
-        self.db = self.master.db
         self.object = FakeObject(self.master, self.codebases)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/www/test_endpointmatchers.py
+++ b/master/buildbot/test/unit/www/test_endpointmatchers.py
@@ -29,7 +29,6 @@ class EndpointBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):
         self.setup_test_reactor()
         self.master = yield self.make_master(url='h:/a/b/')
-        self.db = self.master.db
         self.matcher = self.makeMatcher()
         self.matcher.setAuthz(self.master.authz)
         yield self.insertData()
@@ -45,7 +44,7 @@ class EndpointBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def insertData(self):
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Builder(id=21, name="builder"),
             fakedb.SourceStamp(id=13, branch='secret'),
             fakedb.Master(id=1),

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -40,7 +40,6 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
     def setUpEndpoint(self):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
-        self.db = self.master.db
         self.mq = self.master.mq
         self.data = self.master.data
         self.matcher = pathmatch.Matcher()

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -40,7 +40,6 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
     def setUpEndpoint(self):
         self.setup_test_reactor()
         self.master = yield fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
-        self.mq = self.master.mq
         self.data = self.master.data
         self.matcher = pathmatch.Matcher()
 

--- a/master/buildbot/test/util/reporter.py
+++ b/master/buildbot/test/util/reporter.py
@@ -71,8 +71,7 @@ class ReporterTestMixin:
 
     @defer.inlineCallbacks
     def insert_buildrequest_new(self, insert_patch=False, **kwargs):
-        self.db = self.master.db
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.Master(id=92),
             fakedb.Worker(id=13, name='wrk'),
             fakedb.Builder(id=79, name='Builder0'),
@@ -83,7 +82,7 @@ class ReporterTestMixin:
 
         patchid = 99 if insert_patch else None
 
-        yield self.db.insert_test_data([
+        yield self.master.db.insert_test_data([
             fakedb.BuildsetSourceStamp(buildsetid=98, sourcestampid=234),
             fakedb.SourceStamp(
                 id=234,
@@ -110,7 +109,6 @@ class ReporterTestMixin:
     def insert_test_data(
         self, buildResults, finalResult, insertSS=True, parentPlan=False, insert_patch=False
     ):
-        self.db = self.master.db
         rows = [
             fakedb.Master(id=92),
             fakedb.Worker(id=13, name='wrk'),
@@ -213,7 +211,7 @@ class ReporterTestMixin:
             for k, v in self.reporter_test_props.items():
                 rows += [fakedb.BuildProperty(buildid=20 + i, name=k, value=v)]
 
-        yield self.db.insert_test_data(rows)
+        yield self.master.db.insert_test_data(rows)
 
         self.setup_fake_get_changes_for_build()
 

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -82,7 +82,6 @@ class SchedulerMixin(interfaces.InterfaceTests):
         yield self.master.db.insert_test_data(rows)
 
         # set up a fake master
-        self.db = self.master.db
         self.mq = self.master.mq
         yield scheduler.setServiceParent(self.master)
 
@@ -120,13 +119,13 @@ class SchedulerMixin(interfaces.InterfaceTests):
                 self.addedSourceStamps.append(kwargs)
                 return defer.succeed(300 + len(self.addedSourceStamps) - 1)
 
-            self.db.sourcestamps.addSourceStamp = fake_addSourceStamp
+            self.master.db.sourcestamps.addSourceStamp = fake_addSourceStamp
 
             def fake_addSourceStampSet():
                 self.addedSourceStampSets.append([])
                 return defer.succeed(400 + len(self.addedSourceStampSets) - 1)
 
-            self.db.sourcestamps.addSourceStampSet = fake_addSourceStampSet
+            self.master.db.sourcestamps.addSourceStampSet = fake_addSourceStampSet
 
         # patch methods to detect a failure to upcall the activate and
         # deactivate methods .. unless we're testing BaseScheduler
@@ -235,7 +234,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
         if builderNames is None:
             builderNames = self.sched.builderNames
         builderids = []
-        builders = yield self.db.builders.getBuilders()
+        builders = yield self.master.db.builders.getBuilders()
         for builderName in builderNames:
             for bldrDict in builders:
                 if builderName == bldrDict.name:

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -81,8 +81,6 @@ class SchedulerMixin(interfaces.InterfaceTests):
 
         yield self.master.db.insert_test_data(rows)
 
-        # set up a fake master
-        self.mq = self.master.mq
         yield scheduler.setServiceParent(self.master)
 
         if overrideBuildsetMethods:


### PR DESCRIPTION
Having duplicated members makes tests less consistent and thus it's harder to understand them.