### PR TITLE
Obfuscate secrets in MasterShellCommand logs

### DIFF
--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -31,6 +31,7 @@ from buildbot.process.buildstep import CANCELLED
 from buildbot.process.buildstep import FAILURE
 from buildbot.process.buildstep import SUCCESS
 from buildbot.process.buildstep import BuildStep
+from buildbot.util import bytes2unicode
 from buildbot.util import deferwaiter
 from buildbot.util import runprocess
 
@@ -39,6 +40,31 @@ if TYPE_CHECKING:
 
     from buildbot.interfaces import IMaybeRenderableType
     from buildbot.util.twisted import InlineCallbacksType
+
+
+class _SecretFilteringLog:
+    def __init__(self, step: BuildStep, log: Any) -> None:
+        self.step = step
+        self.log = log
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.log, name)
+
+    def addHeader(self, data: str | bytes) -> defer.Deferred[None]:
+        return self.log.addHeader(self._cleanup(data))
+
+    def addStdout(self, data: str | bytes) -> defer.Deferred[None]:
+        return self.log.addStdout(self._cleanup(data))
+
+    def addStderr(self, data: str | bytes) -> defer.Deferred[None]:
+        return self.log.addStderr(self._cleanup(data))
+
+    def _cleanup(self, data: str | bytes) -> str:
+        if isinstance(data, bytes):
+            decoder = getattr(self.log, "decoder", None)
+            data = decoder(data) if decoder is not None else bytes2unicode(data, errors="replace")
+        assert self.step.build is not None
+        return self.step.build.properties.cleanupTextFromSecrets(data)
 
 
 class MasterShellCommand(BuildStep):
@@ -98,7 +124,7 @@ class MasterShellCommand(BuildStep):
             else:
                 argv = command
 
-        self.stdio_log = yield self.addLog("stdio")
+        self.stdio_log = _SecretFilteringLog(self, (yield self.addLog("stdio")))
 
         if isinstance(command, (str, bytes)):
             yield self.stdio_log.addHeader(command.strip() + "\n\n")

--- a/master/buildbot/test/unit/steps/test_master.py
+++ b/master/buildbot/test/unit/steps/test_master.py
@@ -20,6 +20,7 @@ import pprint
 import sys
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
 
 from twisted.internet import defer
 from twisted.python import runtime
@@ -31,6 +32,7 @@ from buildbot.process.properties import renderer
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import master
+from buildbot.test.fake.logfile import FakeLogFile
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import ExpectMasterShell
 from buildbot.test.steps import TestBuildStepMixin
@@ -105,6 +107,41 @@ class TestMasterShellCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
             yield self.run_step()
         finally:
             del os.environ['WORLD']
+
+    @defer.inlineCallbacks
+    def test_logs_obfuscate_secrets(self) -> InlineCallbacksType[None]:
+        secret = "master-shell-secret"
+        self.setup_step(
+            master.MasterShellCommand(
+                command=["echo", secret],
+                env={"TOKEN": secret},
+            )
+        )
+        self.build.properties.useSecret(secret, "shell_secret")
+
+        if runtime.platformType == 'win32':
+            exp_argv = [r'C:\WINDOWS\system32\cmd.exe', '/c', 'echo', secret]
+        else:
+            exp_argv = ["echo", secret]
+
+        self.expect_commands(
+            ExpectMasterShell(exp_argv)
+            .env({"TOKEN": secret})
+            .stdout(f"{secret}\n".encode())
+            .stderr(f"{secret}\n".encode())
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS)
+
+        yield self.run_step()
+
+        stdio = cast(FakeLogFile, self.get_nth_step(0).logs["stdio"])
+        self.assertNotIn(secret, stdio.header)
+        self.assertNotIn(secret, stdio.stdout)
+        self.assertNotIn(secret, stdio.stderr)
+        self.assertIn("<shell_secret>", stdio.header)
+        self.assertIn("<shell_secret>", stdio.stdout)
+        self.assertIn("<shell_secret>", stdio.stderr)
 
     @defer.inlineCallbacks
     def test_env_list_subst(self) -> InlineCallbacksType[None]:


### PR DESCRIPTION
Fixes secret redaction for MasterShellCommand logs.

Unlike remote commands, `MasterShellCommand` writes directly to its stdio log and bypassed the `RemoteCommand.remoteUpdate()` cleanup path. As a result, secrets rendered via Buildbot’s secret mechanism could appear in command headers, environment logs, stdout, or stderr.

This wraps the master shell `stdio log` so headers/stdout/stderr pass through `cleanupTextFromSecrets()` before being stored.

* [x] I have updated the unit tests
