### PR TITLE
Add Data API endpoint to retrieve triggered builds for a build

### DIFF
--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -547,6 +547,13 @@ types:
                 is:
                 - bbget: {bbtype: test_result_set}
 
+        /triggered_builds:
+            description: |
+                This selects all builds that have been triggered by this particular build
+            get:
+                is:
+                - bbget: {bbtype: build}
+
 /buildsets:
     description: This path selects all buildsets
     get:

--- a/master/buildbot/test/unit/data/test_builds.py
+++ b/master/buildbot/test/unit/data/test_builds.py
@@ -131,6 +131,49 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.master.data.updates.rebuildBuildrequest.assert_called_with(buildrequest)
 
 
+class BuildTriggeredBuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+    endpointClass = builds.BuildTriggeredBuildsEndpoint
+    resourceTypeClass = builds.Build
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpEndpoint()
+        yield self.master.db.insert_test_data([
+            fakedb.Master(id=88),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=77, name="b1"),
+            fakedb.BuildRequest(id=40, buildsetid=20, builderid=77),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=77),
+            fakedb.Worker(id=13, name='wrk'),
+            fakedb.Build(id=50, buildrequestid=41, masterid=88, builderid=77, workerid=13),
+            fakedb.Build(id=51, buildrequestid=40, masterid=88, builderid=77, workerid=13),
+            fakedb.Buildset(id=1000, parent_buildid=51),
+            fakedb.BuildRequest(id=1100, buildsetid=1000, builderid=77),
+            fakedb.BuildRequest(id=1101, buildsetid=1000, builderid=77),
+            fakedb.Build(id=1200, buildrequestid=1100, masterid=88, builderid=77, workerid=13),
+            fakedb.Build(id=1201, buildrequestid=1101, masterid=88, builderid=77, workerid=13),
+            fakedb.Buildset(id=1001, parent_buildid=51),
+            fakedb.BuildRequest(id=1110, buildsetid=1001, builderid=77),
+            fakedb.BuildRequest(id=1111, buildsetid=1001, builderid=77),
+            fakedb.Build(id=1210, buildrequestid=1110, masterid=88, builderid=77, workerid=13),
+            fakedb.Build(id=1211, buildrequestid=1111, masterid=88, builderid=77, workerid=13),
+        ])
+
+    @defer.inlineCallbacks
+    def test_get_not_existing(self):
+        builds = yield self.callGet(('builds', 50, 'triggered_builds'))
+        self.assertEqual(builds, [])
+
+    @defer.inlineCallbacks
+    def test_get(self):
+        builds = yield self.callGet(('builds', 51, 'triggered_builds'))
+
+        for build in builds:
+            self.validateData(build)
+
+        self.assertEqual(sorted([b['buildid'] for b in builds]), [1200, 1201, 1210, 1211])
+
+
 class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     endpointClass = builds.BuildsEndpoint
     resourceTypeClass = builds.Build

--- a/newsfragments/triggered-builds-rest.feature
+++ b/newsfragments/triggered-builds-rest.feature
@@ -1,0 +1,2 @@
+Added `builds/<buildid>/triggered_builds` Data API endpoint to retrieve all builds triggered by
+a particular build.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
