### PR TITLE
process: Fix crash with renderable locks

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -27,9 +27,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Generic
+from typing import Protocol
+from typing import TypeVar
+from typing import Union
 
 from zope.interface import Attribute
 from zope.interface import Interface
+
+T = TypeVar('T')
 
 if TYPE_CHECKING:
     from twisted.internet.defer import Deferred
@@ -223,6 +229,13 @@ class IMachineAction(Interface):
 
 class ILatentMachine(IMachine):
     """A machine that is not always running, but can be started when requested."""
+
+
+class IRenderableType(Protocol, Generic[T]):
+    def getRenderingFor(self, iprops: IProperties) -> Deferred[T]: ...
+
+
+IMaybeRenderableType = Union[IRenderableType[T], T]
 
 
 class IRenderable(Interface):


### PR DESCRIPTION
setLocks() must not assume that the argument will always be iterable.

Fixes: 739cc044a9b4d7c708fb17bbc74b56e5d1f760f4

