### PR TITLE
fix: include owner properties in responsible users

### DIFF
--- a/newsfragments/3476.bugfix
+++ b/newsfragments/3476.bugfix
@@ -1,0 +1,1 @@
+The build page responsible users tab now includes users from the ``owner`` and ``owners`` build properties, including forced builds that do not have associated changes. (:issue:`3476`)

--- a/www/base/src/views/BuildView/BuildView.test.tsx
+++ b/www/base/src/views/BuildView/BuildView.test.tsx
@@ -1,0 +1,44 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {describe, expect, it} from 'vitest';
+import {getResponsibleUsers} from './BuildView';
+
+describe('getResponsibleUsers', () => {
+  it('includes owner and owners build properties', () => {
+    const properties = {
+      owner: ['Forced User <forced@example.com>', 'ForceScheduler'],
+      owners: [
+        ['fallback@example.com', 'Changed User <changed@example.com>', 'no-email-owner'],
+        'Build',
+      ],
+    };
+
+    const responsibleUsers = getResponsibleUsers(
+      properties,
+      new Set(['Changed User <changed@example.com>', 'Commit Author <commit@example.com>']),
+    );
+
+    expect(responsibleUsers).toEqual({
+      'Forced User': 'forced@example.com',
+      fallback: 'fallback@example.com',
+      'Changed User': 'changed@example.com',
+      'no-email-owner': null,
+      'Commit Author': 'commit@example.com',
+    });
+  });
+});

--- a/www/base/src/views/BuildView/BuildView.tsx
+++ b/www/base/src/views/BuildView/BuildView.tsx
@@ -33,6 +33,7 @@ import {
   Worker,
   UNKNOWN,
   findOrNull,
+  getPropertyValueArrayOrEmpty,
   getPropertyValueOrDefault,
   getBuildOrStepResults,
   parseChangeAuthorNameAndEmail,
@@ -121,28 +122,32 @@ const buildTopbarActions = (
   return actions;
 };
 
-const getResponsibleUsers = (
-  propertiesQuery: DataPropertiesCollection,
+export const getResponsibleUsers = (
+  properties: {[key: string]: any},
   changesAuthors: Set<string>,
 ) => {
   const responsibleUsers: {[name: string]: string | null} = {};
-  if (getPropertyValueOrDefault(propertiesQuery.properties, 'scheduler', '') === 'force') {
-    const owner = getPropertyValueOrDefault(propertiesQuery.properties, 'owner', '');
-    if (owner.match(/^.+<.+@.+\..+>.*$/)) {
-      const splitResult = owner.split(new RegExp('<|>'));
-      if (splitResult.length === 2) {
-        const name = splitResult[0];
-        const email = splitResult[1];
-        responsibleUsers[name] = email;
-      }
-    }
-  }
 
-  for (const author of changesAuthors) {
+  const addResponsibleUser = (author: string) => {
     const [name, email] = parseChangeAuthorNameAndEmail(author);
     if (email !== null || !(name in responsibleUsers)) {
       responsibleUsers[name] = email;
     }
+  };
+
+  const owner = getPropertyValueOrDefault(properties, 'owner', null);
+  if (typeof owner === 'string') {
+    addResponsibleUser(owner);
+  }
+
+  for (const owner of getPropertyValueArrayOrEmpty(properties, 'owners')) {
+    if (typeof owner === 'string') {
+      addResponsibleUser(owner);
+    }
+  }
+
+  for (const author of changesAuthors) {
+    addResponsibleUser(author);
   }
 
   return responsibleUsers;
@@ -191,7 +196,10 @@ const ResponsibleUsersTabWidget = ({build, propertiesQuery}: ResponsibleUsersTab
   }
 
   const responsibleUsers = computed(() =>
-    getResponsibleUsers(propertiesQuery, new Set(changesQuery.array.map((c) => c.author))),
+    getResponsibleUsers(
+      propertiesQuery.properties,
+      new Set(changesQuery.array.map((c) => c.author)),
+    ),
   ).get();
 
   return (


### PR DESCRIPTION
# Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory and read its README
* [ ] I have updated the appropriate documentation

## Summary

The build page responsible users tab now includes identities from both the `owner` and `owners` build properties before adding change authors. This covers forced builds that do not have associated changes and preserves existing change-author behavior.

## Testing

* `npm test -- src/views/BuildView/BuildView.test.tsx --reporter=verbose`
* `npx prettier --check src/views/BuildView/BuildView.tsx src/views/BuildView/BuildView.test.tsx`
* `git diff --check`

Closes #3476.