### PR TITLE
reporters: align MS Teams notifications with build context

### DIFF
--- a/master/buildbot/reporters/__init__.py
+++ b/master/buildbot/reporters/__init__.py
@@ -1,1 +1,0 @@
-from .msteams import MsTeamsStatusPush

--- a/master/buildbot/reporters/__init__.py
+++ b/master/buildbot/reporters/__init__.py
@@ -1,0 +1,1 @@
+from .msteams import MsTeamsStatusPush

--- a/master/buildbot/reporters/msteams.py
+++ b/master/buildbot/reporters/msteams.py
@@ -1,99 +1,169 @@
+from __future__ import annotations
+
 # Copyright Buildbot Team Members
 # SPDX-License-Identifier: GPL-2.0-only
-import json
-import time
+
+from typing import TYPE_CHECKING
 from typing import Any
-from typing import Optional
 
-import requests
-
+from twisted.internet import defer
 from twisted.python import log
 
-import treq
-
+from buildbot import config
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
 from buildbot.reporters.base import ReporterBase
-from buildbot.reporters.message import MessageFormatterBaseJinja
+from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
+from buildbot.reporters.message import MessageFormatter
+from buildbot.reporters.message import MessageFormatterEmpty
+from buildbot.util import httpclientservice
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
+
+DEFAULT_BODY_TEMPLATE = """\
+Instance: {{ buildbot_title }} ({{ buildbot_url }})
+Build: {{ buildername }} #{{ build['number'] }} ({{ build_url }})
+Status: {{ summary }} ({{ build_url }})
+{% if failed_step %}Failed step: {{ failed_step['name'] }}{% endif %}"""
+
+DEFAULT_SUBJECT_TEMPLATE = "{{ summary }}"
+
+
+def get_failed_step(build: dict[str, Any]) -> dict[str, Any] | None:
+    if build['results'] not in (FAILURE, EXCEPTION):
+        return None
+
+    steps = build.get('steps', [])
+    for result in (FAILURE, EXCEPTION):
+        for step in steps:
+            if step.get('results') == result:
+                return step
+
+    for step in steps:
+        if step.get('results') != SUCCESS:
+            return step
+
+    return None
+
+
+class MsTeamsMessageFormatter(MessageFormatter):
+    def __init__(self, template: str | None = None) -> None:
+        super().__init__(
+            subject=DEFAULT_SUBJECT_TEMPLATE,
+            template=template or DEFAULT_BODY_TEMPLATE,
+            template_type='plain',
+            want_steps=True,
+        )
+
+    def buildAdditionalContext(self, master: Any, ctx: dict[str, Any]) -> None:
+        super().buildAdditionalContext(master, ctx)
+        ctx['failed_step'] = get_failed_step(ctx['build'])
 
 
 class MsTeamsStatusPush(ReporterBase):
-    name: str = "MsTeamsStatusPush"
-    _last_sent: float = 0.0
-    _rate_limit_seconds: int = 5
+    name: str | None = "MsTeamsStatusPush"
 
-    def __init__(
+    def checkConfig(  # type: ignore[override]
         self,
         webhook_url: str,
-        body_template: Optional[str] = None,
-        card_config: Optional[dict[str, Any]] = None,
-        **kwargs: Any
+        body_template: str | None = None,
+        card_config: dict[str, Any] | None = None,
+        debug: bool | None = None,
+        verify: bool | None = None,
+        generators: list[Any] | None = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(**kwargs)
-        self.webhook_url: str = webhook_url
-        self.body_template: str = body_template or self.default_body_template()
-        self.card_config: dict[str, Any] = card_config or {}
-        self.formatter: MessageFormatterBaseJinja = MessageFormatterBaseJinja(template=self.body_template, template_type="plain")
+        if not isinstance(webhook_url, str):
+            config.error("webhook_url must be a string")
+        if body_template is not None and not isinstance(body_template, str):
+            config.error("body_template must be a string")
+        if card_config is not None and not isinstance(card_config, dict):
+            config.error("card_config must be a dictionary")
 
-    @staticmethod
-    def default_body_template() -> str:
-        return (
-            "The build #{{ build['number'] }} ({{ build_url }}) for project {{ project }}"
-            "{% if project_url %} ({{ project_url }}){% endif %} has {{ results_text }}.\n"
-            "Commit: {{ revision }}\n"
-            "{% if build['triggered_by'] %}Triggered by: {{ build['triggered_by'] }}{% endif %}"
+        if generators is None:
+            generators = self._create_default_generators(body_template)
+
+        super().checkConfig(generators=generators, **kwargs)
+
+    @defer.inlineCallbacks
+    def reconfigService(  # type: ignore[override]
+        self,
+        webhook_url: str,
+        body_template: str | None = None,
+        card_config: dict[str, Any] | None = None,
+        debug: bool | None = None,
+        verify: bool | None = None,
+        generators: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> InlineCallbacksType[None]:
+        self.card_config = {} if card_config is None else dict(card_config)
+        self.debug = debug
+        self.verify = verify
+
+        if generators is None:
+            generators = self._create_default_generators(body_template)
+
+        yield super().reconfigService(generators=generators, **kwargs)
+
+        self._http = yield httpclientservice.HTTPSession(
+            self.master.httpservice,
+            webhook_url,
+            headers={"Content-Type": "application/json"},
+            debug=self.debug,
+            verify=self.verify,
         )
 
-    @inlineCallbacks
-    def buildFinished(self, build: Any, results: Any, master: Any, **kwargs: Any) -> Any:
-        """Send notification to MS Teams when a build finishes."""
-        context = self._get_context(build, results, master)
-        msgdict = yield self.formatter.render_message_dict(master, context)
-        card = self._make_adaptive_card(msgdict)
-        log.msg(f"MsTeamsStatusPush: Sending notification for build {build.get('number')}")
-        yield self._send_to_teams_async(card)
+    def _create_default_generators(self, body_template: str | None) -> list[Any]:
+        return [
+            BuildStartEndStatusGenerator(
+                start_formatter=MessageFormatterEmpty(),
+                end_formatter=MsTeamsMessageFormatter(template=body_template),
+            )
+        ]
 
-    def _get_context(self, build: Any, results: Any, master: Any) -> dict[str, Any]:
-        # This should be expanded to match Buildbot's context for templates
+    @defer.inlineCallbacks
+    def sendMessage(self, reports: list[Any]) -> InlineCallbacksType[None]:
+        report = reports[0]
+        if report['body'] is None:
+            return
+
+        response = yield self._http.post("", json=self._create_message_payload(report))
+        if response.code // 100 != 2:
+            content = yield response.content()
+            log.err(f"{response.code}: unable to send MS Teams notification: {content}")
+
+    def _create_message_payload(self, report: dict[str, Any]) -> dict[str, Any]:
         return {
-            "build": build,
-            "build_url": build.get("url"),
-            "project": build.get("project"),
-            "project_url": build.get("project_url"),
-            "results_text": build.get("results_text"),
-            "revision": build.get("revision"),
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": self._create_card(report),
+                }
+            ],
         }
 
-    def _make_adaptive_card(self, msgdict: dict[str, Any]) -> dict[str, Any]:
+    def _create_card(self, report: dict[str, Any]) -> dict[str, Any]:
+        body = [
+            {
+                "type": "TextBlock",
+                "size": "Medium",
+                "weight": "Bolder",
+                "text": report['subject'] or "Buildbot notification",
+                "wrap": True,
+            }
+        ]
+
+        if report['body']:
+            body.append({"type": "TextBlock", "text": report['body'], "wrap": True})
+
         card = {
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
             "type": "AdaptiveCard",
             "version": "1.4",
-            "body": [
-                {"type": "TextBlock", "size": "Large", "weight": "Bolder", "text": msgdict["subject"] or "Buildbot Notification"},
-                {"type": "TextBlock", "text": msgdict["body"], "wrap": True},
-            ],
+            "body": body,
         }
         card.update(self.card_config)
         return card
-
-    # Removed synchronous _send_to_teams; all notifications are now async
-
-    @inlineCallbacks
-    def _send_to_teams_async(self, card: dict[str, Any]) -> None:
-        """Send the Adaptive Card to MS Teams asynchronously using treq."""
-        try:
-            response = yield treq.post(self.webhook_url, json=card, headers={"Content-Type": "application/json"})
-            text = yield response.text()
-            if response.code >= 400:
-                log.err(f"MsTeamsStatusPush: Failed to send card, status {response.code}, response: {text}")
-            else:
-                log.msg("MsTeamsStatusPush: Notification sent successfully (async).")
-        except Exception as e:
-            log.err(f"MsTeamsStatusPush: Exception sending card (async): {e}")
-
-    @inlineCallbacks
-    def buildStarted(self, build: Any, results: Any, master: Any, **kwargs: Any) -> Any:
-        """Send notification to MS Teams when a build starts."""
-        context = self._get_context(build, results, master)
-        msgdict = yield self.formatter.render_message_dict(master, context)
-        card = self._make_adaptive_card(msgdict)
-        log.msg(f"MsTeamsStatusPush: Sending start notification for build {build.get('number')}")
-        yield self._send_to_teams_async(card)

--- a/master/buildbot/reporters/msteams.py
+++ b/master/buildbot/reporters/msteams.py
@@ -1,0 +1,114 @@
+# Copyright Buildbot Team Members
+# SPDX-License-Identifier: GPL-2.0-only
+import json
+import time
+from typing import Any
+from typing import Optional
+
+import requests
+
+from twisted.python import log
+
+import treq
+
+from buildbot.reporters.base import ReporterBase
+from buildbot.reporters.message import MessageFormatterBaseJinja
+
+
+class MsTeamsStatusPush(ReporterBase):
+    name: str = "MsTeamsStatusPush"
+    _last_sent: float = 0.0
+    _rate_limit_seconds: int = 5
+
+    def __init__(
+        self,
+        webhook_url: str,
+        body_template: Optional[str] = None,
+        card_config: Optional[dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self.webhook_url: str = webhook_url
+        self.body_template: str = body_template or self.default_body_template()
+        self.card_config: dict[str, Any] = card_config or {}
+        self.formatter: MessageFormatterBaseJinja = MessageFormatterBaseJinja(template=self.body_template, template_type="plain")
+
+    @staticmethod
+    def default_body_template() -> str:
+        return (
+            "The build #{{ build['number'] }} ({{ build_url }}) for project {{ project }}"
+            "{% if project_url %} ({{ project_url }}){% endif %} has {{ results_text }}.\n"
+            "Commit: {{ revision }}\n"
+            "{% if build['triggered_by'] %}Triggered by: {{ build['triggered_by'] }}{% endif %}"
+        )
+
+    @inlineCallbacks
+    def buildFinished(self, build: Any, results: Any, master: Any, **kwargs: Any) -> Any:
+        """Send notification to MS Teams when a build finishes."""
+        context = self._get_context(build, results, master)
+        msgdict = yield self.formatter.render_message_dict(master, context)
+        card = self._make_adaptive_card(msgdict)
+        log.msg(f"MsTeamsStatusPush: Sending notification for build {build.get('number')}")
+        self._send_to_teams(card)
+
+    def _get_context(self, build: Any, results: Any, master: Any) -> dict[str, Any]:
+        # This should be expanded to match Buildbot's context for templates
+        return {
+            "build": build,
+            "build_url": build.get("url"),
+            "project": build.get("project"),
+            "project_url": build.get("project_url"),
+            "results_text": build.get("results_text"),
+            "revision": build.get("revision"),
+        }
+
+    def _make_adaptive_card(self, msgdict: dict[str, Any]) -> dict[str, Any]:
+        card = {
+            "type": "AdaptiveCard",
+            "version": "1.4",
+            "body": [
+                {"type": "TextBlock", "size": "Large", "weight": "Bolder", "text": msgdict["subject"] or "Buildbot Notification"},
+                {"type": "TextBlock", "text": msgdict["body"], "wrap": True},
+            ],
+        }
+        card.update(self.card_config)
+        return card
+
+    def _send_to_teams(self, card: dict[str, Any]) -> None:
+        """Send the Adaptive Card to MS Teams and handle errors, with rate limiting."""
+        now = time.time()
+        if now - self._last_sent < self._rate_limit_seconds:
+            log.msg("MsTeamsStatusPush: Rate limit exceeded, skipping notification.")
+            return
+        self._last_sent = now
+        headers = {"Content-Type": "application/json"}
+        try:
+            response = requests.post(self.webhook_url, headers=headers, data=json.dumps(card), timeout=10)
+            if response.status_code >= 400:
+                log.err(f"MsTeamsStatusPush: Failed to send card, status {response.status_code}, response: {response.text}")
+            else:
+                log.msg("MsTeamsStatusPush: Notification sent successfully.")
+        except Exception as e:
+            log.err(f"MsTeamsStatusPush: Exception sending card: {e}")
+
+    @inlineCallbacks
+    def _send_to_teams_async(self, card: dict[str, Any]) -> None:
+        """Send the Adaptive Card to MS Teams asynchronously using treq."""
+        try:
+            response = yield treq.post(self.webhook_url, json=card, headers={"Content-Type": "application/json"})
+            text = yield response.text()
+            if response.code >= 400:
+                log.err(f"MsTeamsStatusPush: Failed to send card, status {response.code}, response: {text}")
+            else:
+                log.msg("MsTeamsStatusPush: Notification sent successfully (async).")
+        except Exception as e:
+            log.err(f"MsTeamsStatusPush: Exception sending card (async): {e}")
+
+    @inlineCallbacks
+    def buildStarted(self, build: Any, results: Any, master: Any, **kwargs: Any) -> Any:
+        """Send notification to MS Teams when a build starts."""
+        context = self._get_context(build, results, master)
+        msgdict = yield self.formatter.render_message_dict(master, context)
+        card = self._make_adaptive_card(msgdict)
+        log.msg(f"MsTeamsStatusPush: Sending start notification for build {build.get('number')}")
+        self._send_to_teams(card)

--- a/master/buildbot/reporters/msteams.py
+++ b/master/buildbot/reporters/msteams.py
@@ -49,7 +49,7 @@ class MsTeamsStatusPush(ReporterBase):
         msgdict = yield self.formatter.render_message_dict(master, context)
         card = self._make_adaptive_card(msgdict)
         log.msg(f"MsTeamsStatusPush: Sending notification for build {build.get('number')}")
-        self._send_to_teams(card)
+        yield self._send_to_teams_async(card)
 
     def _get_context(self, build: Any, results: Any, master: Any) -> dict[str, Any]:
         # This should be expanded to match Buildbot's context for templates
@@ -74,22 +74,7 @@ class MsTeamsStatusPush(ReporterBase):
         card.update(self.card_config)
         return card
 
-    def _send_to_teams(self, card: dict[str, Any]) -> None:
-        """Send the Adaptive Card to MS Teams and handle errors, with rate limiting."""
-        now = time.time()
-        if now - self._last_sent < self._rate_limit_seconds:
-            log.msg("MsTeamsStatusPush: Rate limit exceeded, skipping notification.")
-            return
-        self._last_sent = now
-        headers = {"Content-Type": "application/json"}
-        try:
-            response = requests.post(self.webhook_url, headers=headers, data=json.dumps(card), timeout=10)
-            if response.status_code >= 400:
-                log.err(f"MsTeamsStatusPush: Failed to send card, status {response.status_code}, response: {response.text}")
-            else:
-                log.msg("MsTeamsStatusPush: Notification sent successfully.")
-        except Exception as e:
-            log.err(f"MsTeamsStatusPush: Exception sending card: {e}")
+    # Removed synchronous _send_to_teams; all notifications are now async
 
     @inlineCallbacks
     def _send_to_teams_async(self, card: dict[str, Any]) -> None:
@@ -111,4 +96,4 @@ class MsTeamsStatusPush(ReporterBase):
         msgdict = yield self.formatter.render_message_dict(master, context)
         card = self._make_adaptive_card(msgdict)
         log.msg(f"MsTeamsStatusPush: Sending start notification for build {build.get('number')}")
-        self._send_to_teams(card)
+        yield self._send_to_teams_async(card)

--- a/master/buildbot/test/integration/test_msteams.py
+++ b/master/buildbot/test/integration/test_msteams.py
@@ -1,87 +1,133 @@
+from __future__ import annotations
 
-from twisted.trial import unittest
+from typing import Any
+
 from twisted.internet import defer
+from twisted.trial import unittest
 
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
+from buildbot.reporters.msteams import MsTeamsMessageFormatter
 from buildbot.reporters.msteams import MsTeamsStatusPush
 
-class DummyBuild:
-    def __init__(self, number=1, url="http://buildbot/build/1", project="demo", project_url="http://buildbot/project/demo", results_text="success", revision="abc123", triggered_by=None):
-        self.data = {
-            "number": number,
-            "url": url,
-            "project": project,
-            "project_url": project_url,
-            "results_text": results_text,
-            "revision": revision,
-            "triggered_by": triggered_by,
-        }
-    def get(self, key, default=None):
-        return self.data.get(key, default)
+
+class FakeConfig:
+    title = "Example Buildbot"
+    buildbotURL = "https://buildbot.example/"
 
 
-class DummyMaster:
-    pass
+class FakeMaster:
+    config = FakeConfig()
+    httpservice = object()
+
+
+class FakeResponse:
+    code = 200
+
+    def content(self) -> defer.Deferred[bytes]:
+        return defer.succeed(b"ok")
+
+
+class FakeHttp:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, path: str, json: dict[str, Any]) -> defer.Deferred[FakeResponse]:
+        self.calls.append((path, json))
+        return defer.succeed(FakeResponse())
+
 
 class MsTeamsStatusPushTest(unittest.TestCase):
-    @defer.inlineCallbacks
-    def test_adaptive_card_default(self):
-        sent = {}
-        def fake_post(url, headers, data):
-            sent['url'] = url
-            sent['headers'] = headers
-            sent['data'] = data
-            class Resp: pass
-            return Resp()
-        import buildbot.reporters.msteams as msteams_mod
-        self.patch(msteams_mod.requests, "post", fake_post)
-        reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
-        build = DummyBuild()
-        yield reporter.buildFinished(build, None, DummyMaster())
-        self.assertEqual(sent['url'], "http://example.com/webhook")
-        self.assertIn('AdaptiveCard', sent['data'])
-        self.assertIn('The build #1 (http://buildbot/build/1)', sent['data'])
+    def make_build(
+        self, results: int = SUCCESS, steps: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any]:
+        if steps is None:
+            steps = [{"name": "compile", "results": SUCCESS}]
+
+        return {
+            "buildid": 101,
+            "number": 42,
+            "results": results,
+            "state_string": "tests failed" if results == FAILURE else "",
+            "builder": {"name": "linux-x86_64", "builderid": 7},
+            "properties": {"workername": ("worker1", "test")},
+            "buildset": {
+                "sourcestamps": [
+                    {
+                        "branch": "main",
+                        "revision": "abc123",
+                        "patch": None,
+                        "codebase": "",
+                        "project": "demo",
+                    }
+                ]
+            },
+            "steps": steps,
+        }
 
     @defer.inlineCallbacks
-    def test_adaptive_card_custom_template(self):
-        sent = {}
-        def fake_post(url, headers, data):
-            sent['url'] = url
-            sent['headers'] = headers
-            sent['data'] = data
-            class Resp: pass
-            return Resp()
-        import buildbot.reporters.msteams as msteams_mod
-        self.patch(msteams_mod.requests, "post", fake_post)
-        custom_template = "Build {{ build['number'] }} for {{ project }}."
-        reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook", body_template=custom_template)
-        build = DummyBuild(number=42, project="testproj")
-        yield reporter.buildFinished(build, None, DummyMaster())
-        self.assertIn('Build 42 for testproj.', sent['data'])
+    def test_default_formatter_includes_instance_build_status_and_failed_step(self) -> Any:
+        formatter = MsTeamsMessageFormatter()
+        build = self.make_build(
+            results=FAILURE,
+            steps=[
+                {"name": "checkout", "results": SUCCESS},
+                {"name": "test", "results": FAILURE},
+            ],
+        )
+
+        msg = yield formatter.format_message_for_build(FakeMaster(), build, mode=("failing",))
+
+        self.assertEqual(msg["subject"], "BUILD FAILED: tests failed")
+        self.assertIn("Instance: Example Buildbot (https://buildbot.example/)", msg["body"])
+        self.assertIn(
+            "Build: linux-x86_64 #42 (https://buildbot.example/#/builders/7/builds/42)",
+            msg["body"],
+        )
+        self.assertIn(
+            "Status: BUILD FAILED: tests failed (https://buildbot.example/#/builders/7/builds/42)",
+            msg["body"],
+        )
+        self.assertIn("Failed step: test", msg["body"])
 
     @defer.inlineCallbacks
-    def test_adaptive_card_error(self):
-        sent = {}
-        def fake_post(url, headers, data, timeout=10):
-            sent['url'] = url
-            sent['headers'] = headers
-            sent['data'] = data
-            class Resp:
-                status_code = 500
-                text = "Internal Server Error"
-            return Resp()
-        import buildbot.reporters.msteams as msteams_mod
-        self.patch(msteams_mod.requests, "post", fake_post)
-        reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
-        build = DummyBuild()
-        # Simulate error logging by capturing log.err output
-        from twisted.python import log as twisted_log
-        import io
-        log_stream = io.StringIO()
-        observer = twisted_log.FileLogObserver(log_stream)
-        twisted_log.addObserver(observer.emit)
-        try:
-            yield reporter.buildFinished(build, None, DummyMaster())
-        finally:
-            twisted_log.removeObserver(observer.emit)
-        log_contents = log_stream.getvalue()
-        self.assertIn("Failed to send card", log_contents)
+    def test_custom_template_can_reference_failed_step(self) -> Any:
+        formatter = MsTeamsMessageFormatter(
+            template="{% if failed_step %}Failed step: {{ failed_step['name'] }}{% endif %}"
+        )
+        build = self.make_build(
+            results=FAILURE,
+            steps=[
+                {"name": "checkout", "results": SUCCESS},
+                {"name": "lint", "results": FAILURE},
+            ],
+        )
+
+        msg = yield formatter.format_message_for_build(FakeMaster(), build, mode=("failing",))
+
+        self.assertEqual(msg["body"], "Failed step: lint")
+
+    @defer.inlineCallbacks
+    def test_send_message_wraps_card_in_teams_message_payload(self) -> Any:
+        reporter = MsTeamsStatusPush(webhook_url="https://teams.example/webhook")
+        reporter.card_config = {}
+        reporter._http = FakeHttp()
+
+        yield reporter.sendMessage(
+            [
+                {
+                    "subject": "Build succeeded!",
+                    "body": "Instance: Example Buildbot (https://buildbot.example/)",
+                    "results": SUCCESS,
+                    "builds": [self.make_build()],
+                }
+            ]
+        )
+
+        self.assertEqual(len(reporter._http.calls), 1)
+        path, payload = reporter._http.calls[0]
+        self.assertEqual(path, "")
+        self.assertEqual(payload["type"], "message")
+        self.assertEqual(payload["attachments"][0]["contentType"], "application/vnd.microsoft.card.adaptive")
+        self.assertEqual(payload["attachments"][0]["content"]["type"], "AdaptiveCard")
+        self.assertEqual(payload["attachments"][0]["content"]["body"][0]["text"], "Build succeeded!")

--- a/master/buildbot/test/integration/test_msteams.py
+++ b/master/buildbot/test/integration/test_msteams.py
@@ -1,0 +1,72 @@
+import pytest
+
+from twisted.internet import defer
+
+from buildbot.reporters.msteams import MsTeamsStatusPush
+
+class DummyBuild:
+    def __init__(self, number=1, url="http://buildbot/build/1", project="demo", project_url="http://buildbot/project/demo", results_text="success", revision="abc123", triggered_by=None):
+        self.data = {
+            "number": number,
+            "url": url,
+            "project": project,
+            "project_url": project_url,
+            "results_text": results_text,
+            "revision": revision,
+            "triggered_by": triggered_by,
+        }
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+class DummyMaster:
+    pass
+
+@pytest.inlineCallbacks
+@defer.inlineCallbacks
+def test_adaptive_card_default(monkeypatch):
+    sent = {}
+    def fake_post(url, headers, data):
+        sent['url'] = url
+        sent['headers'] = headers
+        sent['data'] = data
+        class Resp: pass
+        return Resp()
+    monkeypatch.setattr("buildbot.reporters.msteams.requests.post", fake_post)
+    reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
+    build = DummyBuild()
+    yield reporter.buildFinished(build, None, DummyMaster())
+    assert sent['url'] == "http://example.com/webhook"
+    assert 'AdaptiveCard' in sent['data']
+    assert 'The build #1 (http://buildbot/build/1)' in sent['data']
+
+@pytest.inlineCallbacks
+@defer.inlineCallbacks
+def test_adaptive_card_custom_template(monkeypatch):
+    sent = {}
+    def fake_post(url, headers, data):
+        sent['url'] = url
+        sent['headers'] = headers
+        sent['data'] = data
+        class Resp: pass
+        return Resp()
+    monkeypatch.setattr("buildbot.reporters.msteams.requests.post", fake_post)
+    custom_template = "Build {{ build['number'] }} for {{ project }}."
+    reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook", body_template=custom_template)
+    build = DummyBuild(number=42, project="testproj")
+    yield reporter.buildFinished(build, None, DummyMaster())
+    assert 'Build 42 for testproj.' in sent['data']
+
+@pytest.inlineCallbacks
+@defer.inlineCallbacks
+def test_adaptive_card_error(monkeypatch, caplog):
+    def fake_post(url, headers, data, timeout=10):
+        class Resp:
+            status_code = 500
+            text = "Internal Server Error"
+        return Resp()
+    monkeypatch.setattr("buildbot.reporters.msteams.requests.post", fake_post)
+    reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
+    build = DummyBuild()
+    with caplog.at_level("ERROR"):
+        yield reporter.buildFinished(build, None, DummyMaster())
+        assert any("Failed to send card" in r for r in caplog.text.splitlines())

--- a/master/buildbot/test/integration/test_msteams.py
+++ b/master/buildbot/test/integration/test_msteams.py
@@ -1,5 +1,5 @@
-import pytest
 
+from twisted.trial import unittest
 from twisted.internet import defer
 
 from buildbot.reporters.msteams import MsTeamsStatusPush
@@ -18,55 +18,70 @@ class DummyBuild:
     def get(self, key, default=None):
         return self.data.get(key, default)
 
+
 class DummyMaster:
     pass
 
-@pytest.inlineCallbacks
-@defer.inlineCallbacks
-def test_adaptive_card_default(monkeypatch):
-    sent = {}
-    def fake_post(url, headers, data):
-        sent['url'] = url
-        sent['headers'] = headers
-        sent['data'] = data
-        class Resp: pass
-        return Resp()
-    monkeypatch.setattr("buildbot.reporters.msteams.requests.post", fake_post)
-    reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
-    build = DummyBuild()
-    yield reporter.buildFinished(build, None, DummyMaster())
-    assert sent['url'] == "http://example.com/webhook"
-    assert 'AdaptiveCard' in sent['data']
-    assert 'The build #1 (http://buildbot/build/1)' in sent['data']
-
-@pytest.inlineCallbacks
-@defer.inlineCallbacks
-def test_adaptive_card_custom_template(monkeypatch):
-    sent = {}
-    def fake_post(url, headers, data):
-        sent['url'] = url
-        sent['headers'] = headers
-        sent['data'] = data
-        class Resp: pass
-        return Resp()
-    monkeypatch.setattr("buildbot.reporters.msteams.requests.post", fake_post)
-    custom_template = "Build {{ build['number'] }} for {{ project }}."
-    reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook", body_template=custom_template)
-    build = DummyBuild(number=42, project="testproj")
-    yield reporter.buildFinished(build, None, DummyMaster())
-    assert 'Build 42 for testproj.' in sent['data']
-
-@pytest.inlineCallbacks
-@defer.inlineCallbacks
-def test_adaptive_card_error(monkeypatch, caplog):
-    def fake_post(url, headers, data, timeout=10):
-        class Resp:
-            status_code = 500
-            text = "Internal Server Error"
-        return Resp()
-    monkeypatch.setattr("buildbot.reporters.msteams.requests.post", fake_post)
-    reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
-    build = DummyBuild()
-    with caplog.at_level("ERROR"):
+class MsTeamsStatusPushTest(unittest.TestCase):
+    @defer.inlineCallbacks
+    def test_adaptive_card_default(self):
+        sent = {}
+        def fake_post(url, headers, data):
+            sent['url'] = url
+            sent['headers'] = headers
+            sent['data'] = data
+            class Resp: pass
+            return Resp()
+        import buildbot.reporters.msteams as msteams_mod
+        self.patch(msteams_mod.requests, "post", fake_post)
+        reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
+        build = DummyBuild()
         yield reporter.buildFinished(build, None, DummyMaster())
-        assert any("Failed to send card" in r for r in caplog.text.splitlines())
+        self.assertEqual(sent['url'], "http://example.com/webhook")
+        self.assertIn('AdaptiveCard', sent['data'])
+        self.assertIn('The build #1 (http://buildbot/build/1)', sent['data'])
+
+    @defer.inlineCallbacks
+    def test_adaptive_card_custom_template(self):
+        sent = {}
+        def fake_post(url, headers, data):
+            sent['url'] = url
+            sent['headers'] = headers
+            sent['data'] = data
+            class Resp: pass
+            return Resp()
+        import buildbot.reporters.msteams as msteams_mod
+        self.patch(msteams_mod.requests, "post", fake_post)
+        custom_template = "Build {{ build['number'] }} for {{ project }}."
+        reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook", body_template=custom_template)
+        build = DummyBuild(number=42, project="testproj")
+        yield reporter.buildFinished(build, None, DummyMaster())
+        self.assertIn('Build 42 for testproj.', sent['data'])
+
+    @defer.inlineCallbacks
+    def test_adaptive_card_error(self):
+        sent = {}
+        def fake_post(url, headers, data, timeout=10):
+            sent['url'] = url
+            sent['headers'] = headers
+            sent['data'] = data
+            class Resp:
+                status_code = 500
+                text = "Internal Server Error"
+            return Resp()
+        import buildbot.reporters.msteams as msteams_mod
+        self.patch(msteams_mod.requests, "post", fake_post)
+        reporter = MsTeamsStatusPush(webhook_url="http://example.com/webhook")
+        build = DummyBuild()
+        # Simulate error logging by capturing log.err output
+        from twisted.python import log as twisted_log
+        import io
+        log_stream = io.StringIO()
+        observer = twisted_log.FileLogObserver(log_stream)
+        twisted_log.addObserver(observer.emit)
+        try:
+            yield reporter.buildFinished(build, None, DummyMaster())
+        finally:
+            twisted_log.removeObserver(observer.emit)
+        log_contents = log_stream.getvalue()
+        self.assertIn("Failed to send card", log_contents)

--- a/master/prompt.md
+++ b/master/prompt.md
@@ -1,0 +1,21 @@
+You are working on my fork sa2ajj/buildbot, branch pb-interop-flake-diagnostics.
+
+Goal: add PB interop-only diagnostics for flaky tests without affecting other integration tests.
+
+Constraints:
+- Do NOT overwrite buildbot/test/util/integration.py. Make only additive/minimal edits.
+- Diagnostics must run only when:
+  - self.proto == "pb"
+  - and the test module starts with "buildbot.test.integration.interop."
+- Use Twisted logging only: twisted.python.log.msg / log.err (no stdlib logging).
+- Enable DelayedCall.debug for those tests, restore it in cleanup.
+- On test failure (trial sets self._passed == False), dump pending delayed calls.
+- Mypy must pass on Windows typing: call getDelayedCalls via cast(IReactorCore, reactor).
+- Keep output low-noise: only dump delayed calls on failure.
+
+Tasks:
+1) Open buildbot/test/util/integration.py, locate class RunMasterBase(unittest.TestCase).
+2) Add needed imports (cast, DelayedCall, IReactorCore).
+3) Add RunMasterBase.setUp() override + helper(s) implementing the above.
+4) Run formatting/lint/mypy as you normally do, then commit:
+   "tests: add PB interop delayed call diagnostics"

--- a/master/setup.py
+++ b/master/setup.py
@@ -335,6 +335,7 @@ setup_args = {
                     ('buildbot.reporters.irc', ['IRC']),
                     ('buildbot.reporters.telegram', ['TelegramBot']),
                     ('buildbot.reporters.zulip', ['ZulipStatusPush']),
+                    ('buildbot.reporters.msteams', ['MsTeamsStatusPush']),
                 ],
             ),
             (


### PR DESCRIPTION
## Summary
- switch the MS Teams reporter to the standard Buildbot reporter lifecycle
- render instance, build, status, and failed-step details from build context
- wrap the Adaptive Card in the Teams webhook message envelope and update tests

## Testing
- python3 -m twisted.trial buildbot.test.integration.test_msteams

## Personally Tested
- Yes