### PR TITLE
requirements: Bump `typing-extensions` from 4.13.2 to 4.14.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -71,7 +71,7 @@ treq==25.5.0
 Twisted==25.5.0
 txaio==23.1.1
 txrequests==0.9.6
-typing_extensions==4.13.2
+typing_extensions==4.14.0
 unidiff==0.7.5
 # botocore for py3.9 depends on urllib3<1.27
 urllib3==1.26.19; python_version <= "3.9"  # pyup: ignore

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -27,7 +27,8 @@ Twisted==23.8.0;  python_version < "3.8" # pyup: ignore
 Twisted==25.5.0;  python_version >= "3.8"
 txaio==23.1.1
 typing-extensions==4.7.1;  python_version < "3.8" # pyup: ignore
-typing-extensions==4.13.2;  python_version >= "3.8"
+typing-extensions==4.13.2;  python_version >= "3.8" and python_version < "3.9"
+typing-extensions==4.14.0;  python_version >= "3.9"
 zope.interface==6.4.post2;  python_version < "3.8" # pyup: ignore
 zope.interface==7.2;  python_version >= "3.8"
 -e worker


### PR DESCRIPTION
This PR upgrades `typing-extensions` from 4.13.2 to 4.14.0.
PR fixes PR https://github.com/buildbot/buildbot/pull/8583

* [not_needed] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed] I have updated the appropriate documentation
