### PR TITLE
pb: use abortConnection() instead of transport buffer hack

### DIFF
--- a/master/buildbot/test/unit/worker/test_protocols_pb.py
+++ b/master/buildbot/test/unit/worker/test_protocols_pb.py
@@ -150,7 +150,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
 
         self.assertEqual(conn.keepalive_timer, None)
         assert conn.mind is not None
-        conn.mind.broker.transport.loseConnection.assert_called_with()
+        conn.mind.broker.transport.abortConnection.assert_called_with()
 
     def test_remotePrint(self) -> None:
         conn = pb.Connection(self.master, self.worker, self.mind)

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -152,23 +152,7 @@ class Connection(base.Connection, pb.Avatar):
     def loseConnection(self) -> None:
         self.stopKeepaliveTimer()
         assert self.mind is not None
-        tport = self.mind.broker.transport
-        # this is the polite way to request that a socket be closed
-        tport.loseConnection()
-        try:
-            # but really we don't want to wait for the transmit queue to
-            # drain. The remote end is unlikely to ACK the data, so we'd
-            # probably have to wait for a (20-minute) TCP timeout.
-            # tport._closeSocket()
-            # however, doing _closeSocket (whether before or after
-            # loseConnection) somehow prevents the notifyOnDisconnect
-            # handlers from being run. Bummer.
-            tport.offset = 0
-            tport.dataBuffer = b""
-        except Exception:
-            # however, these hacks are pretty internal, so don't blow up if
-            # they fail or are unavailable
-            log.msg("failed to accelerate the shutdown process")
+        self.mind.broker.transport.abortConnection()
 
     # keepalive handling
 


### PR DESCRIPTION
I stumbled over this while working on https://github.com/twisted/twisted/pull/12568

The PB connection's loseConnection() called transport.loseConnection() and then manually cleared internal Twisted transport state (dataBuffer/offset) to avoid waiting for the write buffer to drain, since the remote end is unlikely to ACK the data and we'd wait for a TCP timeout otherwise.

abortConnection() is the supported Twisted API for immediate close (available since Twisted 11.1) and does the same thing properly: it drops buffered data, unregisters from the reactor, and schedules connectionLost via callLater — which correctly fires notifyOnDisconnect handlers. The old _closeSocket() approach that was tried before the hack broke notifyOnDisconnect, but abortConnection() doesn't have that problem.

# Contributor Checklist:


* [x] I have updated the unit tests