### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements-ci-pyinstaller.txt
+++ b/requirements-ci-pyinstaller.txt
@@ -1,4 +1,4 @@
 -r requirements-ci.txt
 altgraph==0.17.4
-pyinstaller==6.13.0
+pyinstaller==6.14.0
 pyinstaller-hooks-contrib==2025.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -65,7 +65,7 @@ responses==0.25.7
 ruff==0.11.13
 s3transfer==0.13.0
 service-identity==24.2.0
-six==1.16.0
+six==1.17.0
 SQLAlchemy==2.0.41
 treq==24.9.1
 Twisted==24.11.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,7 @@
 # we install buildbot www from pypi to avoid the slow nodejs build at each test
 buildbot-www==4.3.0
 
-Markdown==3.7
+Markdown==3.8
 coverage==7.8.2
 docker==7.1.0
 hvac==2.3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -46,7 +46,7 @@ zstandard==0.23.0
 Brotli==1.1.0
 Mako==1.3.10
 MarkupSafe==3.0.2
-moto==5.0.22
+moto==5.1.5
 msgpack==1.1.0
 mypy-extensions==1.0.0
 packaging==25.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ Automat==24.8.1
 boto==2.49.0
 boto3==1.38.32
 botocore==1.38.32
-certifi==2024.8.30
+certifi==2025.4.26
 cffi==1.17.1
 charset-normalizer==3.4.2
 constantly==23.10.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -71,7 +71,7 @@ treq==24.9.1
 Twisted==24.11.0
 txaio==23.1.1
 txrequests==0.9.6
-typing_extensions==4.12.2
+typing_extensions==4.13.2
 unidiff==0.7.5
 # botocore for py3.9 depends on urllib3<1.27
 urllib3==1.26.19; python_version <= "3.9"  # pyup: ignore

--- a/requirements-cidb.txt
+++ b/requirements-cidb.txt
@@ -1,5 +1,5 @@
 psycopg2-binary==2.9.10
-mysqlclient==2.2.6
+mysqlclient==2.2.7
 pg8000==1.31.2
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,5 +1,5 @@
 Sphinx==7.4.7;  python_version == "3.9" # pyup: ignore
-Sphinx==8.1.3;  python_version >= "3.10"
+Sphinx==8.2.3;  python_version >= "3.10"
 sphinx-jinja==2.0.2
 sphinx-rtd-theme==2.0.0;  python_version < "3.10" # pyup: ignore
 sphinx-rtd-theme==3.0.2;  python_version >= "3.10"

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -12,7 +12,7 @@ sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinxcontrib-spelling==8.0.0
 sphinxcontrib-websupport==2.0.0
-Pygments==2.18.0
+Pygments==2.19.1
 towncrier==24.8.0
 
 # The following are transitive dependencies of the above. The versions are pinned so that tests

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -21,7 +21,7 @@ PyHamcrest==2.1.0
 psutil==7.0.0
 pycparser==2.21;  python_version < "3.8" # pyup: ignore
 pycparser==2.22;  python_version >= "3.8"
-six==1.16.0
+six==1.17.0
 Twisted==23.8.0;  python_version < "3.8" # pyup: ignore
 Twisted==24.11.0;  python_version >= "3.8"
 txaio==23.1.1

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -14,7 +14,7 @@ hyperlink==21.0.0
 idna==3.10
 incremental==22.10.0;  python_version < "3.8" # pyup: ignore
 incremental==24.7.2;  python_version >= "3.8"
-mock==5.1.0
+mock==5.2.0
 parameterized==0.9.0
 pbr==6.1.1
 PyHamcrest==2.1.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -26,7 +26,7 @@ Twisted==23.8.0;  python_version < "3.8" # pyup: ignore
 Twisted==24.11.0;  python_version >= "3.8"
 txaio==23.1.1
 typing-extensions==4.7.1;  python_version < "3.8" # pyup: ignore
-typing-extensions==4.12.2;  python_version >= "3.8"
+typing-extensions==4.13.2;  python_version >= "3.8"
 zope.interface==6.4.post2;  python_version < "3.8" # pyup: ignore
 zope.interface==7.2;  python_version >= "3.8"
 -e worker

--- a/www/base/package.json
+++ b/www/base/package.json
@@ -22,7 +22,7 @@
     "moment": "^2.29.4",
     "outdated-browser-rework": "^3.0.1",
     "popper.js": "^1.16.1",
-    "postcss-flexbugs-fixes": "4.2.1",
+    "postcss-flexbugs-fixes": "5.0.1",
     "postcss-loader": "3.0.0",
     "postcss-normalize": "9.0.0",
     "postcss-preset-env": "6.7.2",

--- a/www/base/yarn.lock
+++ b/www/base/yarn.lock
@@ -4060,10 +4060,10 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.8:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
-  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4559,12 +4559,12 @@ postcss-env-function@^2.0.2:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
-postcss-flexbugs-fixes@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz#9218a65249f30897deab1033aced8578562a6690"
-  integrity sha512-9SiofaZ9CWpQWxOwRh1b/r85KD5y7GgvsNt1056k6OYLvWUun0czCvogfJgylC22uJTwW1KzY3Gz65NZRlvoiQ==
+postcss-flexbugs-fixes@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.1.tgz#8a4b84937e94e7c100e48e019eaad33850bc7b33"
+  integrity sha512-CBEfCMk5hcqGlgRb9SDzQ3bIExJlfz89heRsAYNuNRiCJOETlVOL1KfBV1AGKFww8olEpOOSAgGiWeaGTPCkeg==
   dependencies:
-    postcss "^7.0.26"
+    postcss "^8.1.4"
 
 postcss-focus-visible@^4.0.0:
   version "4.0.0"
@@ -4801,7 +4801,7 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^7, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
+postcss@^7, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
   integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
@@ -4809,12 +4809,12 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, po
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.1.0, postcss@^8.4.43, postcss@^8.5.1:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.1.tgz#e2272a1f8a807fafa413218245630b5db10a3214"
-  integrity sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==
+postcss@^8.1.0, postcss@^8.1.4, postcss@^8.4.43, postcss@^8.5.1:
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.4.tgz#d61014ac00e11d5f58458ed7247d899bd65f99c0"
+  integrity sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==
   dependencies:
-    nanoid "^3.3.8"
+    nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
This PR collects dependabot PRs:

#8550: requirements: bump six from 1.16.0 to 1.17.0
#8549: requirements: bump sphinx from 8.1.3 to 8.2.3
#8548: requirements: bump pygments from 2.18.0 to 2.19.1
#8547: requirements: bump mock from 5.1.0 to 5.2.0
#8545: requirements: bump moto from 5.0.22 to 5.1.5
#8544: requirements: bump pyinstaller from 6.13.0 to 6.14.0
#8542: requirements: bump markdown from 3.7 to 3.8
#8541: requirements: bump typing-extensions from 4.12.2 to 4.13.2
#8540: requirements: bump certifi from 2024.8.30 to 2025.4.26
#8538: requirements: bump mysqlclient from 2.2.6 to 2.2.7
#8516: www: bump postcss-flexbugs-fixes from 4.2.1 to 5.0.1 in /www/base

