### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -46,7 +46,7 @@ zstandard==0.23.0
 Brotli==1.1.0
 Mako==1.3.10
 MarkupSafe==3.0.2
-moto==5.1.5
+moto==5.1.6
 msgpack==1.1.1
 mypy-extensions==1.1.0
 packaging==25.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ Automat==25.4.16
 boto==2.49.0
 boto3==1.38.36
 botocore==1.38.36
-certifi==2025.4.26
+certifi==2025.6.15
 cffi==1.17.1
 charset-normalizer==3.4.2
 constantly==23.10.4

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -75,7 +75,7 @@ typing_extensions==4.13.2
 unidiff==0.7.5
 # botocore for py3.9 depends on urllib3<1.27
 urllib3==1.26.19; python_version <= "3.9"  # pyup: ignore
-urllib3==2.4.0; python_version > "3.9"
+urllib3==2.5.0; python_version > "3.9"
 Werkzeug==3.1.3
 xmltodict==0.14.2
 zope.event==5.0


### PR DESCRIPTION
This PR collects dependabot PRs:

#8596: requirements: bump urllib3 from 2.4.0 to 2.5.0
#8592: requirements: bump certifi from 2025.4.26 to 2025.6.15
#8591: requirements: bump moto from 5.1.5 to 5.1.6
