### PR TITLE
Bump min py version in some places

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -36,6 +35,8 @@ from buildbot.util import httpclientservice
 from buildbot.util.pullrequest import PullRequestMixin
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.util.twisted import InlineCallbacksType
 
 

--- a/master/buildbot/changes/filter.py
+++ b/master/buildbot/changes/filter.py
@@ -15,17 +15,20 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Pattern
-from typing import Sequence
 
 from buildbot.util import ComparableMixin
 from buildbot.util import NotABranch
 from buildbot.util.ssfilter import _create_branch_filters
 from buildbot.util.ssfilter import _create_filters
 from buildbot.util.ssfilter import _create_property_filters
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from re import Pattern
 
 
 class ChangeFilter(ComparableMixin):

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -23,8 +23,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Pattern
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -44,6 +42,9 @@ from buildbot.util.protocol import LineProcessProtocol
 from buildbot.util.pullrequest import PullRequestMixin
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from re import Pattern
+
     from buildbot.util.twisted import InlineCallbacksType
 
 

--- a/master/buildbot/changes/github.py
+++ b/master/buildbot/changes/github.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 from typing import cast
 
 from twisted.internet import defer
@@ -35,6 +34,8 @@ from buildbot.util.pullrequest import PullRequestMixin
 from buildbot.util.state import StateMixin
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.util.twisted import InlineCallbacksType
 
 log = Logger()

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -21,7 +21,6 @@ import re
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 from typing import cast
 from urllib.parse import quote as urlquote
 
@@ -42,14 +41,15 @@ from buildbot.util.git import check_ssh_config
 from buildbot.util.git_credential import GitCredentialOptions
 from buildbot.util.git_credential import add_user_password_to_credentials
 from buildbot.util.state import StateMixin
-from buildbot.util.twisted import InlineCallbacksType
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import Callable
     from typing import Literal
 
     from buildbot.interfaces import IRenderable
+    from buildbot.util.twisted import InlineCallbacksType
 
 
 class GitError(Exception):

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -33,6 +32,8 @@ from buildbot.util import runprocess
 from buildbot.util.state import StateMixin
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.util.twisted import InlineCallbacksType
 
 

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -31,7 +31,6 @@ from email.utils import parsedate_tz
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -42,6 +41,8 @@ from buildbot.interfaces import IChangeSource
 from buildbot.util.maildir import MaildirService
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.util.twisted import InlineCallbacksType
 
 

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 
 import dateutil.tz
 from twisted.internet import defer
@@ -42,6 +41,8 @@ from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from twisted.python.failure import Failure
 
     from buildbot.util.twisted import InlineCallbacksType

--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -28,6 +27,8 @@ from buildbot.changes import base
 from buildbot.pbutil import NewCredPerspective
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.config.master import MasterConfig
     from buildbot.util.twisted import InlineCallbacksType
 

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -23,7 +23,6 @@ import xml.dom.minidom
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 from typing import cast
 from urllib.parse import quote_plus as urlquote_plus
 
@@ -36,6 +35,8 @@ from buildbot.util import bytes2unicode
 from buildbot.util import runprocess
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.util.twisted import InlineCallbacksType
 
 # these split_file_* functions are available for use as values to the

--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -23,10 +23,9 @@ import traceback
 import warnings
 from dataclasses import dataclass
 from dataclasses import field
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Generator
-from typing import Sequence
 from typing import cast
 
 from twisted.internet import defer
@@ -54,6 +53,10 @@ from buildbot.warnings import ConfigWarning
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www.authz import authz
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from collections.abc import Sequence
 
 DEFAULT_DB_URL = 'sqlite:///state.sqlite'
 

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -29,7 +29,7 @@ from buildbot.process.results import RETRY
 
 if TYPE_CHECKING:
     import datetime
-    from typing import Sequence
+    from collections.abc import Sequence
 
     from buildbot.data.resultspec import ResultSpec
     from buildbot.db.buildrequests import BuildRequestModel

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -23,8 +23,8 @@ from buildbot.data import base
 from buildbot.data import types
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
     from typing import Any
-    from typing import AsyncGenerator
 
     from buildbot.db.logs import LogModel
 

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -24,7 +24,7 @@ from twisted.python import log
 from buildbot.data import base
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from collections.abc import Sequence
 
 
 class NotSupportedFieldTypeError(TypeError):

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -30,7 +30,7 @@ from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     import datetime
-    from typing import Sequence
+    from collections.abc import Sequence
 
     from buildbot.data.resultspec import ResultSpec
     from buildbot.db.sourcestamps import SourceStampModel

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -37,8 +37,8 @@ from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
     import datetime
+    from collections.abc import Iterable
     from typing import Any
-    from typing import Iterable
     from typing import Literal
 
 

--- a/master/buildbot/db/codebase_commits.py
+++ b/master/buildbot/db/codebase_commits.py
@@ -18,13 +18,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Awaitable
 from typing import Callable
 
 from buildbot.db import base
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     import sqlalchemy as sa
     from twisted.internet import defer
 

--- a/master/buildbot/db/compression/zstd.py
+++ b/master/buildbot/db/compression/zstd.py
@@ -26,9 +26,9 @@ from buildbot.db.compression.protocol import CompressObjInterface
 from buildbot.db.compression.protocol import CompressorInterface
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from typing import Callable
     from typing import ClassVar
-    from typing import Generator
 
 
 _T = TypeVar('_T')

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -271,10 +271,13 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             # Note that row.content is stored as bytes, and our caller expects unicode
             data = self._get_compressor(compressed).read(content)
             # NOTE: we need a streaming decompression interface
-            with io.BytesIO(data) as data_buffer, io.TextIOWrapper(
-                data_buffer,
-                encoding='utf-8',
-            ) as reader:
+            with (
+                io.BytesIO(data) as data_buffer,
+                io.TextIOWrapper(
+                    data_buffer,
+                    encoding='utf-8',
+                ) as reader,
+            ):
                 # last line-ending is stripped from chunk on insert
                 # add it back here to simplify handling after
                 data_buffer.seek(0, os.SEEK_END)

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -43,9 +43,9 @@ from buildbot.util.twisted import async_to_deferred
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
-    from typing import AsyncGenerator
+    from collections.abc import AsyncGenerator
+    from collections.abc import Generator
     from typing import Callable
-    from typing import Generator
     from typing import Literal
     from typing import TypeVar
 

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -23,6 +25,9 @@ from buildbot import util
 from buildbot.util import service
 from buildbot.util import subscription
 from buildbot.util.eventual import eventually
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 if False:  # for debugging  pylint: disable=using-constant-test
     debuglog = log.msg

--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -13,12 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import base64
 import binascii
 import os
 import types
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.application import strports
 from twisted.conch import manhole
@@ -34,6 +36,9 @@ from buildbot import config
 from buildbot.util import ComparableMixin
 from buildbot.util import service
 from buildbot.util import unicode2bytes
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 try:
     from twisted.conch import manhole_ssh

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -20,9 +20,6 @@ from functools import reduce
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Iterable
-from typing import Iterator
-from typing import Sequence
 from typing import cast
 
 from twisted.internet import defer
@@ -53,6 +50,9 @@ from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from collections.abc import Iterator
+    from collections.abc import Sequence
     from pathlib import PurePath
 
     from twisted.internet.defer import Deferred

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -19,8 +19,6 @@ import calendar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Iterable
-from typing import Mapping
 
 from twisted.internet import defer
 
@@ -30,6 +28,9 @@ from buildbot.process import properties
 from buildbot.process.results import SKIPPED
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from collections.abc import Mapping
+
     from twisted.internet.defer import Deferred
 
     from buildbot.data.builders import BuilderData

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 from typing import cast
 
 from twisted.internet import defer
@@ -69,6 +68,7 @@ from buildbot.util import flatten
 from buildbot.util.test_result_submitter import TestResultSubmitter
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import TypeVar
 
     from twisted.internet.base import ReactorBase

--- a/master/buildbot/process/codebase.py
+++ b/master/buildbot/process/codebase.py
@@ -15,11 +15,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from buildbot import util
 from buildbot.config.checks import check_param_str
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Codebase(util.ComparableMixin):

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -19,7 +19,6 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.python import deprecate
 from twisted.python import versions
@@ -40,6 +39,8 @@ from buildbot.steps.source.svn import SVN
 from buildbot.warnings import warn_deprecated
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.process.builder import Builder
 
 

--- a/master/buildbot/process/project.py
+++ b/master/buildbot/process/project.py
@@ -13,14 +13,19 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from buildbot import util
 from buildbot.config.checks import check_markdown_support
 from buildbot.config.checks import check_param_str
 from buildbot.config.checks import check_param_str_none
 from buildbot.config.errors import error
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Project(util.ComparableMixin):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -18,9 +18,9 @@ import collections
 import json
 import re
 import weakref
+from typing import TYPE_CHECKING
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python.components import registerAdapter
@@ -31,6 +31,9 @@ from buildbot import util
 from buildbot.interfaces import IProperties
 from buildbot.interfaces import IRenderable
 from buildbot.util import flatten
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(IProperties)

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -35,8 +35,8 @@ from buildbot.util.twisted import async_to_deferred
 from buildbot.worker.protocols import base
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from typing import Any
-    from typing import Awaitable
     from typing import Callable
 
     from buildbot.process.buildstep import BuildStep

--- a/master/buildbot/reporters/base.py
+++ b/master/buildbot/reporters/base.py
@@ -13,9 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import abc
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -24,6 +26,9 @@ from buildbot import config
 from buildbot.reporters import utils
 from buildbot.util import service
 from buildbot.util import tuplematch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 ENCODING = 'utf-8'
 

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from zope.interface import implementer
@@ -25,6 +27,9 @@ from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterRenderable
 
 from .utils import BuildStatusGeneratorMixin
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(interfaces.IReportGenerator)

--- a/master/buildbot/reporters/generators/buildrequest.py
+++ b/master/buildbot/reporters/generators/buildrequest.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from zope.interface import implementer
@@ -28,6 +30,9 @@ from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatterRenderable
 
 from .utils import BuildStatusGeneratorMixin
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(interfaces.IReportGenerator)

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -12,8 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from zope.interface import implementer
@@ -24,6 +27,9 @@ from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatter
 
 from .utils import BuildStatusGeneratorMixin
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(interfaces.IReportGenerator)

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -28,6 +30,9 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import statusToString
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class BuildStatusGeneratorMixin(util.ComparableMixin):

--- a/master/buildbot/reporters/generators/worker.py
+++ b/master/buildbot/reporters/generators/worker.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from zope.interface import implementer
@@ -23,6 +25,9 @@ from buildbot import config
 from buildbot import interfaces
 from buildbot import util
 from buildbot.reporters.message import MessageFormatterMissingWorker
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 ENCODING = 'utf-8'
 

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import re
-from typing import Generator
+from typing import TYPE_CHECKING
 
 from twisted.internet import defer
 from twisted.python import log
@@ -37,6 +37,9 @@ from buildbot.reporters.generators.buildrequest import BuildRequestGenerator
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.util import httpclientservice
 from buildbot.util.giturlparse import giturlparse
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 HOSTED_BASE_URL = 'https://api.github.com'
 

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -13,9 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import base64
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.application import internet
 from twisted.internet import defer
@@ -39,6 +41,9 @@ from buildbot.reporters.words import ThrottledClientFactory
 from buildbot.reporters.words import dangerousCommand
 from buildbot.util import service
 from buildbot.util import ssl
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class UsageError(ValueError):

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -24,8 +24,8 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 from email.utils import parseaddr
 from io import BytesIO
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -47,6 +47,9 @@ from buildbot.util import unicode2bytes
 
 from .utils import merge_reports_prop
 from .utils import merge_reports_prop_take_first
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # this incantation teaches email to output utf-8 using 7- or 8-bit encoding,
 # although it has no effect before python-2.7.

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 import jinja2
 from twisted.internet import defer
@@ -32,6 +34,9 @@ from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def get_detected_status_text(mode, results, previous_results):

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -19,9 +19,9 @@ import io
 import json
 import random
 import shlex
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -47,6 +47,9 @@ from buildbot.util import epoch2datetime
 from buildbot.util import httpclientservice
 from buildbot.util import service
 from buildbot.util import unicode2bytes
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class TelegramChannel(Channel):

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -14,8 +14,8 @@
 # Copyright Buildbot Team Members
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -28,6 +28,9 @@ from buildbot.process.properties import Properties
 from buildbot.util.service import ClusteredBuildbotService
 from buildbot.util.state import StateMixin
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(interfaces.IScheduler)

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -13,9 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 from collections import defaultdict
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import log
@@ -31,6 +33,9 @@ from buildbot.schedulers import dependent
 from buildbot.util import NotABranch
 from buildbot.util.codebase import AbsoluteSourceStampsMixin
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class BaseBasicScheduler(base.ReconfigurableBaseScheduler):

--- a/master/buildbot/schedulers/canceller.py
+++ b/master/buildbot/schedulers/canceller.py
@@ -13,9 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 
@@ -24,6 +26,9 @@ from buildbot.data import resultspec
 from buildbot.util.service import BuildbotService
 from buildbot.util.ssfilter import SourceStampFilter
 from buildbot.util.ssfilter import extract_filter_values
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class _OldBuildFilterSet:

--- a/master/buildbot/schedulers/canceller_buildset.py
+++ b/master/buildbot/schedulers/canceller_buildset.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 
@@ -24,6 +26,9 @@ from buildbot.process.results import FAILURE
 from buildbot.util.service import BuildbotService
 from buildbot.util.ssfilter import SourceStampFilter
 from buildbot.util.ssfilter import extract_filter_values
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class _FailingSingleBuilderConfig:

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -15,8 +15,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 
@@ -26,6 +26,9 @@ from buildbot import util
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.schedulers import base
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Dependent(base.ReconfigurableBaseScheduler):

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 import re
 import traceback
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python.reflect import accumulateClassList
@@ -29,6 +29,9 @@ from buildbot.process.properties import Properties
 from buildbot.reporters.mail import VALID_EMAIL_ADDR
 from buildbot.schedulers import base
 from buildbot.util import identifiers
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class ValidationError(ValueError):

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -13,10 +13,12 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import datetime
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 import croniter
 from twisted.internet import defer
@@ -31,6 +33,9 @@ from buildbot.process import buildstep
 from buildbot.process import properties
 from buildbot.schedulers import base
 from buildbot.util.codebase import AbsoluteSourceStampsMixin
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # States of objects which have to be observed are registered in the data base table `object_state`.
 # `objectid` in the `object_state` refers to the object from the `object` table.

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -13,9 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.python import failure
@@ -25,6 +27,9 @@ from buildbot.interfaces import ITriggerableScheduler
 from buildbot.process.properties import Properties
 from buildbot.schedulers import base
 from buildbot.util import debounce
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(ITriggerableScheduler)

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -13,12 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import base64
 import json
 import os
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.protocols import basic
@@ -33,6 +35,9 @@ from buildbot.util import netstrings
 from buildbot.util import unicode2bytes
 from buildbot.util.maildir import MaildirService
 from buildbot.util.service import IndependentAsyncMultiService
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class TryBase(base.ReconfigurableBaseScheduler):

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -14,10 +14,12 @@
 # Copyright Buildbot Team Members
 
 
+from __future__ import annotations
+
 import re
 import textwrap
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -29,6 +31,9 @@ from buildbot.process import buildstep
 from buildbot.process import remotecommand
 from buildbot.process import results
 from buildbot.steps.source.base import Source
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(IRenderable)

--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -21,9 +21,9 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Sequence
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -37,6 +37,9 @@ from twisted.python.failure import Failure
 from zope.interface import implementer
 
 from buildbot.util.twisted import async_to_deferred
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # The code here is based on the implementations in
 # https://twistedmatrix.com/trac/ticket/8295

--- a/master/buildbot/test/fakedb/row.py
+++ b/master/buildbot/test/fakedb/row.py
@@ -15,10 +15,13 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 from buildbot.util import unicode2bytes
 from buildbot.util.sautils import hash_columns
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Row:

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -31,9 +31,9 @@ from buildbot.test.util.integration import RunFakeMasterTestCase
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
     from typing import Any
     from typing import Callable
-    from typing import Coroutine
     from typing import TypeVar
 
     from typing_extensions import ParamSpec

--- a/master/buildbot/test/unit/data/test_resultspec.py
+++ b/master/buildbot/test/unit/data/test_resultspec.py
@@ -28,8 +28,8 @@ from buildbot.data.resultspec import NoneComparator
 from buildbot.data.resultspec import ReverseComparator
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import ClassVar
-    from typing import Sequence
 
 
 class ResultSpecMKListMixin:

--- a/master/buildbot/test/unit/db/test_sourcestamps.py
+++ b/master/buildbot/test/unit/db/test_sourcestamps.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Generator
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -28,6 +27,8 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from buildbot.test.fakedb import FakeDBConnector
 
 CREATED_AT = 927845299

--- a/master/buildbot/test/unit/schedulers/test_manager.py
+++ b/master/buildbot/test/unit/schedulers/test_manager.py
@@ -13,8 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 from unittest import mock
 
 from twisted.internet import defer
@@ -25,6 +27,9 @@ from buildbot.schedulers import base
 from buildbot.schedulers import manager
 from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class SchedulerManager(unittest.TestCase):

--- a/master/buildbot/test/unit/util/test_ComparableMixin.py
+++ b/master/buildbot/test/unit/util/test_ComparableMixin.py
@@ -13,12 +13,17 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.trial import unittest
 
 from buildbot import util
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class ComparableMixin(unittest.TestCase):

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -26,7 +26,6 @@ import textwrap
 import time
 from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 from typing import overload
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
@@ -42,8 +41,8 @@ from buildbot.util.misc import deferredLocked
 from ._notifier import Notifier
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import ClassVar
-    from typing import Sequence
     from typing import TypeVar
 
     _T = TypeVar('_T')

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from pathlib import PurePath
 from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from packaging.version import parse as parse_version
 from twisted.internet import defer
@@ -39,6 +38,8 @@ from buildbot.util.misc import writeLocalFile
 from buildbot.util.twisted import async_to_deferred
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from buildbot.changes.gitpoller import GitPoller
     from buildbot.interfaces import IRenderable
     from buildbot.util.git_credential import GitCredentialOptions

--- a/master/buildbot/util/git_credential.py
+++ b/master/buildbot/util/git_credential.py
@@ -15,15 +15,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import NamedTuple
-from typing import Sequence
 
 from zope.interface import implementer
 
 from buildbot.interfaces import IRenderable
 from buildbot.util import ComparableMixin
 from buildbot.util.twisted import async_to_deferred
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @implementer(IRenderable)

--- a/master/buildbot/util/sautils.py
+++ b/master/buildbot/util/sautils.py
@@ -27,9 +27,9 @@ from sqlalchemy.sql.expression import ClauseElement
 from sqlalchemy.sql.expression import Executable
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import Any
     from typing import Callable
-    from typing import Sequence
 
     from sqlalchemy.future.engine import Connection
     from sqlalchemy.future.engine import Engine

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -16,8 +16,8 @@
 from __future__ import annotations
 
 import hashlib
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from twisted.application import service
 from twisted.internet import defer
@@ -33,6 +33,9 @@ from buildbot.util import bytes2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
 from buildbot.warnings import warn_deprecated
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class ReconfigurableServiceMixin:

--- a/master/buildbot/util/ssfilter.py
+++ b/master/buildbot/util/ssfilter.py
@@ -13,12 +13,17 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 from buildbot.util import ComparableMixin
 from buildbot.util import NotABranch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def extract_filter_values(values, filter_name):

--- a/master/buildbot/util/twisted.py
+++ b/master/buildbot/util/twisted.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 
 import inspect
 from functools import wraps
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Coroutine
-from typing import Generator
 from typing import TypeVar
 from typing import Union
 
@@ -29,11 +28,14 @@ from twisted.internet import reactor
 from twisted.python import threadpool
 from typing_extensions import ParamSpec
 
-_T = TypeVar('_T')
-_P = ParamSpec('_P')
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from collections.abc import Generator
 
+    _T = TypeVar('_T')
+    _P = ParamSpec('_P')
 
-InlineCallbacksType = Generator[Union[Any, defer.Deferred[Any]], Any, _T]
+    InlineCallbacksType = Generator[Union[Any, defer.Deferred[Any]], Any, _T]
 
 
 def async_to_deferred(

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Mapping
 from typing import TypeVar
 
 from twisted.internet import defer
@@ -27,6 +26,8 @@ from buildbot.util import subscription
 from buildbot.util.eventual import eventually
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from twisted.internet.defer import Deferred
 
     from buildbot.master import BuildMaster

--- a/master/buildbot/worker/protocols/msgpack.py
+++ b/master/buildbot/worker/protocols/msgpack.py
@@ -21,7 +21,6 @@ from pathlib import PurePosixPath
 from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Iterable
 
 from twisted.internet import defer
 from twisted.python import log
@@ -35,6 +34,7 @@ from buildbot.worker.protocols import base
 from buildbot.worker.protocols.base import RemoteCommandImpl
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import PurePath
 
     from twisted.internet.defer import Deferred

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Generator
 
 from twisted.internet import defer
 from twisted.python import log
@@ -30,6 +29,8 @@ from buildbot.util import deferwaiter
 from buildbot.worker.protocols import base
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from twisted.internet.defer import Deferred
     from twisted.python.failure import Failure
 

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -15,26 +15,21 @@
 
 from __future__ import annotations
 
-import sys
+import importlib.resources
 
 from twisted.web import static
 
 from buildbot.util import bytes2unicode
 
-if sys.version_info[:2] >= (3, 9):
-    # We need importlib.resources.files, which is added in Python 3.9
-    # https://docs.python.org/3/library/importlib.resources.html
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources  # type: ignore[import-not-found]
-
 
 class Application:
     def __init__(self, package_name: str, description: str, ui: bool = True) -> None:
         self.description = description
-        self.version = importlib_resources.files(package_name).joinpath("VERSION")
-        self.version = bytes2unicode(self.version.read_bytes())
-        self.static_dir = importlib_resources.files(package_name) / "static"
+        # type ignore on `importlib.resources.files` since mypy conf target 3.8
+        # where master is 3.9+, so mypy think it does not exists as it was introduced in 3.9.
+        version_file = importlib.resources.files(package_name).joinpath("VERSION")  # type: ignore[attr-defined]
+        self.version = bytes2unicode(version_file.read_bytes())
+        self.static_dir = importlib.resources.files(package_name) / "static"  # type: ignore[attr-defined]
         self.resource = static.File(self.static_dir)
         self.ui = ui
 

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -23,7 +23,6 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Iterator
 from urllib.parse import urlparse
 
 from twisted.internet import defer
@@ -46,6 +45,7 @@ from buildbot.www.encoding import BrotliEncoderFactory
 from buildbot.www.encoding import ZstandardEncoderFactory
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from typing import Any
 
     from twisted.web import server

--- a/master/contrib/bzr_buildbot.py
+++ b/master/contrib/bzr_buildbot.py
@@ -95,11 +95,13 @@ Contact Information
 Maintainer/author: gary.poster@canonical.com
 """
 
+from __future__ import annotations
+
 # Work around Twisted bug.
 # See http://twistedmatrix.com/trac/ticket/3591
 import socket
+from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Sequence
 
 import bzrlib.branch
 import bzrlib.errors
@@ -114,6 +116,9 @@ import twisted.python.log
 import twisted.spread.pb
 from twisted.internet import defer
 from twisted.python import failure
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 try:
     import buildbot.changes.base

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -12,7 +12,7 @@ At a bare minimum, you'll need the following for both the buildmaster and a work
 
 Python: https://www.python.org
 
-  Buildbot master works with Python-3.8+.
+  Buildbot master works with Python-3.9+.
   Buildbot worker works with Python-3.7+.
 
   .. note::

--- a/master/ruff.toml
+++ b/master/ruff.toml
@@ -5,5 +5,4 @@ target-version = "py39"
 [lint]
 extend-ignore = [
     "UP035",
-    "UP036",
 ]

--- a/master/ruff.toml
+++ b/master/ruff.toml
@@ -1,0 +1,9 @@
+extend = "../pyproject.toml"
+
+target-version = "py39"
+
+[lint]
+extend-ignore = [
+    "UP035",
+    "UP036",
+]

--- a/master/ruff.toml
+++ b/master/ruff.toml
@@ -1,8 +1,3 @@
 extend = "../pyproject.toml"
 
 target-version = "py39"
-
-[lint]
-extend-ignore = [
-    "UP035",
-]

--- a/master/setup.py
+++ b/master/setup.py
@@ -653,9 +653,7 @@ setup_args = {
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
-py_38 = sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_info[1] >= 8)
-if not py_38:
-    raise RuntimeError("Buildbot master requires at least Python-3.8")
+setup_args['python_requires'] = ">=3.9"
 
 twisted_ver = ">= 24.7.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.ruff]
 line-length = 100
-target-version = "py38"
 
 [tool.ruff.lint]
     select = ["W", "E", "F", "I", "PL", "UP", "T100", "B", "RUF", "FA", "TC"]

--- a/worker/ruff.toml
+++ b/worker/ruff.toml
@@ -1,0 +1,3 @@
+extend = "../pyproject.toml"
+
+target-version = "py37"


### PR DESCRIPTION
Drop of support for Python 3.8 was missed in a few places.

Also, the mypy conf need to be split between master and worker since they target two different version.

Or could worker also require Py3.9?

I understand the need to support older distribution that can't have newer Python versions, but since older workers can connect to the master, this should be sufficient as worker code doesn't change much?
Any other reason I'm missing?

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
