### PR TITLE
4.0 backports: Add sphinx.configuration key to fix ReadTheDocs build

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -8,3 +8,6 @@ build:
 python:
     install:
         - requirements: requirements-readthedocs.txt
+
+sphinx:
+    configuration: master/docs/conf.py


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/8342 to 4.0.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8299.