### PR TITLE
master: add argument runtime_timeout to MasterShellCommand step

### DIFF
--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -49,6 +49,7 @@ class MasterShellCommand(BuildStep):
         self.usePTY = kwargs.pop('usePTY', 0)
         self.interruptSignal = kwargs.pop('interruptSignal', 'KILL')
         self.logEnviron = kwargs.pop('logEnviron', True)
+        self.runtime_timeout = kwargs.pop('runtime_timeout', 3600)
 
         super().__init__(**kwargs)
 
@@ -140,7 +141,6 @@ class MasterShellCommand(BuildStep):
         on_stdout = lambda data: self._deferwaiter.add(self.stdio_log.addStdout(data))
         on_stderr = lambda data: self._deferwaiter.add(self.stdio_log.addStderr(data))
 
-        # TODO add a timeout?
         self.process = runprocess.create_process(
             reactor,
             argv,
@@ -149,6 +149,7 @@ class MasterShellCommand(BuildStep):
             env=env,
             collect_stdout=on_stdout,
             collect_stderr=on_stderr,
+            runtime_timeout=self.runtime_timeout,
         )
 
         yield self.process.start()

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -123,6 +123,44 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
             del os.environ['WORLD']
             del os.environ['LIST']
 
+    @defer.inlineCallbacks
+    def test_runtime_timeout_success(self):
+        """Test the runtime_timeout argument."""
+        runtime_timeout = 10
+        n_ping = 1
+        cmd = f'ping 127.0.0.1 -n {n_ping}'
+
+        if sys.platform == 'win32':
+            exp_argv = [r'C:\WINDOWS\system32\cmd.exe', '/c', cmd]
+        else:
+            exp_argv = ['/bin/sh', '-c', cmd]
+
+        self.setup_step(master.MasterShellCommand(command=cmd, runtime_timeout=runtime_timeout))
+
+        self.expect_commands(ExpectMasterShell(exp_argv).exit(0))
+        self.expect_outcome(result=SUCCESS)
+
+        yield self.run_step()
+
+    @defer.inlineCallbacks
+    def test_runtime_timeout_failed(self):
+        """Test the runtime_timeout argument aborts the step."""
+        runtime_timeout = 1
+        n_ping = 10
+        cmd = f'ping 127.0.0.1 -n {n_ping}'
+
+        if sys.platform == 'win32':
+            exp_argv = [r'C:\WINDOWS\system32\cmd.exe', '/c', cmd]
+        else:
+            exp_argv = ['/bin/sh', '-c', cmd]
+
+        self.setup_step(master.MasterShellCommand(command=cmd, runtime_timeout=runtime_timeout))
+
+        self.expect_commands(ExpectMasterShell(exp_argv).exit(2))
+        self.expect_outcome(result=FAILURE)
+
+        yield self.run_step()
+
     def test_prop_rendering(self):
         self.setup_step(
             master.MasterShellCommand(

--- a/master/docs/manual/configuration/steps/master_shell_command.rst
+++ b/master/docs/manual/configuration/steps/master_shell_command.rst
@@ -51,3 +51,6 @@ In particular, numeric properties such as ``buildnumber`` must be substituted us
 
 ``interruptSignal``
    (optional) Signal to use to end the process if the step is interrupted.
+
+``runtime_timeout``
+   (optional) Timeout [s] after which the step is killed. Default is 3600 (1h).

--- a/newsfragments/mastershellcommand_timeout_arg.feature
+++ b/newsfragments/mastershellcommand_timeout_arg.feature
@@ -1,0 +1,1 @@
+`MasterShellCommand`: Add argument `runtime_timeout` :issue:`8377`


### PR DESCRIPTION
Add the `runtimeTimeout` argument to the `MasterShellCommand`.

Fix #8377

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
