### PR TITLE
GerritEventLogPoller Fix (Bounded method passed -> Unbounded method passed)

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -1017,7 +1017,9 @@ class GerritEventLogPoller(GerritChangeSourceBase):
             on_lines_received_cb=self._lines_received,
         )
         yield self._connector.setup()
-        self._poller = util.poll.Poller(self._connector.do_poll, self, self.master.reactor)
+        self._poller = util.poll.Poller(
+            type(self._connector).do_poll, self._connector, self.master.reactor
+        )
 
     def getFiles(self, change: str, patchset: str) -> defer.Deferred:
         return self._connector.get_files(change, patchset)

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -1083,6 +1083,33 @@ class TestGerritEventLogPoller(
         self.assertEqual('GerritEventLogPoller:gerrit', self.changesource.name)
 
     @defer.inlineCallbacks
+    def test_poller_uses_correct_signature(self):
+        yield self.master.db.insert_test_data([
+            fakedb.Object(
+                id=self.OBJECTID,
+                name='GerritEventLogPoller:gerrit',
+                class_name='GerritEventLogPoller',
+            )
+        ])
+        yield self.newChangeSource()
+
+        self._http.expect(
+            method='get',
+            params={'t1': '1969-12-02 00:00:00'},
+            ep='/plugins/events-log/events/',
+            content=b"",
+        )
+
+        yield self.startChangeSource()
+
+        d = self.changesource._poller()
+        self.reactor.advance(0)
+        yield d
+
+        d = self.changesource.disownServiceParent()
+        yield d
+
+    @defer.inlineCallbacks
     def test_lineReceived_patchset_created(self):
         yield self.master.db.insert_test_data([
             fakedb.Object(

--- a/newsfragments/buildbot-changes-gerritchangesource.bugfix
+++ b/newsfragments/buildbot-changes-gerritchangesource.bugfix
@@ -1,0 +1,1 @@
+Fixes TypeError that occurs in _run method of Poller after reconfigService method of GerritEventLogPoller creates an instance of Poller (:issue:`8711`)


### PR DESCRIPTION
Fixed the issue described in #8711. The solution was suggested by [flichtenheld](https://github.com/flichtenheld) and I plan on tackling the issue of duplication in the ``GerritEventLogPoller`` (mentioned in the issue) in a separate PR.

**Description of problem (essentially what is mentioned in the issue)**
1. An instance of Poller was being created in gerritchangesource.py where the argument passed for the parameter fn was a bounded method. 
2. When creating the same instance of Poller the argument for instance was one of ``GerritEventLogPoller`` object. 

The first issue eventually causes a TypeError in the _run method of Poller since the bounded method passes ``self`` implicitly causing there to be two arguments being passed to fn instead of one. The second issue is that instead of passing an instance of ``GerritEventLogPoller`` we should be passing an instance of ``GerritHttpEventLogPollerConnector`` since ``do_poll`` (the bounded method in question) calls the method ``poll`` on the instance passed to it. Turns out ``poll`` is a method of ``GerritHttpEventLogPollerConnector`` and not ``GerritEventLogPoller``.

**Solution Implemented**
As suggested in the issue by [flichtenheld](https://github.com/flichtenheld) the for 1. instead of passing a bounded method an unbounded method is passed. For 2. instead of passing an instance of ``GerritEventLogPoller`` (``self``), an instance of ``GerritHttpEventLogPollerConnector`` (``self._connector``) is passed.

**Unit Test Added**
The unit test was added to test_gerritchangesource.py and essentially tries to trigger the TypeError described in the issue. I have tested it with the version with the change made in this PR and it was indeed failing with a TypeError (and of course passing with the change).

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation (Don't think this is needed in this case)
