### PR TITLE
test/unit/data: Actually fix test test_add_test_results

### DIFF
--- a/master/buildbot/test/unit/data/test_test_results.py
+++ b/master/buildbot/test/unit/data/test_test_results.py
@@ -137,9 +137,10 @@ class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase)
         results = yield self.master.db.test_results.getTestResults(
             builderid=88, test_result_setid=13
         )
+        results = sorted(results, key=lambda result: result.id)
         resultid = results[0].id
         self.assertEqual(
-            sorted(results, key=lambda test_result_model: test_result_model.id),
+            results,
             [
                 TestResultModel(
                     id=resultid,


### PR DESCRIPTION
This PR actually fixes https://github.com/buildbot/buildbot/issues/8345.

* [x] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
