### PR TITLE
fix: checkconfig now respects basedir from buildbot.tac

### DIFF
--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -177,6 +177,56 @@ def getConfigFileFromTac(basedir: str, quiet: bool = False) -> str:
     return "master.cfg"
 
 
+def getConfigFromTacForCheckConfig(
+    tacdir: str, quiet: bool = False
+) -> tuple[str, str]:
+    """Execute buildbot.tac and extract basedir and configFile from BuildMaster.
+
+    Instead of looking for specific variable names, this intercepts the
+    BuildMaster constructor to capture the actual basedir and configFileName
+    arguments, regardless of what variable names the user chose in their
+    buildbot.tac file.
+
+    Returns (basedir, configFile) tuple. Falls back to (tacdir, 'master.cfg')
+    if BuildMaster is not instantiated or buildbot.tac doesn't exist.
+    """
+    from buildbot.master import BuildMaster  # noqa: PLC0415
+
+    captured: dict[str, Any] = {}
+
+    original_init = BuildMaster.__init__
+
+    def capturing_init(
+        self: Any,
+        basedir: str | None,
+        configFileName: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        captured['basedir'] = basedir
+        captured['configFileName'] = configFileName
+
+    tacFile = os.path.join(tacdir, 'buildbot.tac')
+    if not os.path.exists(tacFile):
+        return (tacdir, 'master.cfg')
+
+    tacGlobals: dict[str, Any] = {'__file__': tacFile}
+    try:
+        BuildMaster.__init__ = capturing_init  # type: ignore[assignment]
+        with open(tacFile, encoding='utf-8') as f:
+            exec(f.read(), tacGlobals)  # pylint: disable=exec-used
+    except Exception:
+        if not quiet:
+            traceback.print_exc()
+        raise
+    finally:
+        BuildMaster.__init__ = original_init  # type: ignore[method-assign]
+
+    basedir = captured.get('basedir', tacdir)
+    configFile = captured.get('configFileName') or 'master.cfg'
+
+    return (basedir, configFile)
+
+
 class SubcommandOptions(usage.Options):
     # subclasses should set this to a list-of-lists in order to source the
     # .buildbot/options file.  Note that this *only* works with optParameters,

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from buildbot.config.errors import ConfigErrors
 from buildbot.config.master import FileLoader
-from buildbot.scripts.base import getConfigFileFromTac
+from buildbot.scripts.base import getConfigFromTacForCheckConfig
 from buildbot.util import in_reactor
 
 
@@ -47,13 +47,13 @@ def checkconfig(config: dict[str, Any]) -> int:
     configFile = config.get('configFile', os.getcwd())
 
     if os.path.isdir(configFile):
-        basedir = configFile
+        tacdir = configFile
         try:
-            configFile = getConfigFileFromTac(basedir, quiet=quiet)
+            basedir, configFile = getConfigFromTacForCheckConfig(tacdir, quiet=quiet)
         except Exception:
             if not quiet:
                 # the exception is already printed in base.py
-                print(f"Unable to load 'buildbot.tac' from '{basedir}':")
+                print(f"Unable to load 'buildbot.tac' from '{tacdir}':")
             return 1
     else:
         basedir = os.getcwd()

--- a/master/buildbot/test/unit/scripts/test_base.py
+++ b/master/buildbot/test/unit/scripts/test_base.py
@@ -140,6 +140,111 @@ class TestTacFallback(dirs.DirsMixin, unittest.TestCase):
         self.assertEqual(foundConfigFile, os.path.join(self.basedir, "relative.cfg"))
 
 
+class TestGetConfigFromTacForCheckConfig(dirs.DirsMixin, unittest.TestCase):
+    """
+    Tests for L{base.getConfigFromTacForCheckConfig}.
+    """
+
+    def setUp(self) -> None:
+        self.basedir = os.path.abspath('basedir')
+        return self.setUpDirs('basedir')  # type: ignore[return-value]
+
+    def _createBuildbotTac(self, contents: str) -> str:
+        tacfile = os.path.join(self.basedir, "buildbot.tac")
+        with open(tacfile, "w", encoding='utf-8') as f:
+            f.write(contents)
+        return tacfile
+
+    def test_basic(self) -> None:
+        """
+        When buildbot.tac creates a BuildMaster with standard variable names,
+        getConfigFromTacForCheckConfig returns the basedir and configFile
+        from the BuildMaster constructor.
+        """
+        self._createBuildbotTac(
+            textwrap.dedent("""\
+            from buildbot.master import BuildMaster
+            basedir = '/src/project'
+            configfile = 'mymaster.cfg'
+            m = BuildMaster(basedir, configfile, umask=None)
+            """)
+        )
+        result = base.getConfigFromTacForCheckConfig(self.basedir)
+        self.assertEqual(result, ('/src/project', 'mymaster.cfg'))
+
+    def test_custom_variable_names(self) -> None:
+        """
+        When buildbot.tac uses custom variable names (e.g., base_dir, cfg_file),
+        getConfigFromTacForCheckConfig still captures the correct values from
+        the BuildMaster constructor call.
+        """
+        self._createBuildbotTac(
+            textwrap.dedent("""\
+            from buildbot.master import BuildMaster
+            base_dir = '/custom/path'
+            cfg_file = 'custom.cfg'
+            m = BuildMaster(base_dir, cfg_file, umask=None)
+            """)
+        )
+        result = base.getConfigFromTacForCheckConfig(self.basedir)
+        self.assertEqual(result, ('/custom/path', 'custom.cfg'))
+
+    def test_no_tac_file(self) -> None:
+        """
+        When there is no buildbot.tac file, getConfigFromTacForCheckConfig
+        returns the tacdir and 'master.cfg' as defaults.
+        """
+        result = base.getConfigFromTacForCheckConfig(self.basedir)
+        self.assertEqual(result, (self.basedir, 'master.cfg'))
+
+    def test_tac_without_buildmaster(self) -> None:
+        """
+        When buildbot.tac doesn't instantiate BuildMaster,
+        getConfigFromTacForCheckConfig returns the tacdir and 'master.cfg'.
+        """
+        self._createBuildbotTac("# no BuildMaster here\nx = 1\n")
+        result = base.getConfigFromTacForCheckConfig(self.basedir)
+        self.assertEqual(result, (self.basedir, 'master.cfg'))
+
+    def test_tac_with_syntax_error(self) -> None:
+        """
+        When buildbot.tac has a syntax error, getConfigFromTacForCheckConfig
+        raises SyntaxError.
+        """
+        self._createBuildbotTac("def foo(:\n")
+        with self.assertRaises(SyntaxError):
+            base.getConfigFromTacForCheckConfig(self.basedir, quiet=True)
+
+    def test_buildmaster_init_restored(self) -> None:
+        """
+        After getConfigFromTacForCheckConfig returns, BuildMaster.__init__
+        is restored to its original value.
+        """
+        from buildbot.master import BuildMaster  # noqa: PLC0415
+
+        original_init = BuildMaster.__init__
+        self._createBuildbotTac(
+            textwrap.dedent("""\
+            from buildbot.master import BuildMaster
+            m = BuildMaster('/tmp/test', 'master.cfg', umask=None)
+            """)
+        )
+        base.getConfigFromTacForCheckConfig(self.basedir)
+        self.assertIs(BuildMaster.__init__, original_init)
+
+    def test_buildmaster_init_restored_on_error(self) -> None:
+        """
+        Even when buildbot.tac raises an exception, BuildMaster.__init__
+        is restored to its original value.
+        """
+        from buildbot.master import BuildMaster  # noqa: PLC0415
+
+        original_init = BuildMaster.__init__
+        self._createBuildbotTac("raise RuntimeError('boom')\n")
+        with self.assertRaises(RuntimeError):
+            base.getConfigFromTacForCheckConfig(self.basedir, quiet=True)
+        self.assertIs(BuildMaster.__init__, original_init)
+
 class TestSubcommandOptions(unittest.TestCase):
     def fakeOptionsFile(self, **kwargs: Any) -> None:
         self.patch(base.SubcommandOptions, 'loadOptionsFile', lambda self: kwargs.copy())

--- a/master/buildbot/test/unit/scripts/test_checkconfig.py
+++ b/master/buildbot/test/unit/scripts/test_checkconfig.py
@@ -180,10 +180,29 @@ class TestCheckconfig(unittest.TestCase):
 
     def test_checkconfig_syntaxError_quiet(self) -> None:
         """
-        When C{base.getConfigFileFromTac} raises L{SyntaxError},
+        When C{base.getConfigFromTacForCheckConfig} raises L{SyntaxError},
         C{checkconfig.checkconfig} return an error.
         """
-        mockGetConfig = mock.Mock(spec=base.getConfigFileFromTac, side_effect=SyntaxError)
-        self.patch(checkconfig, 'getConfigFileFromTac', mockGetConfig)
+        mockGetConfig = mock.Mock(
+            spec=base.getConfigFromTacForCheckConfig, side_effect=SyntaxError
+        )
+        self.patch(checkconfig, 'getConfigFromTacForCheckConfig', mockGetConfig)
         config: dict[str, Any] = {"configFile": '.', "quiet": True}
         self.assertEqual(checkconfig.checkconfig(config), 1)
+
+    def test_checkconfig_given_dir_custom_basedir(self) -> None:
+        """
+        When C{base.getConfigFromTacForCheckConfig} returns a custom basedir
+        from buildbot.tac, C{checkconfig} uses that basedir instead of the
+        directory argument.
+        """
+        mockGetConfig = mock.Mock(
+            spec=base.getConfigFromTacForCheckConfig,
+            return_value=('/custom/basedir', 'custom.cfg'),
+        )
+        self.patch(checkconfig, 'getConfigFromTacForCheckConfig', mockGetConfig)
+        config: dict[str, Any] = {"configFile": '.'}
+        self.assertEqual(checkconfig.checkconfig(config), 3)
+        self.loadConfig.assert_called_with(
+            basedir='/custom/basedir', configFile='custom.cfg', quiet=None
+        )

--- a/newsfragments/8284.bugfix
+++ b/newsfragments/8284.bugfix
@@ -1,0 +1,1 @@
+``buildbot checkconfig`` now correctly reads ``basedir`` and ``configfile`` from the ``BuildMaster`` constructor in ``buildbot.tac``, instead of using the directory argument as basedir and only looking for a variable literally named ``configfile``.


### PR DESCRIPTION
Fixes #8284. Instead of hardcoding basedir from the CLI argument, checkconfig now intercepts the BuildMaster constructor in buildbot.tac to capture the actual basedir and configFileName values.

## What changed

- Added `getConfigFromTacForCheckConfig()` in `base.py` that temporarily patches `BuildMaster.__init__` during `.tac` execution to capture the actual `basedir` and `configFileName` arguments, regardless of variable names used in `buildbot.tac`.
- Updated `checkconfig.py` to use the new function instead of `getConfigFileFromTac`.
- The existing `getConfigFileFromTac()` is left unchanged for backward compatibility.

# Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
