### PR TITLE
.github: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
+    groups:
+      minor-upgrades:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "e2e/"
+      - "www/**"
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
+    groups:
+      minor-upgrades:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
+    groups:
+      minor-upgrades:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
+    groups:
+      minor-upgrades:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,0 @@
-# update schedule, default is not set
-# the bot will visit the repo once and bundle all updates in a single PR for the given
-# day/week/month
-schedule: "every two weeks" # allowed ["every day", "every week", "every two weeks", "every month"]


### PR DESCRIPTION
NOTE: feel free to close without any discussion as it's not a change validated by maintainers

Relates to https://github.com/buildbot/buildbot/pull/8410#issue-3037447217

dependabot is already used for JS dependencies (https://github.com/buildbot/buildbot/pulls?q=author%3Aapp%2Fdependabot+created%3A%3C%3D2025-05-04+).

Adding the following `.github/dependabot.yml` would setup checks for JS/Python/Docker/GithubActions.

I added `groups` so that major upgrade would have their own PR, but minor/patch are batched into a single PR to avoid noise.

It looks like dependabot honor `# pyup: ignore` (https://github.com/tdesveaux/buildbot/pull/20/files)

I don't think there is other pitfalls this change could have, let me know if you think of any that need investigation.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
