### PR TITLE
www/data-module: Simplify paths used to fetch subresources

### DIFF
--- a/www/console_view/src/views/ConsoleView/ConsoleView.test.ts
+++ b/www/console_view/src/views/ConsoleView/ConsoleView.test.ts
@@ -25,7 +25,7 @@ type TestBuilder = {
 }
 
 function testBuilderToReal(b: TestBuilder) {
-  return new Builder(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Builder(undefined as unknown as IDataAccessor, {
     builderid: b.builderid,
     description: "desc",
     masterids: [1],

--- a/www/console_view/src/views/ConsoleView/ConsoleView.tsx
+++ b/www/console_view/src/views/ConsoleView/ConsoleView.tsx
@@ -205,7 +205,7 @@ function resolveFakeChange(codebase: string, revision: string, whenTimestamp: nu
   }
 
   const newChange = {
-    change: new Change(undefined as unknown as IDataAccessor, "a/1", {
+    change: new Change(undefined as unknown as IDataAccessor, {
       changeid: 0,
       author: "",
       branch: "",

--- a/www/data-module/src/data/BasicDataMultiCollection.test.ts
+++ b/www/data-module/src/data/BasicDataMultiCollection.test.ts
@@ -22,8 +22,8 @@ class TestParentClass extends BaseClass {
   parentdata: string = "";
   parentid: number = 0;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.parentid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "parents", String(object.parentid));
     this.update(object);
   }
 
@@ -52,8 +52,8 @@ class ParentDescriptor implements IDataDescriptor<TestParentClass> {
   restArrayField = "parents";
   fieldId: string = "parentid";
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestParentClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestParentClass(accessor, object);
   }
 }
 
@@ -63,8 +63,8 @@ class TestDataClass extends BaseClass {
   testdata: string = "";
   testid: number = 0;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.testid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "tests", String(object.testid));
     this.update(object);
   }
 
@@ -85,8 +85,8 @@ class TestDescriptor implements IDataDescriptor<TestDataClass> {
   restArrayField = "tests";
   fieldId: string = "testid";
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestDataClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestDataClass(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/DataClient.test.ts
+++ b/www/data-module/src/data/DataClient.test.ts
@@ -21,8 +21,8 @@ class TestDataClass extends BaseClass {
   testdata!: string;
   testid!: number;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.testid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "tests", String(object.testid));
     this.update(object);
   }
 
@@ -43,8 +43,8 @@ class TestDescriptor implements IDataDescriptor<TestDataClass> {
   restArrayField = "tests";
   fieldId: string = 'testid';
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestDataClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestDataClass(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/DataCollection.test.ts
+++ b/www/data-module/src/data/DataCollection.test.ts
@@ -18,8 +18,8 @@ class TestDataClass extends BaseClass {
   testdata: string = '';
   testid: number = 0;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.testid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "tests", String(object.testid));
     this.update(object);
   }
 
@@ -33,8 +33,8 @@ class TestDescriptor implements IDataDescriptor<TestDataClass> {
   restArrayField = "tests";
   fieldId: string = 'testid';
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestDataClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestDataClass(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/DataCollection.ts
+++ b/www/data-module/src/data/DataCollection.ts
@@ -186,7 +186,7 @@ export class DataCollection<DataType extends BaseClass> implements IDataCollecti
     }
 
     // add items that are not filtered out
-    const instance = this.descriptor.parse(this.accessor, this.endpoint, element);
+    const instance = this.descriptor.parse(this.accessor, element);
     this.byId.set(instance.id, instance);
     this.array.push(instance);
   }

--- a/www/data-module/src/data/DataMultiCollection.test.ts
+++ b/www/data-module/src/data/DataMultiCollection.test.ts
@@ -21,8 +21,8 @@ class TestParentClass extends BaseClass {
   parentdata: string = '';
   parentid: number = 0;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.parentid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "parents", String(object.parentid));
     this.update(object);
   }
 
@@ -51,8 +51,8 @@ class ParentDescriptor implements IDataDescriptor<TestParentClass> {
   restArrayField = "parents";
   fieldId: string = 'parentid';
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestParentClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestParentClass(accessor, object);
   }
 }
 
@@ -62,8 +62,8 @@ class TestDataClass extends BaseClass {
   testdata: string = '';
   testid: number = 0;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.testid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "tests", String(object.testid));
     this.update(object);
   }
 
@@ -84,8 +84,8 @@ class TestDescriptor implements IDataDescriptor<TestDataClass> {
   restArrayField = "tests";
   fieldId: string = 'testid';
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestDataClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestDataClass(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/DataPropertiesCollection.test.ts
+++ b/www/data-module/src/data/DataPropertiesCollection.test.ts
@@ -21,8 +21,8 @@ class TestDataClass extends BaseClass {
   testdata: string = '';
   testid: number = 0;
 
-  constructor(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.testid));
+  constructor(accessor: BaseDataAccessor, object: any) {
+    super(accessor, "tests", String(object.testid));
     this.update(object);
   }
 
@@ -51,8 +51,8 @@ class TestDescriptor implements IDataDescriptor<TestDataClass> {
   restArrayField = "tests";
   fieldId: string = 'testid';
 
-  parse(accessor: BaseDataAccessor, endpoint: string, object: any) {
-    return new TestDataClass(accessor, endpoint, object);
+  parse(accessor: BaseDataAccessor, object: any) {
+    return new TestDataClass(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/DataUtils.test.ts
+++ b/www/data-module/src/data/DataUtils.test.ts
@@ -16,7 +16,6 @@ import {
   restPath,
   socketPath,
   socketPathRE,
-  type
 } from "./DataUtils";
 
 describe('Data utils service', function() {
@@ -28,17 +27,6 @@ describe('Data utils service', function() {
 
       result = capitalize('t');
       expect(result).toBe('T');
-    })
-  );
-
-  describe('type(arg)', () =>
-
-    it('should return the type of the parameter endpoint', function() {
-      let result = type('asd/1');
-      expect(result).toBe('asd');
-
-      result = type('asd/1/bnm');
-      expect(result).toBe('bnm');
     })
   );
 

--- a/www/data-module/src/data/DataUtils.test.ts
+++ b/www/data-module/src/data/DataUtils.test.ts
@@ -14,7 +14,6 @@ import {
   numberOrString,
   parse,
   restPath,
-  singularType,
   socketPath,
   socketPathRE,
   type
@@ -40,17 +39,6 @@ describe('Data utils service', function() {
 
       result = type('asd/1/bnm');
       expect(result).toBe('bnm');
-    })
-  );
-
-  describe('singularType(arg)', () =>
-
-    it('should return the singular the type name of the parameter endpoint', function() {
-      let result = singularType('tests/1');
-      expect(result).toBe('test');
-
-      result = singularType('tests');
-      expect(result).toBe('test');
     })
   );
 

--- a/www/data-module/src/data/DataUtils.ts
+++ b/www/data-module/src/data/DataUtils.ts
@@ -21,24 +21,6 @@ export function copyOrSplit(arrayOrString: any) : string[] {
   }
 }
 
-// returns the type of the endpoint
-export function type(arg: string|string[]) {
-  let a = copyOrSplit(arg);
-  a = a.filter(e => e !== '*');
-  if (a.length === 0) {
-    throw Error("Parameter is empty array");
-  }
-  // if the argument count is even, the last argument is an id
-  if ((a.length % 2) === 0) {
-    a.pop();
-  }
-  let type = a.pop();
-  if (type === "contents") {
-    type = "logchunks";
-  }
-  return type!;
-}
-
 export function socketPath(arg: string | string[]) {
   const a = copyOrSplit(arg);
   // if the argument count is even, the last argument is an id

--- a/www/data-module/src/data/DataUtils.ts
+++ b/www/data-module/src/data/DataUtils.ts
@@ -39,25 +39,6 @@ export function type(arg: string|string[]) {
   return type!;
 }
 
-// singularize the type name
-export function singularType(arg: string | string[]) {
-  return type(arg).replace(/s$/, '');
-}
-
-export function className(arg: string | string[]) {
-  return capitalize(singularType(arg));
-}
-
-export function classId(arg: string | string[]) {
-  if (singularType(arg) === "forcescheduler") {
-    return "name";
-  }
-  if (singularType(arg) === "buildset") {
-    return "bsid";
-  }
-  return singularType(arg) + "id";
-}
-
 export function socketPath(arg: string | string[]) {
   const a = copyOrSplit(arg);
   // if the argument count is even, the last argument is an id

--- a/www/data-module/src/data/classes/BaseClass.ts
+++ b/www/data-module/src/data/classes/BaseClass.ts
@@ -5,7 +5,6 @@
   Copyright Buildbot Team Members
 */
 
-import {type} from "../DataUtils";
 import {IDataAccessor} from "../DataAccessor";
 import {IDataDescriptor} from "./DataDescriptor";
 import {ControlParams, RequestQuery} from "../DataQuery";
@@ -21,11 +20,6 @@ export class BaseClass {
     this.accessor = accessor;
     this.id = id;
     this.endpoint = endpoint;
-
-    // reset endpoint to base
-    if (this.id !== null) {
-      this.endpoint = type(this.endpoint);
-    }
   }
 
   update(object: any) {

--- a/www/data-module/src/data/classes/Build.ts
+++ b/www/data-module/src/data/classes/Build.ts
@@ -29,8 +29,8 @@ export class Build extends BaseClass {
   @observable results!: number|null;
   @observable properties!: {[key: string]: any}; // for subscription to properties use getProperties()
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.buildid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "builds", String(object.buildid));
     this.update(object);
     makeObservable(this);
   }
@@ -94,8 +94,8 @@ export class BuildDescriptor implements IDataDescriptor<Build> {
   restArrayField = "builds";
   fieldId: string = "buildid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Build(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Build(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Builder.ts
+++ b/www/data-module/src/data/classes/Builder.ts
@@ -27,8 +27,8 @@ export class Builder extends BaseClass {
   @observable tags!: string[];
   @observable projectid!: string|null;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.builderid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "builders", String(object.builderid));
     this.update(object);
     makeObservable(this);
   }
@@ -88,8 +88,8 @@ export class BuilderDescriptor implements IDataDescriptor<Builder> {
   restArrayField = "builders";
   fieldId: string = "builderid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Builder(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Builder(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Buildrequest.ts
+++ b/www/data-module/src/data/classes/Buildrequest.ts
@@ -27,8 +27,8 @@ export class Buildrequest extends BaseClass {
   @observable submitted_at!: number;
   @observable waited_for!: boolean;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.buildrequestid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "buildrequests", String(object.buildrequestid));
     this.update(object);
     makeObservable(this);
   }
@@ -84,8 +84,8 @@ export class BuildrequestDescriptor implements IDataDescriptor<Buildrequest> {
   restArrayField = "buildrequests";
   fieldId: string = "buildrequestid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Buildrequest(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Buildrequest(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Buildset.ts
+++ b/www/data-module/src/data/classes/Buildset.ts
@@ -37,8 +37,8 @@ export class Buildset extends BaseClass {
   @observable sourcestamps!: BuildsetSourcestamps[];
   @observable submitted_at!: number|null;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.bsid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "buildsets", String(object.bsid));
     this.update(object);
     makeObservable(this);
   }
@@ -86,8 +86,8 @@ export class BuildsetDescriptor implements IDataDescriptor<Buildset> {
   restArrayField = "buildsets";
   fieldId: string = "bsid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Buildset(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Buildset(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Change.ts
+++ b/www/data-module/src/data/classes/Change.ts
@@ -30,8 +30,8 @@ export class Change extends BaseClass {
   @observable sourcestamp!: Sourcestamp;
   @observable when_timestamp!: number;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.changeid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "changes", String(object.changeid));
     this.update(object);
     makeObservable(this);
   }
@@ -91,8 +91,8 @@ export class ChangeDescriptor implements IDataDescriptor<Change> {
   restArrayField = "changes";
   fieldId: string = "changeid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Change(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Change(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Changesource.ts
+++ b/www/data-module/src/data/classes/Changesource.ts
@@ -18,8 +18,8 @@ export class Changesource extends BaseClass {
   @observable master!: any; // FIXME
   @observable name!: string;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.changesourceid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "changesources", String(object.changesourceid));
     this.update(object);
     makeObservable(this);
   }
@@ -47,8 +47,8 @@ export class ChangesourceDescriptor implements IDataDescriptor<Changesource> {
   restArrayField = "changesources";
   fieldId: string = "changesourceid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Changesource(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Changesource(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Codebase.ts
+++ b/www/data-module/src/data/classes/Codebase.ts
@@ -19,8 +19,8 @@ export class Codebase extends BaseClass {
   @observable slug!: string;
   @observable projectid!: number;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.codebaseid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "codebases", String(object.codebaseid));
     this.update(object);
     makeObservable(this);
   }
@@ -58,8 +58,8 @@ export class CodebaseDescriptor implements IDataDescriptor<Codebase> {
   restArrayField = "codebases";
   fieldId: string = "codebaseid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Codebase(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Codebase(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/CodebaseBranch.ts
+++ b/www/data-module/src/data/classes/CodebaseBranch.ts
@@ -17,8 +17,8 @@ export class CodebaseBranch extends BaseClass {
   @observable commitid!: number;
   @observable last_timestamp!: number;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.branchid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "branches", String(object.branchid));
     this.update(object);
     makeObservable(this);
   }
@@ -47,8 +47,8 @@ export class CodebaseBranchDescriptor implements IDataDescriptor<CodebaseBranch>
   restArrayField = "branches";
   fieldId: string = "branchid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new CodebaseBranch(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new CodebaseBranch(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/CodebaseCommit.ts
+++ b/www/data-module/src/data/classes/CodebaseCommit.ts
@@ -20,8 +20,8 @@ export class CodebaseCommit extends BaseClass {
   @observable revision!: string;
   @observable parent_commitid!: number|null;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.commitid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "commits", String(object.commitid));
     this.update(object);
     makeObservable(this);
   }
@@ -55,8 +55,8 @@ export class CodebaseCommitDescriptor implements IDataDescriptor<CodebaseCommit>
   restArrayField = "commits";
   fieldId: string = "commitid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new CodebaseCommit(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new CodebaseCommit(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/DataDescriptor.ts
+++ b/www/data-module/src/data/classes/DataDescriptor.ts
@@ -13,5 +13,5 @@ export interface IAnyDataDescriptor {
 
 export interface IDataDescriptor<T> extends IAnyDataDescriptor {
   fieldId: string;
-  parse(accessor: IDataAccessor, endpoint: string, object: any): T;
+  parse(accessor: IDataAccessor, object: any): T;
 }

--- a/www/data-module/src/data/classes/Forcescheduler.ts
+++ b/www/data-module/src/data/classes/Forcescheduler.ts
@@ -81,8 +81,8 @@ export class Forcescheduler extends BaseClass {
   @observable label!: string;
   @observable tooltip!: string;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, object.name);
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "forceschedulers", object.name);
     this.update(object);
     makeObservable(this);
   }
@@ -116,8 +116,8 @@ export class ForceschedulerDescriptor implements IDataDescriptor<Forcescheduler>
   restArrayField = "forceschedulers";
   fieldId: string = "name";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Forcescheduler(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Forcescheduler(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Log.ts
+++ b/www/data-module/src/data/classes/Log.ts
@@ -20,8 +20,8 @@ export class Log extends BaseClass {
   @observable stepid!: number;
   @observable type!: string;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.logid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "logs", String(object.logid));
     this.update(object);
     makeObservable(this);
   }
@@ -57,8 +57,8 @@ export class LogDescriptor implements IDataDescriptor<Log> {
   restArrayField = "logs";
   fieldId: string = "logid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Log(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Log(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Master.ts
+++ b/www/data-module/src/data/classes/Master.ts
@@ -17,8 +17,8 @@ export class Master extends BaseClass {
   @observable last_active!: number|null;
   @observable name!: string;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.masterid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "masters", String(object.masterid));
     this.update(object);
     makeObservable(this);
   }
@@ -48,8 +48,8 @@ export class MasterDescriptor implements IDataDescriptor<Master> {
   restArrayField = "masters";
   fieldId: string = "masterid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Master(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Master(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Project.ts
+++ b/www/data-module/src/data/classes/Project.ts
@@ -22,8 +22,8 @@ export class Project extends BaseClass {
   @observable name!: string;
   @observable active!: boolean|null;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.projectid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "projects", String(object.projectid));
     this.update(object);
     makeObservable(this);
   }
@@ -65,8 +65,8 @@ export class ProjectDescriptor implements IDataDescriptor<Project> {
   restArrayField = "projects";
   fieldId: string = "projectid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Project(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Project(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Scheduler.ts
+++ b/www/data-module/src/data/classes/Scheduler.ts
@@ -24,8 +24,8 @@ export class Scheduler extends BaseClass {
   @observable master!: SchedulerMaster | null;
   @observable enabled!: boolean;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.schedulerid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "schedulers", String(object.schedulerid));
     this.update(object);
     makeObservable(this);
   }
@@ -55,8 +55,8 @@ export class SchedulerDescriptor implements IDataDescriptor<Scheduler> {
   restArrayField = "schedulers";
   fieldId: string = "schedulerid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Scheduler(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Scheduler(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Sourcestamp.ts
+++ b/www/data-module/src/data/classes/Sourcestamp.ts
@@ -21,8 +21,8 @@ export class Sourcestamp extends BaseClass {
   @observable repository!: string;
   @observable revision!: string|null;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.ssid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "sourcestamps", String(object.ssid));
     this.update(object);
     makeObservable(this);
   }
@@ -60,8 +60,8 @@ export class SourcestampDescriptor implements IDataDescriptor<Sourcestamp> {
   restArrayField = "sourcestamps";
   fieldId: string = "ssid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Sourcestamp(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Sourcestamp(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Step.ts
+++ b/www/data-module/src/data/classes/Step.ts
@@ -32,8 +32,8 @@ export class Step extends BaseClass {
   @observable state_string!: string;
   @observable urls!: StepUrl[];
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.stepid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "steps", String(object.stepid));
     this.update(object);
     makeObservable(this);
   }
@@ -87,8 +87,8 @@ export class StepDescriptor implements IDataDescriptor<Step> {
   restArrayField = "steps";
   fieldId: string = "stepid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Step(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Step(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/TestResult.ts
+++ b/www/data-module/src/data/classes/TestResult.ts
@@ -21,8 +21,10 @@ export class TestResult extends BaseClass {
   @observable line!: number|null;
   @observable value!: string;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.test_resultid));
+  constructor(accessor: IDataAccessor, object: any) {
+    // Note that the endpoint specified below is not valid. This is fine, as test results have
+    // no subresources.
+    super(accessor, "test_results", String(object.test_resultid));
     this.update(object);
     makeObservable(this);
   }
@@ -56,8 +58,8 @@ export class TestResultDescriptor implements IDataDescriptor<TestResult> {
   restArrayField = "test_results";
   fieldId: string = "test_resultid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new TestResult(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new TestResult(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/TestResultSet.ts
+++ b/www/data-module/src/data/classes/TestResultSet.ts
@@ -26,8 +26,8 @@ export class TestResultSet extends BaseClass {
   @observable tests_failed!: number|null;
   @observable complete!: boolean;
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.test_result_setid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "test_result_sets", String(object.test_result_setid));
     this.update(object);
     makeObservable(this);
   }
@@ -73,8 +73,8 @@ export class TestResultSetDescriptor implements IDataDescriptor<TestResultSet> {
   restArrayField = "test_result_sets";
   fieldId: string = "test_result_setid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new TestResultSet(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new TestResultSet(accessor, object);
   }
 }
 

--- a/www/data-module/src/data/classes/Worker.ts
+++ b/www/data-module/src/data/classes/Worker.ts
@@ -31,8 +31,8 @@ export class Worker extends BaseClass {
   @observable graceful!: boolean;
   @observable workerinfo!: {[key: string]: any};
 
-  constructor(accessor: IDataAccessor, endpoint: string, object: any) {
-    super(accessor, endpoint, String(object.workerid));
+  constructor(accessor: IDataAccessor, object: any) {
+    super(accessor, "workers", String(object.workerid));
     this.update(object);
     makeObservable(this);
   }
@@ -74,8 +74,8 @@ export class WorkerDescriptor implements IDataDescriptor<Worker> {
   restArrayField = "workers";
   fieldId: string = "workerid";
 
-  parse(accessor: IDataAccessor, endpoint: string, object: any) {
-    return new Worker(accessor, endpoint, object);
+  parse(accessor: IDataAccessor, object: any) {
+    return new Worker(accessor, object);
   }
 }
 

--- a/www/grid_view/package.json
+++ b/www/grid_view/package.json
@@ -37,6 +37,7 @@
     "buildbot-data-js": "link:../data-module",
     "buildbot-plugin-support": "link:../plugin_support",
     "buildbot-ui": "link:../ui",
+    "jsdom": "^25.0.0",
     "mobx": "^6.13.4",
     "mobx-react": "^9.1.1",
     "moment": "^2.29.4",

--- a/www/grid_view/src/views/GridView/GridView.test.ts
+++ b/www/grid_view/src/views/GridView/GridView.test.ts
@@ -74,7 +74,7 @@ type TestBuilderInfo = {
 };
 
 function testBuildsetToReal(bs: TestBuildset) {
-  return new Buildset(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Buildset(undefined as unknown as IDataAccessor, {
     bsid: bs.bsid,
     complete: false,
     complete_at: null,
@@ -98,7 +98,7 @@ function testBuildsetToReal(bs: TestBuildset) {
 };
 
 function testChangeToReal(c: TestChange) {
-  return new Change(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Change(undefined as unknown as IDataAccessor, {
     changeid: c.changeid,
     author: "author",
     branch: c.branch,
@@ -127,7 +127,7 @@ function testChangeToReal(c: TestChange) {
 }
 
 function testBuilderToReal(b: TestBuilder) {
-  return new Builder(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Builder(undefined as unknown as IDataAccessor, {
     builderid: b.builderid,
     description: "desc",
     masterids: [1],
@@ -137,7 +137,7 @@ function testBuilderToReal(b: TestBuilder) {
 }
 
 function testBuildrequestToReal(b: TestBuildrequest) {
-  return new Buildrequest(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Buildrequest(undefined as unknown as IDataAccessor, {
     buildrequestid: b.buildrequestid,
     builderid: b.builderid,
     buildsetid: b.buildsetid,
@@ -155,7 +155,7 @@ function testBuildrequestToReal(b: TestBuildrequest) {
 }
 
 function testBuildToReal(b: TestBuild) {
-  return new Build(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Build(undefined as unknown as IDataAccessor, {
     buildid: b.buildid,
     buildrequestid: b.buildrequestid,
     builderid: b.builderid,

--- a/www/grid_view/yarn.lock
+++ b/www/grid_view/yarn.lock
@@ -10,6 +10,17 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@asamuzakjp/css-color@^2.8.2":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-2.8.3.tgz#665f0f5e8edb95d8f543847529e30fe5cc437ef7"
+  integrity sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.1"
+    "@csstools/css-color-parser" "^3.0.7"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
@@ -169,6 +180,34 @@
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@csstools/color-helpers@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.0.1.tgz#829f1c76f5800b79c51c709e2f36821b728e0e10"
+  integrity sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==
+
+"@csstools/css-calc@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.1.tgz#a7dbc66627f5cf458d42aed14bda0d3860562383"
+  integrity sha512-rL7kaUnTkL9K+Cvo2pnCieqNpTKgQzy5f+N+5Iuko9HAoasP+xgprVh7KN/MaJVvVL1l0EzQq2MoqBHKSrDrag==
+
+"@csstools/css-color-parser@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.0.7.tgz#442d61d58e54ad258d52c309a787fceb33906484"
+  integrity sha512-nkMp2mTICw32uE5NN+EsJ4f5N+IGFeCFu4bGpiKgb2Pq/7J/MpyLBeQ5ry4KKtRFZaYs6sTmcMYrSRIyj5DFKA==
+  dependencies:
+    "@csstools/color-helpers" "^5.0.1"
+    "@csstools/css-calc" "^2.1.1"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz#74426e93bd1c4dcab3e441f5cc7ba4fb35d94356"
+  integrity sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz#a5502c8539265fecbd873c1e395a890339f119c2"
+  integrity sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==
 
 "@esbuild/aix-ppc64@0.21.5":
   version "0.21.5"
@@ -891,6 +930,11 @@
     loupe "^3.1.2"
     tinyrainbow "^2.0.0"
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
+  integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
+
 ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -1097,10 +1141,33 @@ core-js@^3.19.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.39.0.tgz#57f7647f4d2d030c32a72ea23a0555b2eaa30f83"
   integrity sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==
 
+cssstyle@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.2.1.tgz#5142782410fea95db66fb68147714a652a7c2381"
+  integrity sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==
+  dependencies:
+    "@asamuzakjp/css-color" "^2.8.2"
+    rrweb-cssom "^0.8.0"
+
 csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
+debug@4, debug@^4.3.4, debug@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@^4.1.0, debug@^4.3.1:
   version "4.3.7"
@@ -1109,12 +1176,10 @@ debug@^4.1.0, debug@^4.3.1:
   dependencies:
     ms "^2.1.3"
 
-debug@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
-  dependencies:
-    ms "^2.1.3"
+decimal.js@^10.4.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.5.0.tgz#0f371c7cf6c4898ce0afb09836db73cd82010f22"
+  integrity sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -1148,6 +1213,11 @@ electron-to-chromium@^1.5.41:
   version "1.5.50"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz#d9ba818da7b2b5ef1f3dd32bce7046feb7e93234"
   integrity sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==
+
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 es-module-lexer@^1.6.0:
   version "1.6.0"
@@ -1316,6 +1386,36 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 immutable@^4.0.0:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
@@ -1357,10 +1457,42 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+jsdom@^25.0.0:
+  version "25.0.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-25.0.1.tgz#536ec685c288fc8a5773a65f82d8b44badcc73ef"
+  integrity sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==
+  dependencies:
+    cssstyle "^4.1.0"
+    data-urls "^5.0.0"
+    decimal.js "^10.4.3"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.5"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.12"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.7.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.0.0"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
 
 jsesc@^3.0.2:
   version "3.0.2"
@@ -1397,6 +1529,11 @@ loupe@^3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
   integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
+
+lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -1505,10 +1642,22 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nwsapi@^2.2.12:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.16.tgz#177760bba02c351df1d2644e220c31dfec8cdb43"
+  integrity sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==
+
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+parse5@^7.1.2:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.1.tgz#8928f55915e6125f430cc44309765bf17556a33a"
+  integrity sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==
+  dependencies:
+    entities "^4.5.0"
 
 path-key@^3.0.0:
   version "3.1.1"
@@ -1586,6 +1735,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -1790,12 +1944,27 @@ rollup@^4.30.1:
     "@rollup/rollup-win32-x64-msvc" "4.34.6"
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz#c73451a484b86dd7cfb1e0b2898df4b703183e4b"
+  integrity sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==
+
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sass@^1.56.0:
   version "1.80.6"
@@ -1807,6 +1976,13 @@ sass@^1.56.0:
     source-map-js ">=0.6.2 <2.0.0"
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.23.2:
   version "0.23.2"
@@ -1859,6 +2035,11 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tiny-invariant@^1.1.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
@@ -1889,12 +2070,38 @@ tinyspy@^3.0.2:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
   integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
+tldts-core@^6.1.77:
+  version "6.1.77"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.77.tgz#0fa4563163a7a61d72c4b05650fb66fc7e815500"
+  integrity sha512-bCaqm24FPk8OgBkM0u/SrEWJgHnhBWYqeBo6yUmcZJDCHt/IfyWBb+14CXdGi4RInMv4v7eUAin15W0DoA+Ytg==
+
+tldts@^6.1.32:
+  version "6.1.77"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.77.tgz#714e3d1989e562886f2ed97b65e95a8e9f9e92d9"
+  integrity sha512-lBpoWgy+kYmuXWQ83+R7LlJCnsd9YW8DGpZSHhrMl4b8Ly/1vzOie3OdtmUJDkKxcgRGOehDu5btKkty+JEe+g==
+  dependencies:
+    tldts-core "^6.1.77"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tough-cookie@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.1.tgz#4641c1fdbf024927e29c5532edb7b6e5377ea1f2"
+  integrity sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==
+  dependencies:
+    tldts "^6.1.32"
+
+tr46@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.0.0.tgz#3b46d583613ec7283020d79019f1335723801cec"
+  integrity sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==
+  dependencies:
+    punycode "^2.3.1"
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -2057,6 +2264,13 @@ vscode-uri@^3.0.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
   integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
 
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
 warning@^4.0.0, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
@@ -2064,10 +2278,35 @@ warning@^4.0.0, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.6.2:
   version "3.6.20"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.1.1.tgz#ce71e240c61541315833b5cdafd139a479e47058"
+  integrity sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==
+  dependencies:
+    tr46 "^5.0.0"
+    webidl-conversions "^7.0.0"
 
 why-is-node-running@^2.3.0:
   version "2.3.0"
@@ -2076,6 +2315,21 @@ why-is-node-running@^2.3.0:
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
+
+ws@^8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 yallist@^3.0.2:
   version "3.1.1"

--- a/www/waterfall_view/src/views/WaterfallView/Utils.test.ts
+++ b/www/waterfall_view/src/views/WaterfallView/Utils.test.ts
@@ -29,7 +29,7 @@ type TestBuild = {
 
 
 function testBuildToReal(b: TestBuild) {
-  return new Build(undefined as unknown as IDataAccessor, 'a/1', {
+  return new Build(undefined as unknown as IDataAccessor, {
     buildid: b.buildid,
     buildrequestid: 100,
     builderid: b.builderid,


### PR DESCRIPTION
Currently subresources are fetched using full path of the parent resource. For example:

`/builders/s:buildername/builds/n:build_number/steps/n:step_number/logs`

However, in all cases in the current web frontend parent resources are always fetched. Additionally, parent resources are always available by database ID. This makes it possible to use the following path instead:

`/steps/n:stepid/logs`

This is not only more efficient, but also makes the frontend more flexible. Currently data API needed to support all possible subresources at all paths a parent resource could be accessed from. At high path depths the number of paths that needed to be supported would have exploded.