### PR TITLE
SecretInPass fix failure on warning and support multiline secrets

### DIFF
--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -72,7 +72,7 @@ class SecretInPass(SecretProviderBase):
                 ['pass', entry],
                 env=self._env,
                 collect_stderr=True,
-                stderr_is_error=False, # usually this is true
+                stderr_is_error=False,
             )
             if stderr:
                 log.warn("Got stderr while accessing 'pass {entry}': {stderr}", entry=entry, stderr=stderr)

--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -27,6 +27,8 @@ from twisted.internet import defer
 from buildbot import config
 from buildbot.secrets.providers.base import SecretProviderBase
 from buildbot.util import runprocess
+from twisted.logger import Logger
+log=Logger()
 
 if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
@@ -65,15 +67,25 @@ class SecretInPass(SecretProviderBase):
         get the value from pass identified by 'entry'
         """
         try:
-            rc, output = yield runprocess.run_process(
+            rc, output, stderr = yield runprocess.run_process(
                 self.master.reactor,
                 ['pass', entry],
                 env=self._env,
-                collect_stderr=False,
-                stderr_is_error=True,
+                collect_stderr=True,
+                stderr_is_error=False, # usually this is true
             )
+            if stderr:
+                log.warn("Got stderr while accessing 'pass {entry}': {stderr}", entry=entry, stderr=stderr)
             if rc != 0:
+                log.error("Got RC != 0 accessing 'pass {entry}' RC = {rc}", entry=entry, rc=rc)
                 return None
-            return output.decode("utf-8", "ignore").splitlines()[0]
-        except OSError:
+
+            secret = "\n".join(output.decode("utf-8", "ignore").strip().splitlines())
+            if not secret:
+                return None
+            else:
+                return secret
+
+        except OSError as exception:
+            log.error("OSError accessing `pass {entry}`: {exception}", entry=entry, exception=exception)
             return None

--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -80,7 +80,7 @@ class SecretInPass(SecretProviderBase):
                 log.error("Got RC != 0 accessing 'pass {entry}' RC = {rc}", entry=entry, rc=rc)
                 return None
 
-            secret = "\n".join(output.decode("utf-8", "ignore").strip().splitlines())
+            secret = "\n".join(output.decode("utf-8", "ignore").rstrip('\r\n').splitlines())
             if not secret:
                 return None
             else:

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -98,7 +98,7 @@ class TestSecretInPass(
         )
 
         value = yield self.srvpass.get("secret")
-        self.assertEqual(value, "value1")
+        self.assertEqual(value, "value1\nvalue2\nvalue3")
 
         self.assert_all_commands_ran()
 
@@ -109,7 +109,7 @@ class TestSecretInPass(
         )
 
         value = yield self.srvpass.get("secret")
-        self.assertEqual(value, "value1")
+        self.assertEqual(value, "value1\nvalue2\nvalue3")
 
         self.assert_all_commands_ran()
 
@@ -120,7 +120,7 @@ class TestSecretInPass(
         )
 
         value = yield self.srvpass.get("secret")
-        self.assertEqual(value, "value1")
+        self.assertEqual(value, "value1\nvalue2\nvalue3")
 
         self.assert_all_commands_ran()
 

--- a/master/docs/manual/secretsmanagement.rst
+++ b/master/docs/manual/secretsmanagement.rst
@@ -189,8 +189,7 @@ SecretInPass
     )]
 
 Passwords can be stored in a unix password store, encrypted using GPG keys. Buildbot can query
-secrets via the ``pass`` binary found in the PATH of each worker. While ``pass`` allows for
-multiline entries, the secret must be on the first line of each entry. The only caveat is that all
+secrets via the ``pass`` binary found in the PATH of each worker. The only caveat is that all
 passwords Buildbot needs to access have to be encrypted using the same GPG key.
 
 For more information about ``pass``, please visit _`pass`: https://www.passwordstore.org/

--- a/newsfragments/9034.bugfix
+++ b/newsfragments/9034.bugfix
@@ -1,0 +1,1 @@
+SecretInPass no longer fails to get secret when lock file goes missing mid call

--- a/newsfragments/9034.change
+++ b/newsfragments/9034.change
@@ -1,0 +1,1 @@
+SecretInPass supports multiline secrets now


### PR DESCRIPTION
Allow SecretInPass to support multiline secrets, useful for ssh keys etc 
ie the `sshPrivateKey` param in the git step https://docs.buildbot.net/latest/manual/configuration/steps/source_git.html

Don't fail to retrieve secret if there is stderr in the output, since generally that is just a warning.

example stderr when pass still successfully retrieves secret:  lock files disapearing mid call (this shouldn't flunk the step as the secret is avail)
```
gpg: error opening lockfile '<Home>/.gnupg/pubring.kbx.lock': No such file or directory
gpg: lockfile disappeared
```

# Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
