### PR TITLE
Fix `make docs-release` failure with Sphinx 9.1.0

### DIFF
--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -107,6 +107,7 @@ class BBRefTargetDirective(Directive):
             descnode += signode
 
             contentnode = addnodes.desc_content()
+            contentnode.document = self.state.document
             self.state.nested_parse(self.content, 0, contentnode)
             DocFieldTransformer(self).transform_all(contentnode)
             descnode += contentnode

--- a/newsfragments/9050.bugfix
+++ b/newsfragments/9050.bugfix
@@ -1,0 +1,1 @@
+Fix ``make docs-release`` failure with Sphinx 9.1.0 (:issue:`9050`).


### PR DESCRIPTION
This is mostly guesswork based on some similar code in Sphinx itself, but it seems to fix the docs build for me.

Fixes: #9050

# Contributor Checklist:

> remove items that are not applicable

* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)