### PR TITLE
typing: worker protocols manager

### DIFF
--- a/master/buildbot/test/unit/worker/test_protocols_manager_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_base.py
@@ -16,34 +16,44 @@
 Test clean shutdown functionality of the master
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
 from unittest import mock
 
 from twisted.internet import defer
 from twisted.trial import unittest
+from typing_extensions import Self
 
 from buildbot.worker.protocols.manager.base import BaseDispatcher
 from buildbot.worker.protocols.manager.base import BaseManager
+
+if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class FakeMaster:
     initLock = defer.DeferredLock()
 
-    def addService(self, svc):
+    def addService(self, svc: TestManagerClass) -> None:
         pass
 
     @property
-    def master(self):
+    def master(self) -> Self:
         return self
 
 
 class TestDispatcher(BaseDispatcher):
-    def __init__(self, config_portstr, portstr):
+    def __init__(self, config_portstr: str, portstr: str) -> None:
         super().__init__(portstr)
         self.start_listening_count = 0
         self.stop_listening_count = 0
 
-    def start_listening_port(self):
-        def stopListening():
+    def start_listening_port(self) -> Mock:
+        def stopListening() -> None:
             self.stop_listening_count += 1
 
         self.start_listening_count += 1
@@ -52,46 +62,50 @@ class TestDispatcher(BaseDispatcher):
         return port
 
 
-class TestPort:
-    def __init__(self, test):
-        self.test = test
-
-    def stopListening(self):
-        self.test.stop_listening_count += 1
-
-
 class TestManagerClass(BaseManager):
     dispatcher_class = TestDispatcher
 
 
 class TestBaseManager(unittest.TestCase):
     @defer.inlineCallbacks
-    def setUp(self):
+    def setUp(self) -> InlineCallbacksType[None]:  # type: ignore[override]
         self.manager = TestManagerClass('test_base_manager')
         yield self.manager.setServiceParent(FakeMaster())
 
-    def assert_equal_registration(self, result, expected):
+    def assert_equal_registration(
+        self,
+        result: dict[str, BaseDispatcher],
+        expected: dict[str, dict[str, tuple[str, Any]]],
+    ) -> None:
         result_users = {key: result[key].users for key in result}
         self.assertEqual(result_users, expected)
 
-    def assert_start_stop_listening_counts(self, disp, start_count, stop_count):
+    def assert_start_stop_listening_counts(
+        self,
+        disp: BaseDispatcher,
+        start_count: int,
+        stop_count: int,
+    ) -> None:
+        assert isinstance(disp, TestDispatcher)
         self.assertEqual(disp.start_listening_count, start_count)
         self.assertEqual(disp.stop_listening_count, stop_count)
 
     @defer.inlineCallbacks
-    def test_repr(self):
-        reg = yield self.manager.register('tcp:port', 'x', 'y', 'pf')
+    def test_repr(self) -> InlineCallbacksType[None]:
+        reg = yield self.manager.register('tcp:port', 'x', 'y', mock.Mock())
         self.assertEqual(
             repr(self.manager.dispatchers['tcp:port']), '<base.BaseDispatcher for x on tcp:port>'
         )
         self.assertEqual(repr(reg), '<base.Registration for x on tcp:port>')
 
     @defer.inlineCallbacks
-    def test_register_before_start_service(self):
-        yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+    def test_register_before_start_service(self) -> InlineCallbacksType[None]:
+        pf = mock.Mock()
+        yield self.manager.register('tcp:port', 'user', 'pass', pf)
 
         self.assert_equal_registration(
-            self.manager.dispatchers, {'tcp:port': {'user': ('pass', 'pf')}}
+            self.manager.dispatchers,
+            {'tcp:port': {'user': ('pass', pf)}},
         )
 
         disp = self.manager.dispatchers['tcp:port']
@@ -105,13 +119,15 @@ class TestBaseManager(unittest.TestCase):
         self.assert_start_stop_listening_counts(disp, 1, 1)
 
     @defer.inlineCallbacks
-    def test_same_registration_two_times(self):
+    def test_same_registration_two_times(self) -> InlineCallbacksType[None]:
         yield self.manager.startService()
-        yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+        pfactory = mock.Mock()
+        yield self.manager.register('tcp:port', 'user', 'pass', pfactory)
 
         # one registration is ok
         self.assert_equal_registration(
-            self.manager.dispatchers, {'tcp:port': {'user': ('pass', 'pf')}}
+            self.manager.dispatchers,
+            {'tcp:port': {'user': ('pass', pfactory)}},
         )
         self.assertEqual(len(self.manager.services), 1)
 
@@ -120,17 +136,18 @@ class TestBaseManager(unittest.TestCase):
 
         # same user is not allowed to register
         with self.assertRaises(KeyError):
-            yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+            yield self.manager.register('tcp:port', 'user', 'pass', pfactory)
 
         yield self.manager.stopService()
         self.assert_start_stop_listening_counts(disp, 1, 1)
 
     @defer.inlineCallbacks
-    def test_register_unregister_register(self):
+    def test_register_unregister_register(self) -> InlineCallbacksType[None]:
         yield self.manager.startService()
-        reg = yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+        pfactory = mock.Mock()
+        reg = yield self.manager.register('tcp:port', 'user', 'pass', pfactory)
         self.assert_equal_registration(
-            self.manager.dispatchers, {'tcp:port': {'user': ('pass', 'pf')}}
+            self.manager.dispatchers, {'tcp:port': {'user': ('pass', pfactory)}}
         )
 
         disp = self.manager.dispatchers['tcp:port']
@@ -140,22 +157,24 @@ class TestBaseManager(unittest.TestCase):
         self.assert_equal_registration(self.manager.dispatchers, {})
 
         # allow registering same user again
-        yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+        pf = mock.Mock()
+        yield self.manager.register('tcp:port', 'user', 'pass', pf)
 
         self.assert_equal_registration(
-            self.manager.dispatchers, {'tcp:port': {'user': ('pass', 'pf')}}
+            self.manager.dispatchers, {'tcp:port': {'user': ('pass', pf)}}
         )
 
         yield self.manager.stopService()
         self.assert_start_stop_listening_counts(disp, 1, 1)
 
     @defer.inlineCallbacks
-    def test_register_unregister_empty_disp_users(self):
+    def test_register_unregister_empty_disp_users(self) -> InlineCallbacksType[None]:
         yield self.manager.startService()
-        reg = yield self.manager.register('tcp:port', 'user', 'pass', 'pf')
+        pf = mock.Mock()
+        reg = yield self.manager.register('tcp:port', 'user', 'pass', pf)
         self.assertEqual(len(self.manager.services), 1)
 
-        expected = {'tcp:port': {'user': ('pass', 'pf')}}
+        expected = {'tcp:port': {'user': ('pass', pf)}}
         self.assert_equal_registration(self.manager.dispatchers, expected)
 
         disp = self.manager.dispatchers['tcp:port']
@@ -169,12 +188,13 @@ class TestBaseManager(unittest.TestCase):
         self.assert_start_stop_listening_counts(disp, 1, 1)
 
     @defer.inlineCallbacks
-    def test_different_ports_same_users(self):
+    def test_different_ports_same_users(self) -> InlineCallbacksType[None]:
         yield self.manager.startService()
         # same registrations on different ports is ok
-        reg1 = yield self.manager.register('tcp:port1', "user", "pass", 'pf')
-        reg2 = yield self.manager.register('tcp:port2', "user", "pass", 'pf')
-        reg3 = yield self.manager.register('tcp:port3', "user", "pass", 'pf')
+        pf = mock.Mock()
+        reg1 = yield self.manager.register('tcp:port1', "user", "pass", pf)
+        reg2 = yield self.manager.register('tcp:port2', "user", "pass", pf)
+        reg3 = yield self.manager.register('tcp:port3', "user", "pass", pf)
 
         disp1 = self.manager.dispatchers['tcp:port1']
         self.assert_start_stop_listening_counts(disp1, 1, 0)
@@ -188,9 +208,9 @@ class TestBaseManager(unittest.TestCase):
         self.assert_equal_registration(
             self.manager.dispatchers,
             {
-                'tcp:port1': {'user': ('pass', 'pf')},
-                'tcp:port2': {'user': ('pass', 'pf')},
-                'tcp:port3': {'user': ('pass', 'pf')},
+                'tcp:port1': {'user': ('pass', pf)},
+                'tcp:port2': {'user': ('pass', pf)},
+                'tcp:port3': {'user': ('pass', pf)},
             },
         )
         self.assertEqual(len(self.manager.services), 3)
@@ -198,7 +218,7 @@ class TestBaseManager(unittest.TestCase):
         yield reg1.unregister()
         self.assert_equal_registration(
             self.manager.dispatchers,
-            {'tcp:port2': {'user': ('pass', 'pf')}, 'tcp:port3': {'user': ('pass', 'pf')}},
+            {'tcp:port2': {'user': ('pass', pf)}, 'tcp:port3': {'user': ('pass', pf)}},
         )
         self.assertEqual(reg1.username, None)
         self.assertEqual(len(self.manager.services), 2)
@@ -206,15 +226,15 @@ class TestBaseManager(unittest.TestCase):
 
         yield reg2.unregister()
         self.assert_equal_registration(
-            self.manager.dispatchers, {'tcp:port3': {'user': ('pass', 'pf')}}
+            self.manager.dispatchers,
+            {'tcp:port3': {'user': ('pass', pf)}},
         )
         self.assertEqual(reg2.username, None)
         self.assertEqual(len(self.manager.services), 1)
         self.assert_start_stop_listening_counts(disp2, 1, 1)
 
         yield reg3.unregister()
-        expected = {}
-        self.assert_equal_registration(self.manager.dispatchers, expected)
+        self.assert_equal_registration(self.manager.dispatchers, {})
         self.assertEqual(reg3.username, None)
         self.assertEqual(len(self.manager.services), 0)
         self.assert_start_stop_listening_counts(disp3, 1, 1)
@@ -225,11 +245,12 @@ class TestBaseManager(unittest.TestCase):
         self.assert_start_stop_listening_counts(disp3, 1, 1)
 
     @defer.inlineCallbacks
-    def test_same_port_different_users(self):
+    def test_same_port_different_users(self) -> InlineCallbacksType[None]:
         yield self.manager.startService()
-        reg1 = yield self.manager.register('tcp:port', 'user1', 'pass1', 'pf1')
-        reg2 = yield self.manager.register('tcp:port', 'user2', 'pass2', 'pf2')
-        reg3 = yield self.manager.register('tcp:port', 'user3', 'pass3', 'pf3')
+        pf1, pf2, pf3 = (mock.Mock(), mock.Mock(), mock.Mock())
+        reg1 = yield self.manager.register('tcp:port', 'user1', 'pass1', pf1)
+        reg2 = yield self.manager.register('tcp:port', 'user2', 'pass2', pf2)
+        reg3 = yield self.manager.register('tcp:port', 'user3', 'pass3', pf3)
         disp = self.manager.dispatchers['tcp:port']
 
         self.assertEqual(len(self.manager.services), 1)
@@ -237,9 +258,9 @@ class TestBaseManager(unittest.TestCase):
             self.manager.dispatchers,
             {
                 'tcp:port': {
-                    'user1': ('pass1', 'pf1'),
-                    'user2': ('pass2', 'pf2'),
-                    'user3': ('pass3', 'pf3'),
+                    'user1': ('pass1', pf1),
+                    'user2': ('pass2', pf2),
+                    'user3': ('pass3', pf3),
                 }
             },
         )
@@ -248,21 +269,20 @@ class TestBaseManager(unittest.TestCase):
         yield reg1.unregister()
         self.assert_equal_registration(
             self.manager.dispatchers,
-            {'tcp:port': {'user2': ('pass2', 'pf2'), 'user3': ('pass3', 'pf3')}},
+            {'tcp:port': {'user2': ('pass2', pf2), 'user3': ('pass3', pf3)}},
         )
         self.assertEqual(reg1.username, None)
         self.assertEqual(len(self.manager.services), 1)
 
         yield reg2.unregister()
         self.assert_equal_registration(
-            self.manager.dispatchers, {'tcp:port': {'user3': ('pass3', 'pf3')}}
+            self.manager.dispatchers, {'tcp:port': {'user3': ('pass3', pf3)}}
         )
         self.assertEqual(reg2.username, None)
         self.assertEqual(len(self.manager.services), 1)
 
         yield reg3.unregister()
-        expected = {}
-        self.assert_equal_registration(self.manager.dispatchers, expected)
+        self.assert_equal_registration(self.manager.dispatchers, {})
         self.assertEqual(reg3.username, None)
         self.assertEqual(len(self.manager.services), 0)
 

--- a/master/buildbot/test/unit/worker/test_protocols_manager_base.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_base.py
@@ -47,8 +47,8 @@ class FakeMaster:
 
 
 class TestDispatcher(BaseDispatcher):
-    def __init__(self, config_portstr: str, portstr: str) -> None:
-        super().__init__(portstr)
+    def __init__(self, config_port: str | int) -> None:
+        super().__init__(config_port=config_port)
         self.start_listening_count = 0
         self.stop_listening_count = 0
 

--- a/master/buildbot/test/unit/worker/test_protocols_manager_msgmanager.py
+++ b/master/buildbot/test/unit/worker/test_protocols_manager_msgmanager.py
@@ -430,7 +430,7 @@ class TestBuildbotWebSocketServerProtocol(unittest.TestCase):
         }
         expected: dict[str, Any] = {'op': 'response', 'result': None}
         yield self.send_msg_check_response(self.protocol, msg, expected)
-        command.remote_utime.assert_called_once_with('access_time', 'modified_time')
+        command.remote_utime.assert_called_once_with((1, 2))
 
     @defer.inlineCallbacks
     def test_update_upload_file_close_success(self) -> InlineCallbacksType[None]:

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -418,14 +418,14 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         self.protocol.get_message_result.return_value = defer.succeed(None)
 
         rc_instance = base.RemoteCommandImpl()
-        result_command_id_to_command_map = {1: rc_instance}
+        result_command_id_to_command_map = {"1": rc_instance}
         self.protocol.command_id_to_command_map = {}
         args: dict[str, Any] = {'args': 'args'}
 
         if arg_name is not None:
             args[arg_name] = arg_value
 
-        yield self.conn.remoteStartCommand(rc_instance, 'builder', 1, 'command', args)
+        yield self.conn.remoteStartCommand(rc_instance, 'builder', "1", 'command', args)
         expected_args = args.copy()
         if arg_name is not None:
             expected_args[arg_name] = expected_value
@@ -434,7 +434,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         self.protocol.get_message_result.assert_called_with({
             'op': 'start_command',
             'builder_name': 'builder',
-            'command_id': 1,
+            'command_id': "1",
             'command_name': 'command',
             'args': expected_args,
         })

--- a/master/buildbot/test/unit/worker/test_protocols_pb.py
+++ b/master/buildbot/test/unit/worker/test_protocols_pb.py
@@ -23,6 +23,7 @@ from unittest import mock
 from twisted.internet import defer
 from twisted.internet.address import IPv4Address
 from twisted.spread import pb as twisted_pb
+from twisted.spread.pb import RemoteReference
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
@@ -80,7 +81,8 @@ class TestListener(TestReactorMixin, unittest.TestCase):
         listener = pb.Listener(self.master)
         worker = mock.Mock()
         worker.workername = 'test'
-        mind = mock.Mock()
+        mind = mock.Mock(spec=RemoteReference)
+        mind.broker = mock.Mock()
 
         listener.updateRegistration('example', 'pass', 'tcp:1234')
         self.master.workers.register(worker)

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -28,7 +28,6 @@ from buildbot.util.eventual import eventually
 
 if TYPE_CHECKING:
     from twisted.internet.defer import Deferred
-    from twisted.spread.pb import RemoteReference
 
     from buildbot.master import BuildMaster
     from buildbot.util.twisted import InlineCallbacksType
@@ -84,13 +83,13 @@ class UpdateRegistrationListener(Listener):
     def get_manager(self) -> BaseManager:
         raise NotImplementedError
 
-    def before_connection_setup(self, protocol: RemoteReference, workerName: str) -> None:
+    def before_connection_setup(self, protocol: object, workerName: str) -> None:
         raise NotImplementedError
 
     @defer.inlineCallbacks
     def _create_connection(
         self,
-        mind: RemoteReference,
+        mind: object,
         workerName: str,
     ) -> InlineCallbacksType[_Connection]:
         self.before_connection_setup(mind, workerName)

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -181,6 +181,9 @@ class RemoteCommandImpl:
     def remote_update(self, updates: list[tuple[dict[str | bytes, Any], int]]) -> int:
         raise NotImplementedError
 
+    def remote_update_msgpack(self, updates: list[tuple[str, Any]]) -> None:
+        raise NotImplementedError
+
     def remote_complete(self, failure: Any | None = None) -> None:
         raise NotImplementedError
 

--- a/master/buildbot/worker/protocols/manager/base.py
+++ b/master/buildbot/worker/protocols/manager/base.py
@@ -13,6 +13,12 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Generic
+from typing import TypeVar
 
 from twisted.application import strports
 from twisted.internet import defer
@@ -20,21 +26,39 @@ from twisted.python import log
 
 from buildbot.util import service
 
+if TYPE_CHECKING:
+    from twisted.internet.defer import Deferred
+    from twisted.internet.interfaces import IListeningPort
+    from twisted.internet.protocol import ServerFactory
 
-class BaseManager(service.AsyncMultiService):
+    from buildbot.util.twisted import InlineCallbacksType
+    from buildbot.worker.protocols.base import Connection
+
+_Dispatcher = TypeVar("_Dispatcher", bound="BaseDispatcher")
+
+
+class BaseManager(service.AsyncMultiService, Generic[_Dispatcher]):
     """
     A centralized manager for connection ports and authentication on them.
     Allows various pieces of code to request a (port, username) combo, along
     with a password and a connection factory.
     """
 
-    def __init__(self, name):
+    dispatcher_class: type[_Dispatcher]
+
+    def __init__(self, name: str) -> None:
         super().__init__()
         self.setName(name)
-        self.dispatchers = {}
+        self.dispatchers: dict[str, _Dispatcher] = {}
 
     @defer.inlineCallbacks
-    def register(self, config_portstr, username, password, pfactory):
+    def register(
+        self,
+        config_portstr: str | int,
+        username: str,
+        password: str,
+        pfactory: Callable[[object, str], Deferred[Connection]],
+    ) -> InlineCallbacksType[Registration]:
         """
         Register a connection code to be executed after a user with its USERNAME/PASSWORD
         was authenticated and a valid high level connection can be established on a PORTSTR.
@@ -49,7 +73,8 @@ class BaseManager(service.AsyncMultiService):
         reg = Registration(self, portstr, username)
 
         if portstr not in self.dispatchers:
-            disp = self.dispatchers[portstr] = self.dispatcher_class(config_portstr, portstr)
+            # FIXME: BaseDispatcher.__init__
+            disp = self.dispatchers[portstr] = self.dispatcher_class(config_portstr, portstr)  # type: ignore[call-arg,arg-type]
             yield disp.setServiceParent(self)
         else:
             disp = self.dispatchers[portstr]
@@ -59,8 +84,9 @@ class BaseManager(service.AsyncMultiService):
         return reg
 
     @defer.inlineCallbacks
-    def _unregister(self, registration):
+    def _unregister(self, registration: Registration) -> InlineCallbacksType[None]:
         disp = self.dispatchers[registration.portstr]
+        assert registration.username is not None
         disp.unregister(registration.username)
         registration.username = None
         if not disp.users:
@@ -69,55 +95,58 @@ class BaseManager(service.AsyncMultiService):
 
 
 class Registration:
-    def __init__(self, manager, portstr, username):
+    def __init__(self, manager: BaseManager, portstr: str, username: str) -> None:
         self.portstr = portstr
         "portstr this registration is active on"
-        self.username = username
+        self.username: str | None = username
         "username of this registration"
         self.manager = manager
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<base.Registration for {self.username} on {self.portstr}>"
 
-    def unregister(self):
+    def unregister(self) -> Deferred:
         """
         Unregister this registration, removing the username from the port, and
         closing the port if there are no more users left.  Returns a Deferred.
         """
         return self.manager._unregister(self)
 
-    def getPort(self):
+    def getPort(self) -> int:
         """
         Helper method for testing; returns the TCP port used for this
         registration, even if it was specified as 0 and thus allocated by the
         OS.
         """
         disp = self.manager.dispatchers[self.portstr]
+        assert disp.port is not None
         return disp.port.getHost().port
 
 
 class BaseDispatcher(service.AsyncService):
     debug = False
 
-    def __init__(self, portstr):
-        self.portstr = portstr
-        self.users = {}
-        self.port = None
+    serverFactory: ServerFactory
 
-    def __repr__(self):
+    def __init__(self, portstr: str) -> None:
+        self.portstr = portstr
+        self.users: dict[str, tuple[str, Callable[[object, str], Deferred[Connection]]]] = {}
+        self.port: IListeningPort | None = None
+
+    def __repr__(self) -> str:
         return f'<base.BaseDispatcher for {", ".join(list(self.users))} on {self.portstr}>'
 
-    def start_listening_port(self):
+    def start_listening_port(self) -> IListeningPort:
         return strports.listen(self.portstr, self.serverFactory)
 
-    def startService(self):
+    def startService(self) -> None:
         assert not self.port
         self.port = self.start_listening_port()
 
         return super().startService()
 
     @defer.inlineCallbacks
-    def stopService(self):
+    def stopService(self) -> InlineCallbacksType[None]:
         # stop listening on the port when shut down
         assert self.port
         port = self.port
@@ -125,14 +154,19 @@ class BaseDispatcher(service.AsyncService):
         yield port.stopListening()
         yield super().stopService()
 
-    def register(self, username, password, pfactory):
+    def register(
+        self,
+        username: str,
+        password: str,
+        pfactory: Callable[[object, str], Deferred[Connection]],
+    ) -> None:
         if self.debug:
             log.msg(f"registering username '{username}' on port {self.portstr}: {pfactory}")
         if username in self.users:
             raise KeyError(f"username '{username}' is already registered on port {self.portstr}")
         self.users[username] = (password, pfactory)
 
-    def unregister(self, username):
+    def unregister(self, username: str) -> None:
         if self.debug:
             log.msg(f"unregistering username '{username}' on port {self.portstr}")
         del self.users[username]

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -415,12 +415,12 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
 class Dispatcher(BaseDispatcher):
     DUMMY_PORT = 1
 
-    def __init__(self, config_portstr: int, portstr: str) -> None:
-        super().__init__(portstr)
+    def __init__(self, config_port: str | int) -> None:
+        super().__init__(config_port=config_port)
         try:
-            port = int(config_portstr)
+            port = int(config_port)
         except ValueError as e:
-            raise ValueError(f'portstr unsupported: {config_portstr}') from e
+            raise ValueError(f'portstr unsupported: {config_port}') from e
 
         # Autobahn does not support zero port meaning to pick whatever port number is free, so
         # we work around this by setting the port to nonzero value and resetting the value once

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -13,8 +13,12 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
 
 import base64
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
 
 import msgpack
 from autobahn.twisted.websocket import WebSocketServerFactory
@@ -27,6 +31,18 @@ from buildbot.util import deferwaiter
 from buildbot.util.eventual import eventually
 from buildbot.worker.protocols.manager.base import BaseDispatcher
 from buildbot.worker.protocols.manager.base import BaseManager
+from buildbot.worker.protocols.msgpack import Connection
+
+if TYPE_CHECKING:
+    from autobahn.websocket.types import ConnectionRequest
+    from twisted.internet.defer import Deferred
+    from twisted.internet.interfaces import IListeningPort
+
+    from buildbot.util.twisted import InlineCallbacksType
+    from buildbot.worker.protocols.base import FileReaderImpl
+    from buildbot.worker.protocols.base import FileWriterImpl
+    from buildbot.worker.protocols.base import RemoteCommandImpl
+    from buildbot.worker.protocols.msgpack import BasicRemoteCommand
 
 
 class ConnectioLostError(Exception):
@@ -37,7 +53,7 @@ class RemoteWorkerError(Exception):
     pass
 
 
-def decode_http_authorization_header(value):
+def decode_http_authorization_header(value: str) -> tuple[str, str]:
     if value[:5] != 'Basic':
         raise ValueError("Value should always start with 'Basic'")
 
@@ -49,7 +65,7 @@ def decode_http_authorization_header(value):
     return (username, password)
 
 
-def encode_http_authorization_header(name, password):
+def encode_http_authorization_header(name: bytes, password: bytes) -> str:
     if b":" in name:
         raise ValueError("Username is not allowed to contain a colon.")
     userpass = name + b':' + password
@@ -59,43 +75,44 @@ def encode_http_authorization_header(name, password):
 class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
     debug = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
-        self.seq_num_to_waiters_map = {}
-        self.connection = None
-        self.worker_name = None
+        self.seq_num_to_waiters_map: dict[int, Deferred[Any]] = {}
+        self.connection: Connection | None = None
+        self.worker_name: str | None = None
         self._deferwaiter = deferwaiter.DeferWaiter()
 
-    def get_dispatcher(self):
+    def get_dispatcher(self) -> Dispatcher:
         # This is an instance of class msgpack.Dispatcher set in Dispatcher.__init__().
         # self.factory is set on the protocol instance when creating it in Twisted internals
         return self.factory.buildbot_dispatcher
 
     @defer.inlineCallbacks
-    def onOpen(self):
+    def onOpen(self) -> InlineCallbacksType[None]:
         if self.debug:
             log.msg("WebSocket connection open.")
         self.seq_number = 0
-        self.command_id_to_command_map = {}
-        self.command_id_to_reader_map = {}
-        self.command_id_to_writer_map = {}
+        # FIXME: RemoteCommandImpl should inherit from RemoteCommandImpl
+        self.command_id_to_command_map: dict[str, RemoteCommandImpl | BasicRemoteCommand] = {}
+        self.command_id_to_reader_map: dict[str, FileReaderImpl] = {}
+        self.command_id_to_writer_map: dict[str, FileWriterImpl] = {}
         yield self.initialize()
 
-    def maybe_log_worker_to_master_msg(self, message):
+    def maybe_log_worker_to_master_msg(self, message: dict[str, Any]) -> None:
         if self.debug:
             log.msg("WORKER -> MASTER message: ", message)
 
-    def maybe_log_master_to_worker_msg(self, message):
+    def maybe_log_master_to_worker_msg(self, message: dict[str, Any]) -> None:
         if self.debug:
             log.msg("MASTER -> WORKER message: ", message)
 
-    def contains_msg_key(self, msg, keys):
+    def contains_msg_key(self, msg: dict[str, Any], keys: tuple[str, ...]) -> None:
         for k in keys:
             if k not in msg:
                 raise KeyError(f'message did not contain obligatory "{k}" key')
 
     @defer.inlineCallbacks
-    def initialize(self):
+    def initialize(self) -> InlineCallbacksType[None]:
         try:
             dispatcher = self.get_dispatcher()
             yield dispatcher.master.initLock.acquire()
@@ -103,7 +120,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             if self.worker_name in dispatcher.users:
                 _, afactory = dispatcher.users[self.worker_name]
                 self.connection = yield afactory(self, self.worker_name)
-                yield self.connection.attached(self)
+                yield cast(Connection, self.connection).attached(self)
             else:
                 self.sendClose()
         except Exception as e:
@@ -113,7 +130,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             eventually(dispatcher.master.initLock.release)
 
     @defer.inlineCallbacks
-    def call_update(self, msg):
+    def call_update(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -123,7 +140,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
                 raise KeyError('unknown "command_id"')
 
             command = self.command_id_to_command_map[msg['command_id']]
-            yield command.remote_update_msgpack(msg['args'])
+            yield command.remote_update_msgpack(msg['args'])  # type: ignore[union-attr]
         except Exception as e:
             is_exception = True
             result = str(e)
@@ -131,7 +148,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_complete(self, msg):
+    def call_complete(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -154,7 +171,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_upload_file_write(self, msg):
+    def call_update_upload_file_write(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -171,7 +188,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_upload_file_utime(self, msg):
+    def call_update_upload_file_utime(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -181,14 +198,14 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
                 raise KeyError('unknown "command_id"')
 
             file_writer = self.command_id_to_writer_map[msg['command_id']]
-            yield file_writer.remote_utime('access_time', 'modified_time')
+            yield file_writer.remote_utime('access_time', 'modified_time')  # type: ignore[call-arg,arg-type]
         except Exception as e:
             is_exception = True
             result = str(e)
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_upload_file_close(self, msg):
+    def call_update_upload_file_close(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -205,7 +222,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_read_file(self, msg):
+    def call_update_read_file(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -222,7 +239,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_read_file_close(self, msg):
+    def call_update_read_file_close(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -239,7 +256,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_upload_directory_unpack(self, msg):
+    def call_update_upload_directory_unpack(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -256,7 +273,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.send_response_msg(msg, result, is_exception)
 
     @defer.inlineCallbacks
-    def call_update_upload_directory_write(self, msg):
+    def call_update_upload_directory_write(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
         result = None
         is_exception = False
         try:
@@ -272,7 +289,9 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             result = str(e)
         self.send_response_msg(msg, result, is_exception)
 
-    def send_response_msg(self, msg, result, is_exception):
+    def send_response_msg(
+        self, msg: dict[str, Any], result: str | None, is_exception: bool
+    ) -> None:
         dict_output = {'op': 'response', 'seq_number': msg['seq_number'], 'result': result}
         if is_exception:
             dict_output['is_exception'] = True
@@ -282,7 +301,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
 
         self.sendMessage(payload, isBinary=True)
 
-    def onMessage(self, payload, isBinary):
+    def onMessage(self, payload: bytes, isBinary: bool) -> None:
         if not isBinary:
             name = self.worker_name if self.worker_name is not None else '<???>'
             log.msg(f'Message type from worker {name} unsupported')
@@ -329,7 +348,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             self.send_response_msg(msg, f"Command {msg['op']} does not exist.", is_exception=True)
 
     @defer.inlineCallbacks
-    def get_message_result(self, msg):
+    def get_message_result(self, msg: dict[str, Any]) -> InlineCallbacksType[Any]:
         if msg['op'] != 'print' and msg['op'] != 'get_worker_info' and self.connection is None:
             raise ConnectioLostError("No worker connection")
 
@@ -338,7 +357,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         self.maybe_log_master_to_worker_msg(msg)
 
         object = msgpack.packb(msg, use_bin_type=True)
-        d = defer.Deferred()
+        d: Deferred[Any] = defer.Deferred()
         self.seq_num_to_waiters_map[self.seq_number] = d
 
         self.seq_number = self.seq_number + 1
@@ -347,7 +366,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         return res1
 
     @defer.inlineCallbacks
-    def onConnect(self, request):
+    def onConnect(self, request: ConnectionRequest) -> InlineCallbacksType[None]:
         if self.debug:
             log.msg(f"Client connecting: {request.peer}")
 
@@ -381,7 +400,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         if not authentication:
             raise ConnectionDeny(401, "Unauthorized")
 
-    def onClose(self, wasClean, code, reason):
+    def onClose(self, wasClean: bool, code: int | None, reason: str) -> None:
         if self.debug:
             log.msg(f"WebSocket connection closed: {reason}")
         # stop waiting for the responses of all commands
@@ -396,7 +415,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
 class Dispatcher(BaseDispatcher):
     DUMMY_PORT = 1
 
-    def __init__(self, config_portstr, portstr):
+    def __init__(self, config_portstr: int, portstr: str) -> None:
         super().__init__(portstr)
         try:
             port = int(config_portstr)
@@ -412,22 +431,22 @@ class Dispatcher(BaseDispatcher):
             port = self.DUMMY_PORT
 
         self.serverFactory = WebSocketServerFactory(f"ws://0.0.0.0:{port}")
-        self.serverFactory.buildbot_dispatcher = self
+        self.serverFactory.buildbot_dispatcher = self  # type: ignore[attr-defined]
         self.serverFactory.protocol = BuildbotWebSocketServerProtocol
 
-    def start_listening_port(self):
+    def start_listening_port(self) -> IListeningPort:
         port = super().start_listening_port()
         if self._zero_port:
             # Check that websocket port is actually stored into the port attribute, as we're
             # relying on undocumented behavior.
-            if self.serverFactory.port != self.DUMMY_PORT:
+            if self.serverFactory.port != self.DUMMY_PORT:  # type: ignore[attr-defined]
                 raise RuntimeError("Expected websocket port to be set to dummy port")
-            self.serverFactory.port = port.getHost().port
+            self.serverFactory.port = port.getHost().port  # type: ignore[attr-defined]
         return port
 
 
-class MsgManager(BaseManager):
-    def __init__(self):
+class MsgManager(BaseManager[Dispatcher]):
+    def __init__(self) -> None:
         super().__init__('msgmanager')
 
     dispatcher_class = Dispatcher

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -198,7 +198,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
                 raise KeyError('unknown "command_id"')
 
             file_writer = self.command_id_to_writer_map[msg['command_id']]
-            yield file_writer.remote_utime('access_time', 'modified_time')  # type: ignore[call-arg,arg-type]
+            yield file_writer.remote_utime((msg['access_time'], msg['modified_time']))
         except Exception as e:
             is_exception = True
             result = str(e)

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from buildbot.worker.protocols.base import FileReaderImpl
     from buildbot.worker.protocols.base import FileWriterImpl
     from buildbot.worker.protocols.base import RemoteCommandImpl
-    from buildbot.worker.protocols.msgpack import BasicRemoteCommand
 
 
 class ConnectioLostError(Exception):
@@ -92,8 +91,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         if self.debug:
             log.msg("WebSocket connection open.")
         self.seq_number = 0
-        # FIXME: RemoteCommandImpl should inherit from RemoteCommandImpl
-        self.command_id_to_command_map: dict[str, RemoteCommandImpl | BasicRemoteCommand] = {}
+        self.command_id_to_command_map: dict[str, RemoteCommandImpl] = {}
         self.command_id_to_reader_map: dict[str, FileReaderImpl] = {}
         self.command_id_to_writer_map: dict[str, FileWriterImpl] = {}
         yield self.initialize()
@@ -129,8 +127,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
         finally:
             eventually(dispatcher.master.initLock.release)
 
-    @defer.inlineCallbacks
-    def call_update(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
+    def call_update(self, msg: dict[str, Any]) -> Deferred[None]:
         result = None
         is_exception = False
         try:
@@ -140,15 +137,15 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
                 raise KeyError('unknown "command_id"')
 
             command = self.command_id_to_command_map[msg['command_id']]
-            yield command.remote_update_msgpack(msg['args'])  # type: ignore[union-attr]
+            command.remote_update_msgpack(msg['args'])
         except Exception as e:
             is_exception = True
             result = str(e)
 
         self.send_response_msg(msg, result, is_exception)
+        return defer.succeed(None)
 
-    @defer.inlineCallbacks
-    def call_complete(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:
+    def call_complete(self, msg: dict[str, Any]) -> Deferred[None]:
         result = None
         is_exception = False
         try:
@@ -157,7 +154,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             if msg['command_id'] not in self.command_id_to_command_map:
                 raise KeyError('unknown "command_id"')
             command = self.command_id_to_command_map[msg['command_id']]
-            yield command.remote_complete(msg['args'])
+            command.remote_complete(msg['args'])
 
             if msg['command_id'] in self.command_id_to_command_map:
                 del self.command_id_to_command_map[msg['command_id']]
@@ -169,6 +166,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             is_exception = True
             result = str(e)
         self.send_response_msg(msg, result, is_exception)
+        return defer.succeed(None)
 
     @defer.inlineCallbacks
     def call_update_upload_file_write(self, msg: dict[str, Any]) -> InlineCallbacksType[None]:

--- a/master/buildbot/worker/protocols/manager/pb.py
+++ b/master/buildbot/worker/protocols/manager/pb.py
@@ -35,6 +35,8 @@ from buildbot.worker.protocols.manager.base import BaseDispatcher
 from buildbot.worker.protocols.manager.base import BaseManager
 
 if TYPE_CHECKING:
+    from twisted.cred.credentials import IUsernamePassword
+
     from buildbot.util.twisted import InlineCallbacksType
 
 
@@ -42,7 +44,7 @@ if TYPE_CHECKING:
 class Dispatcher(BaseDispatcher):
     credentialInterfaces = [credentials.IUsernamePassword, credentials.IUsernameHashedPassword]
 
-    def __init__(self, config_portstr, portstr):
+    def __init__(self, config_portstr: str | int, portstr: str) -> None:
         super().__init__(portstr)
         # there's lots of stuff to set up for a PB connection!
         self.portal = portal.Portal(self)
@@ -78,7 +80,7 @@ class Dispatcher(BaseDispatcher):
     # ICredentialsChecker
 
     @defer.inlineCallbacks
-    def requestAvatarId(self, creds):
+    def requestAvatarId(self, creds: IUsernamePassword) -> InlineCallbacksType[bytes | tuple[()]]:
         p = Properties()
         p.master = self.master
         username = bytes2unicode(creds.username)
@@ -100,8 +102,8 @@ class Dispatcher(BaseDispatcher):
             eventually(self.master.initLock.release)
 
 
-class PBManager(BaseManager):
-    def __init__(self):
+class PBManager(BaseManager[Dispatcher]):
+    def __init__(self) -> None:
         super().__init__('pbmanager')
 
     dispatcher_class = Dispatcher

--- a/master/buildbot/worker/protocols/manager/pb.py
+++ b/master/buildbot/worker/protocols/manager/pb.py
@@ -44,8 +44,8 @@ if TYPE_CHECKING:
 class Dispatcher(BaseDispatcher):
     credentialInterfaces = [credentials.IUsernamePassword, credentials.IUsernameHashedPassword]
 
-    def __init__(self, config_portstr: str | int, portstr: str) -> None:
-        super().__init__(portstr)
+    def __init__(self, config_port: str | int) -> None:
+        super().__init__(config_port=config_port)
         # there's lots of stuff to set up for a PB connection!
         self.portal = portal.Portal(self)
         self.portal.registerChecker(self)

--- a/master/buildbot/worker/protocols/manager/pb.py
+++ b/master/buildbot/worker/protocols/manager/pb.py
@@ -67,7 +67,7 @@ class Dispatcher(BaseDispatcher):
 
         persp = None
         if avatarIdStr and avatarIdStr in self.users:
-            _, afactory = self.users.get(avatarIdStr)  # type: ignore[misc]
+            _, afactory = self.users[avatarIdStr]
             persp = yield afactory(mind, avatarIdStr)
 
         if not persp:

--- a/master/buildbot/worker/protocols/manager/pb.py
+++ b/master/buildbot/worker/protocols/manager/pb.py
@@ -14,9 +14,8 @@
 # Copyright Buildbot Team Members
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 from typing import Callable
-from typing import Generator
 
 from twisted.cred import checkers
 from twisted.cred import credentials
@@ -34,6 +33,9 @@ from buildbot.util import unicode2bytes
 from buildbot.util.eventual import eventually
 from buildbot.worker.protocols.manager.base import BaseDispatcher
 from buildbot.worker.protocols.manager.base import BaseManager
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 @implementer(portal.IRealm, checkers.ICredentialsChecker)
@@ -53,7 +55,7 @@ class Dispatcher(BaseDispatcher):
     @defer.inlineCallbacks
     def requestAvatar(
         self, avatarId: bytes | tuple[()], mind: object, *interfaces: type[Interface]
-    ) -> Generator[defer.Deferred[Any], None, tuple[type[Interface], object, Callable]]:
+    ) -> InlineCallbacksType[tuple[type[Interface], object, Callable[[], None]]]:
         assert interfaces[0] == pb.IPerspective
 
         if isinstance(avatarId, tuple) and not avatarId:
@@ -63,7 +65,7 @@ class Dispatcher(BaseDispatcher):
 
         persp = None
         if avatarIdStr and avatarIdStr in self.users:
-            _, afactory = self.users.get(avatarIdStr)
+            _, afactory = self.users.get(avatarIdStr)  # type: ignore[misc]
             persp = yield afactory(mind, avatarIdStr)
 
         if not persp:

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -32,7 +32,6 @@ from buildbot.process import remotecommand
 from buildbot.util import deferwaiter
 from buildbot.util import path_expand_user
 from buildbot.worker.protocols import base
-from buildbot.worker.protocols.manager.msgpack import BuildbotWebSocketServerProtocol
 
 if TYPE_CHECKING:
     from pathlib import PurePath
@@ -432,12 +431,12 @@ class Connection(base.Connection):
                 args["want_stderr"] = False
 
         assert self.protocol is not None
-        self.protocol.command_id_to_command_map[commandId] = remoteCommand
+        self.protocol.command_id_to_command_map[commandId] = remoteCommand  # type: ignore[index]
         if 'reader' in args:
-            self.protocol.command_id_to_reader_map[commandId] = args['reader']
+            self.protocol.command_id_to_reader_map[commandId] = args['reader']  # type: ignore[index]
             del args['reader']
         if 'writer' in args:
-            self.protocol.command_id_to_writer_map[commandId] = args['writer']
+            self.protocol.command_id_to_writer_map[commandId] = args['writer']  # type: ignore[index]
             del args['writer']
         yield self.protocol.get_message_result({
             'op': 'start_command',

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -337,7 +337,7 @@ class Connection(base.Connection):
         self,
         remoteCommand: RemoteCommandImpl,
         builderName: str,
-        commandId: str | int,
+        commandId: str,
         commandName: str,
         args: dict[str, Any],
     ) -> InlineCallbacksType[None]:
@@ -431,12 +431,12 @@ class Connection(base.Connection):
                 args["want_stderr"] = False
 
         assert self.protocol is not None
-        self.protocol.command_id_to_command_map[commandId] = remoteCommand  # type: ignore[index]
+        self.protocol.command_id_to_command_map[commandId] = remoteCommand
         if 'reader' in args:
-            self.protocol.command_id_to_reader_map[commandId] = args['reader']  # type: ignore[index]
+            self.protocol.command_id_to_reader_map[commandId] = args['reader']
             del args['reader']
         if 'writer' in args:
-            self.protocol.command_id_to_writer_map[commandId] = args['writer']  # type: ignore[index]
+            self.protocol.command_id_to_writer_map[commandId] = args['writer']
             del args['writer']
         yield self.protocol.get_message_result({
             'op': 'start_command',

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -32,6 +32,7 @@ from buildbot.process import remotecommand
 from buildbot.util import deferwaiter
 from buildbot.util import path_expand_user
 from buildbot.worker.protocols import base
+from buildbot.worker.protocols.base import RemoteCommandImpl
 
 if TYPE_CHECKING:
     from pathlib import PurePath
@@ -41,7 +42,6 @@ if TYPE_CHECKING:
     from buildbot.master import BuildMaster
     from buildbot.util.twisted import InlineCallbacksType
     from buildbot.worker.base import Worker
-    from buildbot.worker.protocols.base import RemoteCommandImpl
     from buildbot.worker.protocols.manager.msgpack import BuildbotWebSocketServerProtocol
     from buildbot.worker.protocols.manager.msgpack import MsgManager
 
@@ -64,7 +64,7 @@ class Listener(base.UpdateRegistrationListener):
         log.msg(f"worker '{workerName}' attaching")
 
 
-class BasicRemoteCommand:
+class BasicRemoteCommand(RemoteCommandImpl):
     # only has basic functions needed for remoteSetBuilderList in class Connection
     # when waiting for update messages
     def __init__(self, worker_name: str, expected_keys: Iterable[str], error_msg: str) -> None:
@@ -84,7 +84,7 @@ class BasicRemoteCommand:
             if key not in self.update_results:
                 self.update_results[key] = value
 
-    def remote_complete(self, args: None) -> None:
+    def remote_complete(self, failure: Any | None = None) -> None:
         if 'rc' not in self.update_results:
             self.d.errback(
                 Exception(

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -23,6 +23,7 @@ from typing import Generator
 from twisted.internet import defer
 from twisted.python import log
 from twisted.spread import pb
+from twisted.spread.pb import RemoteReference
 
 from buildbot.pbutil import decode
 from buildbot.util import deferwaiter
@@ -31,7 +32,6 @@ from buildbot.worker.protocols import base
 if TYPE_CHECKING:
     from twisted.internet.defer import Deferred
     from twisted.python.failure import Failure
-    from twisted.spread.pb import RemoteReference
 
     from buildbot.master import BuildMaster
     from buildbot.util.twisted import InlineCallbacksType
@@ -51,7 +51,8 @@ class Listener(base.UpdateRegistrationListener):
     def get_manager(self) -> PBManager:
         return self.master.pbmanager
 
-    def before_connection_setup(self, mind: RemoteReference, workerName: str) -> None:
+    def before_connection_setup(self, mind: object, workerName: str) -> None:
+        assert isinstance(mind, RemoteReference), type(mind)
         log.msg(f"worker '{workerName}' attaching from {mind.broker.transport.getPeer()}")
         try:
             mind.broker.transport.setTcpKeepAlive(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -721,7 +721,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.test.unit.worker.test_manager",
       "buildbot.test.unit.worker.test_marathon",
       "buildbot.test.unit.worker.test_openstack",
-      "buildbot.test.unit.worker.test_protocols_manager_msgmanager",
       "buildbot.test.unit.worker.test_upcloud",
       "buildbot.test.unit.www.test_avatar",
       "buildbot.test.unit.www.test_config",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -828,7 +828,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.manager",
       "buildbot.worker.marathon",
       "buildbot.worker.openstack",
-      "buildbot.worker.protocols.manager.base",
       "buildbot.worker.protocols.manager.msgpack",
       "buildbot.worker.protocols.manager.pb",
       "buildbot.worker.upcloud",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -722,7 +722,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.test.unit.worker.test_marathon",
       "buildbot.test.unit.worker.test_openstack",
       "buildbot.test.unit.worker.test_protocols_manager_msgmanager",
-      "buildbot.test.unit.worker.test_protocols_manager_pbmanager",
       "buildbot.test.unit.worker.test_upcloud",
       "buildbot.test.unit.www.test_avatar",
       "buildbot.test.unit.www.test_config",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -721,7 +721,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.test.unit.worker.test_manager",
       "buildbot.test.unit.worker.test_marathon",
       "buildbot.test.unit.worker.test_openstack",
-      "buildbot.test.unit.worker.test_protocols_manager_base",
       "buildbot.test.unit.worker.test_protocols_manager_msgmanager",
       "buildbot.test.unit.worker.test_protocols_manager_pbmanager",
       "buildbot.test.unit.worker.test_upcloud",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -829,7 +829,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.marathon",
       "buildbot.worker.openstack",
       "buildbot.worker.protocols.manager.msgpack",
-      "buildbot.worker.protocols.manager.pb",
       "buildbot.worker.upcloud",
       "buildbot",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -828,7 +828,6 @@ plugins = "mypy_zope:plugin"
       "buildbot.worker.manager",
       "buildbot.worker.marathon",
       "buildbot.worker.openstack",
-      "buildbot.worker.protocols.manager.msgpack",
       "buildbot.worker.upcloud",
       "buildbot",
     ]


### PR DESCRIPTION
Another fairly large one but I think it's better to not split the fixes from the typing, which in turn mean keeping the tests typing as well.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
