### PR TITLE
worker: Cleanup buffer flushing

### DIFF
--- a/worker/buildbot_worker/msgpack.py
+++ b/worker/buildbot_worker/msgpack.py
@@ -129,16 +129,14 @@ class ProtocolCommandMsgpack(ProtocolCommandBase):
 
     @defer.inlineCallbacks
     def protocol_complete(self, failure: Failure | None) -> InlineCallbacksType[None]:
-        d_update = self.flush_command_output()
+        self.flush_command_output()
         if failure is not None:
             failure = str(failure)  # type: ignore[assignment]
-        d_complete: Deferred = self.protocol.get_message_result({
+        yield self.protocol.get_message_result({
             'op': 'complete',
             'args': failure,
             'command_id': self.command_id,
         })
-        yield d_update
-        yield d_complete
 
     def protocol_update_upload_file_close(self, writer: RemoteReference) -> Deferred:
         return self.protocol.get_message_result({

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -200,13 +200,10 @@ class ProtocolCommandPb(ProtocolCommandBase):
 
     @defer.inlineCallbacks
     def protocol_complete(self, failure: Failure | None) -> InlineCallbacksType[None]:
-        d_update = self.flush_command_output()
+        self.flush_command_output()
         assert self.command_ref is not None
         self.command_ref.dontNotifyOnDisconnect(self.on_lost_remote_step)
-        d_complete = self.command_ref.callRemote("complete", failure)
-
-        yield d_update
-        yield d_complete
+        yield self.command_ref.callRemote("complete", failure)
 
     def protocol_update_upload_file_close(self, writer: RemoteReference) -> Deferred:
         return writer.callRemote("close")
@@ -574,11 +571,7 @@ class BotMsgpack(BotBase):
             # command that wasn't actually running
             log.msg(" .. but none was running")
             return
-        d = self.protocol_commands[command_id].flush_command_output()
-        d.addErrback(
-            self.protocol_commands[command_id]._ack_failed,
-            "ProtocolCommandMsgpack.flush_command_output",
-        )
+        self.protocol_commands[command_id].flush_command_output()
         self.protocol_commands[command_id].command.doInterrupt()
 
 


### PR DESCRIPTION
flush_command_output() does not return a Deferred, so it does not need to be waited for.
