### PR TITLE
4.0 backports: Don't apply monkey patches on generic start

### DIFF
--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -72,8 +72,9 @@ def patch_config_for_unit_tests():
     set_is_in_unit_tests(True)
 
 
-def patch_all():
+def patch_all(for_tests=False):
+    if for_tests:
+        patch_testcase_timeout()
+        patch_config_for_unit_tests()
     patch_servicechecks()
-    patch_testcase_timeout()
     patch_decorators()
-    patch_config_for_unit_tests()

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -16,12 +16,11 @@
 
 from __future__ import annotations
 
+import enum
 from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python.constants import NamedConstant
-from twisted.python.constants import Names
 
 if TYPE_CHECKING:
     from buildbot.process.builder import Builder
@@ -29,13 +28,13 @@ if TYPE_CHECKING:
     from buildbot.worker.latent import AbstractLatentWorker
 
 
-class States(Names):
+class States(enum.Enum):
     # The worker isn't attached, or is in the process of attaching.
-    DETACHED = NamedConstant()
+    DETACHED = 0
     # The worker is available to build: either attached, or a latent worker.
-    AVAILABLE = NamedConstant()
+    AVAILABLE = 1
     # The worker is building.
-    BUILDING = NamedConstant()
+    BUILDING = 2
 
 
 class AbstractWorkerForBuilder:

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -33,7 +33,7 @@ from buildbot.warnings import DeprecatedApiWarning  # noqa pylint: disable=wrong
 [mock]
 
 # apply the same patches the buildmaster does when it starts
-monkeypatches.patch_all()
+monkeypatches.patch_all(for_tests=True)
 
 # enable deprecation warnings
 warnings.filterwarnings('always', category=DeprecationWarning)

--- a/newsfragments/fix-deprecation-warnings.bugfix
+++ b/newsfragments/fix-deprecation-warnings.bugfix
@@ -1,0 +1,1 @@
+Fixed deprecation warnings being raised as errors

--- a/newsfragments/twisted-python-constants.bugfix
+++ b/newsfragments/twisted-python-constants.bugfix
@@ -1,0 +1,1 @@
+Fixed compatibility with Twisted 24.11.0 due to ``twisted.python.constants`` module being moved.


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/8278 to 4.0.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8299.