### PR TITLE
Fix deprecation warning from alembic >= 1.16.0

### DIFF
--- a/master/buildbot/db/migrations/alembic.ini
+++ b/master/buildbot/db/migrations/alembic.ini
@@ -8,7 +8,8 @@ script_location = %(here)s/
 file_template = %%(rev)s_%%(year)d-%%(month).2d-%%(day).2d_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
-# defaults to the current working directory.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
 prepend_sys_path = .
 
 # timezone to use when rendering the date
@@ -29,6 +30,33 @@ truncate_slug_length = 40
 # sourceless = false
 
 version_locations = %(here)s/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
 
 # the output encoding used when revision files are written from script.py.mako
 output_encoding = utf-8

--- a/newsfragments/alembic-path-separator.bugfix
+++ b/newsfragments/alembic-path-separator.bugfix
@@ -1,0 +1,1 @@
+Fix deprecation warning from alembic >= 1.16.0.


### PR DESCRIPTION
Following
https://github.com/sqlalchemy/alembic/commit/9913fdb8e20262ccbc34f715b044d36b4be8b5ad, alembic produces a deprecation warning if we don't set `path_separator`. This caused test failures in Debian, as seen in
https://bugs.debian.org/1117391.

## Contributor Checklist:

* [N/A] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [N/A] I have updated the appropriate documentation