### PR TITLE
typing: add type annotations to `Build`

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from buildbot.interfaces import IBuildStep
+    from buildbot.interfaces import IProperties
     from buildbot.locks import BaseLock
     from buildbot.master import BuildMaster
     from buildbot.process.build import Build
@@ -393,7 +394,7 @@ class BuildStep(
     def workdir(self, workdir: str) -> None:
         self._workdir = workdir
 
-    def getProperties(self) -> properties.Properties:
+    def getProperties(self) -> IProperties:
         assert self.build is not None
         return self.build.getProperties()
 
@@ -860,7 +861,7 @@ class BuildStep(
         except Exception:
             log.err(Failure(), "error while formatting exceptions")
 
-    def addLogWithException(self, why: Failure, logprefix: str = "") -> defer.Deferred[None]:
+    def addLogWithException(self, why: Exception, logprefix: str = "") -> defer.Deferred[None]:
         return self.addLogWithFailure(Failure(why), logprefix)
 
     def addLogObserver(self, logname: str, observer: interfaces.ILogObserver) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.plugins.db",
       "buildbot.plugins",
       "buildbot.process.botmaster",
-      "buildbot.process.build",
       "buildbot.process.builder",
       "buildbot.process.buildrequest",
       "buildbot.process.buildrequestdistributor",


### PR DESCRIPTION
Apparently I'm not yet sick of typing stuff.

One thing that need to be defined is the usage of `IBuildStep`/`BuildStep`.
`Build` use a lot of method of `BuildStep` when it should be handling `IBuildStep`.

Maybe these methods are simply missing from the interface, and I can update IBuildStep to match usage.


## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
