### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -32,7 +32,7 @@ cffi==1.17.1
 charset-normalizer==3.4.2
 constantly==23.10.4
 croniter==6.0.0
-cryptography==44.0.1
+cryptography==45.0.3
 dill==0.3.9
 evalidate==2.0.5
 greenlet==3.1.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -61,7 +61,7 @@ python-dateutil==2.9.0.post0
 pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
-responses==0.25.3
+responses==0.25.7
 ruff==0.11.13
 s3transfer==0.10.4
 service-identity==24.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -58,7 +58,7 @@ PyJWT==2.10.1
 pyOpenSSL==25.1.0
 pypugjs==5.12.0
 python-dateutil==2.9.0.post0
-pytz==2024.2
+pytz==2025.2
 PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.7

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,7 +39,7 @@ greenlet==3.1.1
 hyperlink==21.0.0
 idna==3.10
 incremental==24.7.2
-Jinja2==3.1.5
+Jinja2==3.1.6
 jmespath==1.0.1
 lz4==4.3.3
 zstandard==0.23.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -7,7 +7,7 @@ cffi==1.15.1;  python_version < "3.8"  # pyup: ignore
 cffi==1.17.1;  python_version >= "3.8"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==44.0.1
+cryptography==45.0.3
 funcsigs==1.0.2
 hyperlink==21.0.0
 idna==3.10

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -15,7 +15,7 @@ incremental==22.10.0;  python_version < "3.8" # pyup: ignore
 incremental==24.7.2;  python_version >= "3.8"
 mock==5.1.0
 parameterized==0.9.0
-pbr==6.1.0
+pbr==6.1.1
 PyHamcrest==2.1.0
 psutil==7.0.0
 pycparser==2.21;  python_version < "3.8" # pyup: ignore

--- a/requirements-master-docker-extras.txt
+++ b/requirements-master-docker-extras.txt
@@ -1,4 +1,4 @@
 requests==2.32.3
 psycopg2==2.9.10
 txrequests==0.9.6
-pycairo==1.27.0
+pycairo==1.28.0


### PR DESCRIPTION
This PR collects dependabot PRs:

#8525: Bump cryptography from 44.0.1 to 45.0.3
#8524: Bump jinja2 from 3.1.5 to 3.1.6
#8523: Bump pbr from 6.1.0 to 6.1.1
#8520: Bump pycairo from 1.27.0 to 1.28.0
#8519: Bump responses from 0.25.3 to 0.25.7
#8518: Bump pytz from 2024.2 to 2025.2

