### PR TITLE
data: Convert ResourceType.eventPathPatterns to a list

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -26,6 +26,7 @@ from twisted.internet import defer
 
 from buildbot.data import exceptions
 from buildbot.util.twisted import async_to_deferred
+from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     from typing import Any
@@ -52,7 +53,7 @@ class ResourceType:
     name: str | None = None
     plural: str | None = None
     endpoints: list[type[Endpoint]] = []
-    eventPathPatterns = ""
+    eventPathPatterns: list[str] | str = []
     entityType: types.Type | None = None
 
     def __init__(self, master: BuildMaster):
@@ -60,10 +61,15 @@ class ResourceType:
         self.compileEventPathPatterns()
 
     def compileEventPathPatterns(self):
-        # We'll run a single format, and then split the string
-        # to get the final event path tuple
+        # We'll run a single format, to get the final event path tuple
         pathPatterns = self.eventPathPatterns
-        pathPatterns = pathPatterns.split()
+        if isinstance(pathPatterns, str):
+            pathPatterns = pathPatterns.split()
+            warn_deprecated(
+                '4.3.0',
+                'ResourceType.eventPathPatterns as a multiline string is deprecated. Use '
+                'eventPathPatterns as a list of strings instead.',
+            )
         identifiers = re.compile(r':([^/]*)')
         for i, pp in enumerate(pathPatterns):
             pp = identifiers.sub(r'{\1}', pp)

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -86,9 +86,9 @@ class Builder(base.ResourceType):
     name = "builder"
     plural = "builders"
     endpoints = [BuilderEndpoint, BuildersEndpoint]
-    eventPathPatterns = """
-        /builders/:builderid
-    """
+    eventPathPatterns = [
+        "/builders/:builderid",
+    ]
 
     class EntityType(types.Entity):
         builderid = types.Integer()

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -174,11 +174,11 @@ class BuildRequest(base.ResourceType):
     name = "buildrequest"
     plural = "buildrequests"
     endpoints = [BuildRequestEndpoint, BuildRequestsEndpoint]
-    eventPathPatterns = """
-        /buildsets/:buildsetid/builders/:builderid/buildrequests/:buildrequestid
-        /buildrequests/:buildrequestid
-        /builders/:builderid/buildrequests/:buildrequestid
-    """
+    eventPathPatterns = [
+        "/buildsets/:buildsetid/builders/:builderid/buildrequests/:buildrequestid",
+        "/buildrequests/:buildrequestid",
+        "/builders/:builderid/buildrequests/:buildrequestid",
+    ]
 
     class EntityType(types.Entity):
         buildrequestid = types.Integer()

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -211,11 +211,11 @@ class Build(base.ResourceType):
     name = "build"
     plural = "builds"
     endpoints = [BuildEndpoint, BuildsEndpoint, BuildTriggeredBuildsEndpoint]
-    eventPathPatterns = """
-        /builders/:builderid/builds/:number
-        /builds/:buildid
-        /workers/:workerid/builds/:buildid
-    """
+    eventPathPatterns = [
+        "/builders/:builderid/builds/:number",
+        "/builds/:buildid",
+        "/workers/:workerid/builds/:buildid",
+    ]
 
     class EntityType(types.Entity):
         buildid = types.Integer()

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -123,9 +123,9 @@ class Buildset(base.ResourceType):
     name = "buildset"
     plural = "buildsets"
     endpoints = [BuildsetEndpoint, BuildsetsEndpoint]
-    eventPathPatterns = """
-        /buildsets/:bsid
-    """
+    eventPathPatterns = [
+        "/buildsets/:bsid",
+    ]
 
     class EntityType(types.Entity):
         bsid = types.Integer()

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -132,9 +132,9 @@ class Change(base.ResourceType):
     name = "change"
     plural = "changes"
     endpoints = [ChangeEndpoint, ChangesEndpoint]
-    eventPathPatterns = """
-        /changes/:changeid
-    """
+    eventPathPatterns = [
+        "/changes/:changeid",
+    ]
 
     class EntityType(types.Entity):
         changeid = types.Integer()

--- a/master/buildbot/data/codebase_branches.py
+++ b/master/buildbot/data/codebase_branches.py
@@ -78,9 +78,9 @@ class CodebaseBranch(base.ResourceType):
     name = "branch"
     plural = "branches"
     endpoints = [CodebaseBranchEndpoint, CodebaseBranchesEndpoint]
-    eventPathPatterns = """
-        /branches/:branchid
-    """
+    eventPathPatterns = [
+        "/branches/:branchid",
+    ]
 
     class EntityType(types.Entity):
         branchid = types.Integer()

--- a/master/buildbot/data/codebase_commits.py
+++ b/master/buildbot/data/codebase_commits.py
@@ -99,10 +99,10 @@ class CodebaseCommit(base.ResourceType):
     name = "commit"
     plural = "commits"
     endpoints = [CodebaseCommitEndpoint, CodebaseCommitByRevisionEndpoint, CodebaseCommitsEndpoint]
-    eventPathPatterns = """
-        /commits/:commitid
-        /codebases/:codebaseid/commits/:commitid
-    """
+    eventPathPatterns = [
+        "/commits/:commitid",
+        "/codebases/:codebaseid/commits/:commitid",
+    ]
 
     class EntityType(types.Entity):
         commitid = types.Integer()

--- a/master/buildbot/data/codebases.py
+++ b/master/buildbot/data/codebases.py
@@ -84,9 +84,9 @@ class Codebase(base.ResourceType):
     name = "codebase"
     plural = "codebases"
     endpoints = [CodebaseEndpoint, CodebasesEndpoint]
-    eventPathPatterns = """
-        /codebases/:codebaseid
-    """
+    eventPathPatterns = [
+        "/codebases/:codebaseid",
+    ]
 
     class EntityType(types.Entity):
         codebaseid = types.Integer()

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -100,10 +100,10 @@ class Log(base.ResourceType):
     name = "log"
     plural = "logs"
     endpoints = [LogEndpoint, LogsEndpoint]
-    eventPathPatterns = """
-        /logs/:logid
-        /steps/:stepid/logs/:slug
-    """
+    eventPathPatterns = [
+        "/logs/:logid",
+        "/steps/:stepid/logs/:slug",
+    ]
 
     class EntityType(types.Entity):
         logid = types.Integer()

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -87,9 +87,9 @@ class Master(base.ResourceType):
     name = "master"
     plural = "masters"
     endpoints = [MasterEndpoint, MastersEndpoint]
-    eventPathPatterns = """
-        /masters/:masterid
-    """
+    eventPathPatterns = [
+        "/masters/:masterid",
+    ]
 
     class EntityType(types.Entity):
         masterid = types.Integer()

--- a/master/buildbot/data/projects.py
+++ b/master/buildbot/data/projects.py
@@ -85,9 +85,9 @@ class Project(base.ResourceType):
     name = "project"
     plural = "projects"
     endpoints = [ProjectEndpoint, ProjectsEndpoint]
-    eventPathPatterns = """
-        /projects/:projectid
-    """
+    eventPathPatterns = [
+        "/projects/:projectid",
+    ]
 
     class EntityType(types.Entity):
         projectid = types.Integer()

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -91,9 +91,9 @@ class Scheduler(base.ResourceType):
     name = "scheduler"
     plural = "schedulers"
     endpoints = [SchedulerEndpoint, SchedulersEndpoint]
-    eventPathPatterns = """
-        /schedulers/:schedulerid
-    """
+    eventPathPatterns = [
+        "/schedulers/:schedulerid",
+    ]
 
     class EntityType(types.Entity):
         schedulerid = types.Integer()

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -100,10 +100,10 @@ class Step(base.ResourceType):
     name = "step"
     plural = "steps"
     endpoints = [StepEndpoint, StepsEndpoint]
-    eventPathPatterns = """
-        /builds/:buildid/steps/:stepid
-        /steps/:stepid
-    """
+    eventPathPatterns = [
+        "/builds/:buildid/steps/:stepid",
+        "/steps/:stepid",
+    ]
 
     class EntityType(types.Entity):
         stepid = types.Integer()

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -136,9 +136,9 @@ class TestResultSet(base.ResourceType):
         TestResultSetsFromCommitRangeEndpoint,
         TestResultSetEndpoint,
     ]
-    eventPathPatterns = """
-        /test_result_sets/:test_result_setid
-    """
+    eventPathPatterns = [
+        "/test_result_sets/:test_result_setid",
+    ]
 
     class EntityType(types.Entity):
         test_result_setid = types.Integer()

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -68,9 +68,9 @@ class TestResult(base.ResourceType):
     name = "test_result"
     plural = "test_results"
     endpoints = [TestResultsEndpoint]
-    eventPathPatterns = """
-        /test_result_sets/:test_result_setid/results
-    """
+    eventPathPatterns = [
+        "/test_result_sets/:test_result_setid/results",
+    ]
 
     class EntityType(types.Entity):
         test_resultid = types.Integer()

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -121,9 +121,9 @@ class Worker(base.ResourceType):
     name = "worker"
     plural = "workers"
     endpoints = [WorkerEndpoint, WorkersEndpoint]
-    eventPathPatterns = """
-        /workers/:workerid
-    """
+    eventPathPatterns = [
+        "/workers/:workerid",
+    ]
 
     class EntityType(types.Entity):
         workerid = types.Integer()

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -22,6 +22,8 @@ from buildbot.data import base
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import endpoint
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class ResourceType(TestReactorMixin, unittest.TestCase):
@@ -59,7 +61,7 @@ class ResourceType(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_produceEvent(self):
         cls = self.makeResourceTypeSubclass(
-            name='singular', eventPathPatterns="/foo/:fooid/bar/:barid"
+            name='singular', eventPathPatterns=["/foo/:fooid/bar/:barid"]
         )
         master = yield fakemaster.make_master(self, wantMq=True)
         master.mq.verifyMessages = False  # since this is a pretend message
@@ -75,6 +77,19 @@ class ResourceType(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_compilePatterns(self):
         class MyResourceType(base.ResourceType):
+            eventPathPatterns = [
+                "/builder/:builderid/build/:number",
+                "/build/:buildid",
+            ]
+
+        master = yield fakemaster.make_master(self, wantMq=True)
+        master.mq.verifyMessages = False  # since this is a pretend message
+        inst = MyResourceType(master)
+        self.assertEqual(inst.eventPaths, ['builder/{builderid}/build/{number}', 'build/{buildid}'])
+
+    @defer.inlineCallbacks
+    def test_compilePatterns_multiline_string_deprecation(self):
+        class MyResourceType(base.ResourceType):
             eventPathPatterns = """
                 /builder/:builderid/build/:number
                 /build/:buildid
@@ -82,7 +97,11 @@ class ResourceType(TestReactorMixin, unittest.TestCase):
 
         master = yield fakemaster.make_master(self, wantMq=True)
         master.mq.verifyMessages = False  # since this is a pretend message
-        inst = MyResourceType(master)
+        with assertProducesWarnings(
+            DeprecatedApiWarning,
+            message_pattern='.*ResourceType.eventPathPatterns as a multiline string is deprecated.*',
+        ):
+            inst = MyResourceType(master)
         self.assertEqual(inst.eventPaths, ['builder/{builderid}/build/{number}', 'build/{buildid}'])
 
 

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -285,7 +285,7 @@ In ``master/buildbot/data/pubs.py``, create a subclass of :py:class:`ResourceTyp
 
     .. py:attribute:: eventPathPatterns
 
-        :type: str
+        :type: list of strings
 
         This attribute should list the message routes where events should be sent, encoded as a REST like endpoint:
 

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -99,3 +99,9 @@ Reporters
 The ``add_logs`` argument of ``BuildStatusGenerator``, ``BuildStartEndStatusGenerator`` and
 ``BuildSetStatusGenerator`` has been removed. As a replacement, set ``want_logs_content`` of the
 passed message formatter.
+
+Data API
+========
+
+The multiline string type of ``ResourceType.eventPathPatterns`` attribute has been deprecated. Use
+list of strings type instead.

--- a/newsfragments/convert-ResourceType-eventPathPatterns-to-list.removal
+++ b/newsfragments/convert-ResourceType-eventPathPatterns-to-list.removal
@@ -1,0 +1,1 @@
+ResourceType.eventPathPatterns as a multiline string has been deprecated. Use list of strings instead.


### PR DESCRIPTION
This commit makes specifying `eventPathPatterns` less complex, when `ResourceType.eventPathPatterns` is a list instead of a multiline string where each line represents a pattern.
Fixes #8339.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
