### PR TITLE
git: apply partial clone filters when fetching

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 
 GIT_HASH_LENGTH = 40
+COMBINE_FILTER_RESERVED_CHARS = frozenset('~!@#$^&*()[]{}\\;",<>?\'+%')
 
 
 def isTrueOrIsExactlyZero(v: Any) -> bool:
@@ -363,10 +364,66 @@ class Git(Source, GitStepMixin):
             return self.srcdir
         return self.workdir
 
+    def _getPartialCloneRemote(self) -> str:
+        return self.origin or 'origin'
+
+    def _getPartialCloneFilter(self) -> str:
+        assert self.filters is not None
+
+        if len(self.filters) == 1:
+            return self.filters[0]
+
+        return (
+            f"combine:{'+'.join(self._encodeFilterForCombine(filter) for filter in self.filters)}"
+        )
+
+    def _encodeFilterForCombine(self, filter: str) -> str:
+        return ''.join(
+            f'%{ord(char):02X}'
+            if ord(char) <= 0x20 or char in COMBINE_FILTER_RESERVED_CHARS
+            else char
+            for char in filter
+        )
+
+    @defer.inlineCallbacks
+    def _ensurePartialCloneConfig(self) -> InlineCallbacksType[None]:
+        if not self.filters or not self.supportsFilters:
+            return
+
+        remote = self._getPartialCloneRemote()
+        promisor_key = f'remote.{remote}.promisor'
+        filter_key = f'remote.{remote}.partialclonefilter'
+        expected_filter = self._getPartialCloneFilter()
+
+        promisor = yield self._dovccmd(
+            ['config', '--get', promisor_key],
+            abandonOnFailure=False,
+            collectStdout=True,
+        )
+        actual_filter = yield self._dovccmd(
+            ['config', '--get', filter_key],
+            abandonOnFailure=False,
+            collectStdout=True,
+        )
+
+        if promisor.strip() == 'true' and actual_filter.strip() == expected_filter:
+            return
+
+        yield self._dovccmd(
+            ['config', promisor_key, 'true'],
+            abandonOnFailure=False,
+        )
+        yield self._dovccmd(
+            ['config', filter_key, expected_filter],
+            abandonOnFailure=False,
+        )
+
     @defer.inlineCallbacks
     def _fetch(
         self, _: Any, shallowClone: bool | int, abandonOnFailure: bool = True
     ) -> InlineCallbacksType[int | None]:
+        yield self._ensurePartialCloneConfig()
+
         fetch_required = True
 
         # If the revision already exists in the repo, we don't need to fetch. However, if tags
@@ -380,6 +437,9 @@ class Git(Source, GitStepMixin):
             command = ['fetch', '-f']
             if shallowClone:
                 command += ['--depth', str(int(shallowClone))]
+            if self.filters and self.supportsFilters:
+                for filter in self.filters:
+                    command += ['--filter', filter]
             if self.tags:
                 command.append("--tags")
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -127,6 +127,220 @@ class TestGit(
         self.expect_outcome(result=SUCCESS)
         return self.run_step()
 
+    def test_mode_full_clean_filters_existing_repo_2_26(self) -> defer.Deferred[None]:
+        self.setup_step(
+            self.stepClass(
+                repourl='http://github.com/buildbot/buildbot.git',
+                mode='full',
+                method='clean',
+                filters=['tree:0'],
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['git', '--version'])
+            .stdout('git version 2.26.0')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True).exit(1),
+            ExpectListdir(dir='wkdir').files(['.git']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'clean', '-f', '-f', '-d']).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=[
+                    'git',
+                    'fetch',
+                    '-f',
+                    '--progress',
+                    'http://github.com/buildbot/buildbot.git',
+                    'HEAD',
+                ],
+            ).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'checkout', '-f', 'FETCH_HEAD']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
+    def test_mode_full_fresh_filters_existing_repo_2_27(self) -> defer.Deferred[None]:
+        self.setup_step(
+            self.stepClass(
+                repourl='http://github.com/buildbot/buildbot.git',
+                mode='full',
+                method='fresh',
+                filters=['blob:limit=1m', 'tree:0'],
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['git', '--version'])
+            .stdout('git version 2.27.0')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True).exit(1),
+            ExpectListdir(dir='wkdir').files(['.git']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'clean', '-f', '-f', '-d', '-x']).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', '--get', 'remote.origin.promisor'],
+            ).exit(1),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', '--get', 'remote.origin.partialclonefilter'],
+            ).exit(1),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', 'remote.origin.promisor', 'true'],
+            ).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=[
+                    'git',
+                    'config',
+                    'remote.origin.partialclonefilter',
+                    'combine:blob:limit=1m+tree:0',
+                ],
+            ).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=[
+                    'git',
+                    'fetch',
+                    '-f',
+                    '--filter',
+                    'blob:limit=1m',
+                    '--filter',
+                    'tree:0',
+                    '--progress',
+                    'http://github.com/buildbot/buildbot.git',
+                    'HEAD',
+                ],
+            ).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'checkout', '-f', 'FETCH_HEAD']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
+    def test_mode_incremental_filters_existing_repo_already_configured_2_27(
+        self,
+    ) -> defer.Deferred[None]:
+        self.setup_step(
+            self.stepClass(
+                repourl='http://github.com/buildbot/buildbot.git',
+                mode='incremental',
+                filters=['tree:0'],
+                origin='upstream',
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['git', '--version'])
+            .stdout('git version 2.27.0')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True).exit(1),
+            ExpectListdir(dir='wkdir').files(['.git']).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', '--get', 'remote.upstream.promisor'],
+            )
+            .stdout('true')
+            .exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', '--get', 'remote.upstream.partialclonefilter'],
+            )
+            .stdout('tree:0')
+            .exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=[
+                    'git',
+                    'fetch',
+                    '-f',
+                    '--filter',
+                    'tree:0',
+                    '--progress',
+                    'http://github.com/buildbot/buildbot.git',
+                    'HEAD',
+                ],
+            ).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'checkout', '-f', 'FETCH_HEAD']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
+    def test_mode_incremental_filters_existing_repo_changed_filter_2_27(
+        self,
+    ) -> defer.Deferred[None]:
+        self.setup_step(
+            self.stepClass(
+                repourl='http://github.com/buildbot/buildbot.git',
+                mode='incremental',
+                filters=['tree:0'],
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['git', '--version'])
+            .stdout('git version 2.27.0')
+            .exit(0),
+            ExpectStat(file='wkdir/.buildbot-patched', log_environ=True).exit(1),
+            ExpectListdir(dir='wkdir').files(['.git']).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', '--get', 'remote.origin.promisor'],
+            )
+            .stdout('true')
+            .exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', '--get', 'remote.origin.partialclonefilter'],
+            )
+            .stdout('blob:none')
+            .exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', 'remote.origin.promisor', 'true'],
+            ).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=['git', 'config', 'remote.origin.partialclonefilter', 'tree:0'],
+            ).exit(0),
+            ExpectShell(
+                workdir='wkdir',
+                command=[
+                    'git',
+                    'fetch',
+                    '-f',
+                    '--filter',
+                    'tree:0',
+                    '--progress',
+                    'http://github.com/buildbot/buildbot.git',
+                    'HEAD',
+                ],
+            ).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'checkout', '-f', 'FETCH_HEAD']).exit(0),
+            ExpectShell(workdir='wkdir', command=['git', 'rev-parse', 'HEAD'])
+            .stdout('f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS)
+        return self.run_step()
+
+    @parameterized.expand([
+        ('equals_unescaped', 'blob:limit=1m', 'blob:limit=1m'),
+        ('plus', 'sparse:oid=foo+bar', 'sparse:oid=foo%2Bbar'),
+        ('percent', 'sparse:oid=foo%bar', 'sparse:oid=foo%25bar'),
+        ('space', 'sparse:oid=foo bar', 'sparse:oid=foo%20bar'),
+        ('reserved', 'sparse:oid=foo?bar', 'sparse:oid=foo%3Fbar'),
+    ])
+    def test_encode_filter_for_combine(self, name: str, filter: str, encoded_filter: str) -> None:
+        step = self.stepClass(repourl='http://github.com/buildbot/buildbot.git')
+
+        self.assertEqual(step._encodeFilterForCombine(filter), encoded_filter)
+
     @parameterized.expand([
         ('url', 'ssh://github.com/test/test.git', 'ssh://github.com/test/test.git'),
         (

--- a/master/docs/manual/configuration/steps/source_git.rst
+++ b/master/docs/manual/configuration/steps/source_git.rst
@@ -54,8 +54,9 @@ The Git step takes the following arguments:
    This renderable option allows that to be configured to an alternate name.
 
 ``filters`` (optional, type: ``list``)
-   For each string in the passed in list, adds a ``--filter <filter>`` argument to :command:`git clone`.
-   This allows for adding filters like ``--filter "tree:0"`` to speed up the clone step.
+   For each string in the passed in list, adds a ``--filter <filter>`` argument to :command:`git clone` and :command:`git fetch`.
+   For existing repositories, Buildbot also configures the remote as a partial clone promisor remote before fetching.
+   This allows for adding filters like ``--filter "tree:0"`` to speed up clone and fetch operations.
    This requires git version 2.27 or higher.
 
 ``progress`` (optional)

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -676,6 +676,7 @@ prev
 PrivateTemporaryDirectory
 procmail
 prois
+promisor
 ProjectModel
 propertiesDict
 propKey

--- a/newsfragments/9058.bugfix
+++ b/newsfragments/9058.bugfix
@@ -1,0 +1,1 @@
+Fixed the `Git` step to apply configured partial clone filters when fetching existing repositories (:issue:`9058`).


### PR DESCRIPTION
Partial clone filters, while they were applied on initial cloning, it was not the case for later fetches, hence existing repos would grow overtime potentially to full clones, occupying disk space.

Existing repositories are configured as promisor partial clones before fetching and pass the configured filters to git fetch as well. This keeps the update path the same with the clone path.

Supported for git >= 2.27

Fixes #9058


# Contributor Checklist:

> remove items that are not applicable

* [X] I have updated the unit tests
* [X] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
