### PR TITLE
worker.protocols: update `remote_` to be deferred

### DIFF
--- a/master/buildbot/test/steps.py
+++ b/master/buildbot/test/steps.py
@@ -207,11 +207,11 @@ class Expect:
 
             if name == command.stdioLogName:
                 if 'header' in streams:
-                    command.remote_update([({"header": streams['header']}, 0)])
+                    yield command.remote_update([({"header": streams['header']}, 0)])
                 if 'stdout' in streams:
-                    command.remote_update([({"stdout": streams['stdout']}, 0)])
+                    yield command.remote_update([({"stdout": streams['stdout']}, 0)])
                 if 'stderr' in streams:
-                    command.remote_update([({"stderr": streams['stderr']}, 0)])
+                    yield command.remote_update([({"stderr": streams['stderr']}, 0)])
             else:
                 if 'header' in streams or 'stderr' in streams:
                     raise RuntimeError('Non stdio streams only support stdout')
@@ -1086,7 +1086,7 @@ class TestBuildStepMixin(_TestBuildStepMixinBase):
             raise e
 
         if not exp.connection_broken:
-            command.remote_complete()
+            yield command.remote_complete()
 
     def _patched_create_process(
         self,

--- a/master/buildbot/test/unit/worker/test_protocols_msgpack.py
+++ b/master/buildbot/test/unit/worker/test_protocols_msgpack.py
@@ -212,7 +212,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.conn.remoteSetBuilderList(builders)
         return d
 
-    def check_message_send_response(
+    async def check_message_send_response(
         self,
         command_name: str,
         args: dict[str, list[str] | str],
@@ -229,8 +229,8 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         self.d_get_message_result.callback(None)
 
         remote_command = self.protocol.command_id_to_command_map[command_id]
-        remote_command.remote_update_msgpack(update_msg)
-        remote_command.remote_complete(None)
+        await remote_command.remote_update_msgpack(update_msg)
+        await remote_command.remote_complete(None)
 
     def check_message_set_worker_settings(self) -> None:
         newline_re = r'(\r\n|\r(?=.)|\033\[u|\033\[[0-9]+;[0-9]+[Hf]|\033\[2J|\x08+)'
@@ -251,25 +251,25 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'listdir', {'path': 'testdir'}, [('files', ['dir1', 'dir2', 'dir3']), ('rc', 0)]
         )
 
         path = os.path.join('testdir', 'dir1')
-        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
+        yield self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir2')
-        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
+        yield self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         path = os.path.join('testdir', 'dir3')
-        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
+        yield self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         paths = [
             os.path.join('testdir', 'info'),
             os.path.join('testdir', 'test_dir1'),
             os.path.join('testdir', 'test_dir2'),
         ]
-        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
+        yield self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -280,22 +280,22 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'listdir', {'path': 'testdir'}, [('files', ['dir1', 'dir2', 'dir3']), ('rc', 0)]
         )
 
         path = os.path.join('testdir', 'dir1')
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'stat', {'path': path}, [('stat', (stat.S_IFDIR,)), ('rc', 0)]
         )
 
         path = os.path.join('testdir', 'dir2')
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'stat', {'path': path}, [('stat', (stat.S_IFDIR,)), ('rc', 0)]
         )
 
         path = os.path.join('testdir', 'dir3')
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'stat', {'path': path}, [('stat', (stat.S_IFDIR,)), ('rc', 0)]
         )
 
@@ -304,14 +304,14 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
             os.path.join('testdir', 'dir2'),
             os.path.join('testdir', 'dir3'),
         ]
-        self.check_message_send_response('rmdir', {'paths': paths}, [('rc', 0)])
+        yield self.check_message_send_response('rmdir', {'paths': paths}, [('rc', 0)])
 
         paths = [
             os.path.join('testdir', 'info'),
             os.path.join('testdir', 'test_dir1'),
             os.path.join('testdir', 'test_dir2'),
         ]
-        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
+        yield self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -326,7 +326,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         )
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'listdir', {'path': 'testdir'}, [('files', ['dir1', 'dir2', 'dir3']), ('rc', 0)]
         )
 
@@ -335,7 +335,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
             os.path.join('testdir', 'test_dir1'),
             os.path.join('testdir', 'test_dir2'),
         ]
-        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
+        yield self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -346,15 +346,15 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'listdir', {'path': 'testdir'}, [('files', ['dir1', 'test_dir2']), ('rc', 0)]
         )
 
         path = os.path.join('testdir', 'dir1')
-        self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
+        yield self.check_message_send_response('stat', {'path': path}, [('stat', (1,)), ('rc', 0)])
 
         paths = [os.path.join('testdir', 'info'), os.path.join('testdir', 'test_dir1')]
-        self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
+        yield self.check_message_send_response('mkdir', {'paths': paths}, [('rc', 0)])
 
         r = yield d
         self.assertEqual(r, ['builder1', 'builder2'])
@@ -365,7 +365,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'listdir',
             {'path': 'testdir'},
             [('files', ['test_dir1', 'test_dir2', 'info']), ('rc', 0)],
@@ -380,7 +380,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response(
+        yield self.check_message_send_response(
             'listdir', {'path': 'testdir'}, [('no_key', []), ('rc', 0)]
         )
 
@@ -394,7 +394,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         d = self.set_up_set_builder_list([('builder1', 'test_dir1'), ('builder2', 'test_dir2')])
         self.check_message_set_worker_settings()
 
-        self.check_message_send_response('listdir', {'path': 'testdir'}, [('rc', 123)])
+        yield self.check_message_send_response('listdir', {'path': 'testdir'}, [('rc', 123)])
 
         with self.assertRaisesRegex(Exception, "Error number: 123"):
             yield d

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -163,7 +163,7 @@ class Connection:
         commandId: str,
         commandName: str,
         args: dict[str, Any],
-    ) -> Deferred:
+    ) -> Deferred[None]:
         raise NotImplementedError
 
     def remoteShutdown(self) -> Deferred[None]:
@@ -172,7 +172,7 @@ class Connection:
     def remoteStartBuild(self, builderName: str) -> Deferred[None]:
         raise NotImplementedError
 
-    def remoteInterruptCommand(self, builderName: str, commandId: str, why: str) -> Deferred:
+    def remoteInterruptCommand(self, builderName: str, commandId: str, why: str) -> Deferred[None]:
         raise NotImplementedError
 
 

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -178,13 +178,13 @@ class Connection:
 
 # RemoteCommand base implementation and base proxy
 class RemoteCommandImpl:
-    def remote_update(self, updates: list[tuple[dict[str | bytes, Any], int]]) -> int:
+    def remote_update(self, updates: list[tuple[dict[str | bytes, Any], int]]) -> Deferred[int]:
         raise NotImplementedError
 
-    def remote_update_msgpack(self, updates: list[tuple[str, Any]]) -> None:
+    def remote_update_msgpack(self, updates: list[tuple[str, Any]]) -> Deferred[None]:
         raise NotImplementedError
 
-    def remote_complete(self, failure: Any | None = None) -> None:
+    def remote_complete(self, failure: Any | None = None) -> Deferred[None]:
         raise NotImplementedError
 
 

--- a/master/buildbot/worker/protocols/manager/msgpack.py
+++ b/master/buildbot/worker/protocols/manager/msgpack.py
@@ -138,7 +138,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
                 raise KeyError('unknown "command_id"')
 
             command = self.command_id_to_command_map[msg['command_id']]
-            yield command.remote_update_msgpack(msg['args'])  # type: ignore[func-returns-value]
+            yield command.remote_update_msgpack(msg['args'])
         except Exception as e:
             is_exception = True
             result = str(e)
@@ -155,7 +155,7 @@ class BuildbotWebSocketServerProtocol(WebSocketServerProtocol):
             if msg['command_id'] not in self.command_id_to_command_map:
                 raise KeyError('unknown "command_id"')
             command = self.command_id_to_command_map[msg['command_id']]
-            yield command.remote_complete(msg['args'])  # type: ignore[func-returns-value]
+            yield command.remote_complete(msg['args'])
 
             if msg['command_id'] in self.command_id_to_command_map:
                 del self.command_id_to_command_map[msg['command_id']]

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -77,14 +77,16 @@ class BasicRemoteCommand(RemoteCommandImpl):
     def wait_until_complete(self) -> Deferred[None]:
         return self.d
 
-    def remote_update_msgpack(self, args: list[tuple[Any, Any]]) -> None:
+    def remote_update_msgpack(self, args: list[tuple[Any, Any]]) -> Deferred[None]:
         # args is a list of tuples
         # first element of the tuple is a key, second element is a value
         for key, value in args:
             if key not in self.update_results:
                 self.update_results[key] = value
 
-    def remote_complete(self, failure: Any | None = None) -> None:
+        return defer.succeed(None)
+
+    def remote_complete(self, failure: Any | None = None) -> Deferred[None]:
         if 'rc' not in self.update_results:
             self.d.errback(
                 Exception(
@@ -92,7 +94,7 @@ class BasicRemoteCommand(RemoteCommandImpl):
                     f"master failed. {self.error_msg}. 'rc' did not arrive."
                 )
             )
-            return
+            return defer.succeed(None)
 
         if self.update_results['rc'] != 0:
             self.d.errback(
@@ -102,7 +104,7 @@ class BasicRemoteCommand(RemoteCommandImpl):
                     f"{self.update_results['rc']}"
                 )
             )
-            return
+            return defer.succeed(None)
 
         for key in self.expected_keys:
             if key not in self.update_results:
@@ -113,9 +115,10 @@ class BasicRemoteCommand(RemoteCommandImpl):
                         f"Key '{key}' is missing."
                     )
                 )
-                return
+                return defer.succeed(None)
 
         self.d.callback(None)
+        return defer.succeed(None)
 
 
 class Connection(base.Connection):

--- a/master/docs/developer/cls-protocols.rst
+++ b/master/docs/developer/cls-protocols.rst
@@ -77,7 +77,7 @@ to know about protocol calls or handle protocol specific exceptions.
         :type commandName: string
         :param args: arguments for that command
         :type args: List
-        :returns: Deferred
+        :returns: Deferred[None]
 
         Start command on the worker.
 
@@ -102,7 +102,7 @@ to know about protocol calls or handle protocol specific exceptions.
         :type commandId: string
         :param why: reason to interrupt
         :type why: string
-        :returns: Deferred
+        :returns: Deferred[None]
 
         Interrupt the command executed on builderName with given commandId on worker, and print reason "why" to worker logs.
 

--- a/master/docs/developer/cls-protocols.rst
+++ b/master/docs/developer/cls-protocols.rst
@@ -129,7 +129,9 @@ On worker sides, those proxy objects are replaced by a proxy object having a sin
 
     .. py:method:: remote_update(updates)
 
-        :param updates: dictionary of updates
+        :param updates: list of updates, which are tuples of dictionary of updates and a number (not used, present for historical reasons)
+        :type updates: list[tuple[dict[str | bytes, Any], int]]
+        :returns: Deferred[int] the highest number found in the updates tuples
 
         Called when the workers have updates to the current remote command.
 
@@ -159,6 +161,7 @@ On worker sides, those proxy objects are replaced by a proxy object having a sin
     .. :py:method:: remote_complete(failure=None)
 
         :param failure: copy of the failure if any
+        :returns: Deferred[None]
 
             Called by the worker when the command is complete.
 

--- a/master/docs/developer/cls-remotecommands.rst
+++ b/master/docs/developer/cls-remotecommands.rst
@@ -79,6 +79,8 @@ RemoteCommand
     .. py:method:: remote_update(updates)
 
         :param updates: new information from the worker
+        :type updates: list[tuple[dict[str | bytes, Any], int]]
+        :returns: Deferred[int]
 
         Handles updates from the worker on the running command. See :ref:`master-worker-updates`
         for the content of the updates. This class splits the updates out, and handles the
@@ -87,6 +89,7 @@ RemoteCommand
     .. py:method:: remote_complete(failure=None)
 
         :param failure: the failure that caused the step to complete, or None for success
+        :returns: Deferred[None]
 
         Called by the worker to indicate that the command is complete. Normal completion (even with
         a nonzero ``rc``) will finish with no failure; if ``failure`` is set, then the step should


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a?] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
    * Not sure if that constitute a change?
* [x] I have updated the appropriate documentation
    * should have documented while typing as well...