### PR TITLE
SetPropertyFromCommand should preserve command output and results

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -156,9 +156,7 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
             self.descriptionDone = f'{len(property_changes)} properties set'
         elif len(property_changes) == 1:
             self.descriptionDone = f'property \'{next(iter(property_changes))}\' set'
-        if cmd.didFail():
-            return FAILURE
-        return SUCCESS
+        return cmd.results()
 
 
 class ShellCommand(buildstep.ShellMixin, buildstep.BuildStep):

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -135,8 +135,6 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
         property_changes = {}
 
         if self.property:
-            if cmd.didFail():
-                return FAILURE
             result = self.observer.getStdout()
             if self.strip:
                 result = result.strip()

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -267,8 +267,22 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
             .stderr('cannot blarg: File not found')
             .exit(1)
         )
-        self.expect_outcome(result=FAILURE, state_string="'blarg' (failure)")
-        self.expect_no_property("res")
+        self.expect_outcome(result=FAILURE, state_string="property 'res' set (failure)")
+        self.expect_property("res", "")
+        self.expect_log_file('property changes', r"res: " + repr(''))
+        return self.run_step()
+
+    def test_run_failure_with_stdout(self) -> defer.Deferred[None]:
+        self.setup_step(shell.SetPropertyFromCommand(property="res", command="blarg"))
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command="blarg")
+            .stdout('\n\nabcdef\n')
+            .stderr('cannot blarg: File not found')
+            .exit(1)
+        )
+        self.expect_outcome(result=FAILURE, state_string="property 'res' set (failure)")
+        self.expect_property("res", "abcdef")
+        self.expect_log_file('property changes', r"res: " + repr('abcdef'))
         return self.run_step()
 
     def test_run_extract_fn(self) -> defer.Deferred[None]:

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -285,6 +285,20 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
         self.expect_log_file('property changes', r"res: " + repr('abcdef'))
         return self.run_step()
 
+    def test_run_property_decodeRC_warning(self) -> defer.Deferred[None]:
+        self.setup_step(
+            shell.SetPropertyFromCommand(
+                property="res", command="cmd", decodeRC={1: WARNINGS}
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command="cmd").stdout('\n\nabcdef\n').exit(1)
+        )
+        self.expect_outcome(result=WARNINGS, state_string="property 'res' set (warnings)")
+        self.expect_property("res", "abcdef")
+        self.expect_log_file('property changes', r"res: " + repr('abcdef'))
+        return self.run_step()
+
     def test_run_extract_fn(self) -> defer.Deferred[None]:
         def extract_fn(rc: int, stdout: str, stderr: str) -> dict[str, int]:
             self.assertEqual((rc, stdout, stderr), (0, 'startend\n', 'STARTEND\n'))
@@ -326,6 +340,24 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
         self.expect_commands(ExpectShell(workdir='wkdir', command="cmd").exit(3))
         # note that extract_fn *is* called anyway, but returns no properties
         self.expect_outcome(result=FAILURE, state_string="'cmd' (failure)")
+        return self.run_step()
+
+    def test_run_extract_fn_decodeRC_warning(self) -> defer.Deferred[None]:
+        def extract_fn(rc: int, stdout: str, stderr: str) -> dict[str, str]:
+            self.assertEqual((rc, stdout, stderr), (1, 'stdout\n', ''))
+            return {"res": stdout.strip()}
+
+        self.setup_step(
+            shell.SetPropertyFromCommand(
+                extract_fn=extract_fn, command="cmd", decodeRC={1: WARNINGS}
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command="cmd").stdout('stdout\n').exit(1)
+        )
+        self.expect_outcome(result=WARNINGS, state_string="property 'res' set (warnings)")
+        self.expect_property("res", "stdout")
+        self.expect_log_file('property changes', r"res: " + repr('stdout'))
         return self.run_step()
 
     @defer.inlineCallbacks

--- a/master/docs/manual/configuration/steps/set_property_from_command.rst
+++ b/master/docs/manual/configuration/steps/set_property_from_command.rst
@@ -18,6 +18,7 @@ It is usually used like this:
 
 This runs ``uname -a`` and captures its stdout, stripped of leading and trailing whitespace, in the property ``uname``.
 To avoid stripping, add ``strip=False``.
+The property is updated from the captured output even if the command exits with a failure code.
 
 The ``property`` argument can be specified as an :ref:`Interpolate` object, allowing the property name to be built from other property values.
 

--- a/master/docs/manual/configuration/steps/set_property_from_command.rst
+++ b/master/docs/manual/configuration/steps/set_property_from_command.rst
@@ -18,7 +18,8 @@ It is usually used like this:
 
 This runs ``uname -a`` and captures its stdout, stripped of leading and trailing whitespace, in the property ``uname``.
 To avoid stripping, add ``strip=False``.
-The property is updated from the captured output even if the command exits with a failure code.
+The property is updated from the captured output even if the command exits with a non-zero status.
+The step result still follows the command result, including any ``decodeRC`` mapping, in the same way as :bb:step:`ShellCommand`.
 
 The ``property`` argument can be specified as an :ref:`Interpolate` object, allowing the property name to be built from other property values.
 
@@ -31,6 +32,7 @@ Here you can use regular expressions, string interpolation, or whatever you woul
 In this form, :func:`extract_fn` should be passed, and not :class:`Property`.
 The :func:`extract_fn` function is called with three arguments: the exit status of the command, its standard output as a string, and its standard error as a string.
 It should return a dictionary containing all new properties.
+The extracted properties are set before the step returns the command result, so ``decodeRC`` mappings apply here as well.
 
 Note that passing in :func:`extract_fn` will set ``includeStderr`` to ``True``.
 


### PR DESCRIPTION
## Summary
- preserve property updates from command output even when the command exits non-zero
- return `cmd.results()` so `decodeRC` mappings propagate from `SetPropertyFromCommand`
- document the updated failure and result semantics

## Testing
- `python -m twisted.trial buildbot.test.unit.steps.test_shell.SetPropertyFromCommand`