### PR TITLE
Fix passing arguments for custom change_hook_dialects

### DIFF
--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -133,6 +133,7 @@ class ChangeHookResource(resource.Resource):
             options = self.dialects[dialect]
             if isinstance(options, dict) and 'custom_class' in options:
                 klass = options['custom_class']
+                del options['custom_class']
             else:
                 if dialect not in self._plugins:
                     m = (
@@ -142,7 +143,7 @@ class ChangeHookResource(resource.Resource):
                     log.msg(m)
                     raise ValueError(m)
                 klass = self._plugins.get(dialect)
-            self._dialect_handlers[dialect] = klass(self.master, self.dialects[dialect])
+            self._dialect_handlers[dialect] = klass(self.master, **options)
 
         return self._dialect_handlers[dialect]
 


### PR DESCRIPTION
# Contributor Checklist:

> remove items that are not applicable

* [ ] I have updated the unit tests
* [ ] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

This PR fixes passing arguments for custom change_hook_dialects.
Here is the example of code:
```
class GitHubEventHandlerAdvanced(github.GitHubEventHandler):
    def __init__(self, secret, strict, **kwargs):
        print(f'variable "strict" value is: {strict}')
        super().__init__(secret, strict, **kwargs)

c['www']['change_hook_dialects'] = {
    'github': {
        'custom_class': GitHubEventHandlerAdvanced,
        'strict': False
    }
}
```
Before fix **we get the entire dict, but expect a raw value**:
```
variable "strict" value is: {'custom_class': <class 'extensions.bitbucketcloud_extensions.GitHubEventHandlerAdvanced'>, 'strict': False}
```
After fix:
```
variable "strict" value is: False
```

@Mic92 please take a look