### PR TITLE
ui: omit empty branch wrapper in build links

### DIFF
--- a/newsfragments/8046.bugfix
+++ b/newsfragments/8046.bugfix
@@ -1,0 +1,1 @@
+Fixed the default build link badge text to show just the build number when the branch property is empty.

--- a/www/ui/src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx
+++ b/www/ui/src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx
@@ -24,7 +24,7 @@ import {observer} from 'mobx-react';
 import {Builder} from 'buildbot-data-js';
 import {BuildSummaryTooltip} from '../BuildSummaryTooltip/BuildSummaryTooltip';
 import {BadgeRound} from '../BadgeRound/BadgeRound';
-import {formatBuildLinkText} from './utils';
+import {defaultBuildLinkTemplate, formatBuildLinkText} from './utils';
 
 type BuildLinkWithSummaryTooltipProps = {
   build: Build;
@@ -79,7 +79,7 @@ buildbotSetupPlugin((reg) => {
         caption:
           'Format of data displayed in build badges. Use %(prop:build_property) to include ' +
           'build properties, %(build_number) to include build number',
-        defaultValue: '%(prop:branch) (%(build_number))',
+        defaultValue: defaultBuildLinkTemplate,
       },
     ],
   });

--- a/www/ui/src/components/BuildLinkWithSummaryTooltip/utils.test.ts
+++ b/www/ui/src/components/BuildLinkWithSummaryTooltip/utils.test.ts
@@ -1,0 +1,62 @@
+/*
+  This file is part of Buildbot.  Buildbot is free software: you can
+  redistribute it and/or modify it under the terms of the GNU General Public
+  License as published by the Free Software Foundation, version 2.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51
+  Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Copyright Buildbot Team Members
+*/
+
+import {Build} from 'buildbot-data-js';
+import {describe, expect, it} from 'vitest';
+import {defaultBuildLinkTemplate, formatBuildLinkTextWithTemplate} from './utils';
+
+const makeBuild = (properties: {[key: string]: any}): Build => {
+  return {
+    number: 123,
+    properties: properties,
+  } as Build;
+};
+
+describe('formatBuildLinkTextWithTemplate', () => {
+  it('formats the default build link with the branch name when it is set', () => {
+    expect(
+      formatBuildLinkTextWithTemplate(
+        makeBuild({
+          branch: ['main', 'Build'],
+        }),
+        defaultBuildLinkTemplate,
+      ),
+    ).toEqual('main (123)');
+  });
+
+  it('omits the default branch wrapper when the branch name is empty', () => {
+    expect(
+      formatBuildLinkTextWithTemplate(
+        makeBuild({
+          branch: ['', 'Build'],
+        }),
+        defaultBuildLinkTemplate,
+      ),
+    ).toEqual('123');
+  });
+
+  it('leaves custom templates unchanged', () => {
+    expect(
+      formatBuildLinkTextWithTemplate(
+        makeBuild({
+          branch: ['', 'Build'],
+        }),
+        'build %(build_number) %(prop:branch)',
+      ),
+    ).toEqual('build 123 ');
+  });
+});

--- a/www/ui/src/components/BuildLinkWithSummaryTooltip/utils.ts
+++ b/www/ui/src/components/BuildLinkWithSummaryTooltip/utils.ts
@@ -19,6 +19,8 @@ import {buildbotGetSettings} from 'buildbot-plugin-support';
 import {Build} from 'buildbot-data-js';
 import {fillTemplate, parseTemplate} from '../../util/TemplateFormat';
 
+export const defaultBuildLinkTemplate = '%(prop:branch) (%(build_number))';
+
 export const getBuildLinkDisplayProperties = () => {
   const template = buildbotGetSettings().getStringSetting('Links.build_link_template');
   if (template === '') return [];
@@ -27,22 +29,49 @@ export const getBuildLinkDisplayProperties = () => {
     .map((x) => x.substring(5));
 };
 
-export const formatBuildLinkText = (build: Build): string => {
-  const template = buildbotGetSettings().getStringSetting('Links.build_link_template');
+const getBuildPropertyValue = (build: Build, prop: string): string | null => {
+  const value = build.properties[prop];
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const propValue = Array.isArray(value) ? value[0] : value;
+  if (propValue === undefined || propValue === null || propValue === '') {
+    return null;
+  }
+  return `${propValue}`;
+};
+
+export const formatBuildLinkTextWithTemplate = (build: Build, template: string): string => {
   if (template === '') {
     return `${build.number}`;
   }
+
+  if (template === defaultBuildLinkTemplate) {
+    const branch = getBuildPropertyValue(build, 'branch');
+    if (branch === null) {
+      return `${build.number}`;
+    }
+    return `${branch} (${build.number})`;
+  }
+
   const replacements = new Map<string, string>([['build_number', `${build.number}`]]);
   for (const repl of parseTemplate(template).replacements.values()) {
     if (repl.startsWith('prop:')) {
       const prop = repl.substring(5);
-      const value = build.properties[prop];
-      if (value === undefined || value === null || value === '') {
+      const value = getBuildPropertyValue(build, prop);
+      if (value === null) {
         continue;
       }
-      replacements.set(repl, value[0]);
+      replacements.set(repl, value);
     }
   }
 
   return fillTemplate(template, replacements);
+};
+
+export const formatBuildLinkText = (build: Build): string => {
+  return formatBuildLinkTextWithTemplate(
+    build,
+    buildbotGetSettings().getStringSetting('Links.build_link_template'),
+  );
 };


### PR DESCRIPTION
## Summary
- Fixes #8046.
- Keeps the default build badge as `branch (number)` when a branch is present.
- Shows just the build number when the branch property is empty, avoiding dangling parentheses in views that do not have branch data.
- Adds focused coverage for default and custom build link templates.

## Testing
- Built local UI dependencies: `npm run build` in `www/data-module` and `www/plugin_support`.
- `npm test -- src/components/BuildLinkWithSummaryTooltip/utils.test.ts --reporter=verbose`
- `npx prettier --check src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx src/components/BuildLinkWithSummaryTooltip/utils.ts src/components/BuildLinkWithSummaryTooltip/utils.test.ts`
- `npx eslint src/components/BuildLinkWithSummaryTooltip/BuildLinkWithSummaryTooltip.tsx src/components/BuildLinkWithSummaryTooltip/utils.ts src/components/BuildLinkWithSummaryTooltip/utils.test.ts`
- `git diff --check`