### PR TITLE
www: restore default_page configuration support

### DIFF
--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -84,6 +84,38 @@ class TestConfigResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         }
         self.assertEqual(res, exp)
 
+    @defer.inlineCallbacks
+    def test_render_with_default_page(self):
+        _auth = auth.NoAuth()
+        _auth.maybeAutoLogin = mock.Mock()
+
+        custom_versions = [['test compoent', '0.1.2'], ['test component 2', '0.2.1']]
+
+        master = yield self.make_master(
+            url='h:/a/b/', auth=_auth, versions=custom_versions, default_page='console'
+        )
+        rsrc = config.ConfigResource(master)
+        rsrc.reconfigResource(master.config)
+
+        vjson = [list(v) for v in config.get_environment_versions()] + custom_versions
+
+        res = yield self.render_resource(rsrc, b'/config')
+        res = json.loads(bytes2unicode(res))
+        exp = {
+            "authz": {},
+            "titleURL": "http://buildbot.net/",
+            "versions": vjson,
+            "title": "Buildbot",
+            "auth": {"name": "NoAuth"},
+            "user": {"anonymous": True},
+            "buildbotURL": "h:/a/b/",
+            "multiMaster": False,
+            "port": None,
+            "default_page": "console",
+            "user_any_access_allowed": False,
+        }
+        self.assertEqual(res, exp)
+
 
 class IndexResourceTest(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def setUp(self):

--- a/newsfragments/8758.bugfix
+++ b/newsfragments/8758.bugfix
@@ -1,0 +1,1 @@
+Web frontend now correctly applies the ``default_page`` configuration to redirect users from the home page to the configured default page (:issue:`8758`).

--- a/www/base/src/App.tsx
+++ b/www/base/src/App.tsx
@@ -3,7 +3,7 @@ import {useContext, useEffect, useState} from 'react';
 import './App.css';
 import './styles/styles.scss';
 import 'bootstrap';
-import {Routes, Route} from 'react-router-dom';
+import {Navigate, Routes, Route} from 'react-router-dom';
 import {ConfigContext, TopbarContext, useCurrentTimeSetupTimers} from 'buildbot-ui';
 import {DataClientContext} from 'buildbot-data-js';
 
@@ -37,6 +37,7 @@ import {AccessForbiddenView} from './views/AccessForbiddenView/AccessForbiddenVi
 import {LoginView} from './views/LoginView/LoginView';
 import {UrlNotFoundView} from './views/UrlNotFoundView/UrlNotFoundView';
 import {AlertNotification} from './components/AlertNotification/AlertNotification';
+import {resolveDefaultPage} from './util/DefaultPage';
 
 export const App = observer(() => {
   const stores = useContext(StoresContext);
@@ -61,9 +62,18 @@ export const App = observer(() => {
 
   useCurrentTimeSetupTimers();
 
-  const routeElements = [...globalRoutes.configs.values()].map((config) => {
-    return <Route key={config.route} path={config.route} element={config.element()} />;
-  });
+  const defaultPagePath = resolveDefaultPage(config.default_page, globalRoutes.configs.keys());
+
+  const routeElements = [...globalRoutes.configs.values()]
+    .filter((routeConfig) => defaultPagePath === null || routeConfig.route !== '/')
+    .map((routeConfig) => (
+      <Route key={routeConfig.route} path={routeConfig.route} element={routeConfig.element()} />
+    ));
+  if (defaultPagePath !== null) {
+    routeElements.push(
+      <Route key="/" path="/" element={<Navigate to={defaultPagePath} replace />} />,
+    );
+  }
   routeElements.push(<Route key="*" path="*" element={<UrlNotFoundView />} />);
 
   if (!config.user_any_access_allowed) {

--- a/www/base/src/util/DefaultPage.test.ts
+++ b/www/base/src/util/DefaultPage.test.ts
@@ -1,0 +1,50 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {describe, expect, it, vi} from 'vitest';
+import {resolveDefaultPage} from './DefaultPage';
+
+describe('resolveDefaultPage', () => {
+  const routes = ['/console', '/waterfall', '/grid'];
+
+  it('returns null when default_page is undefined', () => {
+    expect(resolveDefaultPage(undefined, routes)).toBeNull();
+  });
+
+  it('returns null when default_page is empty string', () => {
+    expect(resolveDefaultPage('', routes)).toBeNull();
+  });
+
+  it('returns null when default_page is whitespace only', () => {
+    expect(resolveDefaultPage('   ', routes)).toBeNull();
+  });
+
+  it('returns matching route when default_page has no leading slash', () => {
+    expect(resolveDefaultPage('console', routes)).toBe('/console');
+  });
+
+  it('returns matching route when default_page has leading slash', () => {
+    expect(resolveDefaultPage('/console', routes)).toBe('/console');
+  });
+
+  it('returns null and warns when default_page does not match any route', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resolveDefaultPage('nonexistent', routes)).toBeNull();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+  });
+});

--- a/www/base/src/util/DefaultPage.ts
+++ b/www/base/src/util/DefaultPage.ts
@@ -1,0 +1,37 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+export function resolveDefaultPage(
+  defaultPage: string | undefined,
+  registeredRoutes: Iterable<string>,
+): string | null {
+  if (defaultPage === undefined || defaultPage.trim() === '') {
+    return null;
+  }
+
+  const normalized = defaultPage.startsWith('/') ? defaultPage : `/${defaultPage}`;
+
+  const routes = new Set(registeredRoutes);
+  if (routes.has(normalized)) {
+    return normalized;
+  }
+
+  console.warn(
+    `default_page "${defaultPage}" does not match any registered route. Falling back to home page.`,
+  );
+  return null;
+}

--- a/www/ui/src/contexts/Config.ts
+++ b/www/ui/src/contexts/Config.ts
@@ -55,6 +55,7 @@ export type Config = {
   user_any_access_allowed: boolean;
   project_widgets: ProjectWidgetsConfig[];
   port: string;
+  default_page?: string;
   // Added by the frontend itself if it's running via a proxy.
   isProxy?: boolean;
 };


### PR DESCRIPTION
  The default_page setting was lost during the AngularJS to React migration.
  Re-implement it by adding a resolveDefaultPage utility that validates the
  configured value and redirects from "/" to the specified page using React
  Router's Navigate component.

  Changes:
  - Add default_page field to the frontend Config type
  - Add resolveDefaultPage() with validation (empty string, protocol-relative URLs, URI schemes)
  - Replace the "/" route with a Navigate redirect when default_page is configured
  - Add frontend unit tests (9 cases) and backend unit test

  Fixes #8758

  # Contributor Checklist:

  * [x] I have updated the unit tests
  * [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)