### PR TITLE
SetPropertyFromCommand improvements

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -31,6 +31,7 @@ from buildbot.process import remotetransfer
 # for existing configurations that import WithProperties from here.  We like
 # to move this class around just to keep our readers guessing.
 from buildbot.process.properties import WithProperties
+from buildbot.process.results import CANCELLED
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
@@ -132,11 +133,13 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
         stdio_log = yield self.getLog('stdio')
         yield stdio_log.finish()
 
+        command_result = cmd.results()
+        if command_result in (FAILURE, CANCELLED):
+            return command_result
+
         property_changes = {}
 
         if self.property:
-            if cmd.didFail():
-                return FAILURE
             result = self.observer.getStdout()
             if self.strip:
                 result = result.strip()
@@ -158,7 +161,7 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
             self.descriptionDone = f'{len(property_changes)} properties set'
         elif len(property_changes) == 1:
             self.descriptionDone = f'property \'{next(iter(property_changes))}\' set'
-        return cmd.results()
+        return command_result
 
 
 class ShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
@@ -605,7 +608,7 @@ class PerlModuleTestObserver(logobserver.LogLineObserver):
     oldSuccessCountsRe = re.compile(r"Files=\d+, Tests=(\d+),")
 
     def outLineReceived(self, line: str) -> None:
-        if self.warningPattern.match(line):  # type: ignore[union-attr]
+        if self.warningPattern is not None and self.warningPattern.match(line):
             self.warnings += 1
         if self.newStyle:
             if line.startswith('Result: FAIL'):

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -158,9 +158,7 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
             self.descriptionDone = f'{len(property_changes)} properties set'
         elif len(property_changes) == 1:
             self.descriptionDone = f'property \'{next(iter(property_changes))}\' set'
-        if cmd.didFail():
-            return FAILURE
-        return SUCCESS
+        return cmd.results()
 
 
 class ShellCommand(buildstep.ShellMixin, buildstep.BuildStep):

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -260,6 +260,16 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
         self.expect_log_file('property changes', r"res: " + repr('\n\nabcdef\n'))
         return self.run_step()
 
+    def test_run_property_decodeRC(self) -> defer.Deferred[None]:
+        self.setup_step(
+            shell.SetPropertyFromCommand(property="res", command="cmd", decodeRC={1: WARNINGS})
+        )
+        self.expect_commands(ExpectShell(workdir='wkdir', command="cmd").stdout('abcdef\n').exit(1))
+        self.expect_outcome(result=WARNINGS)
+        self.expect_property("res", "abcdef")
+        self.expect_log_file('property changes', r"res: " + repr('abcdef'))
+        return self.run_step()
+
     def test_run_failure(self) -> defer.Deferred[None]:
         self.setup_step(shell.SetPropertyFromCommand(property="res", command="blarg"))
         self.expect_commands(
@@ -286,6 +296,30 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="2 properties set")
+        self.expect_log_file('property changes', 'a: 1\nb: 2')
+        self.expect_property("a", 1)
+        self.expect_property("b", 2)
+        return self.run_step()
+
+    def test_run_extract_fn_decodeRC(self) -> defer.Deferred[None]:
+        def extract_fn(rc: int, stdout: str, stderr: str) -> dict[str, int]:
+            self.assertEqual((rc, stdout, stderr), (1, 'startend\n', 'STARTEND\n'))
+            return {"a": 1, "b": 2}
+
+        self.setup_step(
+            shell.SetPropertyFromCommand(
+                extract_fn=extract_fn, command="cmd", decodeRC={1: WARNINGS}
+            )
+        )
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command="cmd")
+            .stdout('start')
+            .stderr('START')
+            .stdout('end')
+            .stderr('END')
+            .exit(1)
+        )
+        self.expect_outcome(result=WARNINGS)
         self.expect_log_file('property changes', 'a: 1\nb: 2')
         self.expect_property("a", 1)
         self.expect_property("b", 2)

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -26,6 +26,7 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.process import properties
 from buildbot.process import remotetransfer
+from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SKIPPED
@@ -325,28 +326,59 @@ class SetPropertyFromCommand(TestBuildStepMixin, TestReactorMixin, unittest.Test
         self.expect_property("b", 2)
         return self.run_step()
 
-    def test_run_extract_fn_cmdfail(self) -> defer.Deferred[None]:
+    @defer.inlineCallbacks
+    def test_run_extract_fn_cmdfail(self) -> InlineCallbacksType[None]:
+        called = False
+
         def extract_fn(rc: int, stdout: str, stderr: str) -> dict[str, int]:
-            self.assertEqual((rc, stdout, stderr), (3, '', ''))
+            nonlocal called
+            called = True
             return {"a": 1, "b": 2}
 
         self.setup_step(shell.SetPropertyFromCommand(extract_fn=extract_fn, command="cmd"))
         self.expect_commands(ExpectShell(workdir='wkdir', command="cmd").exit(3))
-        # note that extract_fn *is* called anyway
-        self.expect_outcome(result=FAILURE, state_string="2 properties set (failure)")
-        self.expect_log_file('property changes', 'a: 1\nb: 2')
-        return self.run_step()
+        self.expect_outcome(result=FAILURE, state_string="'cmd' (failure)")
+        self.expect_no_property("a")
+        self.expect_no_property("b")
+        yield self.run_step()
+        self.assertFalse(called)
+        self.assertNotIn('property changes', self.get_nth_step(0).logs)
 
-    def test_run_extract_fn_cmdfail_empty(self) -> defer.Deferred[None]:
+    @defer.inlineCallbacks
+    def test_run_extract_fn_cmdfail_empty(self) -> InlineCallbacksType[None]:
+        called = False
+
         def extract_fn(rc: int, stdout: str, stderr: str) -> dict[str, int]:
-            self.assertEqual((rc, stdout, stderr), (3, '', ''))
+            nonlocal called
+            called = True
             return {}
 
         self.setup_step(shell.SetPropertyFromCommand(extract_fn=extract_fn, command="cmd"))
         self.expect_commands(ExpectShell(workdir='wkdir', command="cmd").exit(3))
-        # note that extract_fn *is* called anyway, but returns no properties
         self.expect_outcome(result=FAILURE, state_string="'cmd' (failure)")
-        return self.run_step()
+        yield self.run_step()
+        self.assertFalse(called)
+        self.assertNotIn('property changes', self.get_nth_step(0).logs)
+
+    @defer.inlineCallbacks
+    def test_run_extract_fn_cancelled(self) -> InlineCallbacksType[None]:
+        called = False
+
+        def extract_fn(rc: int, stdout: str, stderr: str) -> dict[str, int]:
+            nonlocal called
+            called = True
+            return {"a": 1}
+
+        exp = ExpectShell(workdir='wkdir', command="cmd").exit(0)
+        exp.interrupted = True
+        self.setup_step(shell.SetPropertyFromCommand(extract_fn=extract_fn, command="cmd"))
+        self.expect_commands(exp)
+        self.expect_outcome(result=CANCELLED)
+        self.expect_no_property("a")
+        self.interrupt_nth_remote_command(0)
+        yield self.run_step()
+        self.assertFalse(called)
+        self.assertNotIn('property changes', self.get_nth_step(0).logs)
 
     @defer.inlineCallbacks
     def test_run_extract_fn_exception(self) -> InlineCallbacksType[None]:

--- a/master/docs/manual/configuration/steps/set_property_from_command.rst
+++ b/master/docs/manual/configuration/steps/set_property_from_command.rst
@@ -18,6 +18,7 @@ It is usually used like this:
 
 This runs ``uname -a`` and captures its stdout, stripped of leading and trailing whitespace, in the property ``uname``.
 To avoid stripping, add ``strip=False``.
+Properties are only updated when the command completes successfully or with a decoded warning result.
 
 The ``property`` argument can be specified as an :ref:`Interpolate` object, allowing the property name to be built from other property values.
 
@@ -30,6 +31,7 @@ Here you can use regular expressions, string interpolation, or whatever you woul
 In this form, :func:`extract_fn` should be passed, and not :class:`Property`.
 The :func:`extract_fn` function is called with three arguments: the exit status of the command, its standard output as a string, and its standard error as a string.
 It should return a dictionary containing all new properties.
+If the command fails or is cancelled, :func:`extract_fn` is not called and no properties are set.
 
 Note that passing in :func:`extract_fn` will set ``includeStderr`` to ``True``.
 

--- a/newsfragments/setproperty-fail-before-extract.change
+++ b/newsfragments/setproperty-fail-before-extract.change
@@ -1,0 +1,1 @@
+`SetPropertyFromCommand` now stops on command failure before running `extract_fn` or recording property changes.


### PR DESCRIPTION
# Summary

Make `SetPropertyFromCommand` return failure before property extraction when the command fails. This prevents failed commands from mutating build properties or creating property-change logs, and aligns the step result with the underlying command outcome. Updated unit tests and step documentation accordingly.

# Contributor Checklist:

> remove items that are not applicable

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
