### PR TITLE
worker: add `path_cls` as an alternative to `path_module`

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from functools import reduce
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -284,6 +285,7 @@ class Build(properties.PropertiesMixin):
     def setupWorkerForBuilder(self, workerforbuilder: AbstractWorkerForBuilder):
         assert workerforbuilder.worker is not None
         self.path_module = workerforbuilder.worker.path_module
+        self.path_cls: type[PurePath] | None = workerforbuilder.worker.path_cls
         self.workername = workerforbuilder.worker.workername
         self.worker_info = workerforbuilder.worker.info
 

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import posixpath
+from pathlib import PurePosixPath
 from unittest import mock
 
 from buildbot import config
@@ -42,6 +43,7 @@ class FakeBuild(properties.PropertiesMixin):
             name='bldr', workernames=['a'], factory=factory.BuildFactory()
         )
         self.path_module = posixpath
+        self.path_cls = PurePosixPath
         self.buildid = 92
         self.number = 13
         self.workdir = 'build'

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import PurePosixPath
 
 from twisted.internet import defer
 from twisted.python.filepath import FilePath
@@ -53,6 +54,7 @@ class FakeWorker:
     def attached(self, conn):
         self.worker_system = 'posix'
         self.path_module = os.path
+        self.path_cls = PurePosixPath
         self.workerid = 1234
         self.worker_basedir = '/wrk'
         return defer.succeed(None)

--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import stat
 import tarfile
 from io import BytesIO
+from pathlib import PurePosixPath
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -1162,9 +1164,11 @@ class TestBuildStepMixin(_TestBuildStepMixinBase):
         self.worker.worker_system = system
         if system == 'nt':
             self.build.path_module = namedModule('ntpath')
+            self.build.path_cls = PureWindowsPath
             self.worker.worker_basedir = '\\wrk'
         else:
             self.build.path_module = namedModule('posixpath')
+            self.build.path_cls = PurePosixPath
             self.worker.worker_basedir = '/wrk'
 
     def interrupt_nth_remote_command(self, number):

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -15,6 +15,7 @@
 
 import operator
 import posixpath
+from pathlib import PurePosixPath
 from unittest.mock import Mock
 from unittest.mock import call
 
@@ -378,6 +379,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         b.builder.config.workerbuilddir = 'test'
         self.workerforbuilder.worker.worker_basedir = "/srv/buildbot/worker"
         self.workerforbuilder.worker.path_module = posixpath
+        self.workerforbuilder.worker.path_cls = PurePosixPath
         b.getProperties = Mock()
         b.setProperty = Mock()
 

--- a/master/buildbot/test/unit/steps/test_source_bzr.py
+++ b/master/buildbot/test/unit/steps/test_source_bzr.py
@@ -15,6 +15,7 @@
 
 
 import os
+from pathlib import PureWindowsPath
 
 from twisted.internet import error
 from twisted.python.reflect import namedModule
@@ -69,6 +70,7 @@ class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             )
         )
         self.build.path_module = namedModule('ntpath')
+        self.build.path_cls = PureWindowsPath
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['bzr', '--version']).exit(0),
             ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True).exit(1),

--- a/master/buildbot/test/unit/steps/test_source_mercurial.py
+++ b/master/buildbot/test/unit/steps/test_source_mercurial.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from pathlib import PureWindowsPath
+
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
@@ -101,6 +103,7 @@ class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.Test
             )
         )
         self.build.path_module = namedModule('ntpath')
+        self.build.path_cls = PureWindowsPath
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['hg', '--verbose', '--version']).exit(0),
             ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True).exit(1),

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -16,6 +16,7 @@
 
 import platform
 import textwrap
+from pathlib import PureWindowsPath
 
 from twisted.internet import error
 from twisted.python import reflect
@@ -51,6 +52,7 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, ConfigErrorsMixin, u
         if _is_windows:
             workspace_dir = r'C:\Users\username\Workspace'
             self.build.path_module = reflect.namedModule("ntpath")
+            self.build.path_cls = PureWindowsPath
         self.build.setProperty('builddir', workspace_dir, 'P4')
 
     def test_no_empty_step_config(self):

--- a/master/buildbot/test/unit/steps/test_source_svn.py
+++ b/master/buildbot/test/unit/steps/test_source_svn.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from pathlib import PureWindowsPath
+
 from parameterized import parameterized
 from twisted.internet import defer
 from twisted.internet import error
@@ -533,6 +535,7 @@ class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
             )
         )
         self.build.path_module = namedModule("ntpath")
+        self.build.path_cls = PureWindowsPath
         self.expect_commands(
             ExpectShell(workdir='wkdir', command=['svn', '--version']).exit(0),
             ExpectStat(file=r'wkdir\.buildbot-patched', log_environ=True).exit(1),

--- a/master/buildbot/test/unit/worker/test_base.py
+++ b/master/buildbot/test/unit/worker/test_base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from pathlib import PurePath
 from unittest import mock
 
 from parameterized import parameterized
@@ -66,6 +67,12 @@ class WorkerInterfaceTests(interfaces.InterfaceTests):
     def test_attr_path_module(self):
         yield self.callAttached()
         self.assertTrue(hasattr(self.wrk, 'path_module'))
+
+    @defer.inlineCallbacks
+    def test_attr_path_cls(self):
+        yield self.callAttached()
+        path_cls = self.wrk.path_cls
+        self.assertTrue(issubclass(path_cls, PurePath))
 
     @defer.inlineCallbacks
     def test_attr_worker_system(self):

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -15,6 +15,7 @@
 
 import os
 import stat
+from pathlib import PurePath
 from unittest import mock
 
 from parameterized import parameterized
@@ -194,6 +195,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         self.conn.info = {'basedir': 'testdir'}
         self.conn.info['delete_leftover_dirs'] = delete_leftover_dirs
         self.conn.path_module = os.path
+        self.conn.path_cls = PurePath
         d = self.conn.remoteSetBuilderList(builders)
         return d
 

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -19,6 +19,7 @@ import os
 import re
 import stat
 from pathlib import Path
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Sequence
@@ -618,6 +619,12 @@ class GitStepAuth(AbstractGitAuth):
     def _path_module(self):
         assert isinstance(self.step, buildstep.BuildStep) and self.step.build is not None
         return self.step.build.path_module
+
+    @property
+    def _path_cls(self) -> type[PurePath]:
+        assert isinstance(self.step, buildstep.BuildStep) and self.step.build is not None
+        assert self.step.build.path_cls is not None
+        return self.step.build.path_cls
 
     @property
     def _master(self):

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -14,6 +14,9 @@
 # Copyright Buildbot Team Members
 
 import stat
+from pathlib import PurePath
+from pathlib import PurePosixPath
+from pathlib import PureWindowsPath
 from typing import Any
 
 from twisted.internet import defer
@@ -112,6 +115,7 @@ class Connection(base.Connection):
         self._keepalive_action_handler = deferwaiter.RepeatedActionHandler(
             master.reactor, self._keepalive_waiter, self.keepalive_interval, self._do_keepalive
         )
+        self.path_cls: type[PurePath] | None = None
 
     # methods called by the BuildbotWebSocketServerProtocol
 
@@ -165,10 +169,12 @@ class Connection(base.Connection):
         if worker_system == "nt":
             self.path_module = namedModule("ntpath")
             self.path_expanduser = path_expand_user.nt_expanduser
+            self.path_cls = PureWindowsPath
         else:
             # most everything accepts / as separator, so posix should be a reasonable fallback
             self.path_module = namedModule("posixpath")
             self.path_expanduser = path_expand_user.posix_expanduser
+            self.path_cls = PurePosixPath
         return self.info
 
     def _set_worker_settings(self):

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -201,13 +201,13 @@ class Connection(base.Connection):
 
     @defer.inlineCallbacks
     def remoteSetBuilderList(self, builders):
+        assert self.path_cls is not None
+
         yield self._set_worker_settings()
 
-        basedir = self.info['basedir']
+        basedir = self.path_cls(self.info['basedir'])
         builder_names = [name for name, _ in builders]
-        self.builder_basedirs = {
-            name: self.path_module.join(basedir, builddir) for name, builddir in builders
-        }
+        self.builder_basedirs = {name: basedir.joinpath(builddir) for name, builddir in builders}
 
         wanted_dirs = {builddir for _, builddir in builders}
         wanted_dirs.add('info')
@@ -222,7 +222,7 @@ class Connection(base.Connection):
             'op': 'start_command',
             'command_id': command_id,
             'command_name': 'listdir',
-            'args': {'path': basedir},
+            'args': {'path': str(basedir)},
         })
 
         # wait until command is over to get the update request message with args['files']
@@ -240,7 +240,7 @@ class Connection(base.Connection):
                     # dictionary with key 'stat'. 'stat' value is a tuple of 10 elements, where
                     # first element is File mode. It goes to S_ISDIR(mode) to check if path is
                     # a directory so that files are not deleted
-                    path = self.path_module.join(basedir, dir)
+                    path = str(basedir.joinpath(dir))
                     command, command_id = self.create_remote_command(
                         self.worker.workername,
                         ['stat'],
@@ -274,9 +274,7 @@ class Connection(base.Connection):
             })
             yield command.wait_until_complete()
 
-        paths_to_mkdir = [
-            self.path_module.join(basedir, dir) for dir in sorted(list(dirs_to_mkdir))
-        ]
+        paths_to_mkdir = [str(basedir.joinpath(dir)) for dir in sorted(list(dirs_to_mkdir))]
         if paths_to_mkdir:
             # make wanted builder directories which do not exist in worker yet
             command, command_id = self.create_remote_command(
@@ -297,84 +295,80 @@ class Connection(base.Connection):
     def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
         if commandName == "mkdir":
             if isinstance(args['dir'], list):
-                args['paths'] = [
-                    self.path_module.join(self.builder_basedirs[builderName], dir)
-                    for dir in args['dir']
-                ]
+                builder_basedir = self._get_builder_basedir(builderName)
+                args['paths'] = [str(builder_basedir.joinpath(dir)) for dir in args['dir']]
             else:
-                args['paths'] = [
-                    self.path_module.join(self.builder_basedirs[builderName], args['dir'])
-                ]
+                builder_basedir = self._get_builder_basedir(builderName)
+                args['paths'] = [str(builder_basedir.joinpath(args['dir']))]
             del args['dir']
 
         if commandName == "rmdir":
+            builder_basedir = self._get_builder_basedir(builderName)
             if isinstance(args['dir'], list):
-                args['paths'] = [
-                    self.path_module.join(self.builder_basedirs[builderName], dir)
-                    for dir in args['dir']
-                ]
+                args['paths'] = [str(builder_basedir.joinpath(dir)) for dir in args['dir']]
             else:
-                args['paths'] = [
-                    self.path_module.join(self.builder_basedirs[builderName], args['dir'])
-                ]
+                args['paths'] = [str(builder_basedir.joinpath(args['dir']))]
             del args['dir']
 
         if commandName == "cpdir":
-            args['from_path'] = self.path_module.join(
-                self.builder_basedirs[builderName], args['fromdir']
-            )
-            args['to_path'] = self.path_module.join(
-                self.builder_basedirs[builderName], args['todir']
-            )
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['from_path'] = str(builder_basedir.joinpath(args['fromdir']))
+            args['to_path'] = str(builder_basedir.joinpath(args['todir']))
             del args['fromdir']
             del args['todir']
 
         if commandName == "stat":
-            args['path'] = self.path_module.join(
-                self.builder_basedirs[builderName], args.get('workdir', ''), args['file']
-            )
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(builder_basedir.joinpath(args.get('workdir', ''), args['file']))
             del args['file']
 
         if commandName == "glob":
-            args['path'] = self.path_module.join(self.builder_basedirs[builderName], args['path'])
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(builder_basedir.joinpath(args['path']))
 
         if commandName == "listdir":
-            args['path'] = self.path_module.join(self.builder_basedirs[builderName], args['dir'])
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(builder_basedir.joinpath(args['dir']))
             del args['dir']
 
         if commandName == "rmfile":
-            args['path'] = self.path_module.join(
-                self.builder_basedirs[builderName],
-                self.path_expanduser(args['path'], self.info['environ']),
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(
+                builder_basedir.joinpath(self.path_expanduser(args['path'], self.info['environ']))
             )
 
         if commandName == "shell":
-            args['workdir'] = self.path_module.join(
-                self.builder_basedirs[builderName], args['workdir']
-            )
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['workdir'] = str(builder_basedir.joinpath(args['workdir']))
 
         if commandName == "uploadFile":
             commandName = "upload_file"
-            args['path'] = self.path_module.join(
-                self.builder_basedirs[builderName],
-                args['workdir'],
-                self.path_expanduser(args['workersrc'], self.info['environ']),
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(
+                builder_basedir.joinpath(
+                    args['workdir'],
+                    self.path_expanduser(args['workersrc'], self.info['environ']),
+                )
             )
 
         if commandName == "uploadDirectory":
             commandName = "upload_directory"
-            args['path'] = self.path_module.join(
-                self.builder_basedirs[builderName],
-                args['workdir'],
-                self.path_expanduser(args['workersrc'], self.info['environ']),
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(
+                builder_basedir.joinpath(
+                    args['workdir'],
+                    self.path_expanduser(args['workersrc'], self.info['environ']),
+                )
             )
 
         if commandName == "downloadFile":
             commandName = "download_file"
-            args['path'] = self.path_module.join(
-                self.builder_basedirs[builderName],
-                args['workdir'],
-                self.path_expanduser(args['workerdest'], self.info['environ']),
+            builder_basedir = self._get_builder_basedir(builderName)
+            args['path'] = str(
+                builder_basedir.joinpath(
+                    args['workdir'],
+                    self.path_expanduser(args['workerdest'], self.info['environ']),
+                )
             )
         if "want_stdout" in args:
             if args["want_stdout"] == 1:
@@ -431,3 +425,7 @@ class Connection(base.Connection):
     def get_peer(self):
         p = self.protocol.transport.getPeer()
         return f"{p.host}:{p.port}"
+
+    def _get_builder_basedir(self, builder_name: str) -> PurePath:
+        assert self.path_cls is not None
+        return self.path_cls(self.builder_basedirs[builder_name])

--- a/newsfragments/worker-pure-path-class-helper.misc
+++ b/newsfragments/worker-pure-path-class-helper.misc
@@ -1,0 +1,2 @@
+Add a ``path_cls`` attribute, being either a ``PureWindowsPath`` or ``PurePosixPath`` depending on the worker system.
+Should replace usage of ``path_module``, providing better ergonomics and typing.


### PR DESCRIPTION
The `path_module` usage is not playing nicely with typing currently being deployed in Buildbot.

A possibility would be to type `AbstractWorker.path_module` using a [module protocol](https://typing.python.org/en/latest/spec/protocol.html#modules-as-implementations-of-protocols), but it would need to be maintained here (although the API is stable, so wouldn't be that much work in the long term).

Another way done here is to use `pathlib.PurePath` implementations.
Usage is mostly the same as before, give or take some `str()` wrapping as `PathLike` are not directly compatible with `str` expected in functions (but requiring `PathLike` when a path is expected would improve safety further).

eg. `worker.path_module.join(a, b)` becomes `worker.path_cls(a, b)`.

There is other side benefits in that the `PurePath` classes does not implement methods that are invalid in this context.

For example, there is usages of `worker.path_module.abspath` and `worker.path_module.normpath`.
Both are unvalid usages as:
- [`os.path.normpath`](https://docs.python.org/3/library/os.path.html#os.path.normpath). [used here](https://github.com/tdesveaux/buildbot/blob/57d0b0a73852dfcddcbea42d37a5437888852b07/master/buildbot/steps/source/p4.py#L307)
    > This string manipulation may change the meaning of a path that contains symbolic links.
- [`os.path.abspath`](https://docs.python.org/3/library/os.path.html#os.path.abspath) will use `os.getcwd()` for non-absolute paths (which would use the master workdir). [used here](https://github.com/tdesveaux/buildbot/blob/57d0b0a73852dfcddcbea42d37a5437888852b07/master/buildbot/steps/source/base.py#L233-L234)

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
