### PR TITLE
Fix sidebar title overlap with Navigation label Add white-space: nowr…

### DIFF
--- a/newsfragments/3514.bugfix
+++ b/newsfragments/3514.bugfix
@@ -1,0 +1,1 @@
+Fixed sidebar title overlap with Navigation label when title is too long

--- a/www/base/src/components/PageWithSidebar/PageWithSidebar.scss
+++ b/www/base/src/components/PageWithSidebar/PageWithSidebar.scss
@@ -136,6 +136,9 @@ $gl-sidebar-width: 600px;
         .bb-sidebar-item {
           font-size: 18px;
           line-height: 50px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
         .menu-icon {
           float: right;


### PR DESCRIPTION
Add white-space: nowrap; overflow: hidden; text-overflow: ellipsis; 
to .bb-sidebar-item to prevent long titles from wrapping and 
overlapping with the Navigation label below.

Fixes #3514