### PR TITLE
ruff: provide context on ignore TC006 runtime-cast-value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ target-version = "py38"
         "RUF012", # mutable-class-default
         "RUF017", # quadratic-list-summation (only used in one case, where didn't like the outcome: https://github.com/buildbot/buildbot/pull/8081)
 
+        # See: https://github.com/buildbot/buildbot/pull/8418#issuecomment-2869007629
+        # quoted types in cast should be considered on a case by case basis
+        # rather than enforced.
         "TC006", # runtime-cast-value
     ]
 


### PR DESCRIPTION
requires #8411

https://docs.astral.sh/ruff/rules/runtime-cast-value/

extracted from #8411 to discuss whether it's beneficial or not.

See:
- https://github.com/buildbot/buildbot/pull/8411#pullrequestreview-2828142875
- https://github.com/buildbot/buildbot/pull/8411#issuecomment-2866422547

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
