### PR TITLE
www/base: Add copy-to-clipboard button for log content

### DIFF
--- a/www/base/src/components/LogDownloadButtons/LogDownloadButtons.tsx
+++ b/www/base/src/components/LogDownloadButtons/LogDownloadButtons.tsx
@@ -16,9 +16,9 @@
 */
 
 import './LogDownloadButtons.scss';
-import {useContext} from 'react';
+import {useContext, useState} from 'react';
 import {Button, ButtonGroup} from 'react-bootstrap';
-import {FaDownload} from 'react-icons/fa';
+import {FaCopy, FaCheck, FaDownload} from 'react-icons/fa';
 import {DataClientContext, Log} from 'buildbot-data-js';
 
 export type LogDownloadButtonsProps = {
@@ -28,6 +28,19 @@ export type LogDownloadButtonsProps = {
 export const LogDownloadButtons = ({log}: LogDownloadButtonsProps) => {
   const dataClient = useContext(DataClientContext);
   const apiRootUrl = dataClient.restClient.rootUrl;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyToClipboard = async () => {
+    try {
+      const response = await fetch(new URL(`logs/${log.id}/raw`, apiRootUrl).toString());
+      const text = await response.text();
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (e) {
+      console.error('Failed to copy log to clipboard', e);
+    }
+  };
 
   return (
     <ButtonGroup>
@@ -38,6 +51,16 @@ export const LogDownloadButtons = ({log}: LogDownloadButtonsProps) => {
         className="bb-log-download-button btn-sm"
       >
         <FaDownload />
+      </Button>
+      <Button
+        variant="default"
+        title={copied ? 'copied!' : 'copy log to clipboard'}
+        className="bb-log-download-button btn-sm"
+        onClick={() => {
+          void handleCopyToClipboard();
+        }}
+      >
+        {copied ? <FaCheck /> : <FaCopy />}
       </Button>
       <Button
         href={new URL(`logs/${log.id}/raw_inline`, apiRootUrl).toString()}


### PR DESCRIPTION
## Summary
- Adds a clipboard copy button to the log download button group (between the download icon and "Raw" link)
- Fetches raw log content via the REST API and copies it to the clipboard using `navigator.clipboard.writeText()`
- Shows a brief check-mark confirmation icon for 2 seconds after a successful copy

## Test plan
- [ ] Navigate to a build page with log output (e.g. stdio)
- [ ] Click the copy icon button next to the download icon
- [ ] Verify the icon changes to a checkmark briefly
- [ ] Paste into a text editor and verify the full raw log content was copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)