### PR TITLE
github: Do not group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
-    groups:
-      minor-upgrades:
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "npm"
     directories:
@@ -18,11 +13,6 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
-    groups:
-      minor-upgrades:
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "docker"
     directories:
@@ -30,19 +20,9 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
-    groups:
-      minor-upgrades:
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "cron"
       cronjob: "0 0 1,15 * *"  # every 1st and 15th of the month
-    groups:
-      minor-upgrades:
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
Dependabot grouping is great because it allows to reduce the number of PRs by grouping small dependency upgrades. It is completely useless because it merges all upgrades into single commit. As a result, it won't be possible to easily bisect if problems later appear.

This is the issue in dependabot that tracks this lack of functionality: https://github.com/dependabot/dependabot-core/issues/8450

This commit disables grouping. There is a script to create a single PR from multiple dependabot PRs - common/gather_dependabot.py. This will reduce the overhead of one PR per dependency.
