### PR TITLE
Ruff: enable typechecking

### DIFF
--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.internet import defer
@@ -26,7 +27,9 @@ from buildbot import config
 from buildbot.interfaces import IChangeSource
 from buildbot.util import service
 from buildbot.util.poll import method as poll_method
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 @implementer(IChangeSource)

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
@@ -33,7 +34,9 @@ from buildbot.util import deferredLocked
 from buildbot.util import epoch2datetime
 from buildbot.util import httpclientservice
 from buildbot.util.pullrequest import PullRequestMixin
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullRequestMixin):

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -19,6 +19,7 @@ import copy
 import datetime
 import hashlib
 import json
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
@@ -41,7 +42,9 @@ from buildbot.util import runprocess
 from buildbot.util import watchdog
 from buildbot.util.protocol import LineProcessProtocol
 from buildbot.util.pullrequest import PullRequestMixin
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 def _canonicalize_event(event: dict) -> dict:

--- a/master/buildbot/changes/github.py
+++ b/master/buildbot/changes/github.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
@@ -32,7 +33,9 @@ from buildbot.util import datetime2epoch
 from buildbot.util import httpclientservice
 from buildbot.util.pullrequest import PullRequestMixin
 from buildbot.util.state import StateMixin
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 log = Logger()
 

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 import time
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
@@ -30,7 +31,9 @@ from buildbot.util import bytes2unicode
 from buildbot.util import deferredLocked
 from buildbot.util import runprocess
 from buildbot.util.state import StateMixin
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -28,6 +28,7 @@ from email.iterators import body_line_iterator
 from email.utils import mktime_tz
 from email.utils import parseaddr
 from email.utils import parsedate_tz
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
 from typing import Sequence
@@ -39,7 +40,9 @@ from zope.interface import implementer
 from buildbot import util
 from buildbot.interfaces import IChangeSource
 from buildbot.util.maildir import MaildirService
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 @implementer(IChangeSource)

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import datetime
 import os
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
@@ -40,7 +41,9 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 debug_logging = False
 

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -34,7 +34,6 @@ from twisted.internet import interfaces
 from twisted.internet import protocol
 from twisted.internet import reactor
 from twisted.python import log
-from twisted.python.failure import Failure
 
 from buildbot import config
 from buildbot import util
@@ -43,6 +42,8 @@ from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
 
 if TYPE_CHECKING:
+    from twisted.python.failure import Failure
+
     from buildbot.util.twisted import InlineCallbacksType
 
 debug_logging = False

--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
 from typing import Sequence
@@ -24,9 +25,11 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot.changes import base
-from buildbot.config.master import MasterConfig
 from buildbot.pbutil import NewCredPerspective
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.config.master import MasterConfig
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class ChangePerspective(NewCredPerspective):

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 import xml.dom.minidom
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
 from typing import Sequence
@@ -33,7 +34,9 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 # these split_file_* functions are available for use as values to the
 # split_file= argument.

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -28,6 +27,7 @@ from buildbot.db.buildrequests import NotClaimedError
 from buildbot.process.results import RETRY
 
 if TYPE_CHECKING:
+    import datetime
     from typing import Sequence
 
     from buildbot.data.resultspec import ResultSpec

--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -16,15 +16,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from twisted.internet import defer
 from twisted.python import deprecate
 from twisted.python import versions
 
 from buildbot.db import NULL
 from buildbot.db import base
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from twisted.internet import defer
 
 
 @dataclass

--- a/master/buildbot/db/codebase_commits.py
+++ b/master/buildbot/db/codebase_commits.py
@@ -21,13 +21,13 @@ from typing import Any
 from typing import Awaitable
 from typing import Callable
 
-import sqlalchemy as sa
-from twisted.internet import defer
-
 from buildbot.db import base
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    import sqlalchemy as sa
+    from twisted.internet import defer
+
     from buildbot.data.resultspec import ResultSpec
 
 

--- a/master/buildbot/db/codebases.py
+++ b/master/buildbot/db/codebases.py
@@ -18,13 +18,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import sqlalchemy as sa
-from twisted.internet import defer
-
 from buildbot.db import base
 from buildbot.util.sautils import hash_columns
 
 if TYPE_CHECKING:
+    import sqlalchemy as sa
+    from twisted.internet import defer
+
     from buildbot.data.resultspec import ResultSpec
 
 

--- a/master/buildbot/db/projects.py
+++ b/master/buildbot/db/projects.py
@@ -16,12 +16,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-from twisted.internet import defer
+from typing import TYPE_CHECKING
 
 from buildbot.db import base
 from buildbot.util.sautils import hash_columns
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from twisted.internet import defer
 
 
 @dataclass

--- a/master/buildbot/db/test_result_sets.py
+++ b/master/buildbot/db/test_result_sets.py
@@ -16,15 +16,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from twisted.internet import defer
 from twisted.python import deprecate
 from twisted.python import versions
 
 from buildbot.db import base
 from buildbot.util.twisted import async_to_deferred
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from twisted.internet import defer
 
 
 @dataclass

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import reduce
-from pathlib import PurePath
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -49,6 +48,8 @@ from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
 
 if TYPE_CHECKING:
+    from pathlib import PurePath
+
     from buildbot.interfaces import IBuildStep
     from buildbot.locks import BaseLockId
     from buildbot.process.builder import Builder

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -26,7 +26,6 @@ from twisted.python import log
 
 from buildbot import interfaces
 from buildbot.data import resultspec
-from buildbot.data.workers import Worker
 from buildbot.interfaces import IRenderable
 from buildbot.process import buildrequest
 from buildbot.process import workerforbuilder
@@ -42,6 +41,7 @@ from buildbot.util.render_description import render_description
 if TYPE_CHECKING:
     from buildbot.config.builder import BuilderConfig
     from buildbot.config.master import MasterConfig
+    from buildbot.data.workers import Worker
     from buildbot.master import BuildMaster
 
 

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -46,7 +46,6 @@ from buildbot.config.checks import check_param_str_none
 from buildbot.db import model_config
 from buildbot.interfaces import IRenderable
 from buildbot.interfaces import WorkerSetupError
-from buildbot.locks import BaseLock
 from buildbot.process import log as plog
 from buildbot.process import properties
 from buildbot.process import remotecommand
@@ -76,6 +75,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from buildbot.interfaces import IBuildStep
+    from buildbot.locks import BaseLock
     from buildbot.master import BuildMaster
     from buildbot.process.build import Build
     from buildbot.process.log import StreamLog

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -26,7 +26,6 @@ from typing import cast
 
 from twisted.internet import defer
 from twisted.internet import error
-from twisted.internet.base import ReactorBase
 from twisted.python import deprecate
 from twisted.python import log
 from twisted.python import versions
@@ -72,6 +71,7 @@ from buildbot.util.test_result_submitter import TestResultSubmitter
 if TYPE_CHECKING:
     from typing import TypeVar
 
+    from twisted.internet.base import ReactorBase
     from typing_extensions import Self
 
     from buildbot.interfaces import IBuildStep

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -39,15 +39,18 @@ import os
 import sys
 from collections import defaultdict
 from collections import deque
+from typing import TYPE_CHECKING
 
 from twisted.application import service
 from twisted.internet import reactor
-from twisted.internet.base import ReactorBase
 from twisted.internet.task import LoopingCall
 from twisted.python import log
 
 from buildbot import util
 from buildbot.util import service as util_service
+
+if TYPE_CHECKING:
+    from twisted.internet.base import ReactorBase
 
 # Make use of the resource module if we can
 try:

--- a/master/buildbot/scripts/copydb.py
+++ b/master/buildbot/scripts/copydb.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import queue
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 
@@ -32,7 +33,9 @@ from buildbot.master import BuildMaster
 from buildbot.scripts import base
 from buildbot.util import in_reactor
 from buildbot.util import misc
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 @in_reactor

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -19,9 +19,9 @@ BuildSteps that are specific to the Twisted source tree
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
-from twisted.internet.base import ReactorBase
 from twisted.python import log
 
 from buildbot import util
@@ -32,6 +32,9 @@ from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import shell
+
+if TYPE_CHECKING:
+    from twisted.internet.base import ReactorBase
 
 
 class HLint(buildstep.ShellMixin, buildstep.BuildStep):

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -15,14 +15,17 @@
 
 from __future__ import annotations
 
-import datetime
 import json
+from typing import TYPE_CHECKING
 
 from buildbot.data import connector
 from buildbot.data import resultspec
 from buildbot.test.util import validation
 from buildbot.util import service
 from buildbot.util.twisted import async_to_deferred
+
+if TYPE_CHECKING:
+    import datetime
 
 
 class FakeUpdates(service.AsyncService):

--- a/master/buildbot/test/unit/db_migrate/test_versions_067_add_codebase_data.py
+++ b/master/buildbot/test/unit/db_migrate/test_versions_067_add_codebase_data.py
@@ -15,12 +15,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
-from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.util import migration
 from buildbot.util import sautils
+
+if TYPE_CHECKING:
+    from twisted.internet import defer
 
 
 class Migration(migration.MigrateTestMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/reporters/test_words.py
+++ b/master/buildbot/test/unit/reporters/test_words.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from unittest import mock
@@ -30,7 +31,9 @@ from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import datetime2epoch
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class ContactMixin(TestReactorMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 from typing import Any
 from unittest import mock
 
@@ -30,11 +31,13 @@ from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
 from twisted.web.resource import IResource
 
-from buildbot.test.fake.fakemaster import FakeMaster
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import auth
+
+if TYPE_CHECKING:
+    from buildbot.test.fake.fakemaster import FakeMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class AuthResourceMixin(ABC):

--- a/master/buildbot/test/unit/www/test_auth.py
+++ b/master/buildbot/test/unit/www/test_auth.py
@@ -25,7 +25,6 @@ from twisted.cred.credentials import UsernamePassword
 from twisted.cred.error import UnauthorizedLogin
 from twisted.internet import defer
 from twisted.trial import unittest
-from twisted.web import server
 from twisted.web.error import Error
 from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
@@ -36,6 +35,8 @@ from buildbot.test.util import www
 from buildbot.www import auth
 
 if TYPE_CHECKING:
+    from twisted.web import server
+
     from buildbot.test.fake.fakemaster import FakeMaster
     from buildbot.util.twisted import InlineCallbacksType
 

--- a/master/buildbot/test/unit/www/test_authz.py
+++ b/master/buildbot/test/unit/www/test_authz.py
@@ -15,13 +15,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test import fakedb
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import authz
 from buildbot.www.authz.endpointmatchers import AnyControlEndpointMatcher
 from buildbot.www.authz.endpointmatchers import AnyEndpointMatcher
@@ -35,6 +36,9 @@ from buildbot.www.authz.roles import RolesFromDomain
 from buildbot.www.authz.roles import RolesFromEmails
 from buildbot.www.authz.roles import RolesFromGroups
 from buildbot.www.authz.roles import RolesFromOwner
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -18,10 +18,10 @@ import os
 import re
 import sys
 from io import StringIO
+from typing import TYPE_CHECKING
 from typing import Any
 from unittest import mock
 
-from twisted.application.service import Service
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
@@ -44,6 +44,9 @@ from buildbot.util.twisted import any_to_async
 from buildbot.util.twisted import async_to_deferred
 from buildbot.worker.local import LocalWorker
 from buildbot_worker.bot import Worker
+
+if TYPE_CHECKING:
+    from twisted.application.service import Service
 
 
 @implementer(IConfigLoader)

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -20,6 +20,7 @@ import os
 from importlib.metadata import entry_points
 from io import BytesIO
 from io import StringIO
+from typing import TYPE_CHECKING
 from typing import Any
 from unittest import mock
 from urllib.parse import parse_qs
@@ -33,10 +34,12 @@ from buildbot.test.fake import fakemaster
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.util.importlib_compat import entry_points_get
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import auth
 from buildbot.www import authz
 from buildbot.www.authz.authz import Authz
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class FakeSession:

--- a/master/buildbot/util/_notifier.py
+++ b/master/buildbot/util/_notifier.py
@@ -21,11 +21,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Generic
 from typing import TypeVar
 
 from twisted.internet.defer import Deferred
-from twisted.python.failure import Failure
+
+if TYPE_CHECKING:
+    from twisted.python.failure import Failure
 
 _SelfResultT = TypeVar("_SelfResultT")
 

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -35,13 +35,13 @@ from buildbot.process.properties import Properties
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util import ComparableMixin
 from buildbot.util import bytes2unicode
-from buildbot.util.git_credential import GitCredentialOptions
 from buildbot.util.misc import writeLocalFile
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
     from buildbot.changes.gitpoller import GitPoller
     from buildbot.interfaces import IRenderable
+    from buildbot.util.git_credential import GitCredentialOptions
 
 RC_SUCCESS = 0
 

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -19,9 +19,9 @@ import time
 from pathlib import PurePath
 from pathlib import PurePosixPath
 from pathlib import PureWindowsPath
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
-from twisted.internet.base import DelayedCall
 from twisted.python import log
 from twisted.python.reflect import namedModule
 from zope.interface import implementer
@@ -34,6 +34,9 @@ from buildbot.util import Notifier
 from buildbot.util import bytes2unicode
 from buildbot.util import deferwaiter
 from buildbot.util import service
+
+if TYPE_CHECKING:
+    from twisted.internet.base import DelayedCall
 
 
 @implementer(IWorker)

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 import enum
 import random
 import string
+from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.internet import defer
-from twisted.internet.base import DelayedCall
 from twisted.python import failure
 from twisted.python import log
 from zope.interface import implementer
@@ -32,6 +32,9 @@ from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
 from buildbot.util import Notifier
 from buildbot.worker.base import AbstractWorker
+
+if TYPE_CHECKING:
+    from twisted.internet.base import DelayedCall
 
 
 class States(enum.Enum):

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import re
 from abc import ABCMeta
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -45,8 +46,10 @@ from zope.interface import implementer
 from buildbot.util import bytes2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import resource
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class AuthRootResource(resource.Resource):

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import fnmatch
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -27,8 +28,10 @@ from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
 from buildbot.util import unicode2bytes
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www.authz.roles import RolesFromOwner
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class Forbidden(Error):

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -16,13 +16,16 @@
 from __future__ import annotations
 
 import inspect
+from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.internet import defer
 
 from buildbot.data.exceptions import InvalidPathError
 from buildbot.util import bytes2unicode
-from buildbot.util.twisted import InlineCallbacksType
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class EndpointMatcherBase:

--- a/master/buildbot/www/avatar.py
+++ b/master/buildbot/www/avatar.py
@@ -32,11 +32,11 @@ from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import unicode2bytes
 from buildbot.util.config import ConfiguredMixin
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import resource
 
 if TYPE_CHECKING:
     from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class AvatarBase(ConfiguredMixin):

--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -33,11 +33,11 @@ from buildbot.plugins.db import get_plugins
 from buildbot.util import bytes2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import unicode2bytes
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import resource
 
 if TYPE_CHECKING:
     from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class ChangeHookResource(resource.Resource):

--- a/master/buildbot/www/encoding.py
+++ b/master/buildbot/www/encoding.py
@@ -16,11 +16,14 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.web import iweb
-from twisted.web.http import Request
 from zope.interface import implementer
+
+if TYPE_CHECKING:
+    from twisted.web.http import Request
 
 try:
     import brotli

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -27,11 +27,12 @@ from typing import Any
 from typing import cast
 
 from twisted.internet import defer
-from twisted.web.server import Request
 
 from buildbot.util import bytes2unicode
 
 if TYPE_CHECKING:
+    from twisted.web.server import Request
+
     from buildbot.master import BuildMaster
 
 

--- a/master/buildbot/www/hooks/bitbucket.py
+++ b/master/buildbot/www/hooks/bitbucket.py
@@ -17,15 +17,18 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 from typing import Any
 
 from dateutil.parser import parse as dateparse
 from twisted.internet import defer
 from twisted.python import log
-from twisted.web.server import Request
 
 from buildbot.util import bytes2unicode
 from buildbot.www.hooks.base import BaseHookHandler
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
 
 _HEADER_EVENT = b'X-Event-Key'
 

--- a/master/buildbot/www/hooks/bitbucketcloud.py
+++ b/master/buildbot/www/hooks/bitbucketcloud.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.python import log
-from twisted.web.server import Request
 
 from buildbot.util import bytes2unicode
 from buildbot.util.pullrequest import PullRequestMixin
@@ -35,6 +34,8 @@ _HEADER_EVENT = b'X-Event-Key'
 
 
 if TYPE_CHECKING:
+    from twisted.web.server import Request
+
     from buildbot.master import BuildMaster
 
 

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -22,12 +22,13 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.python import log
-from twisted.web.server import Request
 
 from buildbot.util import bytes2unicode
 from buildbot.util.pullrequest import PullRequestMixin
 
 if TYPE_CHECKING:
+    from twisted.web.server import Request
+
     from buildbot.master import BuildMaster
 
 GIT_BRANCH_REF = "refs/heads/{}"

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -27,9 +27,7 @@ from typing import Callable
 
 from dateutil.parser import parse as dateparse
 from twisted.internet import defer
-from twisted.internet.defer import Deferred
 from twisted.python import log
-from twisted.web.server import Request
 
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
@@ -39,6 +37,9 @@ from buildbot.util.pullrequest import PullRequestMixin
 from buildbot.www.hooks.base import BaseHookHandler
 
 if TYPE_CHECKING:
+    from twisted.internet.defer import Deferred
+    from twisted.web.server import Request
+
     from buildbot.master import BuildMaster
     from buildbot.util.twisted import InlineCallbacksType
 

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -36,11 +36,11 @@ from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import unicode2bytes
 from buildbot.util.pullrequest import PullRequestMixin
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www.hooks.base import BaseHookHandler
 
 if TYPE_CHECKING:
     from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 _HEADER_EVENT = b'X-GitHub-Event'
 _HEADER_SIGNATURE = b'X-Hub-Signature'

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 
 from dateutil.parser import parse as dateparse
@@ -27,8 +28,10 @@ from twisted.web.server import Request
 
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www.hooks.base import BaseHookHandler
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 _HEADER_EVENT = b'X-Gitlab-Event'
 _HEADER_GITLAB_TOKEN = b'X-Gitlab-Token'

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -24,13 +24,14 @@ from typing import Any
 from dateutil.parser import parse as dateparse
 from twisted.internet.defer import inlineCallbacks
 from twisted.python import log
-from twisted.web.server import Request
 
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.www.hooks.base import BaseHookHandler
 
 if TYPE_CHECKING:
+    from twisted.web.server import Request
+
     from buildbot.util.twisted import InlineCallbacksType
 
 _HEADER_EVENT = b'X-Gitlab-Event'

--- a/master/buildbot/www/hooks/gitorious.py
+++ b/master/buildbot/www/hooks/gitorious.py
@@ -20,15 +20,18 @@ from __future__ import annotations
 
 import json
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 
 from dateutil.parser import parse as dateparse
 from twisted.internet import defer
 from twisted.python import log
-from twisted.web.server import Request
 
 from buildbot.util import bytes2unicode
 from buildbot.www.hooks.base import BaseHookHandler
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
 
 
 class GitoriousHandler(BaseHookHandler):

--- a/master/buildbot/www/hooks/poller.py
+++ b/master/buildbot/www/hooks/poller.py
@@ -19,17 +19,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
-
-from twisted.internet import defer
-from twisted.web.server import Request
 
 from buildbot.changes.base import ReconfigurablePollingChangeSource
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www.hooks.base import BaseHookHandler
 from buildbot.www.service import BuildbotSite
+
+if TYPE_CHECKING:
+    from twisted.internet import defer
+    from twisted.web.server import Request
 
 
 class PollingHandler(BaseHookHandler):

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -35,12 +35,12 @@ import buildbot
 from buildbot import config
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import auth
 from buildbot.www import resource
 
 if TYPE_CHECKING:
     from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 log = Logger()

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -40,7 +40,6 @@ from buildbot.data.resultspec import ResultSpec
 from buildbot.util import bytes2unicode
 from buildbot.util import toJson
 from buildbot.util import unicode2bytes
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import resource
 from buildbot.www.authz import Forbidden
 from buildbot.www.encoding import BrotliEncoderFactory
@@ -54,6 +53,7 @@ if TYPE_CHECKING:
     from buildbot.data.base import Endpoint
     from buildbot.data.resultspec import ResultSpec
     from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class BadJsonRpc2(Exception):

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -45,7 +45,6 @@ from buildbot.plugins.db import get_plugins
 from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util import unicode2bytes
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www import change_hook
@@ -57,6 +56,7 @@ from buildbot.www import ws
 
 if TYPE_CHECKING:
     from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class BuildbotSession(server.Session):

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -28,7 +28,6 @@ import jwt
 import twisted
 from packaging.version import parse as parse_version
 from twisted.application import strports
-from twisted.application.internet import StreamServerEndpointService
 from twisted.cred.portal import IRealm
 from twisted.cred.portal import Portal
 from twisted.internet import defer
@@ -55,6 +54,8 @@ from buildbot.www import sse
 from buildbot.www import ws
 
 if TYPE_CHECKING:
+    from twisted.application.internet import StreamServerEndpointService
+
     from buildbot.master import BuildMaster
     from buildbot.util.twisted import InlineCallbacksType
 

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -37,12 +37,12 @@ except ImportError:
 
 from buildbot.util import bytes2unicode
 from buildbot.util import toJson
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.www import auth
 
 if TYPE_CHECKING:
     from buildbot.master import BuildMaster
     from buildbot.mq.base import QueueRef
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class Subscription:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ target-version = "py38"
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
 
-        "TC001", # typing-only-first-party-import
         "TC002", # typing-only-third-party-import
         "TC003", # typing-only-standard-library-import
         "TC006", # runtime-cast-value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 target-version = "py38"
 
 [tool.ruff.lint]
-    select = ["W", "E", "F", "I", "PL", "UP", "T100", "B", "RUF", "FA"]
+    select = ["W", "E", "F", "I", "PL", "UP", "T100", "B", "RUF", "FA", "TC"]
     ignore = [
         "E711", # comparison to None should be 'if cond is None:'
         "E712", # comparison to False should be 'if cond is False:' or 'if not cond:'
@@ -35,6 +35,11 @@ target-version = "py38"
         # Might be nice to have in future, but requires significant refactoring for now.
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
+
+        "TC001", # typing-only-first-party-import
+        "TC002", # typing-only-third-party-import
+        "TC003", # typing-only-standard-library-import
+        "TC006", # runtime-cast-value
     ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ target-version = "py38"
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
 
-        "TC003", # typing-only-standard-library-import
         "TC006", # runtime-cast-value
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ target-version = "py38"
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
 
-        "TC002", # typing-only-third-party-import
         "TC003", # typing-only-standard-library-import
         "TC006", # runtime-cast-value
     ]

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -26,7 +26,6 @@ from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task
-from twisted.internet.base import DelayedCall
 from twisted.internet.endpoints import clientFromString
 from twisted.python import log
 from twisted.spread import pb
@@ -46,6 +45,8 @@ from buildbot_worker.pbutil import decode
 from buildbot_worker.tunnel import HTTPTunnelEndpoint
 
 if TYPE_CHECKING:
+    from twisted.internet.base import DelayedCall
+
     from buildbot.master import BuildMaster
 
 

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -19,7 +19,6 @@ Support for running 'shell commands'
 
 from __future__ import annotations
 
-import datetime
 import os
 import pprint
 import re
@@ -31,6 +30,7 @@ import sys
 import traceback
 from codecs import getincrementaldecoder
 from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -46,6 +46,9 @@ from buildbot_worker.compat import bytes2NativeString
 from buildbot_worker.compat import bytes2unicode
 from buildbot_worker.compat import unicode2bytes
 from buildbot_worker.exceptions import AbandonChain
+
+if TYPE_CHECKING:
+    import datetime
 
 if runtime.platformType == 'posix':
     from twisted.internet.process import Process

--- a/worker/buildbot_worker/test/fake/reactor.py
+++ b/worker/buildbot_worker/test/fake/reactor.py
@@ -22,8 +22,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 from typing import Any
 
 from twisted.internet import defer
@@ -35,6 +34,10 @@ from twisted.internet.task import Clock
 from twisted.python import log
 from twisted.python.failure import Failure
 from zope.interface import implementer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
 
 # The code here is based on the implementations in
 # https://twistedmatrix.com/trac/ticket/8295


### PR DESCRIPTION
depends on #8410

Enable ruff [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc)

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
