### PR TITLE
docs: Add information about how to remove old logs to Deployment section

### DIFF
--- a/master/docs/manual/configuration/configurators.rst
+++ b/master/docs/manual/configuration/configurators.rst
@@ -13,9 +13,6 @@ Configurators are run (thus prioritized) in the order of the ``configurators`` l
 JanitorConfigurator
 ~~~~~~~~~~~~~~~~~~~
 
-Buildbot stores historical information in its database.
-In a large installation, these can quickly consume disk space, yet developers never consult this historical information in many cases.
-
 :bb:configurator:`JanitorConfigurator` creates a builder and :bb:sched:`Nightly` scheduler which will regularly remove old information.
 At the moment, it only supports cleaning of logs, but it will contain more features as we implement them.
 

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -196,6 +196,15 @@ This can be accomplished by editing :file:`buildbot.tac`. It's already enabled i
 Change the line: `application.setComponent(ILogObserver, FileLogObserver(logfile).emit)`
 to: `application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)`
 
+.. _Deleting-old-logs:
+
+Deleting old logs
+~~~~~~~~~~~~~~~~~
+
+Buildbot stores historical information in its database.
+In a large installation, these can quickly consume disk space, yet developers never consult this historical information in many cases.
+Read more on how to remove obsolete information in: :bb:configurator:`JanitorConfigurator`.
+
 .. _Debugging-with-the-python-debugger:
 
 Debugging with the python debugger


### PR DESCRIPTION
This PR adds information about how to clean old logs to Deployment chapter.
Fixes https://github.com/buildbot/buildbot/issues/7244.

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
