### PR TITLE
Add sphinx.configuration key to fix ReadTheDocs build

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -8,3 +8,6 @@ build:
 python:
     install:
         - requirements: requirements-readthedocs.txt
+
+sphinx:
+    configuration: master/docs/conf.py


### PR DESCRIPTION
See also:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
