### PR TITLE
Update dependencies

### DIFF
--- a/requirements-ci-pyinstaller.txt
+++ b/requirements-ci-pyinstaller.txt
@@ -1,4 +1,4 @@
 -r requirements-ci.txt
 altgraph==0.17.4
 pyinstaller==6.14.0
-pyinstaller-hooks-contrib==2025.4
+pyinstaller-hooks-contrib==2025.5

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -26,7 +26,7 @@ autobahn==24.4.2
 Automat==25.4.16
 boto==2.49.0
 boto3==1.38.32
-botocore==1.38.32
+botocore==1.38.36
 certifi==2025.4.26
 cffi==1.17.1
 charset-normalizer==3.4.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,7 +5,7 @@
 buildbot-www==4.3.0
 
 Markdown==3.8
-coverage==7.8.2
+coverage==7.9.1
 docker==7.1.0
 hvac==2.3.0
 ldap3==2.9.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -47,7 +47,7 @@ Brotli==1.1.0
 Mako==1.3.10
 MarkupSafe==3.0.2
 moto==5.1.5
-msgpack==1.1.0
+msgpack==1.1.1
 mypy-extensions==1.1.0
 packaging==25.0
 parameterized==0.9.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -32,7 +32,7 @@ cffi==1.17.1
 charset-normalizer==3.4.2
 constantly==23.10.4
 croniter==6.0.0
-cryptography==45.0.3
+cryptography==45.0.4
 dill==0.4.0
 evalidate==2.0.5
 greenlet==3.2.3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -60,7 +60,7 @@ pypugjs==5.12.0
 python-dateutil==2.9.0.post0
 pytz==2025.2
 PyYAML==6.0.2
-requests==2.32.3
+requests==2.32.4
 responses==0.25.7
 ruff==0.11.13
 s3transfer==0.13.0

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -9,7 +9,7 @@ cffi==1.15.1;  python_version < "3.8"  # pyup: ignore
 cffi==1.17.1;  python_version >= "3.8"
 constantly==23.10.4; python_version >= "3.8"
 constantly==15.1.0; python_version < "3.8"  # pyup: ignore
-cryptography==45.0.3
+cryptography==45.0.4
 funcsigs==1.0.2
 hyperlink==21.0.0
 idna==3.10

--- a/requirements-master-docker-extras.txt
+++ b/requirements-master-docker-extras.txt
@@ -1,4 +1,4 @@
-requests==2.32.3
+requests==2.32.4
 psycopg2==2.9.10
 txrequests==0.9.6
 pycairo==1.28.0


### PR DESCRIPTION
This PR collects dependabot PRs:

#8584: requirements: bump pyinstaller-hooks-contrib from 2025.4 to 2025.5
#8582: requirements: bump botocore from 1.38.32 to 1.38.36
#8581: requirements: bump coverage from 7.8.2 to 7.9.1
#8580: requirements: bump msgpack from 1.1.0 to 1.1.1
#8577: requirements: bump cryptography from 45.0.3 to 45.0.4
#8569: requirements: bump requests from 2.32.3 to 2.32.4
