### PR TITLE
buildbot_net_usage_data: fix 'db' dialect retrieval when db_url is a renderable (#8451)

### DIFF
--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -141,6 +141,10 @@ def basicData(master: BuildMaster) -> dict[str, Any]:
         # and install it in /var/lib/buildbot
     )
     installid = hashlib.sha1(unicode2bytes(hashInput)).hexdigest()
+    assert master.db.configured_db_config is not None
+    db_config = master.db.configured_db_config
+    assert isinstance(db_config.db_url, str)
+    db_dialect = db_config.db_url.split("://")[0]
     return {
         'installid': installid,
         'versions': dict(get_environment_versions()),
@@ -156,7 +160,7 @@ def basicData(master: BuildMaster) -> dict[str, Any]:
             'distro': get_distro(),
         },
         'plugins': plugins_uses,
-        'db': master.config.db.db_url.split("://")[0],
+        'db': db_dialect,
         'mq': master.config.mq['type'],
         'www_plugins': list(master.config.www['plugins'].keys()),
     }

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -33,6 +33,7 @@ from typing import Any
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
+from sqlalchemy.engine.url import make_url
 from twisted.internet import threads
 from twisted.python import log
 
@@ -144,7 +145,8 @@ def basicData(master: BuildMaster) -> dict[str, Any]:
     assert master.db.configured_db_config is not None
     db_config = master.db.configured_db_config
     assert isinstance(db_config.db_url, str)
-    db_dialect = db_config.db_url.split("://")[0]
+    db_url = make_url(db_config.db_url)
+
     return {
         'installid': installid,
         'versions': dict(get_environment_versions()),
@@ -160,7 +162,7 @@ def basicData(master: BuildMaster) -> dict[str, Any]:
             'distro': get_distro(),
         },
         'plugins': plugins_uses,
-        'db': db_dialect,
+        'db': db_url.drivername,
         'mq': master.config.mq['type'],
         'www_plugins': list(master.config.www['plugins'].keys()),
     }

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -99,9 +99,6 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         # set up child services
         self._services_d = self.create_child_services()
 
-        # db configured values
-        self.configured_db_url = None
-
         # configuration / reconfiguration handling
         self.config = MasterConfig()
         self.config_version = 0  # increased by one on each reconfig

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -591,6 +591,10 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.cfg.load_dbconfig(self.filename, {'db': {'db_url': 'abcd'}})
         self.assertResults(db=config.master.DBConfig(db_url='abcd'))
 
+    def test_load_db_dict_renderable_url(self):
+        self.cfg.load_dbconfig(self.filename, {'db': {'db_url': properties.Interpolate('abcd')}})
+        self.assertResults(db=config.master.DBConfig(db_url='abcd'))
+
     def test_load_db_unk_keys(self):
         with capture_config_errors() as errors:
             self.cfg.load_dbconfig(self.filename, {'db': {'db_url': 'abcd', 'bar': 'bar'}})

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -30,6 +30,7 @@ from buildbot.buildbot_net_usage_data import linux_distribution
 from buildbot.config import BuilderConfig
 from buildbot.master import BuildMaster
 from buildbot.plugins import steps
+from buildbot.process import properties
 from buildbot.process.factory import BuildFactory
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.test.util.integration import DictLoader
@@ -90,6 +91,26 @@ class Tests(unittest.TestCase):
     def test_full(self):
         c = self.getBaseConfig()
         c['buildbotNetUsageData'] = 'full'
+        master = self.getMaster(c)
+        data = computeUsageData(master)
+        self.assertEqual(
+            sorted(data.keys()),
+            sorted([
+                'versions',
+                'db',
+                'installid',
+                'platform',
+                'mq',
+                'plugins',
+                'builders',
+                'www_plugins',
+            ]),
+        )
+
+    def test_full_renderable_db_url(self):
+        c = self.getBaseConfig()
+        c['buildbotNetUsageData'] = 'full'
+        c['db'] = {'db_url': properties.Interpolate('abcd')}
         master = self.getMaster(c)
         data = computeUsageData(master)
         self.assertEqual(

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -12,9 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import annotations
 
 import os
 import platform
+from typing import Any
 from unittest.case import SkipTest
 from urllib import request as urllib_request
 
@@ -40,7 +42,7 @@ from buildbot.worker.base import Worker
 
 
 class Tests(unittest.TestCase):
-    def getMaster(self, config_dict):
+    async def getMaster(self, config_dict: dict[str, Any]) -> BuildMaster:
         """
         Create a started ``BuildMaster`` with the given configuration.
         """
@@ -48,6 +50,7 @@ class Tests(unittest.TestCase):
         basedir.createDirectory()
         master = BuildMaster(basedir.path, reactor=reactor, config_loader=DictLoader(config_dict))
         master.config = master.config_loader.loadConfig()
+        await master.db.setup(check_version=False, verbose=False)
         return master
 
     def getBaseConfig(self):
@@ -65,13 +68,13 @@ class Tests(unittest.TestCase):
             'multiMaster': True,
         }
 
-    def test_basic(self):
+    async def test_basic(self):
         self.patch(config.master, "get_is_in_unit_tests", lambda: False)
         with assertProducesWarning(
             ConfigWarning,
             message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic.",
         ):
-            master = self.getMaster(self.getBaseConfig())
+            master = await self.getMaster(self.getBaseConfig())
         data = computeUsageData(master)
         self.assertEqual(
             sorted(data.keys()),
@@ -88,10 +91,10 @@ class Tests(unittest.TestCase):
             ]),
         )
 
-    def test_full(self):
+    async def test_full(self):
         c = self.getBaseConfig()
         c['buildbotNetUsageData'] = 'full'
-        master = self.getMaster(c)
+        master = await self.getMaster(c)
         data = computeUsageData(master)
         self.assertEqual(
             sorted(data.keys()),
@@ -107,11 +110,11 @@ class Tests(unittest.TestCase):
             ]),
         )
 
-    def test_full_renderable_db_url(self):
+    async def test_full_renderable_db_url(self):
         c = self.getBaseConfig()
         c['buildbotNetUsageData'] = 'full'
-        c['db'] = {'db_url': properties.Interpolate('abcd')}
-        master = self.getMaster(c)
+        c['db'] = {'db_url': properties.Interpolate('sqlite:///state.sqlite')}
+        master = await self.getMaster(c)
         data = computeUsageData(master)
         self.assertEqual(
             sorted(data.keys()),
@@ -127,14 +130,14 @@ class Tests(unittest.TestCase):
             ]),
         )
 
-    def test_custom(self):
+    async def test_custom(self):
         c = self.getBaseConfig()
 
         def myCompute(data):
             return {"db": data['db']}
 
         c['buildbotNetUsageData'] = myCompute
-        master = self.getMaster(c)
+        master = await self.getMaster(c)
         data = computeUsageData(master)
         self.assertEqual(sorted(data.keys()), sorted(['db']))
 

--- a/newsfragments/net_usage-db_url-renderable.bugfix
+++ b/newsfragments/net_usage-db_url-renderable.bugfix
@@ -1,0 +1,1 @@
+Fixes error on startup in NetUsageData when ``db_url`` config is a renderable (:issue:`8451`, introduced in v4.3.0)


### PR DESCRIPTION
Fixes #8451

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
