### PR TITLE
typing: worker protocols

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -538,6 +538,7 @@ class Build(properties.PropertiesMixin):
 
         # tell the remote that it's starting a build, too
         try:
+            assert self.builder.name is not None
             yield self.conn.remoteStartBuild(self.builder.name)
         except Exception:
             yield self.buildPreparationFailure(Failure(), "start_build")

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -932,7 +932,7 @@ class CommandMixin:
     @defer.inlineCallbacks
     def _runRemoteCommand(
         self,
-        cmd: str | list[str],
+        cmd: str,
         abandonOnFailure: bool,
         args: dict[str, Any],
         makeResult: Callable[[remotecommand.RemoteCommand], Any] | None = None,

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -190,8 +190,16 @@ class RemoteCommand(base.RemoteCommandImpl):
         # We will get a single remote_complete when it finishes.
         # We should fire self.deferred when the command is done.
         assert self.conn is not None
+        assert self.builder_name is not None
+        assert self.commandID is not None
+        # FIXME: wrong typing, remote_command CANNOT be a list[str]
+        assert isinstance(self.remote_command, str)
         d = self.conn.remoteStartCommand(
-            self, self.builder_name, self.commandID, self.remote_command, self.args
+            self,
+            self.builder_name,
+            self.commandID,
+            self.remote_command,
+            self.args,
         )
         return d
 
@@ -243,6 +251,8 @@ class RemoteCommand(base.RemoteCommandImpl):
         # when the interrupt command has been delivered.
 
         try:
+            assert self.builder_name is not None
+            assert self.commandID is not None
             await self.conn.remoteInterruptCommand(self.builder_name, self.commandID, str(why))
             # the worker may not have remote_interruptCommand
         except Exception as e:

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -60,7 +60,7 @@ class RemoteCommand(base.RemoteCommandImpl):
 
     def __init__(
         self,
-        remote_command: str | list[str],
+        remote_command: str,
         args: dict[str, Any],
         ignore_updates: bool = False,
         collectStdout: bool = False,
@@ -88,7 +88,7 @@ class RemoteCommand(base.RemoteCommandImpl):
         self._startTime: float | None = None
         self._remoteElapsed: float | None = None
         self.remote_failure_reason = None
-        self.remote_command: str | list[str] = remote_command
+        self.remote_command = remote_command
         self.args: dict[str, Any] = args
         self.ignore_updates: bool = ignore_updates
         self.decodeRC: dict[int | None, int] = decodeRC
@@ -192,8 +192,6 @@ class RemoteCommand(base.RemoteCommandImpl):
         assert self.conn is not None
         assert self.builder_name is not None
         assert self.commandID is not None
-        # FIXME: wrong typing, remote_command CANNOT be a list[str]
-        assert isinstance(self.remote_command, str)
         d = self.conn.remoteStartCommand(
             self,
             self.builder_name,

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -14,11 +14,27 @@
 # Copyright Buildbot Team Members
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Mapping
+from typing import TypeVar
+
 from twisted.internet import defer
 
 from buildbot.util import ComparableMixin
 from buildbot.util import subscription
 from buildbot.util.eventual import eventually
+
+if TYPE_CHECKING:
+    from twisted.internet.defer import Deferred
+    from twisted.spread.pb import RemoteReference
+
+    from buildbot.util.twisted import InlineCallbacksType
+    from buildbot.worker.protocols.manager.base import BaseManager
+    from buildbot.worker.protocols.manager.base import Registration
+
+    _Connection = TypeVar("_Connection", bound="Connection")
 
 
 class Listener:
@@ -26,13 +42,18 @@ class Listener:
 
 
 class UpdateRegistrationListener(Listener):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # username : (password, portstr, manager registration)
-        self._registrations = {}
+        self._registrations: dict[str, tuple[str, str, Registration]] = {}
 
     @defer.inlineCallbacks
-    def updateRegistration(self, username, password, portStr):
+    def updateRegistration(
+        self,
+        username: str,
+        password: str,
+        portStr: str | None,
+    ) -> InlineCallbacksType[Registration | None]:
         # NOTE: this method is only present on the PB and MsgPack protocols; others do not
         # use registrations
         if username in self._registrations:
@@ -57,14 +78,24 @@ class UpdateRegistrationListener(Listener):
             return reg
         return currentReg
 
+    def get_manager(self) -> BaseManager:
+        raise NotImplementedError
+
+    def before_connection_setup(self, protocol: RemoteReference, workerName: str) -> None:
+        raise NotImplementedError
+
     @defer.inlineCallbacks
-    def _create_connection(self, mind, workerName):
+    def _create_connection(
+        self,
+        mind: RemoteReference,
+        workerName: str,
+    ) -> InlineCallbacksType[_Connection]:
         self.before_connection_setup(mind, workerName)
-        worker = self.master.workers.getWorkerByName(workerName)
-        conn = self.ConnectionClass(self.master, worker, mind)
+        worker = self.master.workers.getWorkerByName(workerName)  # type: ignore[attr-defined]
+        conn = self.ConnectionClass(self.master, worker, mind)  # type: ignore[attr-defined]
 
         # inform the manager, logging any problems in the deferred
-        accepted = yield self.master.workers.newConnection(conn, workerName)
+        accepted = yield self.master.workers.newConnection(conn, workerName)  # type: ignore[attr-defined]
 
         # return the Connection as the perspective
         if accepted:
@@ -77,11 +108,11 @@ class UpdateRegistrationListener(Listener):
 class Connection:
     proxies: dict[type, type] = {}
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self._disconnectSubs = subscription.SubscriptionPoint(f"disconnections from {name}")
 
     # This method replace all Impl args by their Proxy protocol implementation
-    def createArgsProxies(self, args):
+    def createArgsProxies(self, args: Mapping) -> dict:
         newargs = {}
         for k, v in args.items():
             for implclass, proxyclass in self.proxies.items():
@@ -90,80 +121,87 @@ class Connection:
             newargs[k] = v
         return newargs
 
-    def get_peer(self):
+    def get_peer(self) -> str:
         raise NotImplementedError
 
     # disconnection handling
 
-    def wait_shutdown_started(self):
-        d = defer.Deferred()
+    def wait_shutdown_started(self) -> Deferred[None]:
+        d: Deferred[None] = defer.Deferred()
         self.notifyOnDisconnect(lambda: eventually(d.callback, None))
         return d
 
-    def waitShutdown(self):
+    def waitShutdown(self) -> Deferred[None]:
         return self._disconnectSubs.waitForDeliveriesToFinish()
 
-    def notifyOnDisconnect(self, cb):
+    def notifyOnDisconnect(self, cb: Callable) -> subscription.Subscription:
         return self._disconnectSubs.subscribe(cb)
 
-    def notifyDisconnected(self):
+    def notifyDisconnected(self) -> None:
         self._disconnectSubs.deliver()
 
-    def loseConnection(self):
+    def loseConnection(self) -> None:
         raise NotImplementedError
 
     # methods to send messages to the worker
 
-    def remotePrint(self, message):
+    def remotePrint(self, message: str) -> Deferred[None]:
         raise NotImplementedError
 
-    def remoteGetWorkerInfo(self):
+    def remoteGetWorkerInfo(self) -> Deferred[Any]:
         raise NotImplementedError
 
-    def remoteSetBuilderList(self, builders):
+    def remoteSetBuilderList(self, builders: list[tuple[str, str]]) -> Deferred[list[str]]:
         raise NotImplementedError
 
-    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
+    def remoteStartCommand(
+        self,
+        remoteCommand: RemoteCommandImpl,
+        builderName: str,
+        commandId: str,
+        commandName: str,
+        args: dict[str, Any],
+    ) -> Deferred:
         raise NotImplementedError
 
-    def remoteShutdown(self):
+    def remoteShutdown(self) -> Deferred[None]:
         raise NotImplementedError
 
-    def remoteStartBuild(self, builderName):
+    def remoteStartBuild(self, builderName: str) -> Deferred[None]:
         raise NotImplementedError
 
-    def remoteInterruptCommand(self, builderName, commandId, why):
+    def remoteInterruptCommand(self, builderName: str, commandId: str, why: str) -> Deferred:
         raise NotImplementedError
 
 
 # RemoteCommand base implementation and base proxy
 class RemoteCommandImpl:
-    def remote_update(self, updates):
+    def remote_update(self, updates: list[tuple[dict[str | bytes, Any], int]]) -> int:
         raise NotImplementedError
 
-    def remote_complete(self, failure=None):
+    def remote_complete(self, failure: Any | None = None) -> None:
         raise NotImplementedError
 
 
 # FileWriter base implementation
 class FileWriterImpl:
-    def remote_write(self, data):
+    def remote_write(self, data: str | bytes) -> Deferred[None]:
         raise NotImplementedError
 
-    def remote_utime(self, accessed_modified):
+    def remote_utime(self, accessed_modified: tuple[float, float]) -> Deferred[None]:
         raise NotImplementedError
 
-    def remote_unpack(self):
+    def remote_unpack(self) -> Deferred[None]:
         raise NotImplementedError
 
-    def remote_close(self):
+    def remote_close(self) -> Deferred[None]:
         raise NotImplementedError
 
 
 # FileReader base implementation
 class FileReaderImpl:
-    def remote_read(self, maxLength):
+    def remote_read(self, maxLength: int) -> Deferred[bytes]:
         raise NotImplementedError
 
-    def remote_close(self):
+    def remote_close(self) -> Deferred[None]:
         raise NotImplementedError

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -34,9 +34,8 @@ class Listener(base.UpdateRegistrationListener):
     name = "MsgPackListener"
 
     def __init__(self, master):
-        super().__init__()
+        super().__init__(master=master)
         self.ConnectionClass = Connection
-        self.master = master
 
     def get_manager(self):
         return self.master.msgmanager

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -13,11 +13,15 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import stat
 from pathlib import PurePath
 from pathlib import PurePosixPath
 from pathlib import PureWindowsPath
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import Iterable
 
 from twisted.internet import defer
 from twisted.python import log
@@ -28,43 +32,60 @@ from buildbot.process import remotecommand
 from buildbot.util import deferwaiter
 from buildbot.util import path_expand_user
 from buildbot.worker.protocols import base
+from buildbot.worker.protocols.manager.msgpack import BuildbotWebSocketServerProtocol
+
+if TYPE_CHECKING:
+    from pathlib import PurePath
+
+    from twisted.internet.defer import Deferred
+
+    from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
+    from buildbot.worker.base import Worker
+    from buildbot.worker.protocols.base import RemoteCommandImpl
+    from buildbot.worker.protocols.manager.msgpack import BuildbotWebSocketServerProtocol
+    from buildbot.worker.protocols.manager.msgpack import MsgManager
 
 
 class Listener(base.UpdateRegistrationListener):
     name = "MsgPackListener"
 
-    def __init__(self, master):
+    def __init__(self, master: BuildMaster) -> None:
         super().__init__(master=master)
         self.ConnectionClass = Connection
 
-    def get_manager(self):
+    def get_manager(self) -> MsgManager:
         return self.master.msgmanager
 
-    def before_connection_setup(self, protocol, workerName):
+    def before_connection_setup(
+        self,
+        protocol: BuildbotWebSocketServerProtocol,  # type: ignore[override]
+        workerName: str,
+    ) -> None:
         log.msg(f"worker '{workerName}' attaching")
 
 
 class BasicRemoteCommand:
     # only has basic functions needed for remoteSetBuilderList in class Connection
     # when waiting for update messages
-    def __init__(self, worker_name, expected_keys, error_msg):
+    def __init__(self, worker_name: str, expected_keys: Iterable[str], error_msg: str) -> None:
         self.worker_name = worker_name
-        self.update_results = {}
+        self.update_results: dict[Any, Any] = {}
         self.expected_keys = expected_keys
         self.error_msg = error_msg
-        self.d = defer.Deferred()
+        self.d: Deferred[None] = defer.Deferred()
 
-    def wait_until_complete(self):
+    def wait_until_complete(self) -> Deferred[None]:
         return self.d
 
-    def remote_update_msgpack(self, args):
+    def remote_update_msgpack(self, args: list[tuple[Any, Any]]) -> None:
         # args is a list of tuples
         # first element of the tuple is a key, second element is a value
         for key, value in args:
             if key not in self.update_results:
                 self.update_results[key] = value
 
-    def remote_complete(self, args):
+    def remote_complete(self, args: None) -> None:
         if 'rc' not in self.update_results:
             self.d.errback(
                 Exception(
@@ -105,11 +126,17 @@ class Connection(base.Connection):
     keepalive_interval = 3600
     info: Any = None
 
-    def __init__(self, master, worker, protocol):
+    def __init__(
+        self,
+        master: BuildMaster,
+        worker: Worker,
+        protocol: BuildbotWebSocketServerProtocol,
+    ) -> None:
+        assert worker.workername is not None
         super().__init__(worker.workername)
         self.master = master
         self.worker = worker
-        self.protocol = protocol
+        self.protocol: BuildbotWebSocketServerProtocol | None = protocol
         self._keepalive_waiter = deferwaiter.DeferWaiter()
         self._keepalive_action_handler = deferwaiter.RepeatedActionHandler(
             master.reactor, self._keepalive_waiter, self.keepalive_interval, self._do_keepalive
@@ -119,48 +146,52 @@ class Connection(base.Connection):
     # methods called by the BuildbotWebSocketServerProtocol
 
     @defer.inlineCallbacks
-    def attached(self, protocol):
+    def attached(self, protocol: BuildbotWebSocketServerProtocol) -> InlineCallbacksType[None]:
         self.startKeepaliveTimer()
         self.notifyOnDisconnect(self._stop_keepalive_timer)
         yield self.worker.attached(self)
 
-    def detached(self, protocol):
+    def detached(self, protocol: BuildbotWebSocketServerProtocol) -> None:
         self.stopKeepaliveTimer()
         self.protocol = None
         self.notifyDisconnected()
 
     # disconnection handling
     @defer.inlineCallbacks
-    def _stop_keepalive_timer(self):
+    def _stop_keepalive_timer(self) -> InlineCallbacksType[None]:
         self.stopKeepaliveTimer()
         yield self._keepalive_waiter.wait()
 
-    def loseConnection(self):
+    def loseConnection(self) -> None:
         self.stopKeepaliveTimer()
+        assert self.protocol is not None
         self.protocol.transport.abortConnection()
 
     # keepalive handling
 
-    def _do_keepalive(self):
+    def _do_keepalive(self) -> Deferred[None]:
         return self.remoteKeepalive()
 
-    def stopKeepaliveTimer(self):
+    def stopKeepaliveTimer(self) -> None:
         self._keepalive_action_handler.stop()
 
-    def startKeepaliveTimer(self):
+    def startKeepaliveTimer(self) -> None:
         assert self.keepalive_interval
         self._keepalive_action_handler.start()
 
     # methods to send messages to the worker
 
-    def remoteKeepalive(self):
+    def remoteKeepalive(self) -> Deferred[None]:
+        assert self.protocol is not None
         return self.protocol.get_message_result({'op': 'keepalive'})
 
-    def remotePrint(self, message):
+    def remotePrint(self, message: str) -> Deferred[None]:
+        assert self.protocol is not None
         return self.protocol.get_message_result({'op': 'print', 'message': message})
 
     @defer.inlineCallbacks
-    def remoteGetWorkerInfo(self):
+    def remoteGetWorkerInfo(self) -> InlineCallbacksType[Any]:
+        assert self.protocol is not None
         info = yield self.protocol.get_message_result({'op': 'get_worker_info'})
         self.info = decode(info)
 
@@ -176,12 +207,13 @@ class Connection(base.Connection):
             self.path_cls = PurePosixPath
         return self.info
 
-    def _set_worker_settings(self):
+    def _set_worker_settings(self) -> Deferred:
         # the lookahead here (`(?=.)`) ensures that `\r` doesn't match at the end
         # of the buffer
         # we also convert cursor control sequence to newlines
         # and ugly \b+ (use of backspace to implement progress bar)
         newline_re = r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)'
+        assert self.protocol is not None
         return self.protocol.get_message_result({
             'op': 'set_worker_settings',
             'args': {
@@ -192,14 +224,22 @@ class Connection(base.Connection):
             },
         })
 
-    def create_remote_command(self, worker_name, expected_keys, error_msg):
+    def create_remote_command(
+        self,
+        worker_name: str,
+        expected_keys: list[str],
+        error_msg: str,
+    ) -> tuple[BasicRemoteCommand, str]:
         command_id = remotecommand.RemoteCommand.generate_new_command_id()
         command = BasicRemoteCommand(worker_name, expected_keys, error_msg)
+        assert self.protocol is not None
         self.protocol.command_id_to_command_map[command_id] = command
         return (command, command_id)
 
     @defer.inlineCallbacks
-    def remoteSetBuilderList(self, builders):
+    def remoteSetBuilderList(
+        self, builders: list[tuple[str, str]]
+    ) -> InlineCallbacksType[list[str]]:
         assert self.path_cls is not None
 
         yield self._set_worker_settings()
@@ -211,12 +251,14 @@ class Connection(base.Connection):
         wanted_dirs = {builddir for _, builddir in builders}
         wanted_dirs.add('info')
         dirs_to_mkdir = set(wanted_dirs)
+        assert self.worker.workername is not None
         command, command_id = self.create_remote_command(
             self.worker.workername,
             ['files'],
             'Worker could not send a list of builder directories.',
         )
 
+        assert self.protocol is not None
         yield self.protocol.get_message_result({
             'op': 'start_command',
             'command_id': command_id,
@@ -265,6 +307,7 @@ class Connection(base.Connection):
             command, command_id = self.create_remote_command(
                 self.worker.workername, [], "Worker could not remove directories."
             )
+            assert self.protocol is not None
             yield self.protocol.get_message_result({
                 'op': 'start_command',
                 'command_id': command_id,
@@ -291,7 +334,14 @@ class Connection(base.Connection):
         return builder_names
 
     @defer.inlineCallbacks
-    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
+    def remoteStartCommand(
+        self,
+        remoteCommand: RemoteCommandImpl,
+        builderName: str,
+        commandId: str | int,
+        commandName: str,
+        args: dict[str, Any],
+    ) -> InlineCallbacksType[None]:
         if commandName == "mkdir":
             if isinstance(args['dir'], list):
                 builder_basedir = self._get_builder_basedir(builderName)
@@ -381,6 +431,7 @@ class Connection(base.Connection):
             else:
                 args["want_stderr"] = False
 
+        assert self.protocol is not None
         self.protocol.command_id_to_command_map[commandId] = remoteCommand
         if 'reader' in args:
             self.protocol.command_id_to_reader_map[commandId] = args['reader']
@@ -397,14 +448,18 @@ class Connection(base.Connection):
         })
 
     @defer.inlineCallbacks
-    def remoteShutdown(self):
+    def remoteShutdown(self) -> InlineCallbacksType[None]:
+        assert self.protocol is not None
         yield self.protocol.get_message_result({'op': 'shutdown'})
 
-    def remoteStartBuild(self, builderName):
-        pass
+    def remoteStartBuild(self, builderName: str) -> Deferred[None]:
+        return defer.succeed(None)
 
     @defer.inlineCallbacks
-    def remoteInterruptCommand(self, builderName, commandId, why):
+    def remoteInterruptCommand(
+        self, builderName: str, commandId: str | int, why: str
+    ) -> InlineCallbacksType[None]:
+        assert self.protocol is not None
         yield self.protocol.get_message_result({
             'op': 'interrupt_command',
             'builder_name': builderName,
@@ -414,14 +469,15 @@ class Connection(base.Connection):
 
     # perspective methods called by the worker
 
-    def perspective_keepalive(self):
+    def perspective_keepalive(self) -> None:
         self.worker.messageReceivedFromWorker()
 
-    def perspective_shutdown(self):
+    def perspective_shutdown(self) -> None:
         self.worker.messageReceivedFromWorker()
         self.worker.shutdownRequested()
 
-    def get_peer(self):
+    def get_peer(self) -> str:
+        assert self.protocol is not None
         p = self.protocol.transport.getPeer()
         return f"{p.host}:{p.port}"
 

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -140,10 +140,8 @@ class Connection(base.Connection):
         return defer.maybeDeferred(self.worker.stopService)
 
     def remoteStartBuild(self, builderName: str) -> Deferred[None]:
-        # FIXME: BotBase should have a remote_startBuild definition
-        return defer.succeed(
-            self.worker.bot.builders[builderName].remote_startBuild(),  # type: ignore[attr-defined]
-        )
+        self.worker.bot.builders[builderName].remote_startBuild()
+        return defer.succeed(None)
 
     def remoteInterruptCommand(self, builderName: str, commandId: str, why: str) -> Deferred:
         workerforbuilder = self.worker.bot.builders[builderName]

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -145,9 +145,8 @@ class Connection(base.Connection):
 
     def remoteInterruptCommand(self, builderName: str, commandId: str, why: str) -> Deferred:
         workerforbuilder = self.worker.bot.builders[builderName]
-        # FIXME: BotBase should have a remote_interruptCommand definition
-        return defer.maybeDeferred(  # type: ignore[call-overload]
-            workerforbuilder.remote_interruptCommand,  # type: ignore[attr-defined]
+        return defer.maybeDeferred(
+            workerforbuilder.remote_interruptCommand,
             commandId,
             why,
         )

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -111,9 +111,8 @@ class Connection(base.Connection):
         self,
         builders: list[tuple[str, str]],
     ) -> Deferred[list[str]]:
-        # FIXME: BotBase should have a remote_setBuilderList definition
-        return defer.maybeDeferred(  # type: ignore[call-overload]
-            self.worker.bot.remote_setBuilderList,  # type: ignore[attr-defined]
+        return defer.maybeDeferred(
+            self.worker.bot.remote_setBuilderList,
             builders,
         )
 

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import cast
 
 from twisted.internet import defer
 from twisted.python import log
@@ -28,6 +29,7 @@ from buildbot.worker.protocols import base
 
 if TYPE_CHECKING:
     from twisted.internet.defer import Deferred
+    from twisted.spread.pb import RemoteReference
 
     from buildbot_worker.null import LocalWorker
 
@@ -124,13 +126,11 @@ class Connection(base.Connection):
         commandName: str,
         args: dict[str, Any],
     ) -> Deferred:
-        remoteCommand = RemoteCommandProxy(remoteCommand)  # type: ignore[assignment]
         args = self.createArgsProxies(args)
         workerforbuilder = self.worker.bot.builders[builderName]
-        # FIXME: BotBase should have a remote_startCommand definition
-        return defer.maybeDeferred(  # type: ignore[call-overload]
-            workerforbuilder.remote_startCommand,  # type: ignore[attr-defined]
-            remoteCommand,
+        return defer.maybeDeferred(
+            workerforbuilder.remote_startCommand,
+            cast("RemoteReference", RemoteCommandProxy(remoteCommand)),
             commandId,
             commandName,
             args,

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -42,7 +42,6 @@ class ProxyMixin:
     def __init__(self, impl: object) -> None:
         assert isinstance(impl, self.ImplClass)
         self.impl = impl
-        self._disconnect_listeners = []  # type: ignore[var-annotated]
 
     def callRemote(self, message: str, *args: Any, **kw: Any) -> Deferred[Any]:
         method = getattr(self.impl, f"remote_{message}", None)

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -13,8 +13,12 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import contextlib
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import Generator
 
 from twisted.internet import defer
 from twisted.python import log
@@ -24,18 +28,30 @@ from buildbot.pbutil import decode
 from buildbot.util import deferwaiter
 from buildbot.worker.protocols import base
 
+if TYPE_CHECKING:
+    from twisted.internet.defer import Deferred
+    from twisted.python.failure import Failure
+    from twisted.spread.pb import RemoteReference
+
+    from buildbot.master import BuildMaster
+    from buildbot.util.twisted import InlineCallbacksType
+    from buildbot.worker.base import Worker
+    from buildbot.worker.protocols.base import RemoteCommandImpl
+    from buildbot.worker.protocols.manager.pb import PBManager
+    from buildbot_worker.base import WorkerForBuilderBase
+
 
 class Listener(base.UpdateRegistrationListener):
     name = "pbListener"
 
-    def __init__(self, master):
+    def __init__(self, master: BuildMaster) -> None:
         super().__init__(master=master)
         self.ConnectionClass = Connection
 
-    def get_manager(self):
+    def get_manager(self) -> PBManager:
         return self.master.pbmanager
 
-    def before_connection_setup(self, mind, workerName):
+    def before_connection_setup(self, mind: RemoteReference, workerName: str) -> None:
         log.msg(f"worker '{workerName}' attaching from {mind.broker.transport.getPeer()}")
         try:
             mind.broker.transport.setTcpKeepAlive(1)
@@ -44,11 +60,13 @@ class Listener(base.UpdateRegistrationListener):
 
 
 class ReferenceableProxy(pb.Referenceable):
-    def __init__(self, impl):
+    ImplClass: type
+
+    def __init__(self, impl: object) -> None:
         assert isinstance(impl, self.ImplClass)
         self.impl = impl
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self.impl, name)
 
 
@@ -70,7 +88,7 @@ class _NoSuchMethod(Exception):
 
 
 @contextlib.contextmanager
-def _wrapRemoteException():
+def _wrapRemoteException() -> Generator[None, Any, None]:
     try:
         yield
     except pb.RemoteError as e:
@@ -83,27 +101,33 @@ def _wrapRemoteException():
 
 
 class Connection(base.Connection, pb.Avatar):
-    proxies = {base.FileWriterImpl: FileWriterProxy, base.FileReaderImpl: FileReaderProxy}
+    proxies: dict[type, type[ReferenceableProxy]] = {
+        base.FileWriterImpl: FileWriterProxy,
+        base.FileReaderImpl: FileReaderProxy,
+    }
     # TODO: configure keepalive_interval in
     # c['protocols']['pb']['keepalive_interval']
     keepalive_timer: None = None
     keepalive_interval = 3600
     info: Any = None
 
-    def __init__(self, master, worker, mind):
+    def __init__(self, master: BuildMaster, worker: Worker, mind: RemoteReference) -> None:
+        assert worker.workername is not None
         super().__init__(worker.workername)
         self.master = master
         self.worker = worker
-        self.mind = mind
+        self.mind: RemoteReference | None = mind
         self._keepalive_waiter = deferwaiter.DeferWaiter()
         self._keepalive_action_handler = deferwaiter.RepeatedActionHandler(
             master.reactor, self._keepalive_waiter, self.keepalive_interval, self._do_keepalive
         )
 
+        self.builders: dict[str, WorkerForBuilderBase]
+
     # methods called by the PBManager
 
     @defer.inlineCallbacks
-    def attached(self, mind):
+    def attached(self, mind: RemoteReference) -> InlineCallbacksType[Connection]:
         self.startKeepaliveTimer()
         self.notifyOnDisconnect(self._stop_keepalive_timer)
         # pbmanager calls perspective.attached; pass this along to the
@@ -112,19 +136,20 @@ class Connection(base.Connection, pb.Avatar):
         # and then return a reference to the avatar
         return self
 
-    def detached(self, mind):
+    def detached(self, mind: RemoteReference) -> None:
         self.stopKeepaliveTimer()
         self.mind = None
         self.notifyDisconnected()
 
     # disconnection handling
     @defer.inlineCallbacks
-    def _stop_keepalive_timer(self):
+    def _stop_keepalive_timer(self) -> InlineCallbacksType[None]:
         self.stopKeepaliveTimer()
         yield self._keepalive_waiter.wait()
 
-    def loseConnection(self):
+    def loseConnection(self) -> None:
         self.stopKeepaliveTimer()
+        assert self.mind is not None
         tport = self.mind.broker.transport
         # this is the polite way to request that a socket be closed
         tport.loseConnection()
@@ -145,26 +170,29 @@ class Connection(base.Connection, pb.Avatar):
 
     # keepalive handling
 
-    def _do_keepalive(self):
+    def _do_keepalive(self) -> Deferred[None]:
+        assert self.mind is not None
         return self.mind.callRemote('print', message="keepalive")
 
-    def stopKeepaliveTimer(self):
+    def stopKeepaliveTimer(self) -> None:
         self._keepalive_action_handler.stop()
 
-    def startKeepaliveTimer(self):
+    def startKeepaliveTimer(self) -> None:
         assert self.keepalive_interval
         self._keepalive_action_handler.start()
 
     # methods to send messages to the worker
 
-    def remotePrint(self, message):
+    def remotePrint(self, message: str) -> Deferred[None]:
+        assert self.mind is not None
         return self.mind.callRemote('print', message=message)
 
     @defer.inlineCallbacks
-    def remoteGetWorkerInfo(self):
+    def remoteGetWorkerInfo(self) -> InlineCallbacksType[Any]:
         try:
             with _wrapRemoteException():
                 # Try to call buildbot-worker method.
+                assert self.mind is not None
                 info = yield self.mind.callRemote('getWorkerInfo')
             return decode(info)
         except _NoSuchMethod:
@@ -181,6 +209,7 @@ class Connection(base.Connection, pb.Avatar):
 
             try:
                 with _wrapRemoteException():
+                    assert self.mind is not None
                     info = yield self.mind.callRemote('getSlaveInfo')
             except _NoSuchMethod:
                 log.msg("Worker.getSlaveInfo is unavailable - ignoring")
@@ -195,12 +224,14 @@ class Connection(base.Connection, pb.Avatar):
             # commands and version using separate requests.
             try:
                 with _wrapRemoteException():
+                    assert self.mind is not None
                     info["worker_commands"] = yield self.mind.callRemote('getCommands')
             except _NoSuchMethod:
                 log.msg("Worker.getCommands is unavailable - ignoring")
 
             try:
                 with _wrapRemoteException():
+                    assert self.mind is not None
                     info["version"] = yield self.mind.callRemote('getVersion')
             except _NoSuchMethod:
                 log.msg("Worker.getVersion is unavailable - ignoring")
@@ -208,28 +239,41 @@ class Connection(base.Connection, pb.Avatar):
             return decode(info)
 
     @defer.inlineCallbacks
-    def remoteSetBuilderList(self, builders):
+    def remoteSetBuilderList(
+        self,
+        builders: list[tuple[str, str]],
+    ) -> InlineCallbacksType[list[str]]:
+        assert self.mind is not None
         builders = yield self.mind.callRemote('setBuilderList', builders)
-        self.builders = builders
-        return builders
+        self.builders = builders  # type: ignore[assignment]
+        return builders  # type: ignore[return-value]
 
-    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
+    def remoteStartCommand(
+        self,
+        remoteCommand: RemoteCommandImpl,
+        builderName: str,
+        commandId: str | None,
+        commandName: str,
+        args: dict[str, Any],
+    ) -> Deferred:
         workerforbuilder = self.builders.get(builderName)
-        remoteCommand = RemoteCommand(remoteCommand)
+        remoteCommand = RemoteCommand(remoteCommand)  # type: ignore[assignment]
         args = self.createArgsProxies(args)
-        return workerforbuilder.callRemote(
+        assert workerforbuilder is not None
+        return workerforbuilder.callRemote(  # type: ignore[attr-defined]
             'startCommand', remoteCommand, commandId, commandName, args
         )
 
     @defer.inlineCallbacks
-    def remoteShutdown(self):
+    def remoteShutdown(self) -> InlineCallbacksType[None]:
         # First, try the "new" way - calling our own remote's shutdown
         # method. The method was only added in 0.8.3, so ignore NoSuchMethod
         # failures.
         @defer.inlineCallbacks
-        def new_way():
+        def new_way() -> InlineCallbacksType[bool]:
             try:
                 with _wrapRemoteException():
+                    assert self.mind is not None
                     yield self.mind.callRemote('shutdown')
                     # successful shutdown request
                     return True
@@ -247,7 +291,7 @@ class Connection(base.Connection, pb.Avatar):
         # Now, the old way. Look for a builder with a remote reference to the
         # client side worker. If we can find one, then call "shutdown" on the
         # remote builder, which will cause the worker buildbot process to exit.
-        def old_way():
+        def old_way() -> Deferred[None]:
             d = None
             for b in self.worker.workerforbuilders.values():
                 if b.remote:
@@ -265,7 +309,7 @@ class Connection(base.Connection, pb.Avatar):
                 # shutdown as expected.
 
                 @d.addErrback
-                def _errback(why):
+                def _errback(why: Failure) -> None:
                     if why.check(pb.PBConnectionLost):
                         log.msg(f"Lost connection to {name}")
                     else:
@@ -277,23 +321,31 @@ class Connection(base.Connection, pb.Avatar):
 
         yield old_way()
 
-    def remoteStartBuild(self, builderName):
+    def remoteStartBuild(self, builderName: str) -> Deferred[None]:
         workerforbuilder = self.builders.get(builderName)
-        return workerforbuilder.callRemote('startBuild')
+        assert workerforbuilder is not None
+        return workerforbuilder.callRemote('startBuild')  # type: ignore[attr-defined]
 
-    def remoteInterruptCommand(self, builderName, commandId, why):
+    def remoteInterruptCommand(self, builderName: str, commandId: str, why: str) -> Deferred:
         workerforbuilder = self.builders.get(builderName)
-        return defer.maybeDeferred(workerforbuilder.callRemote, "interruptCommand", commandId, why)
+        assert workerforbuilder is not None
+        return defer.maybeDeferred(  # type: ignore[call-overload]
+            workerforbuilder.callRemote,  # type: ignore[attr-defined]
+            "interruptCommand",
+            commandId,
+            why,
+        )
 
     # perspective methods called by the worker
 
-    def perspective_keepalive(self):
+    def perspective_keepalive(self) -> None:
         self.worker.messageReceivedFromWorker()
 
-    def perspective_shutdown(self):
+    def perspective_shutdown(self) -> None:
         self.worker.messageReceivedFromWorker()
         self.worker.shutdownRequested()
 
-    def get_peer(self):
+    def get_peer(self) -> str:
+        assert self.mind is not None
         p = self.mind.broker.transport.getPeer()
         return f"{p.host}:{p.port}"

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -29,9 +29,8 @@ class Listener(base.UpdateRegistrationListener):
     name = "pbListener"
 
     def __init__(self, master):
-        super().__init__()
+        super().__init__(master=master)
         self.ConnectionClass = Connection
-        self.master = master
 
     def get_manager(self):
         return self.master.pbmanager

--- a/master/docs/developer/master-worker.rst
+++ b/master/docs/developer/master-worker.rst
@@ -41,7 +41,7 @@ The worker-side Bot object has the following remote methods:
     called after the initial connection is established, with a new
     list, to add or remove builders.
 
-    This method returns a dictionary of :class:`WorkerForBuilder` objects - see below.
+    This method returns a list of builder names.
 
 :meth:`~buildbot_worker.pb.BotPb.remote_print`
     Adds a message to the worker logfile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -832,7 +832,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.manager",
       "buildbot.worker.marathon",
       "buildbot.worker.openstack",
-      "buildbot.worker.protocols.base",
       "buildbot.worker.protocols.manager.base",
       "buildbot.worker.protocols.manager.msgpack",
       "buildbot.worker.protocols.manager.pb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -836,7 +836,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.protocols.manager.msgpack",
       "buildbot.worker.protocols.manager.pb",
       "buildbot.worker.protocols.msgpack",
-      "buildbot.worker.protocols.null",
       "buildbot.worker.protocols.pb",
       "buildbot.worker.upcloud",
       "buildbot",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -835,7 +835,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.protocols.manager.base",
       "buildbot.worker.protocols.manager.msgpack",
       "buildbot.worker.protocols.manager.pb",
-      "buildbot.worker.protocols.msgpack",
       "buildbot.worker.upcloud",
       "buildbot",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -836,7 +836,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.protocols.manager.msgpack",
       "buildbot.worker.protocols.manager.pb",
       "buildbot.worker.protocols.msgpack",
-      "buildbot.worker.protocols.pb",
       "buildbot.worker.upcloud",
       "buildbot",
     ]

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -204,6 +204,9 @@ class WorkerForBuilderBase(service.Service):
     ) -> None:
         raise NotImplementedError
 
+    def remote_startBuild(self) -> None:
+        raise NotImplementedError
+
 
 class BotBase(service.MultiService):
     """I represent the worker-side bot."""

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -207,6 +207,9 @@ class WorkerForBuilderBase(service.Service):
     def remote_startBuild(self) -> None:
         raise NotImplementedError
 
+    def remote_interruptCommand(self, command_id: str, why: str) -> None:
+        raise NotImplementedError
+
 
 class BotBase(service.MultiService):
     """I represent the worker-side bot."""

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -307,6 +307,9 @@ class BotBase(service.MultiService):
         # if this timeout is too short.
         cast("IReactorTime", reactor).callLater(0.2, cast("IReactorCore", reactor).stop)
 
+    def remote_setBuilderList(self, builder_info: list[tuple[str, str]]) -> Deferred[list[str]]:
+        raise NotImplementedError
+
 
 class WorkerBase(service.MultiService):
     name: str | None  # type: ignore[assignment]

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -195,6 +195,15 @@ class ProtocolCommandBase:
 class WorkerForBuilderBase(service.Service):
     ProtocolCommand: type[ProtocolCommandBase] = ProtocolCommandBase
 
+    def remote_startCommand(
+        self,
+        command_ref: RemoteReference,
+        command_id: str,
+        command: str,
+        args: dict[str, list[str] | str],
+    ) -> None:
+        raise NotImplementedError
+
 
 class BotBase(service.MultiService):
     """I represent the worker-side bot."""

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -415,8 +415,8 @@ class BotPbLike(BotBase):
     def remote_setBuilderList(
         self,
         wanted: list[tuple[str, str]],
-    ) -> InlineCallbacksType[dict[str, WorkerForBuilderPbLike]]:
-        retval = {}
+    ) -> InlineCallbacksType[list[str]]:
+        retval: dict[str, WorkerForBuilderBase] = {}
         wanted_names = {name for (name, builddir) in wanted}
         wanted_dirs = {builddir for (name, builddir) in wanted}
         wanted_dirs.add('info')
@@ -475,7 +475,7 @@ class BotPbLike(BotBase):
                             "it now"
                         )
 
-        return retval
+        return retval  # type: ignore[return-value]
 
 
 class BotPb(BotPbLike, pb.Referenceable):


### PR DESCRIPTION
Larger PR but I think it make sense to keep all protocols typing together to have a proper view of it all.

Some doc update might be needed here. Typing brought up some inconsistencies between pb and msgpack.

eg. [Connection.remoteSetBuilderList](https://github.com/buildbot/buildbot/blob/a88ef5c66dd738b43a5ae569c097aa970e90d3b9/master/docs/developer/cls-protocols.rst?plain=1#L61) should return a `Deferred containing PB references XXX`, but msgpack returns only a list of buildernames.

So yeah, fixing these feel not trivial, and not sure if should be done in typing or afterward.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a?] I have updated the appropriate documentation
