### PR TITLE
Display codebase info on runtime error

### DIFF
--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -366,8 +366,8 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
             )
             if projectid is None:
                 raise RuntimeError(
-                    'Could not find project {codebase_config.project} '
-                    'for codebase {codebase_config.name'
+                    f'Could not find project {codebase_config.project} '
+                    f'for codebase {codebase_config.name}'
                 )
 
             codebaseid = await self.master.data.updates.find_codebase_id(


### PR DESCRIPTION
# PR Summary
Small PR - fixes the runtime error to contain the codebase info in `master/buildbot/process/botmaster.py`.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
