### PR TITLE
.github: build and test windows sanboxed worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,29 @@ jobs:
       - name: "Run tests for ${{ matrix.python-version }}"
         run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
         timeout-minutes: 30
+
+  win-sandboxed-worker:
+    runs-on: windows-latest
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: ">=3"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            requirements-ci-pyinstaller.txt
+            master/setup.py
+            worker/setup.py
+            pkg/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ci-pyinstaller.txt
+      - run: pyinstaller pyinstaller/buildbot-worker.spec
+      - run: trial --reporter=text --rterrors buildbot.test.integration.interop
+        env:
+          SANDBOXED_WORKER_PATH: "${{ github.workspace }}/dist/buildbot-worker.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,7 @@ jobs:
             requirements-ci.txt
             worker/setup.py
       - run: python -m pip install -r requirements-pip.txt
-      - run: python -m pip install -r requirements-ci.txt
-      - run: pipx install pyinstaller==6.13.0
+      - run: python -m pip install -r requirements-ci.txt pyinstaller==6.13.0
       - run: pyinstaller pyinstaller/buildbot-worker.spec
       - run: mv "dist/buildbot-worker${{ matrix.ext }}" "dist/${{ env.WORKER_BIN_NAME }}"
       - name: upload worker bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             requirements-pip.txt
+            requirements-ci-pyinstaller.txt
             requirements-ci.txt
             worker/setup.py
       - run: python -m pip install -r requirements-pip.txt
-      - run: python -m pip install -r requirements-ci.txt pyinstaller==6.13.0
+      - run: python -m pip install -r requirements-ci-pyinstaller.txt
       - run: pyinstaller pyinstaller/buildbot-worker.spec
       - run: mv "dist/buildbot-worker${{ matrix.ext }}" "dist/${{ env.WORKER_BIN_NAME }}"
       - name: upload worker bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
 
   build-tarballs:
     runs-on: ubuntu-latest
-    outputs:
-      artifact-id: ${{ steps.artifact-upload-step.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/requirements-ci-pyinstaller.txt
+++ b/requirements-ci-pyinstaller.txt
@@ -1,0 +1,4 @@
+-r requirements-ci.txt
+altgraph==0.17.4
+pyinstaller==6.13.0
+pyinstaller-hooks-contrib==2025.4


### PR DESCRIPTION
This also fixes the pyinstaller build in workflows/release.yml which need pyinstaller to be in the same python env as the python it will build.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
