### PR TITLE
Add Data API endpoint to retrieve test results sets for commit range

### DIFF
--- a/master/buildbot/data/codebase_commits.py
+++ b/master/buildbot/data/codebase_commits.py
@@ -164,9 +164,9 @@ class CodebaseCommitsGraphEndpoint(base.Endpoint):
         if r is None:
             return None
         return {
-            'common': r[0],
-            'from1': r[1],
-            'from2': r[2],
+            'common': r.common_commit_id,
+            'from1': r.to1_commit_ids,
+            'from2': r.to2_commit_ids,
         }
 
 

--- a/master/buildbot/data/codebase_commits.py
+++ b/master/buildbot/data/codebase_commits.py
@@ -165,8 +165,8 @@ class CodebaseCommitsGraphEndpoint(base.Endpoint):
             return None
         return {
             'common': r.common_commit_id,
-            'from1': r.to1_commit_ids,
-            'from2': r.to2_commit_ids,
+            'to1': r.to1_commit_ids,
+            'to2': r.to2_commit_ids,
         }
 
 
@@ -177,7 +177,7 @@ class CodebaseCommitsGraph(base.ResourceType):
 
     class EntityType(types.Entity):
         common = types.Integer()
-        from1 = types.List(of=types.Integer())
-        from2 = types.List(of=types.Integer())
+        to1 = types.List(of=types.Integer())
+        to2 = types.List(of=types.Integer())
 
     entityType = EntityType(name)

--- a/master/buildbot/data/codebase_commits.py
+++ b/master/buildbot/data/codebase_commits.py
@@ -151,7 +151,9 @@ class CodebaseCommit(base.ResourceType):
 
 class CodebaseCommitsGraphEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = "/codebases/n:codebaseid/commits_common_parent/n:commitid1/n:commitid2"
+    pathPatterns = (
+        "/codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/commits_common_parent"
+    )
 
     @async_to_deferred
     async def get(self, resultSpec: base.ResultSpec, kwargs: Any) -> dict[str, Any] | None:

--- a/master/buildbot/test/unit/data/test_codebase_commits.py
+++ b/master/buildbot/test/unit/data/test_codebase_commits.py
@@ -140,7 +140,7 @@ class CodebaseCommitsGraphEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             'commits_common_parent',
         ))
 
-        self.assertEqual(r, {'common': 108, 'from1': [108, 119, 120], 'from2': [108, 109, 110]})
+        self.assertEqual(r, {'common': 108, 'to1': [108, 119, 120], 'to2': [108, 109, 110]})
 
 
 class CodebaseCommitTests(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/data/test_codebase_commits.py
+++ b/master/buildbot/test/unit/data/test_codebase_commits.py
@@ -131,7 +131,14 @@ class CodebaseCommitsGraphEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @async_to_deferred
     async def test_simple(self) -> None:
-        r = await self.callGet(('codebases', '13', 'commits_common_parent', '120', '110'))
+        r = await self.callGet((
+            'codebases',
+            '13',
+            'commit_range',
+            '120',
+            '110',
+            'commits_common_parent',
+        ))
 
         self.assertEqual(r, {'common': 108, 'from1': [108, 119, 120], 'from2': [108, 109, 110]})
 

--- a/master/buildbot/test/unit/data/test_test_result_sets.py
+++ b/master/buildbot/test/unit/data/test_test_result_sets.py
@@ -24,6 +24,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
+from buildbot.util.twisted import async_to_deferred
 
 
 class TestResultSetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -154,6 +155,101 @@ class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         for result in results:
             self.validateData(result)
         self.assertEqual([r['test_result_setid'] for r in results], [13, 14])
+
+
+class TestResultSetsFromCommitRangeEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+    endpointClass = test_result_sets.TestResultSetsFromCommitRangeEndpoint
+    resourceTypeClass = test_result_sets.TestResultSet
+
+    @async_to_deferred
+    async def setUp(self) -> None:  # type: ignore[override]
+        await self.setUpEndpoint()
+
+        master_id = fakedb.FakeDBConnector.MASTER_ID
+        await self.master.db.insert_test_data([
+            fakedb.Master(id=master_id),
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Project(id=100),
+            fakedb.Codebase(id=200, projectid=100),
+            fakedb.CodebaseCommit(id=300, codebaseid=200, revision='rev300'),
+            fakedb.CodebaseCommit(id=301, codebaseid=200, revision='rev301', parent_commitid=300),
+            fakedb.CodebaseCommit(id=302, codebaseid=200, revision='rev302', parent_commitid=301),
+            fakedb.CodebaseCommit(id=303, codebaseid=200, revision='rev303', parent_commitid=302),
+            fakedb.CodebaseCommit(id=304, codebaseid=200, revision='rev304', parent_commitid=303),
+            fakedb.Buildset(id=4000),
+            fakedb.Buildset(id=4010),
+            fakedb.Buildset(id=4020),
+            fakedb.Buildset(id=4021),
+            fakedb.Buildset(id=4040),
+            fakedb.SourceStamp(id=5000, revision='rev300'),
+            fakedb.SourceStamp(id=5010, revision='rev301'),
+            fakedb.SourceStamp(id=5020, revision='rev302'),
+            fakedb.SourceStamp(id=5040, revision='rev304'),
+            fakedb.BuildsetSourceStamp(id=6000, buildsetid=4000, sourcestampid=5000),
+            fakedb.BuildsetSourceStamp(id=6001, buildsetid=4010, sourcestampid=5010),
+            fakedb.BuildsetSourceStamp(id=6002, buildsetid=4020, sourcestampid=5020),
+            fakedb.BuildsetSourceStamp(id=6003, buildsetid=4021, sourcestampid=5020),
+            fakedb.BuildsetSourceStamp(id=6004, buildsetid=4040, sourcestampid=5040),
+            fakedb.Builder(id=400, name='b1'),
+            fakedb.BuildRequest(id=7000, buildsetid=4000, builderid=400),
+            fakedb.BuildRequest(id=7010, buildsetid=4010, builderid=400),
+            fakedb.BuildRequest(id=7020, buildsetid=4020, builderid=400),
+            fakedb.BuildRequest(id=7021, buildsetid=4021, builderid=400),
+            fakedb.BuildRequest(id=7040, buildsetid=4040, builderid=400),
+            fakedb.Build(
+                id=8000, buildrequestid=7000, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8010, buildrequestid=7010, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8020, buildrequestid=7020, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8021, buildrequestid=7021, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8040, buildrequestid=7040, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Step(id=9000, buildid=8000),
+            fakedb.Step(id=9010, buildid=8010),
+            fakedb.Step(id=9020, buildid=8020),
+            fakedb.Step(id=9021, buildid=8021),
+            fakedb.Step(id=9040, buildid=8040),
+            fakedb.TestResultSet(id=10000, builderid=400, buildid=8000, stepid=9000),
+            fakedb.TestResultSet(id=10010, builderid=400, buildid=8010, stepid=9010),
+            fakedb.TestResultSet(id=10020, builderid=400, buildid=8020, stepid=9020),
+            fakedb.TestResultSet(id=10021, builderid=400, buildid=8021, stepid=9021),
+            fakedb.TestResultSet(id=10040, builderid=400, buildid=8040, stepid=9040),
+        ])
+
+    @async_to_deferred
+    async def test_get_full_range(self) -> None:
+        results = await self.callGet((
+            'codebases',
+            200,
+            'commit_range',
+            300,
+            304,
+            'test_result_sets',
+        ))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual(
+            [r['test_result_setid'] for r in results], [10000, 10010, 10020, 10021, 10040]
+        )
+
+    @async_to_deferred
+    async def test_get_opposite_range(self) -> None:
+        results = await self.callGet((
+            'codebases',
+            200,
+            'commit_range',
+            304,
+            300,
+            'test_result_sets',
+        ))
+        self.assertEqual(results, [])
 
 
 class TestResultSet(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):

--- a/master/buildbot/test/unit/db/test_codebase_commits.py
+++ b/master/buildbot/test/unit/db/test_codebase_commits.py
@@ -19,6 +19,7 @@ from parameterized import parameterized
 from twisted.trial import unittest
 
 from buildbot.db import codebase_commits
+from buildbot.db.codebase_commits import CommonCommitInfo
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
@@ -78,14 +79,14 @@ class Tests(TestReactorMixin, unittest.TestCase):
         self.assertIsNone(r)
 
     @parameterized.expand([
-        ('same_commit', 110, 110, (110, [110], [110])),
-        ('same_branch1', 106, 110, (106, [106], [106, 107, 108, 109, 110])),
-        ('same_branch2', 110, 106, (106, [106, 107, 108, 109, 110], [106])),
-        ('different_branches', 110, 120, (108, [108, 109, 110], [108, 119, 120])),
+        ('same_commit', 110, 110, CommonCommitInfo(110, [110], [110])),
+        ('same_branch1', 106, 110, CommonCommitInfo(106, [106], [106, 107, 108, 109, 110])),
+        ('same_branch2', 110, 106, CommonCommitInfo(106, [106, 107, 108, 109, 110], [106])),
+        ('different_branches', 110, 120, CommonCommitInfo(108, [108, 109, 110], [108, 119, 120])),
     ])
     @async_to_deferred
     async def test_get_first_common_commit_with_ranges_does_same_c(
-        self, name: str, id1: int, id2: int, expected: tuple[int, list[int], list[int]]
+        self, name: str, id1: int, id2: int, expected: CommonCommitInfo
     ) -> None:
         r = await self.master.db.codebase_commits.get_first_common_commit_with_ranges(id1, id2)
         self.assertEqual(r, expected)

--- a/master/buildbot/test/unit/db/test_test_result_sets.py
+++ b/master/buildbot/test/unit/db/test_test_result_sets.py
@@ -20,6 +20,7 @@ from buildbot.db import test_result_sets
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
+from buildbot.util.twisted import async_to_deferred
 
 
 class Tests(TestReactorMixin, unittest.TestCase):
@@ -223,6 +224,71 @@ class Tests(TestReactorMixin, unittest.TestCase):
         with self.assertRaises(test_result_sets.TestResultSetAlreadyCompleted):
             yield self.db.test_result_sets.completeTestResultSet(92)
         self.flushLoggedErrors(test_result_sets.TestResultSetAlreadyCompleted)
+
+    @async_to_deferred
+    async def test_get_test_result_sets_for_commits(self) -> None:
+        master_id = fakedb.FakeDBConnector.MASTER_ID
+        await self.db.insert_test_data([
+            fakedb.Master(id=master_id),
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Project(id=100),
+            fakedb.Codebase(id=200, projectid=100),
+            fakedb.CodebaseCommit(id=300, codebaseid=200, revision='rev300'),
+            fakedb.CodebaseCommit(id=301, codebaseid=200, revision='rev301', parent_commitid=300),
+            fakedb.CodebaseCommit(id=302, codebaseid=200, revision='rev302', parent_commitid=301),
+            fakedb.CodebaseCommit(id=303, codebaseid=200, revision='rev303', parent_commitid=302),
+            fakedb.CodebaseCommit(id=304, codebaseid=200, revision='rev304', parent_commitid=303),
+            fakedb.Buildset(id=4000),
+            fakedb.Buildset(id=4010),
+            fakedb.Buildset(id=4020),
+            fakedb.Buildset(id=4021),
+            fakedb.Buildset(id=4040),
+            fakedb.SourceStamp(id=5000, revision='rev300'),
+            fakedb.SourceStamp(id=5010, revision='rev301'),
+            fakedb.SourceStamp(id=5020, revision='rev302'),
+            fakedb.SourceStamp(id=5040, revision='rev304'),
+            fakedb.BuildsetSourceStamp(id=6000, buildsetid=4000, sourcestampid=5000),
+            fakedb.BuildsetSourceStamp(id=6001, buildsetid=4010, sourcestampid=5010),
+            fakedb.BuildsetSourceStamp(id=6002, buildsetid=4020, sourcestampid=5020),
+            fakedb.BuildsetSourceStamp(id=6003, buildsetid=4021, sourcestampid=5020),
+            fakedb.BuildsetSourceStamp(id=6004, buildsetid=4040, sourcestampid=5040),
+            fakedb.Builder(id=400, name='b1'),
+            fakedb.BuildRequest(id=7000, buildsetid=4000, builderid=400),
+            fakedb.BuildRequest(id=7010, buildsetid=4010, builderid=400),
+            fakedb.BuildRequest(id=7020, buildsetid=4020, builderid=400),
+            fakedb.BuildRequest(id=7021, buildsetid=4021, builderid=400),
+            fakedb.BuildRequest(id=7040, buildsetid=4040, builderid=400),
+            fakedb.Build(
+                id=8000, buildrequestid=7000, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8010, buildrequestid=7010, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8020, buildrequestid=7020, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8021, buildrequestid=7021, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Build(
+                id=8040, buildrequestid=7040, masterid=master_id, builderid=400, workerid=47
+            ),
+            fakedb.Step(id=9000, buildid=8000),
+            fakedb.Step(id=9010, buildid=8010),
+            fakedb.Step(id=9020, buildid=8020),
+            fakedb.Step(id=9021, buildid=8021),
+            fakedb.Step(id=9040, buildid=8040),
+            fakedb.TestResultSet(id=10000, builderid=400, buildid=8000, stepid=9000),
+            fakedb.TestResultSet(id=10010, builderid=400, buildid=8010, stepid=9010),
+            fakedb.TestResultSet(id=10020, builderid=400, buildid=8020, stepid=9020),
+            fakedb.TestResultSet(id=10021, builderid=400, buildid=8021, stepid=9021),
+            fakedb.TestResultSet(id=10040, builderid=400, buildid=8040, stepid=9040),
+        ])
+
+        sets = await self.db.test_result_sets.get_test_result_sets_for_commits(
+            commit_ids=[300, 301, 302, 303, 304]
+        )
+        self.assertEqual([set.id for set in sets], [10000, 10010, 10020, 10021, 10040])
 
     @defer.inlineCallbacks
     def test_complete_set_with_test_counts(self):


### PR DESCRIPTION
This is experimental endpoint for now, so no documentation or release notes have been added.