### PR TITLE
typing: process.buildrequest

### DIFF
--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -70,11 +70,7 @@ class Change:
         change.codebase = chdict.codebase
         change.project = chdict.project
         change.number = chdict.changeid
-
-        when = chdict.when_timestamp
-        if when:
-            when = datetime2epoch(when)
-        change.when = when
+        change.when = datetime2epoch(chdict.when_timestamp)
 
         change.files = sorted(chdict.files)
 

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -374,11 +374,11 @@ class P4Source(base.ReconfigurablePollingChangeSource, util.ComparableMixin):
             if not m:
                 raise P4PollerError(f"Unexpected 'p4 describe -s' result: {result!r}")
             who = self.resolvewho_callable(m.group('who'))
-            when = datetime.datetime.strptime(m.group('when'), self.datefmt)
+            when_dt = datetime.datetime.strptime(m.group('when'), self.datefmt)
             if self.server_tz:
                 # Convert from the server's timezone to the local timezone.
-                when = when.replace(tzinfo=self.server_tz)
-            when = util.datetime2epoch(when)
+                when_dt = when_dt.replace(tzinfo=self.server_tz)
+            when = util.datetime2epoch(when_dt)
 
             comment_lines = []
             lines.pop(0)  # describe header

--- a/master/buildbot/config/builder.py
+++ b/master/buildbot/config/builder.py
@@ -31,6 +31,7 @@ from buildbot.util import safeTranslate
 
 if TYPE_CHECKING:
     from buildbot.process.build import Build
+    from buildbot.process.builder import CollapseRequestFn
 
 
 RESERVED_UNDERSCORE_NAMES = ["__Janitor"]
@@ -51,7 +52,7 @@ class BuilderConfig(util_config.ConfiguredMixin):
         locks: list | None = None,
         env: dict | None = None,
         properties: dict | None = None,
-        collapseRequests: bool | Callable | None = None,
+        collapseRequests: bool | CollapseRequestFn | None = None,
         description: str | None = None,
         description_format: str | None = None,
         canStartBuild: Callable | None = None,

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import TypedDict
 
 from twisted.internet import defer
 
@@ -24,9 +25,21 @@ from buildbot.data import types
 
 if TYPE_CHECKING:
     from buildbot.db.builders import BuilderModel
+    from buildbot.util.twisted import InlineCallbacksType
 
 
-def _db2data(builder: BuilderModel):
+class BuilderData(TypedDict):
+    builderid: int
+    name: str
+    masterids: list[int]
+    description: str | None
+    description_format: str | None
+    description_html: str | None
+    projectid: int | None
+    tags: list[str]
+
+
+def _db2data(builder: BuilderModel) -> BuilderData:
     return {
         "builderid": builder.id,
         "name": builder.name,
@@ -48,7 +61,7 @@ class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
     ]
 
     @defer.inlineCallbacks
-    def get(self, resultSpec, kwargs):
+    def get(self, resultSpec, kwargs) -> InlineCallbacksType[BuilderData | None]:
         builderid = yield self.getBuilderId(kwargs)
         if builderid is None:
             return None
@@ -73,7 +86,7 @@ class BuildersEndpoint(base.Endpoint):
     ]
 
     @defer.inlineCallbacks
-    def get(self, resultSpec, kwargs):
+    def get(self, resultSpec, kwargs) -> InlineCallbacksType[list[BuilderData]]:
         bdicts = yield self.master.db.builders.getBuilders(
             masterid=kwargs.get('masterid', None),
             projectid=kwargs.get('projectid', None),

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -50,7 +50,7 @@ class BuildSetData(TypedDict):
     parent_buildid: int | None
     parent_relationship: str | None
     rebuilt_buildid: int | None
-    sourcestamps: list[SourceStampData | None]
+    sourcestamps: list[SourceStampData]
 
 
 @defer.inlineCallbacks
@@ -59,13 +59,13 @@ def _db2data(model: BuildSetModel | None, master) -> InlineCallbacksType[BuildSe
         return None
 
     # gather the actual sourcestamps, in parallel
-    sourcestamps: list[SourceStampData | None] = []
+    sourcestamps: list[SourceStampData] = []
 
     @defer.inlineCallbacks
     def getSs(ssid) -> InlineCallbacksType[None]:
         ss: SourceStampData | None = yield master.data.get(('sourcestamps', str(ssid)))
-        # NOTE: Should check for None?
-        sourcestamps.append(ss)
+        if ss is not None:
+            sourcestamps.append(ss)
 
     yield defer.DeferredList(
         [getSs(id) for id in model.sourcestamps], fireOnOneErrback=True, consumeErrors=True

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -66,7 +66,7 @@ def _db2data(model: BuildSetModel | None, master):
         [getSs(id) for id in model.sourcestamps], fireOnOneErrback=True, consumeErrors=True
     )
 
-    buildset['sourcestamps'] = sourcestamps
+    buildset['sourcestamps'] = sourcestamps  # type: ignore[assignment]
     return buildset
 
 

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -328,7 +328,15 @@ def epoch2datetime(epoch):
     return None
 
 
-def datetime2epoch(dt):
+@overload
+def datetime2epoch(dt: datetime.datetime) -> int: ...
+
+
+@overload
+def datetime2epoch(dt: None) -> None: ...
+
+
+def datetime2epoch(dt: datetime.datetime | None) -> int | None:
     """Convert a non-naive datetime object to a UNIX epoch timestamp"""
     if dt is not None:
         return calendar.timegm(dt.utctimetuple())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.plugins",
       "buildbot.process.botmaster",
       "buildbot.process.builder",
-      "buildbot.process.buildrequest",
       "buildbot.process.buildrequestdistributor",
       "buildbot.process.cache",
       "buildbot.process.debug",


### PR DESCRIPTION
This also introduce the usage of `TypedDict` in the data API.
A bit annoying as calls to it need to be manually re-typed since there is some indirection as the functions are not called directly, but it is still an improvement.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
