### PR TITLE
bbtravis: retrieve trial logfile for master and worker tests

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -161,7 +161,16 @@ script:
 
   - title: master and worker tests
     condition: TESTS in ("dev_virtualenv", "trial")
-    cmd: /tmp/bbvenv/bin/trial -j8 --reporter=text --rterrors buildbot.test buildbot_worker.test
+    step: !ShellCommand
+      name: "master and worker tests"
+      command: |
+        rm -rf _trial_temp && \
+        /tmp/bbvenv/bin/trial \
+          --temp-directory=_trial_temp --logfile=test.log \
+          -j8 --reporter=text --rterrors \
+          buildbot.test buildbot_worker.test
+      logfiles:
+        testlog: _trial_temp/test.log
 
   - title: interop tests
     condition: TESTS == "interop"

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -238,11 +238,23 @@ script:
 
   - title: end to end tests
     condition: TESTS == "e2e_react_whl"
-    cmd: ./common/smokedist-react.sh whl
+    step: !ShellCommand
+      name: "end to end tests"
+      command: ./common/smokedist-react.sh whl
+      logfiles:
+        master-http: e2e/workdir/http.log
+        master-log: e2e/workdir/twistd.log
+        worker-log: e2e/workdir/worker/twistd.log
 
   - title: tarballs end to end tests
     condition: TESTS == "e2e_react_tgz"
-    cmd: ./common/smokedist-react.sh tar.gz
+    step: !ShellCommand
+      name: "tarballs end to end tests"
+      command: ./common/smokedist-react.sh tar.gz
+      logfiles:
+        master-http: e2e/workdir/http.log
+        master-log: e2e/workdir/twistd.log
+        worker-log: e2e/workdir/worker/twistd.log
 
 notifications:
   email: false

--- a/master/buildbot/test/unit/steps/test_cmake.py
+++ b/master/buildbot/test/unit/steps/test_cmake.py
@@ -38,12 +38,12 @@ class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.setup_test_reactor()
         yield self.setup_test_build_step()
 
-    def expect_and_run_command(self, *params: str) -> defer.Deferred[None]:
+    async def expect_and_run_command(self, *params: str) -> None:
         command = [CMake.DEFAULT_CMAKE, *list(params)]
 
         self.expect_commands(ExpectShell(command=command, workdir='wkdir').exit(0))
         self.expect_outcome(result=SUCCESS)
-        return self.run_step()
+        await self.run_step()
 
     def test_definitions_type(self) -> None:
         with self.assertRaises(ConfigErrors):
@@ -78,10 +78,10 @@ class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
-    def test_definitions(self) -> None:
+    async def test_definitions(self) -> None:
         definition = {'a': 'b'}
         self.setup_step(CMake(definitions=definition))
-        self.expect_and_run_command('-Da=b')
+        await self.expect_and_run_command('-Da=b')
 
     def test_environment(self) -> defer.Deferred[None]:
         command = [CMake.DEFAULT_CMAKE]
@@ -91,61 +91,61 @@ class TestCMake(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
-    def test_definitions_interpolation(self) -> None:
+    async def test_definitions_interpolation(self) -> None:
         definitions = {'a': Property('b')}
 
         self.setup_step(CMake(definitions=definitions))
         self.build.setProperty('b', 'real_b', source='test')
-        self.expect_and_run_command('-Da=real_b')
+        await self.expect_and_run_command('-Da=real_b')
 
-    def test_definitions_renderable(self) -> None:
+    async def test_definitions_renderable(self) -> None:
         definitions = Property('b')
         self.setup_step(CMake(definitions=definitions))
         self.build.setProperty('b', {'a': 'real_b'}, source='test')
-        self.expect_and_run_command('-Da=real_b')
+        await self.expect_and_run_command('-Da=real_b')
 
-    def test_generator(self) -> None:
+    async def test_generator(self) -> None:
         generator = 'Ninja'
 
         self.setup_step(CMake(generator=generator))
-        self.expect_and_run_command('-G', generator)
+        await self.expect_and_run_command('-G', generator)
 
-    def test_generator_interpolation(self) -> None:
+    async def test_generator_interpolation(self) -> None:
         value = 'Our_GENERATOR'
 
         self.setup_step(CMake(generator=Property('GENERATOR')))
         self.build.setProperty('GENERATOR', value, source='test')
 
-        self.expect_and_run_command('-G', value)
+        await self.expect_and_run_command('-G', value)
 
-    def test_options(self) -> None:
+    async def test_options(self) -> None:
         options = ('A', 'B')
 
         self.setup_step(CMake(options=options))
-        self.expect_and_run_command(*options)
+        await self.expect_and_run_command(*options)
 
-    def test_options_interpolation(self) -> None:
+    async def test_options_interpolation(self) -> None:
         prop = 'option'
         value = 'value'
 
         self.setup_step(CMake(options=(Property(prop),)))
         self.build.setProperty(prop, value, source='test')
-        self.expect_and_run_command(value)
+        await self.expect_and_run_command(value)
 
-    def test_path(self) -> None:
+    async def test_path(self) -> None:
         path = 'some/path'
 
         self.setup_step(CMake(path=path))
-        self.expect_and_run_command(path)
+        await self.expect_and_run_command(path)
 
-    def test_path_interpolation(self) -> None:
+    async def test_path_interpolation(self) -> None:
         prop = 'path'
         value = 'some/path'
 
         self.setup_step(CMake(path=Property(prop)))
         self.build.setProperty(prop, value, source='test')
-        self.expect_and_run_command(value)
+        await self.expect_and_run_command(value)
 
-    def test_options_path(self) -> None:
+    async def test_options_path(self) -> None:
         self.setup_step(CMake(path='some/path', options=('A', 'B')))
-        self.expect_and_run_command('A', 'B', 'some/path')
+        await self.expect_and_run_command('A', 'B', 'some/path')


### PR DESCRIPTION
This might help debug CI flakiness (like `buildbot.test.integration.interop.test_commandmixin.CommandMixinMasterPB.test_commandmixin`)

# Contributor Checklist:

* [n/a] I have updated the unit tests
* [n/a] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
