### PR TITLE
Remove Db2DataMixin and make functions/fields global scoped

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -69,6 +69,7 @@ def _generate_filtered_properties(props: dict, filters: Sequence) -> dict | None
 
     return {k: v for k, v in props.items() if k in set_filters}
 
+
 buildrequests_field_mapping = {
     'buildrequestid': 'buildrequests.id',
     'buildsetid': 'buildrequests.buildsetid',
@@ -107,7 +108,9 @@ class BuildRequestEndpoint(base.Endpoint):
             return None
 
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
-        properties = yield _get_buildset_properties_filtered(self.master, buildrequest.buildsetid, filters)
+        properties = yield _get_buildset_properties_filtered(
+            self.master, buildrequest.buildsetid, filters
+        )
         return _db2data(buildrequest, properties)
 
     @defer.inlineCallbacks
@@ -164,7 +167,9 @@ class BuildRequestsEndpoint(base.Endpoint):
         results = []
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
         for br in buildrequests:
-            properties = yield _get_buildset_properties_filtered(self.master, br.buildsetid, filters)
+            properties = yield _get_buildset_properties_filtered(
+                self.master, br.buildsetid, filters
+            )
             results.append(_db2data(br, properties))
         return results
 

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -89,7 +89,7 @@ buildrequests_field_mapping = {
 def _get_buildset_properties_filtered(master, buildsetid: int, filters: Sequence):
     if not filters:
         return None
-    
+
     props = yield master.db.buildsets.getBuildsetProperties(buildsetid)
     return _generate_filtered_properties(props, filters)
 

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -69,33 +69,32 @@ def _generate_filtered_properties(props: dict, filters: Sequence) -> dict | None
 
     return {k: v for k, v in props.items() if k in set_filters}
 
-
-class Db2DataMixin:
-    @defer.inlineCallbacks
-    def get_buildset_properties_filtered(self, buildsetid: int, filters: Sequence):
-        if not filters:
-            return None
-        assert hasattr(self, 'master')
-        props = yield self.master.db.buildsets.getBuildsetProperties(buildsetid)
-        return _generate_filtered_properties(props, filters)
-
-    fieldMapping = {
-        'buildrequestid': 'buildrequests.id',
-        'buildsetid': 'buildrequests.buildsetid',
-        'builderid': 'buildrequests.builderid',
-        'priority': 'buildrequests.priority',
-        'complete': 'buildrequests.complete',
-        'results': 'buildrequests.results',
-        'submitted_at': 'buildrequests.submitted_at',
-        'complete_at': 'buildrequests.complete_at',
-        'waited_for': 'buildrequests.waited_for',
-        # br claim
-        'claimed_at': 'buildrequest_claims.claimed_at',
-        'claimed_by_masterid': 'buildrequest_claims.masterid',
-    }
+buildrequests_field_mapping = {
+    'buildrequestid': 'buildrequests.id',
+    'buildsetid': 'buildrequests.buildsetid',
+    'builderid': 'buildrequests.builderid',
+    'priority': 'buildrequests.priority',
+    'complete': 'buildrequests.complete',
+    'results': 'buildrequests.results',
+    'submitted_at': 'buildrequests.submitted_at',
+    'complete_at': 'buildrequests.complete_at',
+    'waited_for': 'buildrequests.waited_for',
+    # br claim
+    'claimed_at': 'buildrequest_claims.claimed_at',
+    'claimed_by_masterid': 'buildrequest_claims.masterid',
+}
 
 
-class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
+@defer.inlineCallbacks
+def _get_buildset_properties_filtered(master, buildsetid: int, filters: Sequence):
+    if not filters:
+        return None
+    
+    props = yield master.db.buildsets.getBuildsetProperties(buildsetid)
+    return _generate_filtered_properties(props, filters)
+
+
+class BuildRequestEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /buildrequests/n:buildrequestid
@@ -108,7 +107,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
             return None
 
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
-        properties = yield self.get_buildset_properties_filtered(buildrequest.buildsetid, filters)
+        properties = yield _get_buildset_properties_filtered(self.master, buildrequest.buildsetid, filters)
         return _db2data(buildrequest, properties)
 
     @defer.inlineCallbacks
@@ -132,7 +131,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
             raise ValueError(f"action: {action} is not supported")
 
 
-class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
+class BuildRequestsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /buildrequests
@@ -154,7 +153,7 @@ class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
             claimed = resultSpec.popBooleanFilter('claimed')
 
         bsid = resultSpec.popOneFilter('buildsetid', 'eq')
-        resultSpec.fieldMapping = self.fieldMapping
+        resultSpec.fieldMapping = buildrequests_field_mapping
         buildrequests = yield self.master.db.buildrequests.getBuildRequests(
             builderid=builderid,
             complete=complete,
@@ -165,7 +164,7 @@ class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
         results = []
         filters = resultSpec.popProperties() if hasattr(resultSpec, 'popProperties') else []
         for br in buildrequests:
-            properties = yield self.get_buildset_properties_filtered(br.buildsetid, filters)
+            properties = yield _get_buildset_properties_filtered(self.master, br.buildsetid, filters)
             results.append(_db2data(br, properties))
         return results
 

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -47,6 +47,7 @@ def _db2data(model: BuildModel):
         'properties': {},
     }
 
+
 builds_field_map = {
     'buildid': 'builds.id',
     'number': 'builds.number',
@@ -60,6 +61,7 @@ builds_field_map = {
     'state_string': 'builds.state_string',
     'results': 'builds.results',
 }
+
 
 def _generate_filtered_properties(props, filters):
     """
@@ -75,11 +77,7 @@ def _generate_filtered_properties(props, filters):
     """
     # by default none properties are returned
     if props and filters:
-        return (
-            props
-            if '*' in filters
-            else dict(((k, v) for k, v in props.items() if k in filters))
-        )
+        return props if '*' in filters else dict(((k, v) for k, v in props.items() if k in filters))
     return None
 
 
@@ -163,7 +161,6 @@ class BuildsEndpoint(base.BuildNestingMixin, base.Endpoint):
         /workers/n:workerid/builds
     """
     rootLinkName = 'builds'
-
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -47,6 +47,20 @@ def _db2data(model: BuildModel):
         'properties': {},
     }
 
+builds_field_map = {
+    'buildid': 'builds.id',
+    'number': 'builds.number',
+    'builderid': 'builds.builderid',
+    'buildrequestid': 'builds.buildrequestid',
+    'workerid': 'builds.workerid',
+    'masterid': 'builds.masterid',
+    'started_at': 'builds.started_at',
+    'complete_at': 'builds.complete_at',
+    "locks_duration_s": "builds.locks_duration_s",
+    'state_string': 'builds.state_string',
+    'results': 'builds.results',
+}
+
 def _generate_filtered_properties(props, filters):
     """
     This method returns Build's properties according to property filters.
@@ -150,19 +164,7 @@ class BuildsEndpoint(base.BuildNestingMixin, base.Endpoint):
     """
     rootLinkName = 'builds'
 
-    fieldMapping = {
-    'buildid': 'builds.id',
-    'number': 'builds.number',
-    'builderid': 'builds.builderid',
-    'buildrequestid': 'builds.buildrequestid',
-    'workerid': 'builds.workerid',
-    'masterid': 'builds.masterid',
-    'started_at': 'builds.started_at',
-    'complete_at': 'builds.complete_at',
-    "locks_duration_s": "builds.locks_duration_s",
-    'state_string': 'builds.state_string',
-    'results': 'builds.results',
-}
+    
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -179,7 +181,7 @@ class BuildsEndpoint(base.BuildNestingMixin, base.Endpoint):
                     return []
             complete = resultSpec.popBooleanFilter("complete")
             buildrequestid = resultSpec.popIntegerFilter("buildrequestid")
-            resultSpec.fieldMapping = self.fieldMapping
+            resultSpec.fieldMapping = builds_field_map
             builds = yield self.master.db.builds.getBuilds(
                 builderid=builderid,
                 buildrequestid=kwargs.get('buildrequestid', buildrequestid),

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -164,7 +164,6 @@ class BuildsEndpoint(base.BuildNestingMixin, base.Endpoint):
     """
     rootLinkName = 'builds'
 
-    
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -71,7 +71,9 @@ class ChangeSourcesEndpoint(base.Endpoint):
             masterid=kwargs.get('masterid')
         )
         csdicts = yield defer.DeferredList(
-            [_db2data(self.master, cs) for cs in changesources], consumeErrors=True, fireOnOneErrback=True
+            [_db2data(self.master, cs) for cs in changesources],
+            consumeErrors=True,
+            fireOnOneErrback=True,
         )
         return [r for (s, r) in csdicts]
 

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -29,21 +29,20 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    @defer.inlineCallbacks
-    def db2data(self, dbdict: ChangeSourceModel):
-        master = None
-        if dbdict.masterid is not None and hasattr(self, 'master'):
-            master = yield self.master.data.get(('masters', dbdict.masterid))
-        data = {
-            'changesourceid': dbdict.id,
-            'name': dbdict.name,
-            'master': master,
-        }
-        return data
+@defer.inlineCallbacks
+def _db2data(master, dbdict: ChangeSourceModel):
+    dbmaster = None
+    if dbdict.masterid is not None:
+        dbmaster = yield master.data.get(('masters', dbdict.masterid))
+    data = {
+        'changesourceid': dbdict.id,
+        'name': dbdict.name,
+        'master': dbmaster,
+    }
+    return data
 
 
-class ChangeSourceEndpoint(Db2DataMixin, base.Endpoint):
+class ChangeSourceEndpoint(base.Endpoint):
     pathPatterns = """
         /changesources/n:changesourceid
         /masters/n:masterid/changesources/n:changesourceid
@@ -55,10 +54,10 @@ class ChangeSourceEndpoint(Db2DataMixin, base.Endpoint):
         if 'masterid' in kwargs:
             if dbdict.masterid != kwargs['masterid']:
                 return None
-        return (yield self.db2data(dbdict)) if dbdict else None
+        return (yield _db2data(self.master, dbdict)) if dbdict else None
 
 
-class ChangeSourcesEndpoint(Db2DataMixin, base.Endpoint):
+class ChangeSourcesEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /changesources
@@ -72,7 +71,7 @@ class ChangeSourcesEndpoint(Db2DataMixin, base.Endpoint):
             masterid=kwargs.get('masterid')
         )
         csdicts = yield defer.DeferredList(
-            [self.db2data(cs) for cs in changesources], consumeErrors=True, fireOnOneErrback=True
+            [_db2data(self.master, cs) for cs in changesources], consumeErrors=True, fireOnOneErrback=True
         )
         return [r for (s, r) in csdicts]
 

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -29,23 +29,22 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: TestResultSetModel):
-        return {
-            'test_result_setid': model.id,
-            'builderid': model.builderid,
-            'buildid': model.buildid,
-            'stepid': model.stepid,
-            'description': model.description,
-            'category': model.category,
-            'value_unit': model.value_unit,
-            'tests_passed': model.tests_passed,
-            'tests_failed': model.tests_failed,
-            'complete': model.complete,
-        }
+def _db2data(model: TestResultSetModel):
+    return {
+        'test_result_setid': model.id,
+        'builderid': model.builderid,
+        'buildid': model.buildid,
+        'stepid': model.stepid,
+        'description': model.description,
+        'category': model.category,
+        'value_unit': model.value_unit,
+        'tests_passed': model.tests_passed,
+        'tests_failed': model.tests_failed,
+        'complete': model.complete,
+    }
 
 
-class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class TestResultSetsEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /test_result_sets
@@ -89,10 +88,10 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
                 complete=complete, result_spec=resultSpec
             )
 
-        return [self.db2data(model) for model in sets]
+        return [_db2data(model) for model in sets]
 
 
-class TestResultSetsFromCommitRangeEndpoint(Db2DataMixin, base.Endpoint):
+class TestResultSetsFromCommitRangeEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/test_result_sets
@@ -113,10 +112,10 @@ class TestResultSetsFromCommitRangeEndpoint(Db2DataMixin, base.Endpoint):
         sets = await self.master.db.test_result_sets.get_test_result_sets_for_commits(
             commit_ids=commit_ids
         )
-        return [self.db2data(model) for model in sets]
+        return [_db2data(model) for model in sets]
 
 
-class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class TestResultSetEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /test_result_sets/n:test_result_setid
@@ -125,7 +124,7 @@ class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint)
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
         model = yield self.master.db.test_result_sets.getTestResultSet(kwargs['test_result_setid'])
-        return self.db2data(model) if model else None
+        return _db2data(model) if model else None
 
 
 class TestResultSet(base.ResourceType):

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -28,21 +28,20 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: TestResultModel):
-        return {
-            'test_resultid': model.id,
-            'builderid': model.builderid,
-            'test_result_setid': model.test_result_setid,
-            'test_name': model.test_name,
-            'test_code_path': model.test_code_path,
-            'line': model.line,
-            'duration_ns': model.duration_ns,
-            'value': model.value,
-        }
+def _db2data(model: TestResultModel):
+    return {
+        'test_resultid': model.id,
+        'builderid': model.builderid,
+        'test_result_setid': model.test_result_setid,
+        'test_name': model.test_name,
+        'test_code_path': model.test_code_path,
+        'line': model.line,
+        'duration_ns': model.duration_ns,
+        'value': model.value,
+    }
 
 
-class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
+class TestResultsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = """
         /test_result_sets/n:test_result_setid/results
@@ -61,7 +60,7 @@ class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
             set_dbdict.builderid, kwargs['test_result_setid'], result_spec=resultSpec
         )
 
-        return [self.db2data(result) for result in result_dbdicts]
+        return [_db2data(result) for result in result_dbdicts]
 
 
 class TestResult(base.ResourceType):

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -29,23 +29,22 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: WorkerModel):
-        return {
-            'workerid': model.id,
-            'name': model.name,
-            'workerinfo': model.workerinfo,
-            'paused': model.paused,
-            "pause_reason": model.pause_reason,
-            'graceful': model.graceful,
-            'connected_to': [{'masterid': id} for id in model.connected_to],
-            'configured_on': [
-                {'masterid': c.masterid, 'builderid': c.builderid} for c in model.configured_on
-            ],
-        }
+def _db2data(model: WorkerModel):
+    return {
+        'workerid': model.id,
+        'name': model.name,
+        'workerinfo': model.workerinfo,
+        'paused': model.paused,
+        "pause_reason": model.pause_reason,
+        'graceful': model.graceful,
+        'connected_to': [{'masterid': id} for id in model.connected_to],
+        'configured_on': [
+            {'masterid': c.masterid, 'builderid': c.builderid} for c in model.configured_on
+        ],
+    }
 
 
-class WorkerEndpoint(Db2DataMixin, base.Endpoint):
+class WorkerEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = """
         /workers/n:workerid
@@ -67,7 +66,7 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
             builderid=kwargs.get('builderid'),
         )
         if sldict:
-            return self.db2data(sldict)
+            return _db2data(sldict)
         return None
 
     @defer.inlineCallbacks
@@ -85,7 +84,7 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
             raise exceptions.exceptions.InvalidPathError("worker not found")
 
 
-class WorkersEndpoint(Db2DataMixin, base.Endpoint):
+class WorkersEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     rootLinkName = 'workers'
     pathPatterns = """
@@ -105,7 +104,7 @@ class WorkersEndpoint(Db2DataMixin, base.Endpoint):
             paused=paused,
             graceful=graceful,
         )
-        return [self.db2data(w) for w in workers_dicts]
+        return [_db2data(w) for w in workers_dicts]
 
 
 class MasterBuilderEntityType(types.Entity):


### PR DESCRIPTION
This commit removes the Db2DataMixin from master/buildbot/data/builds.py. I have replaced the class with appropriate functions/variables and all the test cases were passed. This is one of the fix for issue https://github.com/buildbot/buildbot/issues/8340

* [not required] I have updated the unit tests
* [not required] I have created a file in the newsfragments directory (and read the README.txt in that directory)
* [not required] I have updated the appropriate documentation
