### PR TITLE
.github: Bump Windows runner version to 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   win:
     name: Win / python ${{ matrix.python-version }}
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
windows-2019 runner are deprecated.
