### PR TITLE
scripts: fix cleanupDatabase not an async function

### DIFF
--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -77,7 +77,7 @@ async def doCleanupDatabase(config, master_cfg) -> None:
 
 
 @in_reactor
-async def cleanupDatabase(config):  # pragma: no cover
+def cleanupDatabase(config):  # pragma: no cover
     # we separate the actual implementation to protect unit tests
     # from @in_reactor which stops the reactor
     return defer.Deferred.fromCoroutine(_cleanupDatabase(config))


### PR DESCRIPTION
on older Twisted (like 23.10.0), defer.maybeDeferred would not handle coroutines that return a deferred. Newer seems to handle it.

In any case, this is an obvious mistake.

Fixes #8370

This is not really an issue on master since Twisted >=24.7.0 is now required, which handle this.
So might be a need to backport?
Not sure I should add a newsfragments or not since the bug no longer exists on master.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a?] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
