### PR TITLE
process.buildrequest: deprecate Pascal Case fields

### DIFF
--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -151,7 +151,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
                     for build in list(builder.building):
                         # if build is waited for then this is a sub-build, so
                         # no need to retry it
-                        if sum(br.waitedFor for br in build.requests):
+                        if sum(br.waited_for for br in build.requests):
                             results = CANCELLED
                         else:
                             results = RETRY

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -23,6 +23,8 @@ from typing import Iterable
 from typing import Mapping
 
 from twisted.internet import defer
+from twisted.python.deprecate import deprecated
+from twisted.python.versions import Version
 
 from buildbot.data import resultspec
 from buildbot.db.buildsets import BsProps
@@ -295,6 +297,7 @@ class BuildRequest:
         return self.brid
 
     @property
+    @deprecated(Version("buildbot", 4, 3, 0), ".submitted_at")
     def submittedAt(self) -> int | None:
         return self.submitted_at
 
@@ -444,4 +447,4 @@ class BuildRequest:
         return ", ".join(reasons)
 
     def getSubmitTime(self) -> int | None:
-        return self.submittedAt
+        return self.submitted_at

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -302,6 +302,7 @@ class BuildRequest:
         return self.submitted_at
 
     @property
+    @deprecated(Version("buildbot", 4, 3, 0), ".waitedFor")
     def waitedFor(self) -> int | None:
         return self.waited_for
 

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -505,7 +505,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
                 # parenting is a field of Buildset
                 # get the buildsets only for requests
                 # that are waited for
-                buildset_ids = set(br.bsid for br in breqs if br.waitedFor)
+                buildset_ids = set(br.bsid for br in breqs if br.waited_for)
                 if not buildset_ids:
                     continue
                 # get buildsets if they have a parent

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -350,6 +350,6 @@ class CVS(Source):
         if not changes:
             return None
         lastChange = max(c.when for c in changes)
-        lastSubmit = max(br.submittedAt for br in self.build.requests)
+        lastSubmit = max(br.submitted_at for br in self.build.requests)
         when = (lastChange + lastSubmit) / 2
         return formatdate(when)

--- a/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/process/test_botmaster_BotMaster.py
@@ -21,6 +21,7 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.process import factory
 from buildbot.process.botmaster import BotMaster
+from buildbot.process.buildrequest import BuildRequest
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import RETRY
 from buildbot.test.fake import fakemaster
@@ -46,8 +47,8 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         self.fake_builder = builder = mock.Mock()
         self.build_deferred = defer.Deferred()
 
-        request = mock.Mock()
-        request.waitedFor = waitedFor
+        request = mock.Mock(spec=BuildRequest)
+        request.waited_for = waitedFor
         build = mock.Mock()
         build.stopBuild = self.stopFakeBuild
         build.waitUntilFinished.return_value = self.build_deferred

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -548,7 +548,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
 
         self.assertEqual(br.properties.getProperty('x'), 1)
         self.assertEqual(br.properties.getProperty('y'), 2)
-        self.assertEqual(br.submittedAt, 1200000000)
+        self.assertEqual(br.submitted_at, 1200000000)
         self.assertEqual(br.buildername, 'bldr')
         self.assertEqual(br.priority, 13)
         self.assertEqual(br.id, 288)
@@ -627,7 +627,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
 
         self.assertEqual(br.properties.getProperty('x'), 1)
         self.assertEqual(br.properties.getProperty('y'), 2)
-        self.assertEqual(br.submittedAt, 1200000000)
+        self.assertEqual(br.submitted_at, 1200000000)
         self.assertEqual(br.buildername, 'bldr')
         self.assertEqual(br.priority, 13)
         self.assertEqual(br.id, 288)

--- a/master/docs/manual/upgrading/5.0-upgrade.rst
+++ b/master/docs/manual/upgrading/5.0-upgrade.rst
@@ -105,3 +105,9 @@ Data API
 
 The multiline string type of ``ResourceType.eventPathPatterns`` and ``Enpoint.pathPatterns``
 attribute has been deprecated. Use list of strings type instead.
+
+``buildbot.process.BuildRequest``
+=================================
+
+The ``submittedAt`` and ``waitedFor`` attributes to ``BuildRequest`` have been removed.
+Their respective equivalent are ``submitted_at`` and ``waited_for``.

--- a/newsfragments/buildrequest-fields.removal
+++ b/newsfragments/buildrequest-fields.removal
@@ -1,0 +1,1 @@
+The ``submittedAt``, and ``waitedFor`` fields of ``process.BuildRequest`` have been deprecated in favor of their snake case equivalent (``submitted_at``, and ``waited_for``).


### PR DESCRIPTION
left the `.id`  property as it's clear. Maybe should remove `brid`?

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
