### PR TITLE
www: fix force fields autopopulate

### DIFF
--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -107,7 +107,7 @@ class BaseParameter:
     debug = True
     hide = False
     maxsize: int | None = None
-    autopopulate = None
+    autopopulate: dict[str, dict[str, Any]] | None = None
     tooltip = ""
 
     @property

--- a/master/docs/manual/configuration/schedulers.rst
+++ b/master/docs/manual/configuration/schedulers.rst
@@ -1313,8 +1313,10 @@ All parameter types have a few common arguments:
 
 ``autopopulate`` (optional; default: None)
 
-    If not None, ``autopopulate`` is a dictionary which describes how other parameters are updated
-    if this one changes. This is useful for when you have lots of parameters, and defaults depends
+    If not None, ``autopopulate`` is a dictionary (where the keys are this field's value,
+    and values are dictionaries of the target field full name and new value) which describes
+    how other parameters are updated if this one changes.
+    This is useful for when you have lots of parameters, and defaults depends
     on e.g. the branch. This is implemented generically, and all parameters can update others.
     Beware of infinite loops!
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -47,6 +47,7 @@ autoconf
 autodetected
 automake
 Automat
+autopopulate
 autopull
 autoreconf
 backend

--- a/newsfragments/force-fields-autopopulate.bugfix
+++ b/newsfragments/force-fields-autopopulate.bugfix
@@ -1,0 +1,1 @@
+Fixed a regression in the Force Scheduler UI where autopopulate be ignored

--- a/www/base/src/components/ForceBuildModal/Fields/FieldBase.tsx
+++ b/www/base/src/components/ForceBuildModal/Fields/FieldBase.tsx
@@ -18,6 +18,7 @@
 import {ForceSchedulerFieldBoolean} from 'buildbot-data-js';
 import {ForceBuildModalFieldsState} from '../ForceBuildModalFieldsState';
 import {observer} from 'mobx-react';
+import {useEffect} from 'react';
 
 type FieldBaseProps = {
   field: ForceSchedulerFieldBoolean;
@@ -37,6 +38,27 @@ export const FieldBase = observer(({field, fieldsState, children}: FieldBaseProp
   for (const error of state.errors) {
     errors.push(<div className={'bb-force-build-modal-field-error'}>{error}</div>);
   }
+
+  useEffect(() => {
+    if (field.autopopulate === null) {
+      return;
+    }
+    const autopopulateFields = field.autopopulate[state.value];
+    if (autopopulateFields === undefined) {
+      return;
+    }
+
+    for (const targetFieldname in autopopulateFields) {
+      const targetFieldState = fieldsState.fields.get(targetFieldname);
+      if (targetFieldState === undefined) {
+        console.error(
+          `[${field.fullName}] bad autopopulate (for value: ${state.value}) configuration: ${targetFieldname} is not a field name`,
+        );
+        continue;
+      }
+      targetFieldState.setValue(autopopulateFields[targetFieldname]);
+    }
+  }, [state.value, field.autopopulate, field.fullName, fieldsState.fields]);
 
   return (
     <div>

--- a/www/data-module/src/data/classes/Forcescheduler.ts
+++ b/www/data-module/src/data/classes/Forcescheduler.ts
@@ -24,7 +24,7 @@ export type ForceSchedulerFieldBase = {
   regex: string | null;
   hide: boolean;
   maxsize: number | null;
-  autopopulate: boolean | null;
+  autopopulate: {[key: string]: {[key: string]: any}} | null;
   tooltip: string;
 };
 


### PR DESCRIPTION
Re-implements ForceScheduler Param's autopopulate in react, and clarify the expected type.

# Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
