### PR TITLE
Bump Twisted requirement to 24.7.0 or newer

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -36,8 +36,7 @@ matrix:
 
     # include "ci" string into the name of the status that is eventually submitted to Github, so
     # that the codecov.io service would wait until this build is finished before creating report.
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.1.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
-    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=22.4.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
+    - env: PYTHON=3.9 TREQ=22.2.0 TWISTED=24.7.0 SQLALCHEMY=latest NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=1.4.52 NUM_CPU=2 TESTS=trial
     - env: PYTHON=3.9 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=ci/coverage
     - env: PYTHON=3.10 TWISTED=latest SQLALCHEMY=latest NUM_CPU=2 TESTS=trial

--- a/master/setup.py
+++ b/master/setup.py
@@ -657,7 +657,7 @@ py_38 = sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_inf
 if not py_38:
     raise RuntimeError("Buildbot master requires at least Python-3.8")
 
-twisted_ver = ">= 22.1.0"
+twisted_ver = ">= 24.7.0"
 
 bundle_version = version.split("-")[0]
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -669,7 +669,6 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     'msgpack >= 0.6.0',
     "croniter >= 1.3.0",
-    'importlib-resources >= 5; python_version < "3.9"',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
     'sqlalchemy >= 1.4.0',

--- a/newsfragments/twisted-24.7.removal
+++ b/newsfragments/twisted-24.7.removal
@@ -1,0 +1,1 @@
+Minimum version of Twisted is now 24.7 for the Buildbot master.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,8 +5,7 @@
 buildbot-www==4.1.0
 
 Markdown==3.7
-coverage==7.6.8;  python_version >= "3.9"
-coverage==7.6.1; python_version < "3.9" # pyup: ignore
+coverage==7.6.8
 docker==7.1.0
 hvac==2.3.0
 ldap3==2.9.1
@@ -21,8 +20,7 @@ psutil==6.1.0
 
 alembic==1.14.0
 attrs==24.2.0
-autobahn==24.4.2;  python_version >= "3.9"
-autobahn==22.7.1;  python_version < "3.9" # pyup: ignore
+autobahn==24.4.2
 Automat==24.8.1
 boto==2.49.0
 boto3==1.35.72
@@ -39,15 +37,13 @@ greenlet==3.1.1
 hyperlink==21.0.0
 idna==3.10
 incremental==24.7.2
-incremental==22.10.0;  python_version < "3.8" # pyup: ignore
 Jinja2==3.1.5
 jmespath==1.0.1
 lz4==4.3.3
 zstandard==0.23.0
 Brotli==1.1.0
 Mako==1.3.6
-MarkupSafe==3.0.2;  python_version >= "3.9"
-MarkupSafe==2.1.5;  python_version < "3.9" # pyup: ignore
+MarkupSafe==3.0.2
 moto==5.0.22
 msgpack==1.1.0
 mypy-extensions==1.0.0
@@ -56,8 +52,7 @@ parameterized==0.9.0
 pyasn1==0.6.1
 pyasn1-modules==0.4.1
 pycparser==2.22
-PyJWT==2.10.1;  python_version >= "3.9"
-PyJWT==2.9.0; python_version < "3.9" # pyup: ignore
+PyJWT==2.10.1
 pyOpenSSL==24.3.0
 pypugjs==5.11.0
 python-dateutil==2.9.0.post0
@@ -71,8 +66,7 @@ service-identity==24.2.0
 setuptools-trial==0.6.0
 six==1.16.0
 SQLAlchemy==2.0.36
-treq==24.9.1;  python_version >= "3.9"
-treq==22.2.0;  python_version < "3.9" # pyup: ignore
+treq==24.9.1
 Twisted==24.11.0
 txaio==23.1.1
 txrequests==0.9.6
@@ -80,8 +74,7 @@ typing_extensions==4.12.2
 unidiff==0.7.5
 # botocore depends on urllib3<1.27
 urllib3==1.26.19  # pyup: ignore
-Werkzeug==3.1.3;  python_version >= "3.9"
-Werkzeug==3.0.6;  python_version < "3.9" # pyup: ignore
+Werkzeug==3.1.3
 xmltodict==0.14.2
 zope.event==5.0
 zope.interface==7.2

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,24 +1,17 @@
-Sphinx==7.1.2;  python_version < "3.9" # pyup: ignore
 Sphinx==7.4.7;  python_version == "3.9" # pyup: ignore
 Sphinx==8.1.3;  python_version >= "3.10"
 sphinx-jinja==2.0.2
 sphinx-rtd-theme==2.0.0;  python_version < "3.10" # pyup: ignore
 sphinx-rtd-theme==3.0.2;  python_version >= "3.10"
-sphinxcontrib-applehelp==1.0.4;  python_version < "3.9" # pyup: ignore
-sphinxcontrib-applehelp==2.0.0;  python_version >= "3.9"
-sphinxcontrib-devhelp==1.0.2;  python_version < "3.9" # pyup: ignore
-sphinxcontrib-devhelp==2.0.0;  python_version >= "3.9"
-sphinxcontrib-htmlhelp==2.0.1;  python_version < "3.9" # pyup: ignore
-sphinxcontrib-htmlhelp==2.1.0;  python_version >= "3.9"
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jquery==4.1.0
 sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3;  python_version < "3.9" # pyup: ignore
-sphinxcontrib-qthelp==2.0.0;  python_version >= "3.9"
-sphinxcontrib-serializinghtml==1.1.5;  python_version < "3.9" # pyup: ignore
-sphinxcontrib-serializinghtml==2.0.0;  python_version >= "3.9"
+sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-serializinghtml==2.0.0
 sphinxcontrib-spelling==8.0.0
-sphinxcontrib-websupport==1.2.4;  python_version < "3.9" # pyup: ignore
-sphinxcontrib-websupport==2.0.0;  python_version >= "3.9"
+sphinxcontrib-websupport==2.0.0
 Pygments==2.18.0
 towncrier==24.8.0
 
@@ -29,7 +22,6 @@ towncrier==24.8.0
 
 alabaster==1.0.0; python_version >= "3.10"
 alabaster==0.7.16; python_version == "3.9" # pyup: ignore 1.0.0 dropped support for Python 3.9 and earlier
-alabaster==0.7.13; python_version < "3.9" # pyup: ignore 0.7.14 dropped support for Python 3.8 and earlier
 Babel==2.16.0
 click==8.1.7
 docutils==0.20.1  # pyup: ignore (sphinx-rtd-theme 2.0.0 requires docutils<0.21)


### PR DESCRIPTION
Major change in Twisted 24.7.0 is that inlineCallbacks and async code can now safely interoperate.