### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -67,7 +67,7 @@ s3transfer==0.13.0
 service-identity==24.2.0
 six==1.17.0
 SQLAlchemy==2.0.41
-treq==24.9.1
+treq==25.5.0
 Twisted==24.11.0
 txaio==23.1.1
 txrequests==0.9.6

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -33,7 +33,7 @@ charset-normalizer==3.4.2
 constantly==23.10.4
 croniter==6.0.0
 cryptography==45.0.3
-dill==0.3.9
+dill==0.4.0
 evalidate==2.0.5
 greenlet==3.2.3
 hyperlink==21.0.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -41,7 +41,7 @@ idna==3.10
 incremental==24.7.2
 Jinja2==3.1.6
 jmespath==1.0.1
-lz4==4.3.3
+lz4==4.4.4
 zstandard==0.23.0
 Brotli==1.1.0
 Mako==1.3.10

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -48,7 +48,7 @@ Mako==1.3.10
 MarkupSafe==3.0.2
 moto==5.1.5
 msgpack==1.1.0
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
 packaging==25.0
 parameterized==0.9.0
 pyasn1==0.6.1

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -23,7 +23,8 @@ towncrier==24.8.0
 alabaster==1.0.0; python_version >= "3.10"
 alabaster==0.7.16; python_version == "3.9" # pyup: ignore 1.0.0 dropped support for Python 3.9 and earlier
 Babel==2.17.0
-click==8.1.7
+click==8.1.8; python_version == "3.9"
+click==8.2.1; python_version >= "3.10"
 docutils==0.20.1  # pyup: ignore (sphinx-rtd-theme 2.0.0 requires docutils<0.21)
 imagesize==1.4.1
 pyenchant==3.2.2

--- a/www/base/package.json
+++ b/www/base/package.json
@@ -76,7 +76,7 @@
     "jsdom": "^25.0.0",
     "less": "^4.3.0",
     "process": "^0.11.10",
-    "rollup-plugin-visualizer": "^6.0.1",
+    "rollup-plugin-visualizer": "^6.0.3",
     "sass": "^1.56.0",
     "vite": "~5.4.12",
     "vite-plugin-checker": "~0.7.2",

--- a/www/base/yarn.lock
+++ b/www/base/yarn.lock
@@ -1781,7 +1781,7 @@ browserslist@^4.12.0, browserslist@^4.18.1, browserslist@^4.24.0, browserslist@^
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.3"
 
-"buffer-polyfill@npm:buffer@^6.0.3", buffer@^6.0.3:
+"buffer-polyfill@npm:buffer@^6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -1802,21 +1802,39 @@ buffer@^5.7.1:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 "build-config-buildbot@link:../common-config":
-  version "0.0.0"
-  uid ""
+  version "0.1.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^8.32.1"
+    "@typescript-eslint/parser" "^8.32.1"
+    eslint-plugin-import "^2.22.1"
+    eslint-plugin-jsx-a11y "^6.3.1"
+    eslint-plugin-react "^7.21.5"
+    eslint-plugin-react-hooks "^5.2.0"
+    eslint-plugin-react-refresh "^0.4.20"
+    globals "^16.2.0"
+    prettier "^3.5.3"
+    typescript-eslint "^8.32.1"
 
 "buildbot-data-js@link:../data-module":
-  version "0.0.0"
-  uid ""
+  version "4.0.0"
 
 "buildbot-plugin-support@link:../plugin_support":
-  version "0.0.0"
-  uid ""
+  version "1.0.0"
 
 "buildbot-ui@link:../ui":
-  version "0.0.0"
-  uid ""
+  version "0.1.0"
+  dependencies:
+    buildbot-data-js "link:../data-module"
+    react-icons "^5.3.0"
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -5522,10 +5540,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-visualizer@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.1.tgz#dd00e7295335bb3a8a5fd8ec0ed922f479b31e00"
-  integrity sha512-NjlGElvLXCSZSAi3gNRZbfX3qlQbQcJ9TW97c5JpqfVwMhttj9YwEdPwcvbKj91RnMX2PWAjonvSEv6UEYtnRQ==
+rollup-plugin-visualizer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.3.tgz#d05bd17e358a6d04bf593cf73556219c9c6d8dad"
+  integrity sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==
   dependencies:
     open "^8.0.0"
     picomatch "^4.0.2"


### PR DESCRIPTION
This PR collects dependabot PRs:

#8561: www: bump rollup-plugin-visualizer from 6.0.1 to 6.0.3 in /www/base
#8558: requirements: bump lz4 from 4.3.3 to 4.4.4
#8557: requirements: bump click from 8.1.7 to 8.2.1
#8556: requirements: bump treq from 24.9.1 to 25.5.0
#8555: requirements: bump mypy-extensions from 1.0.0 to 1.1.0
#8554: requirements: bump dill from 0.3.9 to 0.4.0
