### PR TITLE
www: fix GlobalSettings.getSettingItem for unknown selector

### DIFF
--- a/newsfragments/www-crash-getSettingItem.bugfix
+++ b/newsfragments/www-crash-getSettingItem.bugfix
@@ -1,0 +1,1 @@
+Fixed a WebUI crash when loading an unknown settings :issue:`8369`

--- a/www/base/src/plugins/GlobalSettings.test.ts
+++ b/www/base/src/plugins/GlobalSettings.test.ts
@@ -194,6 +194,26 @@ describe('GlobalSettings', () => {
     expect(settings.getSetting('Group.setting_boolean')).toEqual(false);
   });
 
+  it('returns default on unknown setting', () => {
+    const settings = new GlobalSettings();
+    settings.addGroup({
+      name: 'Group',
+      caption: 'group caption',
+      items: [
+        {
+          type: 'integer',
+          name: 'setting_integer',
+          caption: 'caption2',
+          defaultValue: 1,
+        },
+      ],
+    });
+    settings.fillDefaults({
+      'Group.unknown': 2,
+    });
+    expect(settings.getIntegerSetting('Group.unknown')).toEqual(0);
+  });
+
   it('setting retrieval with overridden default value', () => {
     const settings = new GlobalSettings();
     settings.addGroup({

--- a/www/base/src/plugins/GlobalSettings.ts
+++ b/www/base/src/plugins/GlobalSettings.ts
@@ -134,7 +134,7 @@ export class GlobalSettings implements ISettings {
     localStorage.setItem('settings', JSON.stringify(storedGroups));
   }
 
-  private getSettingItem(selector: string) {
+  private getSettingItem(selector: string): SettingItem | null {
     const groupAndSetting = this.getGroupBySelector(selector);
     if (groupAndSetting === null) {
       return null;
@@ -143,7 +143,7 @@ export class GlobalSettings implements ISettings {
     if (!(settingName in group.items)) {
       console.error(`bad setting name ${selector}: setting does not exist`);
     }
-    return group.items[settingName];
+    return group.items[settingName] ?? null;
   }
 
   getSetting(selector: string) {


### PR DESCRIPTION
Relates to #8369

# Contributor Checklist:

> remove items that are not applicable

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
