### PR TITLE
3.11 backports: Don't apply monkey patches on generic start

### DIFF
--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -67,8 +67,9 @@ def patch_config_for_unit_tests():
     set_is_in_unit_tests(True)
 
 
-def patch_all():
+def patch_all(for_tests=False):
+    if for_tests:
+        patch_testcase_timeout()
+        patch_config_for_unit_tests()
     patch_servicechecks()
-    patch_testcase_timeout()
     patch_decorators()
-    patch_config_for_unit_tests()

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -29,7 +29,7 @@ from buildbot.warnings import DeprecatedApiWarning  # noqa pylint: disable=wrong
 [mock]
 
 # apply the same patches the buildmaster does when it starts
-monkeypatches.patch_all()
+monkeypatches.patch_all(for_tests=True)
 
 # enable deprecation warnings
 warnings.filterwarnings('always', category=DeprecationWarning)

--- a/newsfragments/fix-deprecation-warnings.bugfix
+++ b/newsfragments/fix-deprecation-warnings.bugfix
@@ -1,0 +1,1 @@
+Fixed deprecation warnings being raised as errors


### PR DESCRIPTION
This PR backports https://github.com/buildbot/buildbot/pull/8278 to 3.11.x.
Partial fix for https://github.com/buildbot/buildbot/issues/8298.