### PR TITLE
appveyor: Re-add empty configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+# AppVeyor CI
+# https://www.appveyor.com/docs
+
+image:
+  - Visual Studio 2019
+
+build: false
+
+test_script:
+  - ps: |
+          echo Success
+


### PR DESCRIPTION
This is needed because otherwise Appveyor sends a failure status to Github. Appveyor cannot be turned off due to it being still used for old release branches.