### PR TITLE
process: Deprecate BuildFactory workdir callable support

### DIFF
--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -37,6 +37,7 @@ from buildbot.steps.shell import ShellCommand
 from buildbot.steps.shell import Test
 from buildbot.steps.source.cvs import CVS
 from buildbot.steps.source.svn import SVN
+from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     from buildbot.process.builder import Builder
@@ -75,6 +76,11 @@ class BuildFactory(util.ComparableMixin):
         b = self.buildClass(requests, builder)
         b.useProgress = self.useProgress
         b.workdir = self.workdir
+        if callable(self.workdir):
+            warn_deprecated(
+                '4.3.0',
+                'BuildFactory workdir callable support has been deprecated. Use renderables instead',
+            )
         b.setStepFactories(self.steps)
         return b
 

--- a/master/docs/manual/configuration/buildfactories.rst
+++ b/master/docs/manual/configuration/buildfactories.rst
@@ -76,10 +76,10 @@ The following attributes can be set on a build factory after it is created, e.g.
 
 :attr:`workdir`
     (defaults to 'build'): workdir given to every build step created by this factory as default.
-    The workdir can be overridden in a build step definition.
+    The workdir can be overridden in a build step definition. The workdir can be renderable.
 
-    If this attribute is set to a string, that string will be used for constructing the workdir (worker base + builder builddir + workdir).
-    The attribute can also be a Python callable, for more complex cases, as described in :ref:`Factory-Workdir-Functions`.
+    The attribute will be used for constructing the workdir (worker base + builder builddir +
+    workdir).
 
 .. _DynamicBuildFactories:
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -776,18 +776,13 @@ determines which steps to run. The skeleton of such a project would look like:
 Factory Workdir Functions
 -------------------------
 
-.. note::
-
-    While the factory workdir function is still supported, it is better to just use the fact that
-    workdir is a :index:`renderable <renderable>` attribute of a step. A Renderable has access to
-    much more contextual information and can also return a deferred. So you could say
-    ``build_factory.workdir = util.Interpolate("%(src:repository)s`` to achieve similar goal.
-
 It is sometimes helpful to have a build's workdir determined at runtime based on the parameters of
-the build. To accomplish this, set the ``workdir`` attribute of the build factory to a callable.
-That callable will be invoked with the list of :class:`SourceStamp` for the build, and should
-return the appropriate workdir. Note that the value must be returned immediately - Deferreds are
-not supported.
+the build. To accomplish this, set the ``workdir`` attribute of the build factory to a
+:index:`renderable <renderable>`.
+
+There is deprecated support for setting ``workdir`` to a callable. That callable will be invoked
+with the list of :class:`SourceStamp` for the build, and should return the appropriate workdir.
+Note that the value must be returned immediately - Deferreds are not supported.
 
 This can be useful, for example, in scenarios with multiple repositories submitting changes to
 Buildbot. In this case you likely will want to have a dedicated workdir per repository, since

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -46,6 +46,12 @@ The following methods of ``httpclientservice.HTTPClientService`` have been depre
 
 As a replacement, use ``httpclientservice.HTTPSession`` and call corresponding methods on it.
 
+Build factories
+===============
+
+``BuildFactory`` ``workdir`` attribute no longer supports callables. As a replacement, use a
+renderable instead.
+
 Database connectors
 ===================
 

--- a/newsfragments/buildfactory-builddir.removal
+++ b/newsfragments/buildfactory-builddir.removal
@@ -1,0 +1,1 @@
+BuildFactory workdir callable support has been deprecated. Use renderables instead.


### PR DESCRIPTION
It has already been deprecated in documentation.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
