### PR TITLE
www: Fix log copy on Chromium browser missing line breaks

### DIFF
--- a/newsfragments/fix-chromium-log-copy.bugfix
+++ b/newsfragments/fix-chromium-log-copy.bugfix
@@ -1,0 +1,1 @@
+Fixed Log copy on Chromium browser would not have line breaks (:issue:8704)

--- a/www/base/src/components/LogViewer/LogTextManager.ts
+++ b/www/base/src/components/LogViewer/LogTextManager.ts
@@ -433,7 +433,7 @@ export class LogTextManager {
     const lineIndexInChunk = index - chunk.firstLine;
     const lineType = chunk.lineTypes[lineIndexInChunk];
     const lineStartInChunk = chunk.textLineBounds[lineIndexInChunk];
-    const lineEndInChunk = chunk.textLineBounds[lineIndexInChunk + 1] - 1; // exclude trailing newline
+    const lineEndInChunk = chunk.textLineBounds[lineIndexInChunk + 1];
     const lineCssClassesWithText = this.getCssClassesForChunk(chunkIndex)[lineIndexInChunk];
     const lineContent = escapeClassesToHtml(
       chunk.text,


### PR DESCRIPTION
Fixes #8704

Firefox and Chromium works differently on this.
Firefox adds the line breaks to keep consistency with how the elements are displayed.

# Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
