### PR TITLE
www: Fix /config missing `user_any_access_allowed` field

### DIFF
--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -80,6 +80,7 @@ class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             "buildbotURL": "h:/a/b/",
             "multiMaster": False,
             "port": None,
+            "user_any_access_allowed": False,
         }
         self.assertEqual(res, exp)
 


### PR DESCRIPTION
This would break frontend dev server setup (`npm run start` in `www/base`) as it uses `/config` instead of the injection as in production.

# Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
