### PR TITLE
Remove Db2DataMixin and make functions/field global scoped

### DIFF
--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -48,44 +48,40 @@ def _db2data(model: BuildModel):
     }
 
 
-class Db2DataMixin:
-    def _generate_filtered_properties(self, props, filters):
-        """
-        This method returns Build's properties according to property filters.
-
-        .. seealso::
-
-            `Official Documentation <https://docs.buildbot.net/latest/developer/rtype-build.html>`_
-
-        :param props: The Build's properties as a dict (from db)
-        :param filters: Desired properties keys as a list (from API URI)
-
-        """
-        # by default none properties are returned
-        if props and filters:
-            return (
-                props
-                if '*' in filters
-                else dict(((k, v) for k, v in props.items() if k in filters))
-            )
-        return None
-
-    fieldMapping = {
-        'buildid': 'builds.id',
-        'number': 'builds.number',
-        'builderid': 'builds.builderid',
-        'buildrequestid': 'builds.buildrequestid',
-        'workerid': 'builds.workerid',
-        'masterid': 'builds.masterid',
-        'started_at': 'builds.started_at',
-        'complete_at': 'builds.complete_at',
-        "locks_duration_s": "builds.locks_duration_s",
-        'state_string': 'builds.state_string',
-        'results': 'builds.results',
-    }
+builds_field_map = {
+    'buildid': 'builds.id',
+    'number': 'builds.number',
+    'builderid': 'builds.builderid',
+    'buildrequestid': 'builds.buildrequestid',
+    'workerid': 'builds.workerid',
+    'masterid': 'builds.masterid',
+    'started_at': 'builds.started_at',
+    'complete_at': 'builds.complete_at',
+    "locks_duration_s": "builds.locks_duration_s",
+    'state_string': 'builds.state_string',
+    'results': 'builds.results',
+}
 
 
-class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+def _generate_filtered_properties(props, filters):
+    """
+    This method returns Build's properties according to property filters.
+
+    .. seealso::
+
+       `Official Documentation <https://docs.buildbot.net/latest/developer/rtype-build.html>`_
+
+    :param props: The Build's properties as a dict (from db)
+    :param filters: Desired properties keys as a list (from API URI)
+
+    """
+    # by default none properties are returned
+    if props and filters:
+        return props if '*' in filters else dict(((k, v) for k, v in props.items() if k in filters))
+    return None
+
+
+class BuildEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = [
         "/builds/n:buildid",
@@ -114,7 +110,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
                     props = yield self.master.db.builds.getBuildProperties(data['buildid'])
                 except (KeyError, TypeError):
                     props = {}
-                filtered_properties = self._generate_filtered_properties(props, filters)
+                filtered_properties = _generate_filtered_properties(props, filters)
                 if filtered_properties:
                     data['properties'] = filtered_properties
         return data
@@ -142,7 +138,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         return res
 
 
-class BuildTriggeredBuildsEndpoint(Db2DataMixin, base.Endpoint):
+class BuildTriggeredBuildsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/builds/n:buildid/triggered_builds",
@@ -154,7 +150,7 @@ class BuildTriggeredBuildsEndpoint(Db2DataMixin, base.Endpoint):
         return [_db2data(b) for b in builds]
 
 
-class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class BuildsEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/builds",
@@ -181,7 +177,7 @@ class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
                     return []
             complete = resultSpec.popBooleanFilter("complete")
             buildrequestid = resultSpec.popIntegerFilter("buildrequestid")
-            resultSpec.fieldMapping = self.fieldMapping
+            resultSpec.fieldMapping = builds_field_map
             builds = yield self.master.db.builds.getBuilds(
                 builderid=builderid,
                 buildrequestid=kwargs.get('buildrequestid', buildrequestid),
@@ -199,7 +195,7 @@ class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
             # Avoid to request DB for Build's properties if not specified
             if filters:
                 props = yield self.master.db.builds.getBuildProperties(data["buildid"])
-                filtered_properties = self._generate_filtered_properties(props, filters)
+                filtered_properties = _generate_filtered_properties(props, filters)
                 if filtered_properties:
                     data["properties"] = filtered_properties
 

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -29,22 +29,21 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    @defer.inlineCallbacks
-    def db2data(self, dbdict: SchedulerModel):
-        master = None
-        if dbdict.masterid is not None and hasattr(self, 'master'):
-            master = yield self.master.data.get(('masters', dbdict.masterid))
-        data = {
-            'schedulerid': dbdict.id,
-            'name': dbdict.name,
-            'enabled': dbdict.enabled,
-            'master': master,
-        }
-        return data
+@defer.inlineCallbacks
+def _db2data(master, dbdict: SchedulerModel):
+    dbmaster = None
+    if dbdict.masterid is not None:
+        dbmaster = yield master.data.get(('masters', dbdict.masterid))
+    data = {
+        'schedulerid': dbdict.id,
+        'name': dbdict.name,
+        'enabled': dbdict.enabled,
+        'master': dbmaster,
+    }
+    return data
 
 
-class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
+class SchedulerEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = [
         "/schedulers/n:schedulerid",
@@ -57,7 +56,7 @@ class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
         if 'masterid' in kwargs:
             if dbdict.masterid != kwargs['masterid']:
                 return None
-        return (yield self.db2data(dbdict)) if dbdict else None
+        return (yield _db2data(self.master, dbdict)) if dbdict else None
 
     @defer.inlineCallbacks
     def control(self, action, args, kwargs):
@@ -68,7 +67,7 @@ class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
         return None
 
 
-class SchedulersEndpoint(Db2DataMixin, base.Endpoint):
+class SchedulersEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/schedulers",
@@ -80,7 +79,7 @@ class SchedulersEndpoint(Db2DataMixin, base.Endpoint):
     def get(self, resultSpec, kwargs):
         schedulers = yield self.master.db.schedulers.getSchedulers(masterid=kwargs.get('masterid'))
         schdicts = yield defer.DeferredList(
-            [self.db2data(schdict) for schdict in schedulers],
+            [_db2data(self.master, schdict) for schdict in schedulers],
             consumeErrors=True,
             fireOnOneErrback=True,
         )

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -27,25 +27,24 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: StepModel):
-        return {
-            'stepid': model.id,
-            'number': model.number,
-            'name': model.name,
-            'buildid': model.buildid,
-            'started_at': model.started_at,
-            "locks_acquired_at": model.locks_acquired_at,
-            'complete': model.complete_at is not None,
-            'complete_at': model.complete_at,
-            'state_string': model.state_string,
-            'results': model.results,
-            'urls': [{'name': item.name, 'url': item.url} for item in model.urls],
-            'hidden': model.hidden,
-        }
+def _db2data(model: StepModel):
+    return {
+        'stepid': model.id,
+        'number': model.number,
+        'name': model.name,
+        'buildid': model.buildid,
+        'started_at': model.started_at,
+        "locks_acquired_at": model.locks_acquired_at,
+        'complete': model.complete_at is not None,
+        'complete_at': model.complete_at,
+        'state_string': model.state_string,
+        'results': model.results,
+        'urls': [{'name': item.name, 'url': item.url} for item in model.urls],
+        'hidden': model.hidden,
+    }
 
 
-class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class StepEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = [
         "/steps/n:stepid",
@@ -61,17 +60,17 @@ class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     def get(self, resultSpec, kwargs):
         if 'stepid' in kwargs:
             dbdict = yield self.master.db.steps.getStep(kwargs['stepid'])
-            return self.db2data(dbdict) if dbdict else None
+            return _db2data(dbdict) if dbdict else None
         buildid = yield self.getBuildid(kwargs)
         if buildid is None:
             return None
         dbdict = yield self.master.db.steps.getStep(
             buildid=buildid, number=kwargs.get('step_number'), name=kwargs.get('step_name')
         )
-        return self.db2data(dbdict) if dbdict else None
+        return _db2data(dbdict) if dbdict else None
 
 
-class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class StepsEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/builds/n:buildid/steps",
@@ -88,7 +87,7 @@ class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
             if buildid is None:
                 return None
         steps = yield self.master.db.steps.getSteps(buildid=buildid)
-        return [self.db2data(model) for model in steps]
+        return [_db2data(model) for model in steps]
 
 
 class UrlEntityType(types.Entity):

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -29,23 +29,22 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: TestResultSetModel):
-        return {
-            'test_result_setid': model.id,
-            'builderid': model.builderid,
-            'buildid': model.buildid,
-            'stepid': model.stepid,
-            'description': model.description,
-            'category': model.category,
-            'value_unit': model.value_unit,
-            'tests_passed': model.tests_passed,
-            'tests_failed': model.tests_failed,
-            'complete': model.complete,
-        }
+def _db2data(model: TestResultSetModel):
+    return {
+        'test_result_setid': model.id,
+        'builderid': model.builderid,
+        'buildid': model.buildid,
+        'stepid': model.stepid,
+        'description': model.description,
+        'category': model.category,
+        'value_unit': model.value_unit,
+        'tests_passed': model.tests_passed,
+        'tests_failed': model.tests_failed,
+        'complete': model.complete,
+    }
 
 
-class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class TestResultSetsEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/test_result_sets",
@@ -89,10 +88,10 @@ class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint
                 complete=complete, result_spec=resultSpec
             )
 
-        return [self.db2data(model) for model in sets]
+        return [_db2data(model) for model in sets]
 
 
-class TestResultSetsFromCommitRangeEndpoint(Db2DataMixin, base.Endpoint):
+class TestResultSetsFromCommitRangeEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/codebases/n:codebaseid/commit_range/n:commitid1/n:commitid2/test_result_sets",
@@ -113,10 +112,10 @@ class TestResultSetsFromCommitRangeEndpoint(Db2DataMixin, base.Endpoint):
         sets = await self.master.db.test_result_sets.get_test_result_sets_for_commits(
             commit_ids=commit_ids
         )
-        return [self.db2data(model) for model in sets]
+        return [_db2data(model) for model in sets]
 
 
-class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class TestResultSetEndpoint(base.BuildNestingMixin, base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = [
         "/test_result_sets/n:test_result_setid",
@@ -125,7 +124,7 @@ class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint)
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
         model = yield self.master.db.test_result_sets.getTestResultSet(kwargs['test_result_setid'])
-        return self.db2data(model) if model else None
+        return _db2data(model) if model else None
 
 
 class TestResultSet(base.ResourceType):

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -28,21 +28,20 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: TestResultModel):
-        return {
-            'test_resultid': model.id,
-            'builderid': model.builderid,
-            'test_result_setid': model.test_result_setid,
-            'test_name': model.test_name,
-            'test_code_path': model.test_code_path,
-            'line': model.line,
-            'duration_ns': model.duration_ns,
-            'value': model.value,
-        }
+def _db2data(model: TestResultModel):
+    return {
+        'test_resultid': model.id,
+        'builderid': model.builderid,
+        'test_result_setid': model.test_result_setid,
+        'test_name': model.test_name,
+        'test_code_path': model.test_code_path,
+        'line': model.line,
+        'duration_ns': model.duration_ns,
+        'value': model.value,
+    }
 
 
-class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
+class TestResultsEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     pathPatterns = [
         "/test_result_sets/n:test_result_setid/results",
@@ -61,7 +60,7 @@ class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
             set_dbdict.builderid, kwargs['test_result_setid'], result_spec=resultSpec
         )
 
-        return [self.db2data(result) for result in result_dbdicts]
+        return [_db2data(result) for result in result_dbdicts]
 
 
 class TestResult(base.ResourceType):

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -29,23 +29,22 @@ if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class Db2DataMixin:
-    def db2data(self, model: WorkerModel):
-        return {
-            'workerid': model.id,
-            'name': model.name,
-            'workerinfo': model.workerinfo,
-            'paused': model.paused,
-            "pause_reason": model.pause_reason,
-            'graceful': model.graceful,
-            'connected_to': [{'masterid': id} for id in model.connected_to],
-            'configured_on': [
-                {'masterid': c.masterid, 'builderid': c.builderid} for c in model.configured_on
-            ],
-        }
+def _db2data(model: WorkerModel):
+    return {
+        'workerid': model.id,
+        'name': model.name,
+        'workerinfo': model.workerinfo,
+        'paused': model.paused,
+        "pause_reason": model.pause_reason,
+        'graceful': model.graceful,
+        'connected_to': [{'masterid': id} for id in model.connected_to],
+        'configured_on': [
+            {'masterid': c.masterid, 'builderid': c.builderid} for c in model.configured_on
+        ],
+    }
 
 
-class WorkerEndpoint(Db2DataMixin, base.Endpoint):
+class WorkerEndpoint(base.Endpoint):
     kind = base.EndpointKind.SINGLE
     pathPatterns = [
         "/workers/n:workerid",
@@ -67,7 +66,7 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
             builderid=kwargs.get('builderid'),
         )
         if sldict:
-            return self.db2data(sldict)
+            return _db2data(sldict)
         return None
 
     @defer.inlineCallbacks
@@ -85,7 +84,7 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
             raise exceptions.exceptions.InvalidPathError("worker not found")
 
 
-class WorkersEndpoint(Db2DataMixin, base.Endpoint):
+class WorkersEndpoint(base.Endpoint):
     kind = base.EndpointKind.COLLECTION
     rootLinkName = 'workers'
     pathPatterns = [
@@ -105,7 +104,7 @@ class WorkersEndpoint(Db2DataMixin, base.Endpoint):
             paused=paused,
             graceful=graceful,
         )
-        return [self.db2data(w) for w in workers_dicts]
+        return [_db2data(w) for w in workers_dicts]
 
 
 class MasterBuilderEntityType(types.Entity):


### PR DESCRIPTION
This commit removes the Db2DataMixin from master/buildbot/data/builds.py. I have replaced the class with appropriate functions/variables and all the test cases were passed. This is one of the fix for issue https://github.com/buildbot/buildbot/issues/8340

* [not required] I have updated the unit tests
* [not required] I have created a file in the newsfragments directory (and read the README.txt in that directory)
* [not required] I have updated the appropriate documentation