### PR TITLE
Don't use the -v option for cp on AIX when running cpdir

### DIFF
--- a/newsfragments/buildbot-worker-commands-CopyDirectory.bugfix
+++ b/newsfragments/buildbot-worker-commands-CopyDirectory.bugfix
@@ -1,0 +1,1 @@
+``:class:CopyDirectory`` now provides the correct options when run on AIX (remove -v)

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -217,7 +217,7 @@ class CopyDirectory(base.Command):
                     f"cp target '{to_path}' already exists -- cp will not do what you think!"
                 )
 
-            if platform.system().lower().find('solaris') >= 0:
+            if platform.system().lower().find('solaris') >= 0 or platform.system().lower() == 'aix':
                 command = ['cp', '-R', '-P', '-p', from_path, to_path]
             else:
                 command = ['cp', '-R', '-P', '-p', '-v', from_path, to_path]


### PR DESCRIPTION
Remove the -v option from cp when running the cpdir command on AIX. This should allow AIX to use buildbot.steps.source.git.Git with method copy.

I don't see tests relating to the solaris check, so I assume that a new unit test isn't required. Let me know if I'm wrong. 

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
