### PR TITLE
circleci: Don't build docs anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
           name: run tests
           command: |
             . .venv/bin/activate
-            make docs-release
             make tarballs
             # Note that installing www/base depends on frontend_deps target being built, which is
             # a dependency of the tarballs target.
@@ -53,9 +52,6 @@ jobs:
       - persist_to_workspace:
           root: dist
           paths: .
-      - store_artifacts:
-          path: master/docs/_build/html/
-          destination: docs
       - store_artifacts:
           path: dist
           destination: dist


### PR DESCRIPTION
This is done in a buildbot job. Since circleci is used for building release artifacts, the job should contain only what's necessary for a release. Otherwise unrelated errors may fail building release artifacts and then lenghty manual recovery is needed.
