### PR TITLE
process: Add a mutable env attribute to Build

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -15,9 +15,11 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from functools import reduce
 from pathlib import PurePath
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import cast
 
 from twisted.internet import defer
@@ -134,6 +136,10 @@ class Build(properties.PropertiesMixin):
 
         # tracks the config version for locks
         self.config_version = builder.config_version
+
+        self.env: dict[str, Any] = {}
+        if builder.config is not None:
+            self.env.update(deepcopy(builder.config.env))
 
     def getProperties(self):
         return self.properties

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1088,12 +1088,10 @@ class ShellMixin:
         # lazylogfiles are handled below
         del kwargs['lazylogfiles']
 
-        # merge the builder's environment with that supplied here
+        # merge the build's environment with that supplied here
         assert self.build is not None
-        assert self.build.builder.config is not None
-        builderEnv = self.build.builder.config.env
         kwargs['env'] = {
-            **(yield self.build.render(builderEnv)),
+            **(yield self.build.render(self.build.env)),
             **kwargs['env'],
         }
         kwargs['stdioLogName'] = stdioLogName

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -57,6 +57,7 @@ class FakeBuild(properties.PropertiesMixin):
         self.properties = props
         self.master = None
         self.config_version = 0
+        self.env = {}
 
     def getProperties(self):
         return self.properties

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -764,7 +764,7 @@ class TestBuildStepMixin(_TestBuildStepMixinBase):
 
         build.getWorkerCommandVersion = getWorkerVersion
         build.workerEnvironment = worker_env.copy()
-        build.builder.config.env = worker_env.copy()
+        build.env = worker_env.copy()
 
         return build
 

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1455,7 +1455,7 @@ class TestShellMixin(
     @defer.inlineCallbacks
     def test_env(self):
         self.setup_step(SimpleShellCommand(command=['cmd', 'arg'], env={'BAR': 'BAR'}))
-        self.build.builder.config.env = {'FOO': 'FOO'}
+        self.build.env = {'FOO': 'FOO'}
         self.expect_commands(
             ExpectShell(
                 workdir='wkdir', command=['cmd', 'arg'], env={'FOO': 'FOO', 'BAR': 'BAR'}

--- a/master/docs/developer/cls-build.rst
+++ b/master/docs/developer/cls-build.rst
@@ -33,3 +33,8 @@ Build
         Returns url of the build in the UI.
         Build must be started.
         This is useful for custom steps.
+
+    .. py:attribute:: env
+
+        Initialized from :py:class:`BuilderConfig`'s env by deep copy.
+        This attribute is mutable, steps can update it to change the environment of subsequent steps.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -311,6 +311,7 @@ Encodings
 endsWith
 entityType
 entrypoint
+env
 ep
 eq
 errback

--- a/newsfragments/build-mutable-env.change
+++ b/newsfragments/build-mutable-env.change
@@ -1,0 +1,2 @@
+``Build`` now has a mutable ``env`` attribute, deep copied from the ``Builder``'s ``BuilderConfig.env``.
+This allow steps to mutate their current build's env if needed.


### PR DESCRIPTION
Allow steps to change the running env for the remaining of the Build's lifetime.

For example, a step that create a Python virtual environment in the worker tmp location can update the build's env so that subsequent steps use it without the need to configure them for this case.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
