### PR TITLE
Remove run-time dependency on setuptools

### DIFF
--- a/master/pyproject.toml
+++ b/master/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    'setuptools >= 8.0',
     'Twisted >= 24.7.0',
     'treq >= 20.9',
     'Jinja2 >= 2.1',
@@ -73,6 +72,8 @@ test = [
     "Markdown>=3.0.0",
     'parameterized',
     'lz4',
+    # imported by buildbot.test
+    'setuptools >= 8.0',
 ]
 
 # NOTE: packages in the 'bundle' extra will be pinned to

--- a/newsfragments/remove-setuptools-dependency.misc
+++ b/newsfragments/remove-setuptools-dependency.misc
@@ -1,0 +1,1 @@
+Remove unnecessary run-time dependency on setuptools.


### PR DESCRIPTION
setuptools is only needed to build wheels (for which `build-system.requires` in `pyproject.toml` files is sufficient), and by one possibly-obsolete import in `master/buildbot/test/__init__.py` which is better expressed as a test dependency.  Remove the run-time dependency on it.

# Contributor Checklist:

* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)