### PR TITLE
monkeypatches: Work around old workers not being able to connect

### DIFF
--- a/newsfragments/fix-connection-to-old-workers.bugfix
+++ b/newsfragments/fix-connection-to-old-workers.bugfix
@@ -1,0 +1,1 @@
+Work around bug in Twisted 24.7 or newer that causes failures for old (pre Buildbot 0.9) workers to connect to the master.


### PR DESCRIPTION
The cause of the error is this new code in Twisted:

https://github.com/twisted/twisted/commit/2ac17b0efd15f828214bb54ac5dee8a99b4df75e#diff-3ee4b290d7221a2e082e7c4c040b64321158a7fdb26bfdb5aefebe4c54075e78R488-R492

Old workers may not send parents attribute in their state, thus they will fail to connect. The same problem may happen on newer workers as well, but it will only be triggered when an exception is sent to the master.

Fixes: https://github.com/buildbot/buildbot/issues/8374