### PR TITLE
process: remove BuildRequest.brid

### DIFF
--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -220,7 +220,7 @@ class BuildRequest:
     @ivar bsid: ID of the parent buildset
     """
 
-    brid: int
+    id: int
     bsid: int
     buildername: str
     builderid: int
@@ -278,7 +278,7 @@ class BuildRequest:
             ss.changes = [TempChange(change) for change in changes]
 
         return cls(
-            brid=brid,
+            id=brid,
             bsid=brdict.buildsetid,
             buildername=brdict.buildername,
             builderid=brdict.builderid,
@@ -292,10 +292,6 @@ class BuildRequest:
             properties=properties.Properties.fromDict(buildset_properties),
             sources=sources,
         )
-
-    @property
-    def id(self) -> int:
-        return self.brid
 
     @property
     @deprecated(Version("buildbot", 4, 3, 0), ".submitted_at")


### PR DESCRIPTION
Introduced in e4bdc1484b43a43aeee949799bea36fa3a44532b.

`id` is clear enough since it's a field of the `BuildRequest` class.
It was not released, so no need for a newsfragment.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
