### PR TITLE
Fix sidebar title overlap with Navigation label

### DIFF
--- a/www/base/src/components/PageWithSidebar/PageWithSidebar.scss
+++ b/www/base/src/components/PageWithSidebar/PageWithSidebar.scss
@@ -136,6 +136,9 @@ $gl-sidebar-width: 600px;
         .bb-sidebar-item {
           font-size: 18px;
           line-height: 50px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
         .menu-icon {
           float: right;


### PR DESCRIPTION
Adds white-space: nowrap to prevent long titles from wrapping and overlapping the Navigation label below.

Closes #3514
