### PR TITLE
fix: populate Owners column in pending buildrequests views

### DIFF
--- a/www/base/src/components/ProjectWidgets/ProjectPendingBuildRequestsWidget.tsx
+++ b/www/base/src/components/ProjectWidgets/ProjectPendingBuildRequestsWidget.tsx
@@ -63,6 +63,7 @@ export const ProjectPendingBuildRequestsWidget = observer(
           order: ['-priority', '-submitted_at'],
           claimed: false,
           builderid__eq: builderIds,
+          property: ['owner', 'owners'],
         },
       }),
     );

--- a/www/base/src/views/BuilderView/BuilderView.tsx
+++ b/www/base/src/views/BuilderView/BuilderView.tsx
@@ -145,6 +145,7 @@ export const BuilderView = observer(() => {
         query: {
           builderid: builder.builderid,
           claimed: false,
+          property: ['owner', 'owners'],
         },
       }),
     ),

--- a/www/base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
+++ b/www/base/src/views/PendingBuildRequestsView/PendingBuildRequestsView.tsx
@@ -40,6 +40,7 @@ export const PendingBuildRequestsView = observer(() => {
         limit: requestsFetchLimit,
         order: ['-priority', '-submitted_at'],
         claimed: false,
+        property: ['owner', 'owners'],
       },
     }),
   );


### PR DESCRIPTION
Owners column shows (none) for all pending buildrequests in the React UI (4.0 regression). Same issue was fixed for the old AngularJS UI in #5942 / #5887.

The Buildbot API only returns properties when explicitly requested via the property query param. The React rewrite was not passing it, so buildRequest.properties was always empty.

On top of that, PendingBuildRequestsTable was making per-row GET /buildrequests/<id>/properties calls via getRelatedProperties(), which 404'd and spammed the console.

Fix:
- Add property=['owner','owners'] to all three pending buildrequest queries (global page, builder page, project widget)
- Remove the broken per-row getRelatedProperties() fetch
- Render the Owner cell from inline properties with fallback (owner -> owners -> (none))
- Render the Properties column from inline properties instead of the removed per-row fetch

Verification:
- Pending Buildrequests page shows owner names instead of (none)
- Builder page pending queue shows owner names
- Project widget pending queue shows owner names
- Network request includes property=owner&property=owners
- No more /buildrequests/<id>/properties 404 requests in console
- Properties column still renders