### PR TITLE
process: allow to collapse build requests when the builder object is not defined.

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -28,7 +28,6 @@ from twisted.python import log
 from buildbot import interfaces
 from buildbot.data import resultspec
 from buildbot.interfaces import IRenderable
-from buildbot.process import buildrequest
 from buildbot.process import workerforbuilder
 from buildbot.process.build import Build
 from buildbot.process.locks import get_real_locks_from_accesses_raw
@@ -55,7 +54,7 @@ if TYPE_CHECKING:
     from buildbot.worker.base import AbstractWorker as AbstractWorkerType
 
     CollapseRequestFn = Callable[
-        [BuildMaster, "Builder", BuildRequestData, BuildRequestData],
+        [BuildMaster, "Builder | None", BuildRequestData, BuildRequestData],
         "bool | Deferred[bool]",
     ]
 
@@ -541,37 +540,3 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
         # it will be handled outside of this function. TODO: test that!
 
         return self._startBuildFor(workerforbuilder, breqs)
-
-    # a few utility functions to make the maybeStartBuild a bit shorter and
-    # easier to read
-
-    def getCollapseRequestsFn(
-        self,
-    ) -> CollapseRequestFn | None:
-        """Helper function to determine which collapseRequests function to use
-        from L{_collapseRequests}, or None for no merging"""
-        # first, seek through builder, global, and the default
-        assert self.config is not None
-        collapseRequests_fn: CollapseRequestFn | bool | None = self.config.collapseRequests
-        if collapseRequests_fn is None:
-            assert self.master is not None
-            collapseRequests_fn = self.master.config.collapseRequests
-        if collapseRequests_fn is None:
-            collapseRequests_fn = True
-
-        # then translate False and True properly
-        if collapseRequests_fn is False:
-            return None
-        elif collapseRequests_fn is True:
-            return self._defaultCollapseRequestFn
-
-        return collapseRequests_fn
-
-    @staticmethod
-    def _defaultCollapseRequestFn(
-        master: BuildMaster,
-        builder: Builder,
-        brdict1: BuildRequestData,
-        brdict2: BuildRequestData,
-    ) -> defer.Deferred[bool]:
-        return buildrequest.BuildRequest.canBeCollapsed(master, brdict1, brdict2)

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
     from buildbot.db.buildrequests import BuildRequestModel
     from buildbot.db.buildsets import BuildSetModel
     from buildbot.master import BuildMaster
+    from buildbot.process.builder import Builder
+    from buildbot.process.builder import CollapseRequestFn
     from buildbot.util.twisted import InlineCallbacksType
 
 
@@ -89,10 +91,8 @@ class BuildRequestCollapser:
             assert bldrdict is not None
             # Get the builder object
             bldr = self.master.botmaster.builders.get(bldrdict['name'])
-            if not bldr:
-                continue
             # Get the Collapse BuildRequest function (from the configuration)
-            collapseRequestsFn = bldr.getCollapseRequestsFn()
+            collapseRequestsFn = self.getCollapseRequestsFn(bldr)
             unclaim_brs: list[BuildRequestData] = yield self._getUnclaimedBrs(builderid)
 
             # short circuit if there is no merging to do
@@ -115,6 +115,41 @@ class BuildRequestCollapser:
                 collapsed_brids.append(brid)
 
         return collapsed_brids
+
+    def getCollapseRequestsFn(
+        self,
+        builder: Builder | None,
+    ) -> CollapseRequestFn | None:
+        """Helper function to determine which collapseRequests function to use
+        from L{_collapseRequests}, or None for no merging"""
+        # first, seek through builder, global, and the default
+        collapseRequests_fn: CollapseRequestFn | bool | None = None
+        # The builder object may not exist on some asymmetric multi-master configurations
+        if builder is not None:
+            assert builder.config is not None
+            collapseRequests_fn = builder.config.collapseRequests
+        if collapseRequests_fn is None:
+            assert self.master is not None
+            collapseRequests_fn = self.master.config.collapseRequests
+        if collapseRequests_fn is None:
+            collapseRequests_fn = True
+
+        # then translate False and True properly
+        if collapseRequests_fn is False:
+            return None
+        elif collapseRequests_fn is True:
+            return self._defaultCollapseRequestFn
+
+        return collapseRequests_fn
+
+    @staticmethod
+    def _defaultCollapseRequestFn(
+        master: BuildMaster,
+        builder: Builder | None,
+        brdict1: BuildRequestData,
+        brdict2: BuildRequestData,
+    ) -> defer.Deferred[bool]:
+        return BuildRequest.canBeCollapsed(master, brdict1, brdict2)
 
 
 class TempSourceStamp:

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -27,6 +27,7 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.config.master import MasterConfig
 from buildbot.process import builder
+from buildbot.process import buildrequest
 from buildbot.process import factory
 from buildbot.process.properties import Properties
 from buildbot.process.properties import renderer
@@ -234,9 +235,10 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
         self.master.config.collapseRequests = global_param
 
-        fn = self.bldr.getCollapseRequestsFn()
+        br_collapser = buildrequest.BuildRequestCollapser(self.master, [])
+        fn = br_collapser.getCollapseRequestsFn(self.bldr)
 
-        if fn == builder.Builder._defaultCollapseRequestFn:
+        if fn == buildrequest.BuildRequestCollapser._defaultCollapseRequestFn:
             fn = "default"  # type: ignore[assignment]
         elif fn is cble:
             fn = 'callable'  # type: ignore[assignment]

--- a/master/buildbot/test/unit/process/test_buildrequest.py
+++ b/master/buildbot/test/unit/process/test_buildrequest.py
@@ -24,7 +24,6 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process import buildrequest
-from buildbot.process.builder import Builder
 from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.reactor import TestReactorMixin
@@ -32,6 +31,7 @@ from buildbot.test.reactor import TestReactorMixin
 if TYPE_CHECKING:
     from buildbot.data.buildrequests import BuildRequestData
     from buildbot.master import BuildMaster
+    from buildbot.process.builder import Builder
     from buildbot.test.fakedb.row import Row
     from buildbot.util.twisted import InlineCallbacksType
 
@@ -60,7 +60,8 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         bldr.master = self.master
         self.master.botmaster.builders[name] = bldr
         self.builders[name] = bldr
-        bldr.getCollapseRequestsFn = lambda: False
+        bldr.config = mock.Mock()
+        bldr.config.collapseRequests = False
 
         return bldr
 
@@ -82,7 +83,7 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
             # pylint: disable=unreachable
             return True
 
-        self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
+        self.bldr.config.collapseRequests = collapseRequests_fn
         rows = [
             fakedb.Builder(id=77, name='A'),
             fakedb.SourceStamp(id=234, revision='r234', repository='repo', codebase='A'),
@@ -128,7 +129,7 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
             # Fail all collapse attempts
             return False
 
-        self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
+        self.bldr.config.collapseRequests = collapseRequests_fn
         yield self.master.db.insert_test_data(self.BASE_ROWS)
         yield self.do_request_collapse([21], [])
 
@@ -143,7 +144,7 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
             # collapse all attempts
             return True
 
-        self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
+        self.bldr.config.collapseRequests = collapseRequests_fn
         yield self.master.db.insert_test_data(self.BASE_ROWS)
         yield self.do_request_collapse([21], [19, 20])
 
@@ -158,9 +159,33 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
             # collapse all attempts
             return True
 
-        self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
+        self.bldr.config.collapseRequests = collapseRequests_fn
         yield self.master.db.insert_test_data(self.BASE_ROWS)
         yield self.do_request_collapse([21, 21], [19, 20])
+
+    @defer.inlineCallbacks
+    def test_collapseRequests_builder_missing_uses_master_callable(
+        self,
+    ) -> InlineCallbacksType[None]:
+        collapse_calls = []
+
+        def collapseRequests_fn(
+            master: BuildMaster,
+            builder: Builder,
+            brdict1: BuildRequestData,
+            brdict2: BuildRequestData,
+        ) -> bool:
+            collapse_calls.append(builder)
+            return True
+
+        self.master.config.collapseRequests = collapseRequests_fn
+        del self.master.botmaster.builders['A']
+
+        yield self.master.db.insert_test_data(self.BASE_ROWS)
+        yield self.do_request_collapse([21], [19, 20])
+
+        self.assertTrue(collapse_calls)
+        self.assertTrue(all(bldr is None for bldr in collapse_calls))
 
     # As documented:
     # Sourcestamps are compatible if all of the below conditions are met:
@@ -237,7 +262,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 223)
         rows += self.makeBuildRequestRows(20, 120, None, 223)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
         yield self.do_request_collapse([21], [19, 20])
@@ -254,11 +281,23 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 222)
         rows += self.makeBuildRequestRows(19, 119, None, 222)
         rows += self.makeBuildRequestRows(20, 120, None, 222)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([19], [])
         yield self.do_request_collapse([20], [19])
         yield self.do_request_collapse([21], [20])
+
+    @defer.inlineCallbacks
+    def test_collapseRequests_builder_missing_uses_default(
+        self,
+    ) -> InlineCallbacksType[None]:
+        self.master.config.collapseRequests = None
+        del self.master.botmaster.builders['A']
+
+        yield self.master.db.insert_test_data(self.BASE_ROWS)
+        yield self.do_request_collapse([21], [19, 20])
 
     @defer.inlineCallbacks
     def test_collapseRequests_collapse_default_does_not_collapse_concurrent_claims(
@@ -285,10 +324,12 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
             if not claimed:
                 yield self.master.data.updates.claimBuildRequests([20])
                 claimed.append(20)
-            res = yield Builder._defaultCollapseRequestFn(master, builder, brdict1, brdict2)
+            res = yield buildrequest.BuildRequestCollapser._defaultCollapseRequestFn(
+                master, builder, brdict1, brdict2
+            )
             return res
 
-        self.bldr.getCollapseRequestsFn = lambda: collapse_fn
+        self.bldr.config.collapseRequests = collapse_fn
 
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([21], [19])
@@ -319,7 +360,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         )
         rows += self.makeBuildRequestRows(16, 116, None, 222)
 
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
 
         yield self.master.db.insert_test_data(rows)
         # only the same property coming from a scheduler is matched
@@ -342,7 +385,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 223)
         rows += self.makeBuildRequestRows(20, 120, None, 224)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
 
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
@@ -363,7 +408,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 223)
         rows += self.makeBuildRequestRows(20, 120, None, 224)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
 
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
@@ -384,7 +431,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 223)
         rows += self.makeBuildRequestRows(20, 120, None, 224)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
 
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
@@ -412,7 +461,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 224)
         rows += self.makeBuildRequestRows(20, 120, None, 223)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
         yield self.do_request_collapse([21], [20])
@@ -430,7 +481,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, 123, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 223)
         rows += self.makeBuildRequestRows(20, 120, 124, 223)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
         yield self.do_request_collapse([21], [19, 20])
@@ -451,7 +504,9 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
         rows += self.makeBuildRequestRows(21, 121, None, 223)
         rows += self.makeBuildRequestRows(19, 119, None, 224)
         rows += self.makeBuildRequestRows(20, 120, None, 223)
-        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        self.bldr.config.collapseRequests = (
+            buildrequest.BuildRequestCollapser._defaultCollapseRequestFn
+        )
         yield self.master.db.insert_test_data(rows)
         yield self.do_request_collapse([22], [])
         yield self.do_request_collapse([21], [20])

--- a/master/buildbot/test/unit/process/test_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/process/test_buildrequestdistributor.py
@@ -142,7 +142,6 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
             return d
 
         bldr.maybeStartBuild = maybeStartBuild
-        bldr.getCollapseRequestsFn = lambda: False
 
         bldr.workers = []
         bldr.getAvailableWorkers = lambda: [w for w in bldr.workers if w.isAvailable()]
@@ -152,6 +151,7 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
             bldr.config.nextBuild = None
         else:
             bldr.config = builder_config
+        bldr.config.collapseRequests = False
 
         def canStartBuild(*args: Any) -> bool:
             can = bldr.config.canStartBuild

--- a/master/docs/manual/configuration/builders.rst
+++ b/master/docs/manual/configuration/builders.rst
@@ -209,6 +209,9 @@ Sourcestamps are compatible if all of the below conditions are met:
 * Neither source stamp has a patch (e.g., from a try scheduler)
 * Either both source stamps are associated with changes, or neither is associated with changes but they have matching revisions.
 
+Note that on asymmetric multimaster configurations the value of ``collapseRequests`` for the builder will be the one defined on the master that runs the collapse function (typically the one that runs the Web UI).
+If the builder is not defined on that master then the globally defined ``collapseRequests`` value will be used instead.
+
 .. index:: Builds; priority
 
 .. _Prioritizing-Builds:

--- a/newsfragments/collapse-requests-no-builder-defined.bugfix
+++ b/newsfragments/collapse-requests-no-builder-defined.bugfix
@@ -1,0 +1,1 @@
+On asymmetric multimaster configurations `collapseRequests` will work now when a given builder is not defined on the master running the collapse request, defaulting in that case to run the globally configured `collapseRequests` setting.


### PR DESCRIPTION


On asymmetric multi-master configurations where one master runs the Web UI and the other master works with the builders and workers, it is possible to configure the Web UI master with an empty list of builders and workers.

However, the code to collapse the build requests runs on the Web UI master and if this list is empty then it can't find the builder object to evaluate if a custom collapse function is defined for it, so it fails to collapse anything.

Instead of doing that, it should continue and use the globally defined collapse function or the default collapse function.

This patch moves the code to evaluate getCollapseRequestsFn to the class BuildRequestCollapser allowing it to work even when the builder object is not defined.

This issue was observed on the WebKit's Buildbot CI deployment and there it was work-arounded by defining also the builders/workers for the Web UI master. See https://bugs.webkit.org/show_bug.cgi?id=300920

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
