### PR TITLE
www/base: Add an alert to notify user of WebSocket disconnection

### DIFF
--- a/newsfragments/www-alert-websocket-disconnect.feature
+++ b/newsfragments/www-alert-websocket-disconnect.feature
@@ -1,0 +1,1 @@
+An alert now appears at the top of the web UI when the WebSocket disconnects, indicating that live updates have stopped.


### PR DESCRIPTION
WebSocket disconnection prevents further updates to the current view. There was no indicator of it, leaving users waiting for ie. Build finishing which would never happen.

WebSocket disconnection happen when the master is restarted.

I thought about auto-reconnecting, but it bring a whole can of worms with re-subscribing to events, then what to do with missed events, ...
So I think this is an acceptable solution.

<img width="1864" height="400" alt="image" src="https://github.com/user-attachments/assets/4d649fae-a838-42da-8b92-cccaf6d5938d" />

# Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
