### PR TITLE
typing: run mypy for different platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ ruff:
 
 mypy:
 	mypy --platform linux --config-file ./pyproject.toml master/buildbot worker/buildbot_worker
+	mypy --platform win32 --config-file ./pyproject.toml master/buildbot worker/buildbot_worker
 
 docker: docker-buildbot-worker docker-buildbot-master
 	echo done

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,7 @@ ruff:
 	ruff format .
 
 mypy:
-	(cd ./master && mypy --config-file ../pyproject.toml buildbot)
-	(cd ./worker && mypy --config-file ../pyproject.toml buildbot_worker)
+	mypy --platform linux --config-file ./pyproject.toml master/buildbot worker/buildbot_worker
 
 docker: docker-buildbot-worker docker-buildbot-master
 	echo done

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -15,6 +15,7 @@
 
 
 import os
+import platform
 import signal
 import socket
 
@@ -121,9 +122,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         check_functional_environment(self.config)
 
         # figure out local hostname
-        try:
-            self.hostname = os.uname()[1]  # only on unix
-        except AttributeError:
+        self.hostname = platform.uname()[1]
+        if not self.hostname:
             self.hostname = socket.getfqdn()
 
         # public attributes

--- a/master/buildbot/test/unit/process/test_metrics.py
+++ b/master/buildbot/test/unit/process/test_metrics.py
@@ -15,6 +15,7 @@
 
 import gc
 import sys
+from unittest import skipIf
 
 from twisted.internet import defer
 from twisted.internet import task
@@ -167,11 +168,12 @@ class TestPeriodicChecks(TestMetricBase):
         self.assertEqual(report['counters']['gc.garbage'], 2)
         self.assertEqual(report['alarms']['gc.garbage'][0], 'WARN')
 
+    @skipIf(
+        sys.platform != 'linux',
+        "only available on linux platforms",
+    )
     def testGetRSS(self):
         self.assertTrue(metrics._get_rss() > 0)
-
-    if sys.platform != 'linux':
-        testGetRSS.skip = "only available on linux platforms"
 
 
 class TestReconfig(TestMetricBase):

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -28,25 +28,6 @@ if TYPE_CHECKING:
     from twisted.trial import unittest
 
 
-class PatcherMixin:
-    """
-    Mix this in to get a few special-cased patching methods
-    """
-
-    def patch_os_uname(self, replacement):
-        # twisted's 'patch' doesn't handle the case where an attribute
-        # doesn't exist..
-        if hasattr(os, 'uname'):
-            self.patch(os, 'uname', replacement)
-        else:
-
-            def cleanup():
-                del os.uname
-
-            self.addCleanup(cleanup)
-            os.uname = replacement
-
-
 if TYPE_CHECKING:
     _StdoutAssertionsMixinBase = unittest.TestCase
 else:

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os.path
+import platform
 import socket
 import sys
 import time
@@ -344,9 +345,8 @@ class WorkerBase(service.MultiService):
         log.msg("recording hostname in twistd.hostname")
         filename = os.path.join(basedir, "twistd.hostname")
 
-        try:
-            hostname = os.uname()[1]  # only on unix
-        except AttributeError:
+        hostname = platform.uname()[1]
+        if not hostname:
             # this tends to fail on non-connected hosts, e.g., laptops
             # on planes
             hostname = socket.getfqdn()

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os.path
 import shutil
 import signal
+import sys
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -865,8 +866,13 @@ class Worker(WorkerBase):
         WorkerBase.startService(self)
 
         if self.allow_shutdown == 'signal':
-            log.msg("Setting up SIGHUP handler to initiate shutdown")
-            signal.signal(signal.SIGHUP, self._handleSIGHUP)
+            if sys.platform != "win32":
+                log.msg("Setting up SIGHUP handler to initiate shutdown")
+                signal.signal(signal.SIGHUP, self._handleSIGHUP)
+            else:
+                raise ValueError(
+                    f"Shutdown method 'signal' is not available on this platform ({sys.platform})"
+                )
         elif self.allow_shutdown == 'file':
             log.msg(f"Watching {self.shutdown_file}'s mtime to initiate shutdown")
             if os.path.exists(self.shutdown_file):

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -213,7 +213,8 @@ if runtime.platformType == 'posix':
             # this will cause the child to be the leader of its own process group;
             # it's also spelled setpgrp() on BSD, but this spelling seems to work
             # everywhere
-            os.setpgid(0, 0)
+            if sys.platform != "win32":
+                os.setpgid(0, 0)
 
 
 class RunProcessPP(protocol.ProcessProtocol):

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -116,9 +116,7 @@ def startWorker(basedir: str, quiet: bool, nodaemon: bool) -> int:
         return launch(nodaemon)
 
     # we probably can't do this os.fork under windows
-    from twisted.python.runtime import platformType
-
-    if platformType == "win32":
+    if sys.platform == "win32":
         return launch(nodaemon)
 
     # fork a child to launch the daemon, while the parent process tails the

--- a/worker/buildbot_worker/test/unit/runprocess-scripts.py
+++ b/worker/buildbot_worker/test/unit/runprocess-scripts.py
@@ -40,6 +40,12 @@ if TYPE_CHECKING:
 # utils
 
 
+def _alarm(seconds: int) -> int:
+    if not hasattr(signal, 'alarm'):
+        return 0
+    return signal.alarm(seconds)
+
+
 def invoke_script(function: str, *args: str) -> None:
     cmd = [sys.executable, __file__, function, *list(args)]
     if os.name == 'nt':
@@ -66,7 +72,7 @@ def write_pidfile(pidfile: str) -> None:
 
 
 def sleep_forever() -> NoReturn:
-    signal.alarm(110)  # die after 110 seconds
+    _alarm(110)  # die after 110 seconds
     while True:
         time.sleep(10)
 
@@ -139,10 +145,7 @@ def assert_stdin_closed() -> None:
 
 # make sure this process dies if necessary
 
-if not hasattr(signal, 'alarm'):
-    signal.alarm = lambda t: 0
-signal.alarm(110)  # die after 110 seconds
-
+_alarm(110)  # die after 110 seconds
 # dispatcher
 
 script_fns[sys.argv[1]]()

--- a/worker/buildbot_worker/test/unit/runprocess-scripts.py
+++ b/worker/buildbot_worker/test/unit/runprocess-scripts.py
@@ -111,7 +111,7 @@ def wait_for_pid_death_and_write_pidfile_and_sleep() -> NoReturn:
 
 @script
 def double_fork() -> NoReturn:
-    if os.name == 'posix':
+    if sys.platform != "win32":
         # when using a PTY, the child process will get SIGHUP when the
         # parent process exits, so ignore that.
         signal.signal(signal.SIGHUP, signal.SIG_IGN)

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -31,7 +31,6 @@ from buildbot_worker.scripts import base
 
 if TYPE_CHECKING:
     from typing import Any
-    from typing import Callable
 
 
 def nl(s: str | Any) -> str | Any:
@@ -66,26 +65,6 @@ class IsWorkerDirMixin:
         self.isWorkerDir = mock.Mock(return_value=return_value)
         assert isinstance(self, TestCase)
         self.patch(base, "isWorkerDir", self.isWorkerDir)
-
-
-class PatcherMixin:
-    """
-    Mix this in to get a few special-cased patching methods
-    """
-
-    def patch_os_uname(self, replacement: Callable[[], os.uname_result]) -> None:
-        # twisted's 'patch' doesn't handle the case where an attribute
-        # doesn't exist..
-        assert isinstance(self, TestCase)
-        if hasattr(os, 'uname'):
-            self.patch(os, 'uname', replacement)
-        else:
-
-            def cleanup() -> None:
-                del os.uname
-
-            self.addCleanup(cleanup)
-            os.uname = replacement
 
 
 class FileIOMixin:


### PR DESCRIPTION
Draft PR as a FYI, I'll look into fixing the issues before it's ready to merge.

mypy was running on a linux worker thus only testing types in the linux context, leaving the win32 codepaths unchecked.

With this change, the `make mypy` will test both linux and win32.
Should we add other platforms such as macOS? Or Windows/Cygwin?

## Contributor Checklist:

* [ ] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
