### PR TITLE
Fix SetupTools warning 'License classifiers are deprecated'

### DIFF
--- a/master/setup.cfg
+++ b/master/setup.cfg
@@ -11,12 +11,12 @@ maintainer_email = dustin@v.igoro.us
 description = The Continuous Integration Framework
 url = http://buildbot.net/
 long_description = file: README.rst
+license = GPL-2.0-or-later
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: No Input/Output (Daemon)
     Environment :: Web Environment
     Intended Audience :: Developers
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Topic :: Software Development :: Build Tools
     Topic :: Software Development :: Testing
     Programming Language :: Python :: 3

--- a/pkg/setup.cfg
+++ b/pkg/setup.cfg
@@ -4,8 +4,7 @@ author = Pierre Tardy
 author_email = tardyp@gmail.com
 description = Buildbot packaging tools
 url = http://buildbot.net/
-classifiers =
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
+license = GPL-2.0-or-later
 install_requires =
     setuptools >= 34.4.0
 

--- a/worker/setup.cfg
+++ b/worker/setup.cfg
@@ -10,11 +10,11 @@ maintainer_email = dustin@v.igoro.us
 description = Buildbot Worker Daemon
 url = http://buildbot.net/
 long_description = See the 'buildbot' package for details
+license = GPL-2.0-or-later
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: No Input/Output (Daemon)
     Intended Audience :: Developers
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Topic :: Software Development :: Build Tools
     Topic :: Software Development :: Testing
     Programming Language :: Python :: 3

--- a/www/badges/setup.py
+++ b/www/badges/setup.py
@@ -47,5 +47,5 @@ setup_www_plugin(
         [buildbot.www]
         badges = buildbot_badges:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )

--- a/www/base/setup.py
+++ b/www/base/setup.py
@@ -47,5 +47,5 @@ setup_www_plugin(
         [buildbot.www]
         base = buildbot_www:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )

--- a/www/console_view/setup.py
+++ b/www/console_view/setup.py
@@ -45,5 +45,5 @@ setup_www_plugin(
         [buildbot.www]
         console_view = buildbot_console_view:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )

--- a/www/grid_view/setup.py
+++ b/www/grid_view/setup.py
@@ -39,5 +39,5 @@ setup_www_plugin(
         [buildbot.www]
         grid_view = buildbot_grid_view:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )

--- a/www/nestedexample/setup.py
+++ b/www/nestedexample/setup.py
@@ -26,5 +26,5 @@ setup_www_plugin(
         [buildbot.www]
         nestedexample = buildbot_nestedexample:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )

--- a/www/waterfall_view/setup.py
+++ b/www/waterfall_view/setup.py
@@ -39,5 +39,5 @@ setup_www_plugin(
         [buildbot.www]
         waterfall_view = buildbot_waterfall_view:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )

--- a/www/wsgi_dashboards/setup.py
+++ b/www/wsgi_dashboards/setup.py
@@ -39,5 +39,5 @@ setup_www_plugin(
         [buildbot.www]
         wsgi_dashboards = buildbot_wsgi_dashboards:ep
     """,
-    classifiers=['License :: OSI Approved :: GNU General Public License v2 (GPLv2)'],
+    license='GPL-2.0-or-later',
 )


### PR DESCRIPTION
ref: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

# Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
