### PR TITLE
mypy: extract worker config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,10 @@ ruff:
 	ruff format .
 
 mypy:
-	mypy --platform linux --config-file ./pyproject.toml master/buildbot worker/buildbot_worker
-	mypy --platform win32 --config-file ./pyproject.toml master/buildbot worker/buildbot_worker
+	mypy --platform linux --config-file ./pyproject.toml master/buildbot
+	mypy --platform win32 --config-file ./pyproject.toml master/buildbot
+	mypy --platform linux --config-file ./worker/.mypy.ini worker/buildbot_worker
+	mypy --platform win32 --config-file ./worker/.mypy.ini worker/buildbot_worker
 
 docker: docker-buildbot-worker docker-buildbot-master
 	echo done

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -25,11 +25,9 @@ from buildbot.util import bytes2unicode
 class Application:
     def __init__(self, package_name: str, description: str, ui: bool = True) -> None:
         self.description = description
-        # type ignore on `importlib.resources.files` since mypy conf target 3.8
-        # where master is 3.9+, so mypy think it does not exists as it was introduced in 3.9.
-        version_file = importlib.resources.files(package_name).joinpath("VERSION")  # type: ignore[attr-defined]
+        version_file = importlib.resources.files(package_name).joinpath("VERSION")
         self.version = bytes2unicode(version_file.read_bytes())
-        self.static_dir = importlib.resources.files(package_name) / "static"  # type: ignore[attr-defined]
+        self.static_dir = str(importlib.resources.files(package_name) / "static")
         self.resource = static.File(self.static_dir)
         self.ui = ui
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ disallow_untyped_calls = false
 disallow_untyped_defs = true
 warn_unused_ignores = true
 no_implicit_optional = true
-mypy_path = "$MYPY_CONFIG_FILE_DIR/master:$MYPY_CONFIG_FILE_DIR/worker"
+mypy_path = "$MYPY_CONFIG_FILE_DIR/master"
 plugins = "mypy_zope:plugin"
     [[tool.mypy.overrides]]
     module = [
@@ -149,7 +149,6 @@ plugins = "mypy_zope:plugin"
 
     [[tool.mypy.overrides]]
     module = [
-      "buildbot_worker.scripts.windows_service",
       "buildbot.asyncio",
       "buildbot.clients.sendchange",
       "buildbot.clients.tryclient",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ quote-style = "preserve"
         showcontent = true
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 namespace_packages = true
 pretty = true
 warn_redundant_casts = true

--- a/worker/.mypy.ini
+++ b/worker/.mypy.ini
@@ -1,0 +1,25 @@
+[mypy]
+# should target 3.7, but mypy doesn't support it
+python_version = 3.8
+namespace_packages = true
+pretty = true
+warn_redundant_casts = true
+disallow_untyped_calls = false
+disallow_untyped_defs = true
+warn_unused_ignores = true
+no_implicit_optional = true
+plugins=mypy_zope:plugin
+
+[mypy-autobahn.*,msgpack.*,parameterized.*,psutil.*,pythoncom.*,pywintypes.*,servicemanager.*]
+ignore_missing_imports = true
+[mypy-win32api.*,win32com.*,win32con.*,win32event.*,win32file.*,win32job.*,win32pipe.*]
+ignore_missing_imports = true
+[mypy-win32process.*,win32security.*,win32service.*,win32serviceutil.*,winerror.*]
+ignore_missing_imports = true
+
+[mypy-buildbot_worker.scripts.windows_service]
+disallow_untyped_defs = false
+
+[mypy-buildbot.scripts,buildbot,buildbot.scripts.runner,buildbot.util.twisted,buildbot.worker.protocols.null]
+# known typed, but not marked as typed
+follow_untyped_imports = true

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -115,7 +115,10 @@ setup_args = {
     'package_data': {
         '': [
             'VERSION',
-        ]
+        ],
+        'buildbot_worker': [
+            'py.typed',
+        ],
     },
     'cmdclass': {'install_data': our_install_data, 'sdist': our_sdist},
     'entry_points': {


### PR DESCRIPTION
worker need to target a different python version than master.
Mypy doesn't allow to override the python version per module, not inherit value from another config, so had to create a whole configuration.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
