### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ attrs==25.3.0
 autobahn==24.4.2
 Automat==24.8.1
 boto==2.49.0
-boto3==1.35.72
+boto3==1.38.32
 botocore==1.35.72
 certifi==2024.8.30
 cffi==1.17.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -63,7 +63,7 @@ PyYAML==6.0.2
 requests==2.32.3
 responses==0.25.7
 ruff==0.11.13
-s3transfer==0.10.4
+s3transfer==0.13.0
 service-identity==24.2.0
 six==1.16.0
 SQLAlchemy==2.0.36

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -52,7 +52,7 @@ mypy-extensions==1.0.0
 packaging==25.0
 parameterized==0.9.0
 pyasn1==0.6.1
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
 pycparser==2.22
 PyJWT==2.10.1
 pyOpenSSL==25.1.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -35,7 +35,7 @@ croniter==6.0.0
 cryptography==45.0.3
 dill==0.3.9
 evalidate==2.0.5
-greenlet==3.1.1
+greenlet==3.2.3
 hyperlink==21.0.0
 idna==3.10
 incremental==24.7.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -26,7 +26,7 @@ autobahn==24.4.2
 Automat==24.8.1
 boto==2.49.0
 boto3==1.38.32
-botocore==1.35.72
+botocore==1.38.32
 certifi==2024.8.30
 cffi==1.17.1
 charset-normalizer==3.4.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -66,7 +66,7 @@ ruff==0.11.13
 s3transfer==0.13.0
 service-identity==24.2.0
 six==1.16.0
-SQLAlchemy==2.0.36
+SQLAlchemy==2.0.41
 treq==24.9.1
 Twisted==24.11.0
 txaio==23.1.1

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -22,7 +22,7 @@ towncrier==24.8.0
 
 alabaster==1.0.0; python_version >= "3.10"
 alabaster==0.7.16; python_version == "3.9" # pyup: ignore 1.0.0 dropped support for Python 3.9 and earlier
-Babel==2.16.0
+Babel==2.17.0
 click==8.1.7
 docutils==0.20.1  # pyup: ignore (sphinx-rtd-theme 2.0.0 requires docutils<0.21)
 imagesize==1.4.1


### PR DESCRIPTION
This PR collects dependabot PRs:

#8532: requirements: bump greenlet from 3.1.1 to 3.2.3
#8531: requirements: bump babel from 2.16.0 to 2.17.0
#8530: requirements: bump pyasn1-modules from 0.4.1 to 0.4.2
#8526: Bump boto3 from 1.35.72 to 1.38.32
#8522: Bump s3transfer from 0.10.4 to 0.13.0
#8506: build(deps): bump sqlalchemy from 2.0.36 to 2.0.41

