### PR TITLE
Improved reporters handling, especially in case of a lot reporters (50+)

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -237,6 +237,7 @@ class MasterConfig(util.ComparableMixin):
             "logfileName": 'http.log',
         }
         self.services = {}
+        self.reporters_scheduler_filter = None
 
     _known_config_keys = set([
         "buildbotNetUsageData",
@@ -278,6 +279,7 @@ class MasterConfig(util.ComparableMixin):
         "validation",
         "www",
         "workers",
+        "reporters_scheduler_filter",
     ])
     compare_attrs: ClassVar[Sequence[str]] = list(_known_config_keys)
 
@@ -532,6 +534,8 @@ class MasterConfig(util.ComparableMixin):
                 error("revlink must be a callable")
             else:
                 self.revlink = revlink
+
+        copy_str_param('reporters_scheduler_filter')
 
     def load_validation(self, filename: str, config_dict: dict[str, Any]) -> None:
         validation = config_dict.get("validation", {})

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -25,6 +25,9 @@ from twisted.internet import defer
 
 from buildbot.db import NULL
 from buildbot.db import base
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import RETRY
+from buildbot.process.results import SKIPPED
 from buildbot.util import epoch2datetime
 from buildbot.util.twisted import async_to_deferred
 from buildbot.warnings import warn_deprecated
@@ -162,6 +165,117 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
             offset += increment
 
         return rv
+
+    def getPrevBuild(
+        self, builderid: int, number: int, scheduler_filter: str | None = None
+    ) -> defer.Deferred[tuple[int | None, int | None]]:
+        def thd(conn: sa.engine.Connection) -> tuple[int | None, int | None]:
+            builds_tbl = self.db.model.builds
+            if scheduler_filter:
+                buildrequests_tbl = self.db.model.buildrequests
+                buildset_properties_tbl = self.db.model.buildset_properties
+                from_clause = builds_tbl.join(
+                    buildrequests_tbl,
+                    buildrequests_tbl.c.id == builds_tbl.c.buildrequestid,
+                )
+                from_clause = from_clause.join(
+                    buildset_properties_tbl,
+                    buildset_properties_tbl.c.buildsetid == buildrequests_tbl.c.buildsetid,
+                )
+                q = (
+                    sa
+                    .select(builds_tbl.c.number, builds_tbl.c.results)
+                    .select_from(from_clause)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number < number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                        & (buildset_properties_tbl.c.property_name == "scheduler")
+                        # buildset_properties_tbl.c.property_value is a tuple '["name...", "Scheduler"]'
+                        & buildset_properties_tbl.c.property_value.startswith(
+                            f'["{scheduler_filter}'
+                        )
+                    )
+                    .order_by(sa.desc(builds_tbl.c.number))
+                    .limit(1)
+                )
+            else:
+                q = (
+                    sa
+                    .select(builds_tbl.c.number, builds_tbl.c.results)
+                    .select_from(builds_tbl)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number < number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                    )
+                    .order_by(sa.desc(builds_tbl.c.number))
+                    .limit(1)
+                )
+            row = conn.execute(q).first()
+            return (row.number, row.results) if row is not None else (None, None)
+
+        return self.db.pool.do(thd)
+
+    def getNextBuild(
+        self, builderid: int, number: int, scheduler_filter: str | None = None
+    ) -> defer.Deferred[tuple[int | None, int | None]]:
+        def thd(conn: sa.engine.Connection) -> tuple[int | None, int | None]:
+            builds_tbl = self.db.model.builds
+            if scheduler_filter:
+                buildrequests_tbl = self.db.model.buildrequests
+                buildset_properties_tbl = self.db.model.buildset_properties
+                from_clause = builds_tbl.join(
+                    buildrequests_tbl,
+                    buildrequests_tbl.c.id == builds_tbl.c.buildrequestid,
+                )
+                from_clause = from_clause.join(
+                    buildset_properties_tbl,
+                    buildset_properties_tbl.c.buildsetid == buildrequests_tbl.c.buildsetid,
+                )
+                q = (
+                    sa
+                    .select(builds_tbl.c.id, builds_tbl.c.results)
+                    .select_from(from_clause)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number > number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                        & (buildset_properties_tbl.c.property_name == "scheduler")
+                        # buildset_properties_tbl.c.property_value is a tuple '["name...", "Scheduler"]'
+                        & buildset_properties_tbl.c.property_value.startswith(
+                            f'["{scheduler_filter}'
+                        )
+                    )
+                    .order_by(builds_tbl.c.number)
+                    .limit(1)
+                )
+            else:
+                q = (
+                    sa
+                    .select(builds_tbl.c.id, builds_tbl.c.results)
+                    .select_from(builds_tbl)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number > number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                    )
+                    .order_by(builds_tbl.c.number)
+                    .limit(1)
+                )
+
+            row = conn.execute(q).first()
+            return (row.id, row.results) if row is not None else (None, None)
+
+        return self.db.pool.do(thd)
 
     def getBuildsForChange(self, changeid: int) -> defer.Deferred[list[BuildModel]]:
         assert changeid > 0

--- a/master/buildbot/reporters/base.py
+++ b/master/buildbot/reporters/base.py
@@ -24,6 +24,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import config
+from buildbot.process.results import FAILURE
 from buildbot.reporters import utils
 from buildbot.util import service
 from buildbot.util import tuplematch
@@ -121,9 +122,12 @@ class ReporterBase(service.BuildbotService):
 
         try:
             reports = []
+            generators_want_previous_build = []
             assert self.generators is not None
             for g in self.generators:
                 if self._does_generator_want_key(g, key):
+                    if hasattr(g.__class__, "_want_previous_build") and g._want_previous_build():
+                        generators_want_previous_build.append(g)
                     try:
                         report = yield g.generate(self.master, self, key, msg)
                         if report is not None:
@@ -134,6 +138,38 @@ class ReporterBase(service.BuildbotService):
                             "Got exception when handling reporter events: "
                             f"key: {key} generator: {g}",
                         )
+
+            if (
+                generators_want_previous_build
+                and tuplematch.matchTuple(key, ("builds", None, "finished"))
+                and msg.get("builderid") is not None
+                and msg.get("number") is not None
+                and msg.get("results") is not None
+            ):
+                # Check if there is the next completed build.
+                next_build_id, next_build_results = yield self.master.db.builds.getNextBuild(
+                    builderid=msg["builderid"],
+                    number=msg["number"],
+                    scheduler_filter=self.master.config.reporters_scheduler_filter,
+                )
+                if next_build_id is not None and next_build_results is not None:
+                    log.msg(
+                        f'{self.name}: builderid={msg["builderid"]}, build={msg["number"]}: Next build id {next_build_id} is already completed, results {next_build_results}.'
+                    )
+                    # Process reports for the mode change or problem.
+                    if next_build_results != msg["results"] or next_build_results == FAILURE:
+                        next_build = yield self.master.data.get(("builds", str(next_build_id)))
+                        for g in generators_want_previous_build:
+                            try:
+                                report = yield g.generate(self.master, self, key, next_build)
+                                if report is not None:
+                                    reports.append(report)
+                            except Exception as e:
+                                log.err(
+                                    e,
+                                    "Got exception when handling reporter events: "
+                                    f"key: {key} generator: {g}",
+                                )
 
             if reports:
                 yield self.sendMessage(reports)

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -140,7 +140,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
     def is_message_needed_by_results(self, build: Any) -> bool:
         results = build['results']
         if "change" in self.mode:
-            prev = build['prev_build']
+            prev = build.get('prev_build', None)
             if prev and prev['results'] != results:
                 return True
         if "failing" in self.mode and results == FAILURE:
@@ -148,8 +148,9 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
         if "passing" in self.mode and results == SUCCESS:
             return True
         if "problem" in self.mode and results == FAILURE:
-            prev = build['prev_build']
-            if prev and prev['results'] != FAILURE:
+            prev = build.get('prev_build', None)
+            # prev is None if the previous build is incomplete yet
+            if prev and prev['results'] in [SUCCESS, WARNINGS]:
                 return True
         if "warnings" in self.mode and results == WARNINGS:
             return True

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -26,7 +26,6 @@ from twisted.python import log
 from buildbot.data import resultspec
 from buildbot.process.properties import Properties
 from buildbot.process.properties import renderer
-from buildbot.process.results import RETRY
 from buildbot.util import flatten
 
 if TYPE_CHECKING:
@@ -39,16 +38,15 @@ if TYPE_CHECKING:
 def getPreviousBuild(
     master: BuildMaster, build: dict[str, Any]
 ) -> InlineCallbacksType[dict[str, Any] | None]:
-    # naive n-1 algorithm. Still need to define what we should skip
-    # SKIP builds? forced builds? rebuilds?
-    # don't hesitate to contribute improvements to that algorithm
-    n = build['number'] - 1
-    while n >= 0:
-        prev = yield master.data.get(("builders", build['builderid'], "builds", n))
+    builderid = build["builderid"]
+    prev_build_number, prev_build_results = yield master.db.builds.getPrevBuild(
+        builderid, build["number"], master.config.reporters_scheduler_filter
+    )
+    # If results is None it means that the previous build is incomplete yet.
+    if prev_build_number is not None and prev_build_results is not None:
+        prev_build = yield master.data.get(("builders", builderid, "builds", prev_build_number))
+        return prev_build
 
-        if prev and prev['results'] != RETRY:
-            return prev
-        n -= 1
     return None
 
 
@@ -121,16 +119,22 @@ def getDetailsForBuild(
     build['parentbuild'] = parentbuild
     build['parentbuilder'] = parentbuilder
 
-    ret = yield getDetailsForBuilds(
+    # getDetailsForBuilds() will request only the missing data.
+    # Don't try to call it in parallel.
+    # We will significantly improve performance in case of many reporters if
+    # allow the first call to completely request the necessary data just once.
+    l = build.setdefault('details_lock', defer.DeferredLock())
+    ret = yield l.run(
+        getDetailsForBuilds,
         master,
         buildset,
         [build],
-        want_properties=want_properties,
-        want_steps=want_steps,
-        want_previous_build=want_previous_build,
-        want_logs=want_logs,
-        add_logs=add_logs,
-        want_logs_content=want_logs_content,
+        want_properties,
+        want_steps,
+        want_previous_build,
+        want_logs,
+        add_logs,
+        want_logs_content,
     )
     return ret
 
@@ -177,28 +181,54 @@ def getDetailsForBuilds(
     add_logs: list[str] | bool | None = None,
     want_logs_content: bool | list[str] = False,
 ) -> InlineCallbacksType[None]:
-    builderids = {build['builderid'] for build in builds}
+    # The master buildbot may have a lot of reporters.
+    # Each reporter's generator calls getDetailsForBuilds().
+    # Request only the missing data.
 
-    builders = yield defer.gatherResults(
-        [master.data.get(("builders", _id)) for _id in builderids], consumeErrors=True
-    )
+    # Collect builds where the builder is missing.
+    _builds = []
+    for build in builds:
+        if not build.get('builder'):
+            _builds.append(build)
 
-    buildersbyid = {builder['builderid']: builder for builder in builders}
-
-    if want_properties:
-        buildproperties = yield defer.gatherResults(
-            [master.data.get(("builds", build['buildid'], 'properties')) for build in builds],
+    if _builds:
+        # Request missing builders.
+        builders = yield defer.gatherResults(
+            [master.data.get(("builders", build['builderid'])) for build in _builds],
             consumeErrors=True,
         )
-    else:  # we still need a list for the big zip
-        buildproperties = list(range(len(builds)))
+        buildersbyid = {builder['builderid']: builder for builder in builders}
+        for build in _builds:
+            build['builder'] = buildersbyid[build['builderid']]
+
+    if want_properties:
+        # Collect builds where properties are missing.
+        _builds = []
+        for build in builds:
+            if not build.get('properties'):
+                _builds.append(build)
+        if _builds:
+            # Request missing properties.
+            buildproperties = yield defer.gatherResults(
+                [master.data.get(("builds", build['buildid'], 'properties')) for build in _builds],
+                consumeErrors=True,
+            )
+            for build, properties in zip(_builds, buildproperties):
+                build['properties'] = properties
 
     if want_previous_build:
-        prev_builds = yield defer.gatherResults(
-            [getPreviousBuild(master, build) for build in builds], consumeErrors=True
-        )
-    else:  # we still need a list for the big zip
-        prev_builds = list(range(len(builds)))
+        # Collect builds where the prev build is missing.
+        _builds = []
+        for build in builds:
+            if not build.get('prev_build'):
+                _builds.append(build)
+        if _builds:
+            # Request missing prev_build.
+            prev_builds = yield defer.gatherResults(
+                [getPreviousBuild(master, build) for build in _builds], consumeErrors=True
+            )
+            for build, prev_build in zip(_builds, prev_builds):
+                build['prev_build'] = prev_build
 
     if add_logs is not None:
         logs_config = add_logs
@@ -213,13 +243,26 @@ def getDetailsForBuilds(
         want_steps = True
 
     if want_steps:  # pylint: disable=too-many-nested-blocks
-        buildsteps = yield defer.gatherResults(
-            [master.data.get(("builds", build['buildid'], 'steps')) for build in builds],
-            consumeErrors=True,
-        )
+        # Collect builds where steps are missing.
+        _builds = []
+        for build in builds:
+            if not build.get('steps'):
+                _builds.append(build)
+        if _builds:
+            # Request missing steps.
+            buildsteps = yield defer.gatherResults(
+                [master.data.get(("builds", build['buildid'], 'steps')) for build in _builds],
+                consumeErrors=True,
+            )
+            for build, steps in zip(_builds, buildsteps):
+                build['steps'] = list(steps)
+
         if want_logs:
-            for build, build_steps in zip(builds, buildsteps):
-                for s in build_steps:
+            for build in builds:
+                for s in build['steps']:
+                    # Request logs if necessary.
+                    if s.get('logs'):
+                        continue
                     logs = yield master.data.get(("steps", s['stepid'], 'logs'))
                     s['logs'] = list(logs)
                     for l in s['logs']:
@@ -229,26 +272,17 @@ def getDetailsForBuilds(
                         )
                         l['url_raw'] = get_url_for_log_raw(master, l['logid'], 'raw')
                         l['url_raw_inline'] = get_url_for_log_raw(master, l['logid'], 'raw_inline')
+                for s in build['steps']:
+                    for l in s['logs']:
+                        # Request logs content if necessary.
+                        if l.get('content'):
+                            continue
                         if should_attach_log(logs_config, l):
                             l['content'] = yield master.data.get(("logs", l['logid'], 'contents'))
 
-    else:  # we still need a list for the big zip
-        buildsteps = list(range(len(builds)))
-
-    # a big zip to connect everything together
-    for build, properties, steps, prev in zip(builds, buildproperties, buildsteps, prev_builds):
-        build['builder'] = buildersbyid[build['builderid']]
+    for build in builds:
         build['buildset'] = buildset
         build['url'] = getURLForBuild(master, build['builderid'], build['number'])
-
-        if want_properties:
-            build['properties'] = properties
-
-        if want_steps:
-            build['steps'] = list(steps)
-
-        if want_previous_build:
-            build['prev_build'] = prev
 
 
 # perhaps we need data api for users with sourcestamps/:id/users

--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -77,6 +77,10 @@ c['builders'].append(
 
 c['services'] = []
 
+# buildbot/reporters/utils.getPreviousBuild() can search only builds where 
+# the scheduler name starts with reporters_scheduler_filter
+# c['reporters_scheduler_filter'] = "main:"
+
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's

--- a/master/buildbot/test/unit/reporters/test_generators_buildset.py
+++ b/master/buildbot/test/unit/reporters/test_generators_buildset.py
@@ -212,6 +212,7 @@ class TestBuildSetGenerator(TestBuildSetGeneratorBase):
         del build['buildrequest']
         del build['parentbuild']
         del build['parentbuilder']
+        del build['details_lock']
 
         self.assertEqual(
             report,
@@ -451,6 +452,7 @@ class TestBuildSetCombinedGenerator(TestBuildSetGeneratorBase):
         del build['buildrequest']
         del build['parentbuild']
         del build['parentbuilder']
+        del build['details_lock']
 
         self.assertEqual(
             report,

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -184,6 +184,9 @@ class BuildDictLookAlike:
             "url",
             "workerid",
         ]
+        self.ignore_keys = [
+            "details_lock",
+        ]
         if extra_keys:
             self.keys.extend(extra_keys)
         if expected_missing_keys is not None:
@@ -193,11 +196,12 @@ class BuildDictLookAlike:
         self.assertions = assertions
 
     def __eq__(self, b: Any) -> bool:
-        if sorted(b.keys()) != self.keys:
+        b_keys = [k for k in b.keys() if k not in self.ignore_keys]
+        if sorted(b_keys) != self.keys:
             raise AssertionError(
                 'BuildDictLookAlike is not equal to build: '
-                f'Extra keys: {set(b.keys()) - set(self.keys)} '
-                f'Missing keys: {set(self.keys) - set(b.keys())}'
+                f'Extra keys: {set(b_keys) - set(self.keys)} '
+                f'Missing keys: {set(self.keys) - set(b_keys)}'
             )
         for k, v in self.assertions.items():
             if b[k] != v:


### PR DESCRIPTION
The current implementation of getPreviousBuild() may cause catastrophic performance degradation in high-load systems.
Handled the case when the previous build is not completed yet (if few workers are used).
We will significantly improve performance in case of many reporters (with the mode `problem`, especially with logs) if allow the first call getDetailsForBuilds() to completely request the necessary data (and cache) just once.

- Implemented db.builds.getPrevBuild() and db.builds.getNextBuild() to get the prev/next build by a single SQL request with minimal overheads.
- Filter the prev/next build by the scheduler name to ignore manually triggered builds.
- Avoid exceptions when getPreviousBuild() returned None.
- Cache everything in getDetailsForBuilds() and do not call getDetailsForBuilds() in parallel.
