### PR TITLE
Fix #8712 worker proto behind haproxy

### DIFF
--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -338,7 +338,8 @@ class TestedRealMaster(TestedMaster):
                 # We currently don't handle connection closing cleanly.
                 dispatcher.serverFactory.setProtocolOptions(closeHandshakeTimeout=0)
 
-            worker_port = dispatcher.port.getHost().port
+            assert dispatcher.bound_port is not None
+            worker_port = dispatcher.bound_port
 
             # create a worker, and attach it to the master, it will be started, and stopped
             # along with the master

--- a/master/buildbot/worker/protocols/manager/pb.py
+++ b/master/buildbot/worker/protocols/manager/pb.py
@@ -35,6 +35,7 @@ from buildbot.worker.protocols.manager.base import BaseManager
 
 if TYPE_CHECKING:
     from twisted.cred.credentials import IUsernamePassword
+    from twisted.internet.protocol import ServerFactory
 
     from buildbot.util.twisted import InlineCallbacksType
 
@@ -44,12 +45,15 @@ class Dispatcher(BaseDispatcher):
     credentialInterfaces = [credentials.IUsernamePassword, credentials.IUsernameHashedPassword]
 
     def __init__(self, config_port: str | int) -> None:
-        super().__init__(config_port=config_port)
         # there's lots of stuff to set up for a PB connection!
         self.portal = portal.Portal(self)
         self.portal.registerChecker(self)
-        self.serverFactory = pb.PBServerFactory(self.portal)
-        self.serverFactory.unsafeTracebacks = True
+        super().__init__(config_port=config_port)
+
+    def _create_server_factory(self, config_port: str | int) -> ServerFactory:
+        serverFactory = pb.PBServerFactory(self.portal)
+        serverFactory.unsafeTracebacks = True
+        return serverFactory
 
     # IRealm
 

--- a/newsfragments/worker-protocol-haproxy.bugfix
+++ b/newsfragments/worker-protocol-haproxy.bugfix
@@ -1,0 +1,1 @@
+Fix issue when using the `haproxy:` prefix in the master's worker protocol configuration (PB or MsgPack).


### PR DESCRIPTION
fixes #8712 

Twisted's `strports.listen` is not compatible with the `haproxy:` prefix to a connection string.
This change switches the dispatcher's use of `listen` to `service`.

# Contributor Checklist:

> remove items that are not applicable

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
