### PR TITLE
Lock down websocket connection

### DIFF
--- a/master/buildbot/test/unit/www/test_service.py
+++ b/master/buildbot/test/unit/www/test_service.py
@@ -233,7 +233,7 @@ class TestBuildbotSite(unittest.SynchronousTestCase):
 
     def test_getSession_from_correct_jwt(self):
         payload = {'user_info': {'some': 'payload'}}
-        uid = jwt.encode(payload, self.SECRET, algorithm=service.SESSION_SECRET_ALGORITHM)
+        uid = jwt.encode(payload, self.SECRET, algorithm=auth.SESSION_SECRET_ALGORITHM)
         session = self.site.getSession(uid)
         self.assertEqual(session.user_info, {'some': 'payload'})
 
@@ -242,13 +242,13 @@ class TestBuildbotSite(unittest.SynchronousTestCase):
         exp = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(weeks=1)
         exp = calendar.timegm(datetime.datetime.timetuple(exp))
         payload = {'user_info': {'some': 'payload'}, 'exp': exp}
-        uid = jwt.encode(payload, self.SECRET, algorithm=service.SESSION_SECRET_ALGORITHM)
+        uid = jwt.encode(payload, self.SECRET, algorithm=auth.SESSION_SECRET_ALGORITHM)
         with self.assertRaises(KeyError):
             self.site.getSession(uid)
 
     def test_getSession_with_no_user_info(self):
         payload = {'foo': 'bar'}
-        uid = jwt.encode(payload, self.SECRET, algorithm=service.SESSION_SECRET_ALGORITHM)
+        uid = jwt.encode(payload, self.SECRET, algorithm=auth.SESSION_SECRET_ALGORITHM)
         with self.assertRaises(KeyError):
             self.site.getSession(uid)
 
@@ -263,7 +263,7 @@ class TestBuildbotSite(unittest.SynchronousTestCase):
         session.updateSession(request)
         self.assertEqual(len(request.cookies), 1)
         _, value = request.cookies[0].split(b";")[0].split(b"=")
-        decoded = jwt.decode(value, self.SECRET, algorithms=[service.SESSION_SECRET_ALGORITHM])
+        decoded = jwt.decode(value, self.SECRET, algorithms=[auth.SESSION_SECRET_ALGORITHM])
         self.assertEqual(decoded['user_info'], {'anonymous': True})
         self.assertIn('exp', decoded)
 

--- a/master/buildbot/test/unit/www/test_ws.py
+++ b/master/buildbot/test/unit/www/test_ws.py
@@ -12,17 +12,24 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import annotations
 
+import datetime
 import json
 import re
-from unittest.mock import Mock
+from typing import Any
+from unittest import mock
 
+import jwt
+from autobahn.websocket.types import ConnectionDeny
+from autobahn.websocket.types import ConnectionRequest
 from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
 from buildbot.util import bytes2unicode
+from buildbot.www import auth
 from buildbot.www import ws
 
 
@@ -33,7 +40,7 @@ class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         self.master = master = yield self.make_master(url="h:/a/b/", wantMq=True, wantGraphql=True)
         self.ws = ws.WsResource(master)
         self.proto = self.ws._factory.buildProtocol("me")
-        self.proto.sendMessage = Mock(spec=self.proto.sendMessage)
+        self.proto.sendMessage = mock.Mock(spec=self.proto.sendMessage)
 
     def assert_called_with_json(self, obj, expected_json):
         jsonArg = obj.call_args[0][0]
@@ -53,14 +60,6 @@ class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             actual_json.pop(key)
 
         self.assertEqual(actual_json, expected_json)
-
-    def do_onConnect(self, protocols):
-        class FakeRequest:
-            pass
-
-        r = FakeRequest()
-        r.protocols = protocols
-        return self.proto.onConnect(r)
 
     def test_ping(self):
         self.proto.onMessage(json.dumps({"cmd": 'ping', "_id": 1}), False)
@@ -138,6 +137,198 @@ class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             json.dumps({"cmd": 'stopConsuming', "path": 'builds/*/*', "_id": 2}), False
         )
         self.assert_called_with_json(self.proto.sendMessage, {"msg": "OK", "code": 200, "_id": 2})
+
+    def build_token(self, expired: bool, user_info: dict[str, Any]) -> str:
+        delta = datetime.timedelta(weeks=1)
+        if expired:
+            delta = -delta
+
+        expiration = datetime.datetime.now(datetime.timezone.utc) + delta
+
+        payload = {'user_info': user_info, 'exp': expiration}
+        return jwt.encode(
+            payload, self.master.www.site.session_secret, algorithm=auth.SESSION_SECRET_ALGORITHM
+        )
+
+    @defer.inlineCallbacks
+    def test_on_connect_no_ssl(self):
+        self.master.www = mock.Mock()
+        self.master.www.authz = mock.Mock()
+        self.master.www.authz.assertUserAllowed = mock.Mock(return_value=defer.succeed(None))
+
+        request = ConnectionRequest(
+            path='/ws',
+            headers={'cookie': ''},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+        yield self.proto.onConnect(request)
+        self.master.www.authz.assertUserAllowed.assert_called_once_with(
+            'masters', 'get', {}, {'anonymous': True}
+        )
+
+    @defer.inlineCallbacks
+    def test_on_connect_with_token(self):
+        self.master.www = mock.Mock()
+        self.master.www.site = mock.Mock()
+        self.master.www.site.session_secret = 'secret'
+        self.master.www.authz = mock.Mock()
+        self.master.www.authz.assertUserAllowed = mock.Mock(return_value=defer.succeed(None))
+
+        token = self.build_token(expired=False, user_info={'some': 'payload'})
+
+        request = ConnectionRequest(
+            path='/ws',
+            headers={'cookie': f'TWISTED_SESSION={token}'},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+
+        yield self.proto.onConnect(request)
+        self.master.www.authz.assertUserAllowed.assert_called_once_with(
+            'masters', 'get', {}, {'some': 'payload'}
+        )
+
+    @defer.inlineCallbacks
+    def test_on_connect_with_expired_token(self):
+        self.master.www = mock.Mock()
+        self.master.www.site = mock.Mock()
+        self.master.www.site.session_secret = 'secret'
+        self.master.www.authz = mock.Mock()
+        self.master.www.authz.assertUserAllowed = mock.Mock(return_value=defer.succeed(None))
+
+        token = self.build_token(expired=True, user_info={'some': 'payload'})
+
+        request = ConnectionRequest(
+            path='/ws',
+            headers={'cookie': f'TWISTED_SESSION={token}'},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+
+        with self.assertRaises(ConnectionDeny) as cm:
+            yield self.proto.onConnect(request)
+        self.assertEqual(cm.exception.args, (403, 'Forbidden'))
+
+    @defer.inlineCallbacks
+    def test_on_connect_invalid_token(self):
+        self.master.www = mock.Mock()
+        self.master.www.site = mock.Mock()
+        self.master.www.site.session_secret = 'secret'
+        self.master.www.authz = mock.Mock()
+
+        request = ConnectionRequest(
+            path='/ws',
+            headers={'cookie': 'TWISTED_SESSION=invalid_token'},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+
+        with self.assertRaises(ConnectionDeny) as cm:
+            yield self.proto.onConnect(request)
+        self.assertEqual(cm.exception.args, (403, 'Forbidden'))
+        self.assertEqual(len(self.flushLoggedErrors(jwt.exceptions.DecodeError)), 1)
+
+    @defer.inlineCallbacks
+    def test_on_connect_with_ssl(self):
+        self.master.www = mock.Mock()
+        self.master.www.site = mock.Mock()
+        self.master.www.site.session_secret = 'secret'
+        self.master.www.authz = mock.Mock()
+        self.master.www.authz.assertUserAllowed = mock.Mock(return_value=defer.succeed(None))
+
+        self.proto.is_secure = mock.Mock(return_value=True)
+
+        token = self.build_token(expired=False, user_info={'some': 'payload'})
+        request = ConnectionRequest(
+            path='/ws',
+            headers={'cookie': f'TWISTED_SECURE_SESSION={token}'},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+
+        yield self.proto.onConnect(request)
+        self.master.www.authz.assertUserAllowed.assert_called_once_with(
+            'masters', 'get', {}, {'some': 'payload'}
+        )
+
+    @defer.inlineCallbacks
+    def test_on_connect_different_path(self):
+        self.master.www = mock.Mock()
+        self.master.www.site = mock.Mock()
+        self.master.www.site.session_secret = 'secret'
+        self.master.www.authz = mock.Mock()
+        self.master.www.authz.assertUserAllowed = mock.Mock(return_value=defer.succeed(None))
+
+        token = self.build_token(expired=False, user_info={'some': 'payload'})
+
+        request = ConnectionRequest(
+            path='/custom/ws',
+            headers={'cookie': f'TWISTED_SESSION_custom={token}'},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+
+        yield self.proto.onConnect(request)
+        self.master.www.authz.assertUserAllowed.assert_called_once_with(
+            'masters', 'get', {}, {'some': 'payload'}
+        )
+
+    @defer.inlineCallbacks
+    def test_on_connect_direct_connection_deny(self):
+        self.master.www = mock.Mock()
+        self.master.www.site = mock.Mock()
+        self.master.www.site.session_secret = 'secret'
+        self.master.www.authz = mock.Mock()
+        self.master.www.authz.assertUserAllowed = mock.Mock(
+            side_effect=ConnectionDeny(403, "Forbidden")
+        )
+
+        request = ConnectionRequest(
+            path='/ws',
+            headers={'cookie': 'auth_token=valid'},
+            peer='tcp:127.0.0.1:1234',
+            host='localhost',
+            origin='http://localhost',
+            protocols=[],
+            version=13,
+            params={},
+            extensions=[],
+        )
+
+        with self.assertRaises(ConnectionDeny) as cm:
+            yield self.proto.onConnect(request)
+        self.assertEqual(cm.exception.args, (403, 'Forbidden'))
 
 
 class TestParseCookies(unittest.TestCase):

--- a/master/buildbot/test/unit/www/test_ws.py
+++ b/master/buildbot/test/unit/www/test_ws.py
@@ -138,3 +138,29 @@ class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             json.dumps({"cmd": 'stopConsuming', "path": 'builds/*/*', "_id": 2}), False
         )
         self.assert_called_with_json(self.proto.sendMessage, {"msg": "OK", "code": 200, "_id": 2})
+
+
+class TestParseCookies(unittest.TestCase):
+    def test_parse_cookies_single(self):
+        result = ws.parse_cookies("name=value")
+        self.assertEqual(result, {"name": "value"})
+
+    def test_parse_cookies_multiple_comma(self):
+        result = ws.parse_cookies("name1=value1,name2=value2")
+        self.assertEqual(result, {"name1": "value1", "name2": "value2"})
+
+    def test_parse_cookies_multiple_semicolon(self):
+        result = ws.parse_cookies("name1=value1; name2=value2")
+        self.assertEqual(result, {"name1": "value1", "name2": "value2"})
+
+    def test_parse_cookies_mixed_separators(self):
+        result = ws.parse_cookies("name1=value1,name2=value2; name3=value3")
+        self.assertEqual(result, {"name1": "value1", "name2": "value2", "name3": "value3"})
+
+    def test_parse_cookies_malformed(self):
+        result = ws.parse_cookies("name1=value1; invalid; name2=value2")
+        self.assertEqual(result, {"name1": "value1", "name2": "value2"})
+
+    def test_parse_cookies_empty(self):
+        result = ws.parse_cookies("")
+        self.assertEqual(result, {})

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -41,6 +41,21 @@ class Subscription:
         self.last_value_chksum = None
 
 
+def parse_cookies(header_value: str) -> dict[str, str]:
+    cookies: dict[str, str] = {}
+
+    # autobahn appends multiple cookies using ','
+    for kv1 in header_value.split(","):
+        for kv in kv1.split(";"):
+            kv = kv.lstrip()
+            try:
+                k, v = kv.split("=", 1)
+                cookies[k] = v
+            except ValueError:
+                pass
+    return cookies
+
+
 class WsProtocol(WebSocketServerProtocol):
     def __init__(self, master: BuildMaster):
         super().__init__()

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -159,7 +159,7 @@ class WsProtocol(WebSocketServerProtocol):
 
 
 class WsProtocolFactory(WebSocketServerFactory):
-    def __init__(self, master: Any):
+    def __init__(self, master: BuildMaster):
         super().__init__()
         self.master = master
         pingInterval = self.master.config.www.get("ws_ping_interval", 0)
@@ -172,5 +172,5 @@ class WsProtocolFactory(WebSocketServerFactory):
 
 
 class WsResource(WebSocketResource):
-    def __init__(self, master: Any):
+    def __init__(self, master: BuildMaster):
         super().__init__(WsProtocolFactory(master))

--- a/newsfragments/websocket-auth.bugfix
+++ b/newsfragments/websocket-auth.bugfix
@@ -1,0 +1,1 @@
+Websocket connections no longer allow unauthenticated users to connect if authorization is setup.


### PR DESCRIPTION
Up until now it was not recommended to run Buildbot and expect any kind of data privacy. This is a step in the direction of addressing this.