### PR TITLE
Add properties to data get method

### DIFF
--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -127,9 +127,16 @@ class DataConnector(service.AsyncService):
     def getResourceType(self, name):
         return getattr(self.rtypes, name, None)
 
-    def get(self, path, filters=None, fields=None, order=None, limit=None, offset=None):
+    def get(
+        self, path, filters=None, fields=None, order=None, limit=None, offset=None, properties=None
+    ):
         resultSpec = resultspec.ResultSpec(
-            filters=filters, fields=fields, order=order, limit=limit, offset=offset
+            filters=filters,
+            fields=fields,
+            order=order,
+            limit=limit,
+            offset=offset,
+            properties=[resultspec.Property(b"property", "eq", properties)] if properties else None,
         )
         return self.get_with_resultspec(path, resultSpec)
 

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -598,11 +598,19 @@ class FakeDataConnector(service.AsyncMultiService):
     def getResourceType(self, name):
         return getattr(self.rtypes, name)
 
-    def get(self, path, filters=None, fields=None, order=None, limit=None, offset=None):
+    def get(
+        self, path, filters=None, fields=None, order=None, limit=None, offset=None, properties=None
+    ):
         if not isinstance(path, tuple):
             raise TypeError('path must be a tuple')
         return self.realConnector.get(
-            path, filters=filters, fields=fields, order=order, limit=limit, offset=offset
+            path,
+            filters=filters,
+            fields=fields,
+            order=order,
+            limit=limit,
+            offset=offset,
+            properties=properties,
         )
 
     def get_with_resultspec(self, path, rspec):

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -38,7 +38,16 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_get(self):
         @self.assertArgSpecMatches(self.data.get)
-        def get(self, path, filters=None, fields=None, order=None, limit=None, offset=None):
+        def get(
+            self,
+            path,
+            filters=None,
+            fields=None,
+            order=None,
+            limit=None,
+            offset=None,
+            properties=None,
+        ):
             pass
 
     def test_signature_getEndpoint(self):

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -81,7 +81,7 @@ which is a :py:class:`DataConnector` instance.
     should always be a tuple. Integer arguments can be presented as either integers or strings that
     can be parsed by ``int``; all other arguments must be strings.
 
-    .. py:method:: get(path, filters=None, fields=None, order=None, limit=None, offset=None)
+    .. py:method:: get(path, filters=None, fields=None, order=None, limit=None, offset=None, properties=None)
 
         :param tuple path: A tuple of path elements representing the API path to fetch.
             Numbers can be passed as strings or integers
@@ -90,6 +90,7 @@ which is a :py:class:`DataConnector` instance.
         :param order: result spec order
         :param limit: result spec limit
         :param offset: result spec offset
+        :param properties: create result spec Property list from list of strings
         :raises: :py:exc:`~buildbot.data.exceptions.InvalidPathError`
         :returns: a resource or list via Deferred, or None
 
@@ -97,7 +98,7 @@ which is a :py:class:`DataConnector` instance.
         Depending on the path, it will return a single resource or a list of resources.
         If a single resource is not specified, it returns ``None``.
 
-        The ``filters``, ``fields``, ``order``, ``limit``, and ``offset`` are passed to the
+        The ``filters``, ``fields``, ``order``, ``limit``, ``offset``, and ``properties`` are passed to the
         :py:class:`~buildbot.data.resultspec.ResultSpec`, which will then be forwarded to the
         endpoint.
 
@@ -120,7 +121,10 @@ which is a :py:class:`DataConnector` instance.
                 ],
                 fields=["buildrequestid", "buildsetid"],
                 order=("-buildrequestid",),
-                limit=2
+                limit=2,
+                properties=[
+                    "reason",
+                ]
             )
 
     .. py:method:: getEndpoint(path)

--- a/newsfragments/DataConnector-get-properties.feature
+++ b/newsfragments/DataConnector-get-properties.feature
@@ -1,0 +1,1 @@
+``:class:DataConnector`` get method now has a ``properties`` parameter, which is a ``List[str]`` will be passed into ``ResultSpec`` as ``List[resultspec.Property]``.


### PR DESCRIPTION
## Allow user to specify properties in the data.get method to keep this interface at parity with the rest api

associated issue https://github.com/buildbot/buildbot/issues/8503

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
