### PR TITLE
worker: remove unnecessary Python2 compat

### DIFF
--- a/worker/buildbot_worker/compat.py
+++ b/worker/buildbot_worker/compat.py
@@ -20,7 +20,6 @@ between Python 2 and Python 3.
 
 from __future__ import annotations
 
-from io import StringIO as NativeStringIO
 from typing import TYPE_CHECKING
 from typing import overload
 
@@ -78,4 +77,4 @@ def bytes2unicode(x: Any | None, encoding: str = 'utf-8', errors: str = 'strict'
     return str(x, encoding, errors)
 
 
-__all__ = ["NativeStringIO", "bytes2unicode", "unicode2bytes"]
+__all__ = ["bytes2unicode", "unicode2bytes"]

--- a/worker/buildbot_worker/compat.py
+++ b/worker/buildbot_worker/compat.py
@@ -32,35 +32,6 @@ if TYPE_CHECKING:
 
 
 @overload
-def bytes2NativeString(x: bytes, encoding: str = 'utf-8') -> str: ...
-
-
-@overload
-def bytes2NativeString(x: _T, encoding: str = 'utf-8') -> _T: ...
-
-
-def bytes2NativeString(x: _T, encoding: str = 'utf-8') -> str | _T:
-    """
-    Convert C{bytes} to a native C{str}.
-
-    On Python 3 and higher, str and bytes
-    are not equivalent.  In this case, decode
-    the bytes, and return a native string.
-
-    On Python 2 and lower, str and bytes
-    are equivalent.  In this case, just
-    just return the native string.
-
-    @param x: a string of type C{bytes}
-    @param encoding: an optional codec, default: 'utf-8'
-    @return: a string of type C{str}
-    """
-    if isinstance(x, bytes) and str != bytes:
-        return x.decode(encoding)
-    return x
-
-
-@overload
 def unicode2bytes(x: str, encoding: str = 'utf-8', errors: str = 'strict') -> bytes: ...
 
 
@@ -107,4 +78,4 @@ def bytes2unicode(x: Any | None, encoding: str = 'utf-8', errors: str = 'strict'
     return str(x, encoding, errors)
 
 
-__all__ = ["NativeStringIO", "bytes2NativeString", "bytes2unicode", "unicode2bytes"]
+__all__ = ["NativeStringIO", "bytes2unicode", "unicode2bytes"]

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -45,7 +45,6 @@ from twisted.python import runtime
 from twisted.python.win32 import quoteArguments
 
 from buildbot_worker import util
-from buildbot_worker.compat import bytes2NativeString
 from buildbot_worker.compat import bytes2unicode
 from buildbot_worker.compat import unicode2bytes
 from buildbot_worker.exceptions import AbandonChain
@@ -81,7 +80,7 @@ def win32_batch_quote(cmd_list: list[bytes], unicode_encoding: str = 'utf-8') ->
     # Windows batch file. This is not quite the same as quoting it for the
     # shell, as cmd.exe doesn't support the %% escape in interactive mode.
     def escape_arg(arg_bytes: bytes) -> str:
-        arg = bytes2NativeString(arg_bytes, unicode_encoding)
+        arg = bytes2unicode(arg_bytes, unicode_encoding)
         arg = quoteArguments([arg])
         # escape shell special characters
         arg = re.sub(r'[@()^"<>&|]', r'^\g<0>', arg)
@@ -701,7 +700,7 @@ class RunProcess:
         # echo off hides this cheat from the log files.
         tf.write("@echo off\n")
         if isinstance(self.command, (str, bytes)):
-            tf.write(bytes2NativeString(self.command, self.unicode_encoding))
+            tf.write(bytes2unicode(self.command, self.unicode_encoding))
         else:
             tf.write(win32_batch_quote(self.command, self.unicode_encoding))
         tf.close()

--- a/worker/buildbot_worker/test/unit/test_scripts_base.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_base.py
@@ -13,12 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import os
 import sys
+from io import StringIO
 
 from twisted.trial import unittest
 
-from buildbot_worker.compat import NativeStringIO
 from buildbot_worker.scripts import base
 from buildbot_worker.test.util import misc
 
@@ -28,7 +30,7 @@ class TestIsWorkerDir(misc.FileIOMixin, misc.StdoutAssertionsMixin, unittest.Tes
 
     def setUp(self) -> None:
         # capture output to stdout
-        self.mocked_stdout = NativeStringIO()
+        self.mocked_stdout = StringIO()
         self.patch(sys, "stdout", self.mocked_stdout)
 
         # generate OS specific relative path to buildbot.tac inside basedir


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a?] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
