### PR TITLE
Update urllib3 from 1.26.19 to 2.4.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -72,8 +72,9 @@ txaio==23.1.1
 txrequests==0.9.6
 typing_extensions==4.12.2
 unidiff==0.7.5
-# botocore depends on urllib3<1.27
-urllib3==1.26.19  # pyup: ignore
+# botocore for py3.9 depends on urllib3<1.27
+urllib3==1.26.19; python_version <= "3.9"  # pyup: ignore
+urllib3==2.4.0; python_version > "3.9"
 Werkzeug==3.1.3
 xmltodict==0.14.2
 zope.event==5.0


### PR DESCRIPTION
botocore on py3.10+ no longer limit urllib3 version.