### PR TITLE
Use twisted new(-ish) logger

### DIFF
--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -35,7 +35,7 @@ from urllib import request as urllib_request
 
 from sqlalchemy.engine.url import make_url
 from twisted.internet import threads
-from twisted.python import log
+from twisted.logger import Logger
 
 from buildbot.process.buildstep import _BuildStepFactory
 from buildbot.util import unicode2bytes
@@ -223,7 +223,8 @@ def _sendWithRequests(url: str, data: dict[str, Any]) -> str | None:
 
 
 def _sendBuildbotNetUsageData(data: dict[str, Any]) -> None:
-    log.msg(f"buildbotNetUsageData: sending {data}")
+    logger = Logger()
+    logger.info("sending {data}", data=data)
     # first try with requests, as this is the most stable http library
     res: str | bytes | None = _sendWithRequests(PHONE_HOME_URL, data)
     # then we try with stdlib, which not always work with https
@@ -231,14 +232,14 @@ def _sendBuildbotNetUsageData(data: dict[str, Any]) -> None:
         res = _sendWithUrlib(PHONE_HOME_URL, data)
     # at last stage
     if res is None:
-        log.msg(
-            "buildbotNetUsageData: Could not send using https, "
+        logger.warn(
+            "Could not send using https, "
             "please `pip install 'requests[security]'` for proper SSL implementation`"
         )
         data['buggySSL'] = True
         res = _sendWithUrlib(PHONE_HOME_URL.replace("https://", "http://"), data)
 
-    log.msg("buildbotNetUsageData: buildbot.net said:", res)
+    logger.info("buildbot.net said: {res}", res=res)
 
 
 def sendBuildbotNetUsageData(master: BuildMaster) -> None:

--- a/master/buildbot/scripts/buildbot_tac.tmpl
+++ b/master/buildbot/scripts/buildbot_tac.tmpl
@@ -26,10 +26,18 @@ if basedir == '.':
 application = service.Application('buildmaster')
 {% if not no_logrotate -%}
 from twisted.python.logfile import LogFile
-from twisted.python.log import ILogObserver, FileLogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import textFileLogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import FilteringLogObserver
 logfile = LogFile.fromFullPath(os.path.join(basedir, "twistd.log"), rotateLength=rotateLength,
                                 maxRotatedFiles=maxRotatedFiles)
-application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(logfile), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 {%- endif %}
 
 m = BuildMaster(basedir, configfile, umask)

--- a/master/buildbot/test/unit/schedulers/test_base.py
+++ b/master/buildbot/test/unit/schedulers/test_base.py
@@ -1204,7 +1204,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCas
 
         sched.activate = activate
 
-        sched.startService()
+        yield sched.startService()
         self.assertEqual(1, len(self.flushLoggedErrors(RuntimeError)))
 
     @defer.inlineCallbacks

--- a/master/contrib/docker/master/buildbot.tac
+++ b/master/contrib/docker/master/buildbot.tac
@@ -1,8 +1,10 @@
 import sys
 
 from twisted.application import service
-from twisted.python.log import FileLogObserver
-from twisted.python.log import ILogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import textFileLogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import FilteringLogObserver
 
 from buildbot.master import BuildMaster
 
@@ -12,7 +14,12 @@ configfile = 'master.cfg'
 # note: this line is matched against to check that this is a buildmaster
 # directory; do not edit it.
 application = service.Application('buildmaster')
-application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(sys.stdout), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 
 m = BuildMaster(basedir, configfile, umask=None)
 m.setServiceParent(application)

--- a/master/docker-example/pypy/master/buildbot.tac
+++ b/master/docker-example/pypy/master/buildbot.tac
@@ -2,7 +2,10 @@ import sys
 
 from buildbot.master import BuildMaster
 from twisted.application import service
-from twisted.python.log import FileLogObserver, ILogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import textFileLogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import FilteringLogObserver
 
 basedir = '/usr/src/app'
 configfile = 'master.cfg'
@@ -10,7 +13,12 @@ configfile = 'master.cfg'
 # note: this line is matched against to check that this is a buildmaster
 # directory; do not edit it.
 application = service.Application('buildmaster')
-application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(sys.stdout), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 
 m = BuildMaster(basedir, configfile, umask=None)
 m.setServiceParent(application)

--- a/master/docker-example/pypy/worker/buildbot.tac
+++ b/master/docker-example/pypy/worker/buildbot.tac
@@ -3,8 +3,10 @@ import os
 import sys
 
 from twisted.application import service
-from twisted.python.log import FileLogObserver
-from twisted.python.log import ILogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import textFileLogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import FilteringLogObserver
 
 from buildslave.bot import BuildSlave
 
@@ -13,7 +15,12 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 application = service.Application('buildbot-worker')
 
 
-application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(sys.stdout), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 # and worker on the same process!
 buildmaster_host = os.environ.get("BUILDMASTER", 'localhost')
 port = int(os.environ.get("BUILDMASTER_PORT", 9989))

--- a/master/docker/buildbot.tac
+++ b/master/docker/buildbot.tac
@@ -2,8 +2,10 @@ import os
 import sys
 
 from twisted.application import service
-from twisted.python.log import FileLogObserver
-from twisted.python.log import ILogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import textFileLogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import FilteringLogObserver
 
 from buildbot.master import BuildMaster
 
@@ -14,7 +16,12 @@ configfile = 'master.cfg'
 # note: this line is matched against to check that this is a buildmaster
 # directory; do not edit it.
 application = service.Application('buildmaster')
-application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(sys.stdout), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 
 m = BuildMaster(basedir, configfile, umask=None)
 m.setServiceParent(application)

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -1109,6 +1109,11 @@ them should actually trigger the required builds.
 
     * BuildbotServiceManager calls reconfigService() for the second time for services that have their configuration changed.
 
+    .. py:attribute:: _logger
+
+        :type: :py:class:`twisted.logger.Logger`
+
+        A logger instance which namespace is the service's name, providing an unified way for service's to log messages.
 
     .. py:method:: __init__(self, *args, **kwargs)
 

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -193,8 +193,8 @@ Logging to stdout
 It can be useful to let buildbot output it's log to stdout instead of a logfile.
 For example when running via docker, supervisor or when buildbot is started with --no-daemon.
 This can be accomplished by editing :file:`buildbot.tac`. It's already enabled in the docker :file:`buildbot.tac`
-Change the line: `application.setComponent(ILogObserver, FileLogObserver(logfile).emit)`
-to: `application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)`
+Change the line: `application.setComponent(ILogObserver, textFileLogObserver(logfile))`
+to: `application.setComponent(ILogObserver, textFileLogObserver(sys.stdout))`
 
 .. _Deleting-old-logs:
 

--- a/newsfragments/BuildbotService-Logger.feature
+++ b/newsfragments/BuildbotService-Logger.feature
@@ -1,0 +1,1 @@
+``:class:BuildbotService`` now has a ``_logger`` field, which is a ``twisted.logger.Logger`` instance using the service's name as it's namespace.

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -42,11 +42,19 @@ application = service.Application('buildbot-worker')
 """,
     """
 from twisted.python.logfile import LogFile
-from twisted.python.log import ILogObserver, FileLogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import textFileLogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import FilteringLogObserver
 logfile = LogFile.fromFullPath(
     os.path.join(basedir, "twistd.log"), rotateLength=rotateLength,
     maxRotatedFiles=maxRotatedFiles)
-application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(logfile), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 """,
     """
 buildmaster_host = %(host)r

--- a/worker/docker/buildbot.tac
+++ b/worker/docker/buildbot.tac
@@ -3,8 +3,10 @@ import os
 import sys
 
 from twisted.application import service
-from twisted.python.log import FileLogObserver
-from twisted.python.log import ILogObserver
+from twisted.logger import FilteringLogObserver
+from twisted.logger import ILogObserver
+from twisted.logger import LogLevelFilterPredicate
+from twisted.logger import textFileLogObserver
 
 from buildbot_worker.bot import Worker
 
@@ -12,9 +14,13 @@ from buildbot_worker.bot import Worker
 basedir = os.environ.get("BUILDBOT_BASEDIR",
     os.path.abspath(os.path.dirname(__file__)))
 application = service.Application('buildbot-worker')
+application.setComponent(
+    ILogObserver,
+    FilteringLogObserver(
+        textFileLogObserver(sys.stdout), predicates=[LogLevelFilterPredicate()]
+    ),
+)
 
-
-application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)
 # and worker on the same process!
 buildmaster_host = os.environ.get("BUILDMASTER", 'localhost')
 port = int(os.environ.get("BUILDMASTER_PORT", 9989))


### PR DESCRIPTION
The newer Twisted logger allow to specify a level as well as namespace, making identifying logs origin easier.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
