### PR TITLE
www: Fix favicon missing due to double slash in icon URL path

### DIFF
--- a/newsfragments/favicon-double-slash.bugfix
+++ b/newsfragments/favicon-double-slash.bugfix
@@ -1,0 +1,1 @@
+Fixed favicon missing on most pages due to double slash in URL path (:issue:`8722`).

--- a/www/ui/src/util/FavIcon.test.tsx
+++ b/www/ui/src/util/FavIcon.test.tsx
@@ -1,0 +1,127 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {createRoot, Root} from 'react-dom/client';
+import axios from 'axios';
+import {UNKNOWN, SUCCESS} from 'buildbot-data-js';
+import {Config, ConfigContext} from '../contexts/Config';
+import {useFavIcon} from './FavIcon';
+
+function TestFavIcon({result}: {result: number}) {
+  useFavIcon(result);
+  return null;
+}
+
+async function flushEffects() {
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('FavIcon', () => {
+  let iconElement: HTMLLinkElement;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  function makeConfig(overrides: Partial<Config> = {}): Config {
+    return {
+      title: 'Buildbot',
+      titleURL: '',
+      buildbotURL: 'http://localhost:8080/',
+      multiMaster: false,
+      ui_default_config: {},
+      versions: [],
+      auth: {name: '', oauth2: false, fa_icon: '', autologin: false},
+      avatar_methods: [],
+      plugins: {},
+      user: {anonymous: true},
+      user_any_access_allowed: false,
+      project_widgets: [],
+      port: '8080',
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    iconElement = document.createElement('link');
+    iconElement.id = 'bbicon';
+    document.head.appendChild(iconElement);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      root.unmount();
+    }
+    iconElement.remove();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('should not produce double slash in fallback icon URL', async () => {
+    const config = makeConfig({buildbotURL: 'http://localhost:8080/'});
+
+    root = createRoot(container);
+    root.render(
+      <ConfigContext.Provider value={config}>
+        <TestFavIcon result={UNKNOWN} />
+      </ConfigContext.Provider>,
+    );
+    await flushEffects();
+
+    // When result is UNKNOWN, setFavIconUrlOriginal is called which sets icon.png
+    const href = iconElement.getAttribute('href');
+    expect(href).toContain('icon.png');
+    expect(href).not.toContain('//icon');
+  });
+
+  it('should not produce double slash in SVG fetch URL', async () => {
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValue({data: '<svg></svg>'});
+    const config = makeConfig({buildbotURL: 'http://localhost:8080/'});
+
+    root = createRoot(container);
+    root.render(
+      <ConfigContext.Provider value={config}>
+        <TestFavIcon result={SUCCESS} />
+      </ConfigContext.Provider>,
+    );
+    await flushEffects();
+
+    expect(getSpy).toHaveBeenCalledWith('http://localhost:8080/icon.svg');
+  });
+
+  it('should use relative path when isProxy is true', async () => {
+    const config = makeConfig({buildbotURL: 'http://localhost:8080/', isProxy: true});
+
+    root = createRoot(container);
+    root.render(
+      <ConfigContext.Provider value={config}>
+        <TestFavIcon result={UNKNOWN} />
+      </ConfigContext.Provider>,
+    );
+    await flushEffects();
+
+    // When isProxy is true, url becomes empty string ''
+    // So href should be 'icon.png' (relative), not '/icon.png' (absolute)
+    const href = iconElement.getAttribute('href');
+    expect(href).toBe('icon.png');
+  });
+});

--- a/www/ui/src/util/FavIcon.ts
+++ b/www/ui/src/util/FavIcon.ts
@@ -28,7 +28,7 @@ function setFavIconUrl(url: string) {
 }
 
 function setFavIconUrlOriginal(buildbotUrl: string) {
-  setFavIconUrl(buildbotUrl + '/icon.png');
+  setFavIconUrl(buildbotUrl + 'icon.png');
 }
 
 async function setFavIcon(buildbotUrl: string, result: number) {
@@ -37,7 +37,7 @@ async function setFavIcon(buildbotUrl: string, result: number) {
     return;
   }
 
-  const response = await axios.get(buildbotUrl + '/icon.svg');
+  const response = await axios.get(buildbotUrl + 'icon.svg');
   const iconSvg = response.data;
 
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
 buildbotUrl is guaranteed to end with '/' by the backend (copy_str_url_param_with_trailing_slash), but FavIcon.ts concatenated  '/icon.png' and '/icon.svg', producing double slashes like 'http://host//icon.png' which results in 404.                                               Remove the leading '/' from icon path literals so that the URL is correctly formed. 
 Fixes #8722                                                                                                                                  

# Contributor Checklist: 
 [x] I have updated the unit tests                                                                                                          
 [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)