### PR TITLE
data: Convert Endpoint.PathPatterns to a list

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -127,7 +127,7 @@ class SubResource:
 
 
 class Endpoint:
-    pathPatterns = ""
+    pathPatterns: list[str] | str = []
     rootLinkName: str | None = None
     isPseudoCollection = False
     kind = EndpointKind.SINGLE
@@ -156,7 +156,9 @@ class Endpoint:
         return action_method(args, kwargs)
 
     def __repr__(self):
-        return "endpoint for " + ",".join(self.pathPatterns.split())
+        if isinstance(self.pathPatterns, str):
+            self.pathPatterns = self.pathPatterns.split()
+        return "endpoint for " + ",".join(self.pathPatterns)
 
 
 class NestedBuildDataRetriever:

--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -38,11 +38,11 @@ def _db2data(model: BuildDataModel):
 
 class BuildDatasNoValueEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /builders/n:builderid/builds/n:build_number/data
-        /builders/s:buildername/builds/n:build_number/data
-        /builds/n:buildid/data
-        """
+    pathPatterns = [
+        "/builders/n:builderid/builds/n:build_number/data",
+        "/builders/s:buildername/builds/n:build_number/data",
+        "/builds/n:buildid/data",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -58,11 +58,11 @@ class BuildDatasNoValueEndpoint(base.BuildNestingMixin, base.Endpoint):
 
 class BuildDataNoValueEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /builders/n:builderid/builds/n:build_number/data/i:name
-        /builders/s:buildername/builds/n:build_number/data/i:name
-        /builds/n:buildid/data/i:name
-    """
+    pathPatterns = [
+        "/builders/n:builderid/builds/n:build_number/data/i:name",
+        "/builders/s:buildername/builds/n:build_number/data/i:name",
+        "/builds/n:buildid/data/i:name",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -76,11 +76,11 @@ class BuildDataNoValueEndpoint(base.BuildNestingMixin, base.Endpoint):
 
 class BuildDataEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.RAW
-    pathPatterns = """
-        /builders/n:builderid/builds/n:build_number/data/i:name/value
-        /builders/s:buildername/builds/n:build_number/data/i:name/value
-        /builds/n:buildid/data/i:name/value
-    """
+    pathPatterns = [
+        "/builders/n:builderid/builds/n:build_number/data/i:name/value",
+        "/builders/s:buildername/builds/n:build_number/data/i:name/value",
+        "/builds/n:buildid/data/i:name/value",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -41,11 +41,11 @@ def _db2data(builder: BuilderModel):
 
 class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /builders/n:builderid
-        /builders/s:buildername
-        /masters/n:masterid/builders/n:builderid
-    """
+    pathPatterns = [
+        "/builders/n:builderid",
+        "/builders/s:buildername",
+        "/masters/n:masterid/builders/n:builderid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -65,12 +65,12 @@ class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
 class BuildersEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     rootLinkName = 'builders'
-    pathPatterns = """
-        /builders
-        /masters/n:masterid/builders
-        /projects/n:projectid/builders
-        /workers/n:workerid/builders
-    """
+    pathPatterns = [
+        "/builders",
+        "/masters/n:masterid/builders",
+        "/projects/n:projectid/builders",
+        "/workers/n:workerid/builders",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -97,9 +97,9 @@ class Db2DataMixin:
 
 class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /buildrequests/n:buildrequestid
-    """
+    pathPatterns = [
+        "/buildrequests/n:buildrequestid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec: ResultSpec, kwargs):
@@ -134,10 +134,10 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
 
 class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /buildrequests
-        /builders/n:builderid/buildrequests
-    """
+    pathPatterns = [
+        "/buildrequests",
+        "/builders/n:builderid/buildrequests",
+    ]
     rootLinkName = 'buildrequests'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -87,11 +87,11 @@ class Db2DataMixin:
 
 class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /builds/n:buildid
-        /builders/n:builderid/builds/n:build_number
-        /builders/s:buildername/builds/n:build_number
-    """
+    pathPatterns = [
+        "/builds/n:buildid",
+        "/builders/n:builderid/builds/n:build_number",
+        "/builders/s:buildername/builds/n:build_number",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -144,9 +144,9 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
 class BuildTriggeredBuildsEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /builds/n:buildid/triggered_builds
-    """
+    pathPatterns = [
+        "/builds/n:buildid/triggered_builds",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> list[dict[str, Any]]:
@@ -156,14 +156,14 @@ class BuildTriggeredBuildsEndpoint(Db2DataMixin, base.Endpoint):
 
 class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /builds
-        /builders/n:builderid/builds
-        /builders/s:buildername/builds
-        /buildrequests/n:buildrequestid/builds
-        /changes/n:changeid/builds
-        /workers/n:workerid/builds
-    """
+    pathPatterns = [
+        "/builds",
+        "/builders/n:builderid/builds",
+        "/builders/s:buildername/builds",
+        "/buildrequests/n:buildrequestid/builds",
+        "/changes/n:changeid/builds",
+        "/workers/n:workerid/builds",
+    ]
     rootLinkName = 'builds'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -86,9 +86,9 @@ class Db2DataMixin:
 
 class BuildsetEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /buildsets/n:bsid
-    """
+    pathPatterns = [
+        "/buildsets/n:bsid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -99,9 +99,9 @@ class BuildsetEndpoint(Db2DataMixin, base.Endpoint):
 
 class BuildsetsEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /buildsets
-    """
+    pathPatterns = [
+        "/buildsets",
+    ]
     rootLinkName = 'buildsets'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -81,9 +81,9 @@ class FixerMixin:
 
 class ChangeEndpoint(FixerMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /changes/n:changeid
-    """
+    pathPatterns = [
+        "/changes/n:changeid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -95,12 +95,12 @@ class ChangeEndpoint(FixerMixin, base.Endpoint):
 
 class ChangesEndpoint(FixerMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /changes
-        /builders/n:builderid/builds/n:build_number/changes
-        /builds/n:buildid/changes
-        /sourcestamps/n:ssid/changes
-    """
+    pathPatterns = [
+        "/changes",
+        "/builders/n:builderid/builds/n:build_number/changes",
+        "/builds/n:buildid/changes",
+        "/sourcestamps/n:ssid/changes",
+    ]
     rootLinkName = 'changes'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -44,10 +44,10 @@ class Db2DataMixin:
 
 
 class ChangeSourceEndpoint(Db2DataMixin, base.Endpoint):
-    pathPatterns = """
-        /changesources/n:changesourceid
-        /masters/n:masterid/changesources/n:changesourceid
-    """
+    pathPatterns = [
+        "/changesources/n:changesourceid",
+        "/masters/n:masterid/changesources/n:changesourceid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -60,10 +60,10 @@ class ChangeSourceEndpoint(Db2DataMixin, base.Endpoint):
 
 class ChangeSourcesEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /changesources
-        /masters/n:masterid/changesources
-    """
+    pathPatterns = [
+        "/changesources",
+        "/masters/n:masterid/changesources",
+    ]
     rootLinkName = 'changesources'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/codebase_branches.py
+++ b/master/buildbot/data/codebase_branches.py
@@ -47,9 +47,9 @@ branches_field_map = {
 
 class CodebaseBranchEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /branches/n:branchid
-    """
+    pathPatterns = [
+        "/branches/n:branchid",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> dict[str, Any] | None:
@@ -61,9 +61,9 @@ class CodebaseBranchEndpoint(base.Endpoint):
 
 class CodebaseBranchesEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /codebases/n:codebaseid/branches
-    """
+    pathPatterns = [
+        "/codebases/n:codebaseid/branches",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> list[dict[str, Any]]:

--- a/master/buildbot/data/codebase_commits.py
+++ b/master/buildbot/data/codebase_commits.py
@@ -52,9 +52,9 @@ commits_field_map = {
 
 class CodebaseCommitEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /commits/n:commitid
-    """
+    pathPatterns = [
+        "/commits/n:commitid",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> dict[str, Any] | None:
@@ -66,9 +66,9 @@ class CodebaseCommitEndpoint(base.Endpoint):
 
 class CodebaseCommitByRevisionEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /codebases/n:codebaseid/commits_by_revision/s:revision
-    """
+    pathPatterns = [
+        "/codebases/n:codebaseid/commits_by_revision/s:revision",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> dict[str, Any] | None:
@@ -82,9 +82,9 @@ class CodebaseCommitByRevisionEndpoint(base.Endpoint):
 
 class CodebaseCommitsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /codebases/n:codebaseid/commits
-    """
+    pathPatterns = [
+        "/codebases/n:codebaseid/commits",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> list[dict[str, Any]]:
@@ -151,9 +151,9 @@ class CodebaseCommit(base.ResourceType):
 
 class CodebaseCommitsGraphEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = (
-        "/codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/commits_common_parent"
-    )
+    pathPatterns = [
+        "/codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/commits_common_parent",
+    ]
 
     @async_to_deferred
     async def get(self, resultSpec: base.ResultSpec, kwargs: Any) -> dict[str, Any] | None:

--- a/master/buildbot/data/codebases.py
+++ b/master/buildbot/data/codebases.py
@@ -45,10 +45,10 @@ codebases_field_map = {
 
 class CodebaseEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /codebases/n:codebaseid
-        /projects/n:projectid/codebases/i:codebasename
-    """
+    pathPatterns = [
+        "/codebases/n:codebaseid",
+        "/projects/n:projectid/codebases/i:codebasename",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> dict[str, Any] | None:
@@ -69,9 +69,9 @@ class CodebaseEndpoint(base.Endpoint):
 class CodebasesEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     rootLinkName = 'codebases'
-    pathPatterns = """
-        /codebases
-    """
+    pathPatterns = [
+        "/codebases",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec: base.ResultSpec, kwargs: Any) -> list[dict[str, Any]]:

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -92,7 +92,13 @@ class DataConnector(service.AsyncService):
                     # don't use inherited values for these parameters
                     clsdict = ep.__class__.__dict__
                     pathPatterns = clsdict.get('pathPatterns', '')
-                    pathPatterns = pathPatterns.split()
+                    if isinstance(pathPatterns, str):
+                        pathPatterns = pathPatterns.split()
+                        warn_deprecated(
+                            '4.3.0',
+                            'Endpoint.pathPatterns as a multiline string is deprecated. Use pathPatterns as a '
+                            'list of strings instead.',
+                        )
                     pathPatterns = [tuple(pp.split('/')[1:]) for pp in pathPatterns]
                     for pp in pathPatterns:
                         # special-case the root

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -37,9 +37,9 @@ def forceScheduler2Data(sched):
 
 class ForceSchedulerEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /forceschedulers/i:schedulername
-    """
+    pathPatterns = [
+        "/forceschedulers/i:schedulername",
+    ]
 
     def findForceScheduler(self, schedulername):
         # eventually this may be db backed. This is why the API is async
@@ -71,10 +71,10 @@ class ForceSchedulerEndpoint(base.Endpoint):
 
 class ForceSchedulersEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /forceschedulers
-        /builders/:builderid/forceschedulers
-    """
+    pathPatterns = [
+        "/forceschedulers",
+        "/builders/:builderid/forceschedulers",
+    ]
     rootLinkName = 'forceschedulers'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -96,15 +96,15 @@ class LogChunkEndpoint(LogChunkEndpointBase):
     # offset/limit query params in ResultSpec
     kind = base.EndpointKind.SINGLE
     isPseudoCollection = True
-    pathPatterns = """
-        /logchunks
-        /logs/n:logid/contents
-        /steps/n:stepid/logs/i:log_slug/contents
-        /builds/n:buildid/steps/i:step_name/logs/i:log_slug/contents
-        /builds/n:buildid/steps/n:step_number/logs/i:log_slug/contents
-        /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/contents
-        /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/contents
-    """
+    pathPatterns = [
+        "/logchunks",
+        "/logs/n:logid/contents",
+        "/steps/n:stepid/logs/i:log_slug/contents",
+        "/builds/n:buildid/steps/i:step_name/logs/i:log_slug/contents",
+        "/builds/n:buildid/steps/n:step_number/logs/i:log_slug/contents",
+        "/builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/contents",
+        "/builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/contents",
+    ]
     rootLinkName = "logchunks"
 
     @defer.inlineCallbacks
@@ -137,14 +137,14 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
     # Note that this is a singular endpoint, even though it overrides the
     # offset/limit query params in ResultSpec
     kind = base.EndpointKind.RAW
-    pathPatterns = """
-        /logs/n:logid/raw
-        /steps/n:stepid/logs/i:log_slug/raw
-        /builds/n:buildid/steps/i:step_name/logs/i:log_slug/raw
-        /builds/n:buildid/steps/n:step_number/logs/i:log_slug/raw
-        /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/raw
-        /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/raw
-    """
+    pathPatterns = [
+        "/logs/n:logid/raw",
+        "/steps/n:stepid/logs/i:log_slug/raw",
+        "/builds/n:buildid/steps/i:step_name/logs/i:log_slug/raw",
+        "/builds/n:buildid/steps/n:step_number/logs/i:log_slug/raw",
+        "/builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/raw",
+        "/builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/raw",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -174,14 +174,14 @@ class RawInlineLogChunkEndpoint(LogChunkEndpointBase):
     # Note that this is a singular endpoint, even though it overrides the
     # offset/limit query params in ResultSpec
     kind = base.EndpointKind.RAW_INLINE
-    pathPatterns = """
-        /logs/n:logid/raw_inline
-        /steps/n:stepid/logs/i:log_slug/raw_inline
-        /builds/n:buildid/steps/i:step_name/logs/i:log_slug/raw_inline
-        /builds/n:buildid/steps/n:step_number/logs/i:log_slug/raw_inline
-        /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/raw_inline
-        /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/raw_inline
-    """
+    pathPatterns = [
+        "/logs/n:logid/raw_inline",
+        "/steps/n:stepid/logs/i:log_slug/raw_inline",
+        "/builds/n:buildid/steps/i:step_name/logs/i:log_slug/raw_inline",
+        "/builds/n:buildid/steps/n:step_number/logs/i:log_slug/raw_inline",
+        "/builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug/raw_inline",
+        "/builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug/raw_inline",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -45,16 +45,16 @@ class EndpointMixin:
 
 class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /logs/n:logid
-        /steps/n:stepid/logs/i:log_slug
-        /builds/n:buildid/steps/i:step_name/logs/i:log_slug
-        /builds/n:buildid/steps/n:step_number/logs/i:log_slug
-        /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug
-        /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug
-        /builders/s:buildername/builds/n:build_number/steps/i:step_name/logs/i:log_slug
-        /builders/s:buildername/builds/n:build_number/steps/n:step_number/logs/i:log_slug
-    """
+    pathPatterns = [
+        "/logs/n:logid",
+        "/steps/n:stepid/logs/i:log_slug",
+        "/builds/n:buildid/steps/i:step_name/logs/i:log_slug",
+        "/builds/n:buildid/steps/n:step_number/logs/i:log_slug",
+        "/builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug",
+        "/builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug",
+        "/builders/s:buildername/builds/n:build_number/steps/i:step_name/logs/i:log_slug",
+        "/builders/s:buildername/builds/n:build_number/steps/n:step_number/logs/i:log_slug",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -73,15 +73,15 @@ class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
 
 class LogsEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /steps/n:stepid/logs
-        /builds/n:buildid/steps/i:step_name/logs
-        /builds/n:buildid/steps/n:step_number/logs
-        /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs
-        /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs
-        /builders/s:buildername/builds/n:build_number/steps/i:step_name/logs
-        /builders/s:buildername/builds/n:build_number/steps/n:step_number/logs
-    """
+    pathPatterns = [
+        "/steps/n:stepid/logs",
+        "/builds/n:buildid/steps/i:step_name/logs",
+        "/builds/n:buildid/steps/n:step_number/logs",
+        "/builders/n:builderid/builds/n:build_number/steps/i:step_name/logs",
+        "/builders/n:builderid/builds/n:build_number/steps/n:step_number/logs",
+        "/builders/s:buildername/builds/n:build_number/steps/i:step_name/logs",
+        "/builders/s:buildername/builds/n:build_number/steps/n:step_number/logs",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -45,10 +45,10 @@ def _db2data(model: MasterModel):
 
 class MasterEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /masters/n:masterid
-        /builders/n:builderid/masters/n:masterid
-    """
+    pathPatterns = [
+        "/masters/n:masterid",
+        "/builders/n:builderid/masters/n:masterid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -64,10 +64,10 @@ class MasterEndpoint(base.Endpoint):
 
 class MastersEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /masters
-        /builders/n:builderid/masters
-    """
+    pathPatterns = [
+        "/masters",
+        "/builders/n:builderid/masters",
+    ]
     rootLinkName = 'masters'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/projects.py
+++ b/master/buildbot/data/projects.py
@@ -40,10 +40,10 @@ def project_db_to_data(model: ProjectModel, active=None):
 
 class ProjectEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /projects/n:projectid
-        /projects/i:projectname
-    """
+    pathPatterns = [
+        "/projects/n:projectid",
+        "/projects/i:projectname",
+    ]
 
     @defer.inlineCallbacks
     def get(self, result_spec, kwargs):
@@ -60,9 +60,9 @@ class ProjectEndpoint(base.BuildNestingMixin, base.Endpoint):
 class ProjectsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     rootLinkName = 'projects'
-    pathPatterns = """
-        /projects
-    """
+    pathPatterns = [
+        "/projects",
+    ]
 
     @defer.inlineCallbacks
     def get(self, result_spec, kwargs):

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -31,9 +31,9 @@ if TYPE_CHECKING:
 
 class BuildsetPropertiesEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /buildsets/n:bsid/properties
-    """
+    pathPatterns = [
+        "/buildsets/n:bsid/properties",
+    ]
 
     def get(self, resultSpec, kwargs):
         return self.master.db.buildsets.getBuildsetProperties(kwargs['bsid'])
@@ -41,10 +41,10 @@ class BuildsetPropertiesEndpoint(base.Endpoint):
 
 class BuildPropertiesEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /builders/n:builderid/builds/n:build_number/properties
-        /builds/n:buildid/properties
-    """
+    pathPatterns = [
+        "/builders/n:builderid/builds/n:build_number/properties",
+        "/builds/n:buildid/properties",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -56,11 +56,11 @@ class BuildPropertiesEndpoint(base.Endpoint):
 
 class PropertiesListEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /builds/n:buildid/property_list
-        /buildsets/n:bsid/properties_list
-        /changes/n:changeid/properties_list
-    """
+    pathPatterns = [
+        "/builds/n:buildid/property_list",
+        "/buildsets/n:bsid/properties_list",
+        "/changes/n:changeid/properties_list",
+    ]
     buildFieldMapping = {
         "name": "build_properties.name",
         "source": "build_properties.source",

--- a/master/buildbot/data/root.py
+++ b/master/buildbot/data/root.py
@@ -23,7 +23,9 @@ from buildbot.warnings import warn_deprecated
 
 class RootEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = "/"
+    pathPatterns = [
+        "/",
+    ]
 
     def get(self, resultSpec, kwargs):
         warn_deprecated('4.3.0', 'the root endpoint with endpoint directory has been deprecated')
@@ -43,7 +45,9 @@ class Root(base.ResourceType):
 
 class SpecEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = "/application.spec"
+    pathPatterns = [
+        "/application.spec",
+    ]
 
     def get(self, resultSpec, kwargs):
         return defer.succeed(self.master.data.allEndpoints())

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -46,10 +46,10 @@ class Db2DataMixin:
 
 class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /schedulers/n:schedulerid
-        /masters/n:masterid/schedulers/n:schedulerid
-    """
+    pathPatterns = [
+        "/schedulers/n:schedulerid",
+        "/masters/n:masterid/schedulers/n:schedulerid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -70,10 +70,10 @@ class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
 
 class SchedulersEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /schedulers
-        /masters/n:masterid/schedulers
-    """
+    pathPatterns = [
+        "/schedulers",
+        "/masters/n:masterid/schedulers",
+    ]
     rootLinkName = 'schedulers'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -54,9 +54,9 @@ def _db2data(ss: SourceStampModel):
 
 class SourceStampEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /sourcestamps/n:ssid
-    """
+    pathPatterns = [
+        "/sourcestamps/n:ssid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -66,10 +66,10 @@ class SourceStampEndpoint(base.Endpoint):
 
 class SourceStampsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /sourcestamps
-        /buildsets/:buildsetid/sourcestamps
-    """
+    pathPatterns = [
+        "/sourcestamps",
+        "/buildsets/:buildsetid/sourcestamps",
+    ]
     rootLinkName = 'sourcestamps'
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -47,15 +47,15 @@ class Db2DataMixin:
 
 class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /steps/n:stepid
-        /builds/n:buildid/steps/i:step_name
-        /builds/n:buildid/steps/n:step_number
-        /builders/n:builderid/builds/n:build_number/steps/i:step_name
-        /builders/n:builderid/builds/n:build_number/steps/n:step_number
-        /builders/s:buildername/builds/n:build_number/steps/i:step_name
-        /builders/s:buildername/builds/n:build_number/steps/n:step_number
-        """
+    pathPatterns = [
+        "/steps/n:stepid",
+        "/builds/n:buildid/steps/i:step_name",
+        "/builds/n:buildid/steps/n:step_number",
+        "/builders/n:builderid/builds/n:build_number/steps/i:step_name",
+        "/builders/n:builderid/builds/n:build_number/steps/n:step_number",
+        "/builders/s:buildername/builds/n:build_number/steps/i:step_name",
+        "/builders/s:buildername/builds/n:build_number/steps/n:step_number",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -73,11 +73,11 @@ class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
 class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /builds/n:buildid/steps
-        /builders/n:builderid/builds/n:build_number/steps
-        /builders/s:buildername/builds/n:build_number/steps
-    """
+    pathPatterns = [
+        "/builds/n:buildid/steps",
+        "/builders/n:builderid/builds/n:build_number/steps",
+        "/builders/s:buildername/builds/n:build_number/steps",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -47,13 +47,13 @@ class Db2DataMixin:
 
 class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /test_result_sets
-        /builders/n:builderid/test_result_sets
-        /builders/s:buildername/test_result_sets
-        /builds/n:buildid/test_result_sets
-        /steps/n:stepid/test_result_sets
-        """
+    pathPatterns = [
+        "/test_result_sets",
+        "/builders/n:builderid/test_result_sets",
+        "/builders/s:buildername/test_result_sets",
+        "/builds/n:buildid/test_result_sets",
+        "/steps/n:stepid/test_result_sets",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -94,9 +94,9 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
 
 class TestResultSetsFromCommitRangeEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/test_result_sets
-        """
+    pathPatterns = [
+        "/codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/test_result_sets",
+    ]
 
     @async_to_deferred
     async def get(self, result_spec, kwargs) -> list[dict[str, Any]]:
@@ -118,9 +118,9 @@ class TestResultSetsFromCommitRangeEndpoint(Db2DataMixin, base.Endpoint):
 
 class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /test_result_sets/n:test_result_setid
-    """
+    pathPatterns = [
+        "/test_result_sets/n:test_result_setid",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -44,9 +44,9 @@ class Db2DataMixin:
 
 class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-        /test_result_sets/n:test_result_setid/results
-        """
+    pathPatterns = [
+        "/test_result_sets/n:test_result_setid/results",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -47,16 +47,16 @@ class Db2DataMixin:
 
 class WorkerEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-        /workers/n:workerid
-        /workers/i:name
-        /masters/n:masterid/workers/n:workerid
-        /masters/n:masterid/workers/i:name
-        /masters/n:masterid/builders/n:builderid/workers/n:workerid
-        /masters/n:masterid/builders/n:builderid/workers/i:name
-        /builders/n:builderid/workers/n:workerid
-        /builders/n:builderid/workers/i:name
-    """
+    pathPatterns = [
+        "/workers/n:workerid",
+        "/workers/i:name",
+        "/masters/n:masterid/workers/n:workerid",
+        "/masters/n:masterid/workers/i:name",
+        "/masters/n:masterid/builders/n:builderid/workers/n:workerid",
+        "/masters/n:masterid/builders/n:builderid/workers/i:name",
+        "/builders/n:builderid/workers/n:workerid",
+        "/builders/n:builderid/workers/i:name",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -88,12 +88,12 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
 class WorkersEndpoint(Db2DataMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     rootLinkName = 'workers'
-    pathPatterns = """
-        /workers
-        /masters/n:masterid/workers
-        /masters/n:masterid/builders/n:builderid/workers
-        /builders/n:builderid/workers
-    """
+    pathPatterns = [
+        "/workers",
+        "/masters/n:masterid/workers",
+        "/masters/n:masterid/builders/n:builderid/workers",
+        "/builders/n:builderid/workers",
+    ]
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -47,10 +47,10 @@ stepData = {
 
 class TestsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = """
-    /tests
-    /test
-    """
+    pathPatterns = [
+        "/tests",
+        "/test",
+    ]
     rootLinkName = 'tests'
 
     def get(self, resultSpec, kwargs):
@@ -60,7 +60,9 @@ class TestsEndpoint(base.Endpoint):
 
 class RawTestsEndpoint(base.Endpoint):
     kind = base.EndpointKind.RAW
-    pathPatterns = "/rawtest"
+    pathPatterns = [
+        "/rawtest",
+    ]
 
     def get(self, resultSpec, kwargs):
         return defer.succeed({"filename": "test.txt", "mime-type": "text/test", 'raw': 'value'})
@@ -68,7 +70,9 @@ class RawTestsEndpoint(base.Endpoint):
 
 class FailEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = "/test/fail"
+    pathPatterns = [
+        "/test/fail",
+    ]
 
     def get(self, resultSpec, kwargs):
         return defer.fail(RuntimeError('oh noes'))
@@ -76,10 +80,10 @@ class FailEndpoint(base.Endpoint):
 
 class TestEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = """
-    /tests/n:testid
-    /test/n:testid
-    """
+    pathPatterns = [
+        "/tests/n:testid",
+        "/test/n:testid",
+    ]
 
     def get(self, resultSpec, kwargs):
         if kwargs['testid'] == 0:
@@ -94,7 +98,9 @@ class TestEndpoint(base.Endpoint):
 
 class StepsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
-    pathPatterns = "/tests/n:testid/steps"
+    pathPatterns = [
+        "/tests/n:testid/steps",
+    ]
 
     def get(self, resultSpec, kwargs):
         data = [step for step in stepData.values() if step['testid'] == kwargs['testid']]
@@ -104,7 +110,9 @@ class StepsEndpoint(base.Endpoint):
 
 class StepEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
-    pathPatterns = "/tests/n:testid/steps/n:stepid"
+    pathPatterns = [
+        "/tests/n:testid/steps/n:stepid",
+    ]
 
     def get(self, resultSpec, kwargs):
         if kwargs['testid'] == 0:

--- a/master/buildbot/test/unit/data/test_base.py
+++ b/master/buildbot/test/unit/data/test_base.py
@@ -110,9 +110,9 @@ class Endpoint(endpoint.EndpointMixin, unittest.TestCase):
         name = "my"
 
     class MyEndpoint(base.Endpoint):
-        pathPatterns = """
-            /my/pattern
-        """
+        pathPatterns = [
+            "/my/pattern",
+        ]
 
     endpointClass = MyEndpoint
     resourceTypeClass = MyResourceType

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -50,7 +50,7 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
 
         # this usually fails when a single-element pathPattern does not have a
         # trailing comma
-        pathPatterns = self.ep.pathPatterns.split()
+        pathPatterns = self.ep.pathPatterns
         for pp in pathPatterns:
             if pp == '/':
                 continue

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -345,18 +345,19 @@ path. See that module's description for details.
 
     .. py:attribute:: pathPatterns
 
-        :type: string
+        :type: list of strings
 
         This attribute defines the path patterns which incoming paths must match to select this
         endpoint. Paths are specified as URIs, and can contain variables as parsed by
-        :py:class:`buildbot.util.pathmatch.Matcher`. Multiple paths are separated by whitespace.
+        :py:class:`buildbot.util.pathmatch.Matcher`. Each string in a list represents a path
+        pattern.
 
         For example, the following specifies two paths with the second having a single variable::
 
-            pathPatterns = """
-                /bugs
-                /component/i:component_name/bugs
-            """
+            pathPatterns = [
+                "/bugs",
+                "/component/i:component_name/bugs",
+            ]
 
     .. py:attribute:: rootLinkName
 

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -103,5 +103,5 @@ passed message formatter.
 Data API
 ========
 
-The multiline string type of ``ResourceType.eventPathPatterns`` attribute has been deprecated. Use
-list of strings type instead.
+The multiline string type of ``ResourceType.eventPathPatterns`` and ``Enpoint.pathPatterns``
+attribute has been deprecated. Use list of strings type instead.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -628,6 +628,7 @@ Patchset
 pathmatch
 pathname
 pathnames
+pathPatterns
 pb
 pbuilder
 pem

--- a/newsfragments/convert-Endpoint-pathPatterns-to-list.removal
+++ b/newsfragments/convert-Endpoint-pathPatterns-to-list.removal
@@ -1,0 +1,1 @@
+Endpoint.pathPatterns as a multiline string has been deprecated. Use list of strings instead.


### PR DESCRIPTION
This PR makes specifying ` pathPatterns`  less complex, when `Endpoint.pathPatterns` is a list instead of a multiline string where each line represents a pattern.
Fixes #8338.

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
