### PR TITLE
worker: declare min required python version

### DIFF
--- a/newsfragments/worker-min-python-ver.misc
+++ b/newsfragments/worker-min-python-ver.misc
@@ -1,0 +1,1 @@
+Declare Python 3.7 as minimum version for Worker.

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "buildbot-worker"
+requires-python = ">=3.7"
 authors = [
     { name = "Brian Warner", email = "warner-buildbot@lothar.com" },
 ]


### PR DESCRIPTION
It was the case at least since the introduction
of __future__ import annotations (ref. https://github.com/buildbot/buildbot/issues/9031).
