### PR TITLE
Add a built-in MCP (Model Context Protocol) server (#9000)

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -831,6 +831,7 @@ class MasterConfig(util.ComparableMixin):
             'logRotateLength',
             'logfileName',
             'maxRotatedFiles',
+            'mcp',
             'plugins',
             'port',
             'rest_minimum_version',

--- a/master/buildbot/test/unit/config/test_master.py
+++ b/master/buildbot/test/unit/config/test_master.py
@@ -1020,6 +1020,12 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 
         self.assertConfigError(errors, "unknown www configuration parameter(s) foo")
 
+    def test_load_www_mcp(self) -> None:
+        with capture_config_errors() as errors:
+            self.cfg.load_www(self.filename, {"www": {"mcp": True}})
+
+        self.assertEqual(errors.errors, [])
+
     def test_load_services_nominal(self) -> None:
         testcase = self
 

--- a/master/buildbot/test/unit/www/test_mcp.py
+++ b/master/buildbot/test/unit/www/test_mcp.py
@@ -28,6 +28,7 @@ from buildbot.test.util import www
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import mcp
+from buildbot.www.authz import Forbidden
 
 if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
@@ -154,6 +155,9 @@ class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         self.master = yield self.make_master(url=b'http://localhost:8010/')  # type: ignore[arg-type]
         self.mcp = mcp.McpResource(self.master)
         self.mcp.reconfigResource(self.master.config)
+        # www is a Mock here; authorization is exercised explicitly per test.
+        # (Mock blocks attribute names starting with "assert", so set it.)
+        self.master.www.assertUserAllowed = lambda *a, **k: defer.succeed(None)
         yield self.master.db.insert_test_data([
             fakedb.Builder(id=21, name="builder-a"),
             fakedb.Builder(id=22, name="builder-b"),
@@ -245,6 +249,8 @@ class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
                 "get_recent_builds",
                 "get_build",
                 "get_build_logs",
+                "force_build",
+                "cancel_build",
             },
         )
 
@@ -377,3 +383,63 @@ class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def test_get_build_logs_unknown_build(self) -> InlineCallbacksType[None]:
         res = yield self._call("get_build_logs", {"build_id": 999})
         self.assertTrue(res["result"]["isError"])
+
+    @defer.inlineCallbacks
+    def test_force_build(self) -> InlineCallbacksType[None]:
+        calls = []
+
+        def fake_control(action: str, args: dict[str, Any], path: Any) -> defer.Deferred[Any]:
+            calls.append((action, args, path))
+            return defer.succeed((1, {21: 2}))
+
+        self.master.data.control = fake_control
+        res = yield self._call(
+            "force_build", {"scheduler": "force", "builder": "builder-a", "reason": "ci"}
+        )
+        data = self._tool_data(res)
+        self.assertTrue(data["forced"])
+        self.assertEqual(calls[0][0], "force")
+        self.assertEqual(calls[0][2], ("forceschedulers", "force"))
+        self.assertEqual(calls[0][1]["builderid"], 21)
+        self.assertEqual(calls[0][1]["reason"], "ci")
+
+    @defer.inlineCallbacks
+    def test_force_build_requires_scheduler(self) -> InlineCallbacksType[None]:
+        res = yield self._call("force_build", {"builder": "builder-a"})
+        self.assertTrue(res["result"]["isError"])
+
+    @defer.inlineCallbacks
+    def test_cancel_build(self) -> InlineCallbacksType[None]:
+        calls = []
+
+        def fake_control(action: str, args: dict[str, Any], path: Any) -> defer.Deferred[Any]:
+            calls.append((action, args, path))
+            return defer.succeed(None)
+
+        self.master.data.control = fake_control
+        res = yield self._call("cancel_build", {"build_id": 18, "reason": "stop it"})
+        data = self._tool_data(res)
+        self.assertTrue(data["stopped"])
+        self.assertEqual(calls[0][0], "stop")
+        self.assertEqual(calls[0][2], ("builds", 18))
+        self.assertEqual(calls[0][1]["reason"], "stop it")
+
+    @defer.inlineCallbacks
+    def test_cancel_build_not_found(self) -> InlineCallbacksType[None]:
+        res = yield self._call("cancel_build", {"build_id": 999})
+        self.assertTrue(res["result"]["isError"])
+
+    @defer.inlineCallbacks
+    def test_write_tool_authz_denied(self) -> InlineCallbacksType[None]:
+        control_called = []
+        self.master.www.assertUserAllowed = lambda *a: defer.fail(Forbidden(b"need role"))
+
+        def fake_control(*a: Any) -> defer.Deferred[Any]:
+            control_called.append(a)
+            return defer.succeed(None)
+
+        self.master.data.control = fake_control
+        res = yield self._call("cancel_build", {"build_id": 18})
+        self.assertTrue(res["result"]["isError"])
+        # authorization must be checked before any control action runs
+        self.assertEqual(control_called, [])

--- a/master/buildbot/test/unit/www/test_mcp.py
+++ b/master/buildbot/test/unit/www/test_mcp.py
@@ -1,0 +1,43 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.test.reactor import TestReactorMixin
+from buildbot.test.util import www
+from buildbot.www import mcp
+
+if TYPE_CHECKING:
+    from buildbot.util.twisted import InlineCallbacksType
+
+
+class McpResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+    @defer.inlineCallbacks
+    def setUp(self) -> InlineCallbacksType[None]:  # type: ignore[override]
+        self.setup_test_reactor()
+        self.master = yield self.make_master(url=b'h:/a/b/')  # type: ignore[arg-type]
+        self.mcp = mcp.McpResource(self.master)
+
+    @defer.inlineCallbacks
+    def test_not_implemented(self) -> InlineCallbacksType[None]:
+        # The scaffold endpoint is reachable but not yet implemented; it must
+        # respond with a clean 501 rather than erroring.
+        yield self.render_resource(self.mcp, b'/')
+        self.assertRequest(responseCode=501)

--- a/master/buildbot/test/unit/www/test_mcp.py
+++ b/master/buildbot/test/unit/www/test_mcp.py
@@ -22,6 +22,7 @@ from typing import Any
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.test import fakedb
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
 from buildbot.util import bytes2unicode
@@ -144,3 +145,159 @@ class McpProtocol(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         res = self._written_json()
         self.assertEqual(res["id"], 6)
         self.assertEqual(res["result"], {})
+
+
+class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+    @defer.inlineCallbacks
+    def setUp(self) -> InlineCallbacksType[None]:  # type: ignore[override]
+        self.setup_test_reactor()
+        self.master = yield self.make_master(url=b'http://localhost:8010/')  # type: ignore[arg-type]
+        self.mcp = mcp.McpResource(self.master)
+        self.mcp.reconfigResource(self.master.config)
+        yield self.master.db.insert_test_data([
+            fakedb.Builder(id=21, name="builder-a"),
+            fakedb.Builder(id=22, name="builder-b"),
+            fakedb.Master(id=1),
+            fakedb.Worker(id=2, name="worker-1"),
+            fakedb.Buildset(id=17),
+            fakedb.BuildRequest(id=16, buildsetid=17, builderid=21),
+            fakedb.Build(
+                id=15,
+                number=1,
+                buildrequestid=16,
+                masterid=1,
+                workerid=2,
+                builderid=21,
+                complete_at=1304262300,
+                state_string="finished",
+                results=0,
+            ),
+            fakedb.Build(
+                id=18,
+                number=2,
+                buildrequestid=16,
+                masterid=1,
+                workerid=2,
+                builderid=21,
+                state_string="building",
+                results=None,
+            ),
+        ])
+
+    @defer.inlineCallbacks
+    def _call(
+        self, name: str, arguments: dict[str, Any] | None = None, msg_id: int = 1
+    ) -> InlineCallbacksType[dict[str, Any]]:
+        yield self.render_resource(
+            self.mcp,
+            b'/',
+            method=b'POST',
+            content=unicode2bytes(
+                json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "method": "tools/call",
+                    "params": {"name": name, "arguments": arguments or {}},
+                })
+            ),
+            content_type=b'application/json',
+        )
+        return json.loads(bytes2unicode(self.request.written))
+
+    def _tool_data(self, res: dict[str, Any]) -> dict[str, Any]:
+        result = res["result"]
+        self.assertFalse(result.get("isError"), msg=result)
+        return json.loads(result["content"][0]["text"])
+
+    @defer.inlineCallbacks
+    def test_tools_list(self) -> InlineCallbacksType[None]:
+        yield self.render_resource(
+            self.mcp,
+            b'/',
+            method=b'POST',
+            content=unicode2bytes(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})),
+            content_type=b'application/json',
+        )
+        res = json.loads(bytes2unicode(self.request.written))
+        names = {t["name"] for t in res["result"]["tools"]}
+        self.assertEqual(
+            names,
+            {"get_status", "get_builders", "get_workers", "get_recent_builds", "get_build"},
+        )
+
+    @defer.inlineCallbacks
+    def test_get_status(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_status")
+        data = self._tool_data(res)
+        self.assertEqual(data["builders"], 2)
+        self.assertEqual(data["workers"]["total"], 1)
+        self.assertEqual([b["buildid"] for b in data["running_builds"]], [18])
+
+    @defer.inlineCallbacks
+    def test_get_builders(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_builders")
+        data = self._tool_data(res)
+        self.assertEqual(data["total_count"], 2)
+        self.assertFalse(data["has_more"])
+        self.assertEqual([b["name"] for b in data["builders"]], ["builder-a", "builder-b"])
+
+    @defer.inlineCallbacks
+    def test_get_builders_pagination(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_builders", {"limit": 1})
+        data = self._tool_data(res)
+        self.assertEqual(data["returned"], 1)
+        self.assertEqual(data["total_count"], 2)
+        self.assertTrue(data["has_more"])
+
+    @defer.inlineCallbacks
+    def test_get_workers(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_workers")
+        data = self._tool_data(res)
+        self.assertEqual([w["name"] for w in data["workers"]], ["worker-1"])
+        self.assertFalse(data["workers"][0]["connected"])
+
+    @defer.inlineCallbacks
+    def test_get_recent_builds(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_recent_builds")
+        data = self._tool_data(res)
+        self.assertEqual([b["buildid"] for b in data["builds"]], [18, 15])
+
+    @defer.inlineCallbacks
+    def test_get_recent_builds_only_running(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_recent_builds", {"only_running": True})
+        data = self._tool_data(res)
+        self.assertEqual([b["buildid"] for b in data["builds"]], [18])
+
+    @defer.inlineCallbacks
+    def test_get_recent_builds_by_builder(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_recent_builds", {"builder": "builder-a"})
+        data = self._tool_data(res)
+        self.assertEqual(sorted(b["buildid"] for b in data["builds"]), [15, 18])
+
+    @defer.inlineCallbacks
+    def test_get_recent_builds_unknown_builder(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_recent_builds", {"builder": "nope"})
+        self.assertTrue(res["result"]["isError"])
+
+    @defer.inlineCallbacks
+    def test_get_build(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_build", {"build_id": 15})
+        data = self._tool_data(res)
+        self.assertEqual(data["build"]["buildid"], 15)
+        self.assertEqual(data["build"]["result"], "success")
+
+    @defer.inlineCallbacks
+    def test_get_build_running_label(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_build", {"build_id": 18})
+        data = self._tool_data(res)
+        self.assertEqual(data["build"]["result"], "running")
+
+    @defer.inlineCallbacks
+    def test_get_build_not_found(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_build", {"build_id": 999})
+        self.assertTrue(res["result"]["isError"])
+
+    @defer.inlineCallbacks
+    def test_unknown_tool(self) -> InlineCallbacksType[None]:
+        res = yield self._call("does_not_exist")
+        self.assertEqual(res["error"]["code"], -32602)

--- a/master/buildbot/test/unit/www/test_mcp.py
+++ b/master/buildbot/test/unit/www/test_mcp.py
@@ -182,6 +182,22 @@ class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
                 state_string="building",
                 results=None,
             ),
+            fakedb.Step(id=50, number=0, name="compile", buildid=15),
+            fakedb.Log(id=60, stepid=50, name="text", slug="text", type="t", num_lines=4),
+            fakedb.LogChunk(
+                logid=60,
+                first_line=0,
+                last_line=3,
+                content="alpha\nbeta\nERROR boom\ngamma",
+            ),
+            # a stdio (type 's') log: each line carries a leading channel char
+            fakedb.Log(id=61, stepid=50, name="stdio", slug="stdio", type="s", num_lines=3),
+            fakedb.LogChunk(
+                logid=61,
+                first_line=0,
+                last_line=2,
+                content="ohello\neoops ERROR\nodone",
+            ),
         ])
 
     @defer.inlineCallbacks
@@ -222,7 +238,14 @@ class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         names = {t["name"] for t in res["result"]["tools"]}
         self.assertEqual(
             names,
-            {"get_status", "get_builders", "get_workers", "get_recent_builds", "get_build"},
+            {
+                "get_status",
+                "get_builders",
+                "get_workers",
+                "get_recent_builds",
+                "get_build",
+                "get_build_logs",
+            },
         )
 
     @defer.inlineCallbacks
@@ -301,3 +324,56 @@ class McpTools(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def test_unknown_tool(self) -> InlineCallbacksType[None]:
         res = yield self._call("does_not_exist")
         self.assertEqual(res["error"]["code"], -32602)
+
+    @defer.inlineCallbacks
+    def test_get_build_logs_manifest(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_build_logs", {"build_id": 15})
+        data = self._tool_data(res)
+        self.assertEqual(data["build_id"], 15)
+        self.assertEqual({lg["slug"] for lg in data["logs"]}, {"text", "stdio"})
+        self.assertTrue(all(lg["step"] == 0 for lg in data["logs"]))
+
+    @defer.inlineCallbacks
+    def test_get_build_logs_content_text(self) -> InlineCallbacksType[None]:
+        # a text (type 't') log is returned verbatim, with no stripping
+        res = yield self._call("get_build_logs", {"build_id": 15, "step": 0, "log": "text"})
+        data = self._tool_data(res)
+        self.assertEqual(data["lines_returned"], 4)
+        self.assertIn("alpha", data["content"])
+        self.assertIn("ERROR boom", data["content"])
+
+    @defer.inlineCallbacks
+    def test_get_build_logs_search_text(self) -> InlineCallbacksType[None]:
+        res = yield self._call(
+            "get_build_logs", {"build_id": 15, "step": 0, "log": "text", "query": "ERROR"}
+        )
+        data = self._tool_data(res)
+        self.assertEqual(data["match_count"], 1)
+        self.assertIn("ERROR boom", data["matches"][0]["text"])
+        self.assertEqual(data["matches"][0]["line"], 2)
+
+    @defer.inlineCallbacks
+    def test_get_build_logs_content_stdio_strips_channel(self) -> InlineCallbacksType[None]:
+        # stdio (type 's') lines carry a leading channel char (o/e/h) which must
+        # be stripped from the returned content.
+        res = yield self._call("get_build_logs", {"build_id": 15, "step": 0, "log": "stdio"})
+        data = self._tool_data(res)
+        self.assertEqual(data["lines_returned"], 3)
+        self.assertEqual(data["content"], "hello\noops ERROR\ndone")
+        self.assertNotIn("ohello", data["content"])
+
+    @defer.inlineCallbacks
+    def test_get_build_logs_search_stdio_strips_channel(self) -> InlineCallbacksType[None]:
+        res = yield self._call(
+            "get_build_logs", {"build_id": 15, "step": 0, "log": "stdio", "query": "ERROR"}
+        )
+        data = self._tool_data(res)
+        self.assertEqual(data["match_count"], 1)
+        # the matched text is the line without its leading channel character
+        self.assertEqual(data["matches"][0]["text"], "oops ERROR")
+        self.assertEqual(data["matches"][0]["line"], 1)
+
+    @defer.inlineCallbacks
+    def test_get_build_logs_unknown_build(self) -> InlineCallbacksType[None]:
+        res = yield self._call("get_build_logs", {"build_id": 999})
+        self.assertTrue(res["result"]["isError"])

--- a/master/buildbot/test/unit/www/test_mcp.py
+++ b/master/buildbot/test/unit/www/test_mcp.py
@@ -15,29 +15,132 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
+from typing import Any
 
 from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
+from buildbot.util import bytes2unicode
+from buildbot.util import unicode2bytes
 from buildbot.www import mcp
 
 if TYPE_CHECKING:
     from buildbot.util.twisted import InlineCallbacksType
 
 
-class McpResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+class McpProtocol(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self) -> InlineCallbacksType[None]:  # type: ignore[override]
         self.setup_test_reactor()
-        self.master = yield self.make_master(url=b'h:/a/b/')  # type: ignore[arg-type]
+        self.master = yield self.make_master(url=b'http://localhost:8010/')  # type: ignore[arg-type]
         self.mcp = mcp.McpResource(self.master)
+        self.mcp.reconfigResource(self.master.config)
+
+    def _post(self, body: dict[str, Any], **kwargs: Any) -> defer.Deferred[Any]:
+        return self.render_resource(
+            self.mcp,
+            b'/',
+            method=b'POST',
+            content=unicode2bytes(json.dumps(body)),
+            content_type=b'application/json',
+            **kwargs,
+        )
+
+    def _written_json(self) -> dict[str, Any]:
+        return json.loads(bytes2unicode(self.request.written))
 
     @defer.inlineCallbacks
-    def test_not_implemented(self) -> InlineCallbacksType[None]:
-        # The scaffold endpoint is reachable but not yet implemented; it must
-        # respond with a clean 501 rather than erroring.
-        yield self.render_resource(self.mcp, b'/')
-        self.assertRequest(responseCode=501)
+    def test_initialize(self) -> InlineCallbacksType[None]:
+        yield self._post({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0"},
+            },
+        })
+        res = self._written_json()
+        self.assertEqual(res["jsonrpc"], "2.0")
+        self.assertEqual(res["id"], 1)
+        self.assertEqual(res["result"]["protocolVersion"], "2025-11-25")
+        self.assertEqual(res["result"]["serverInfo"]["name"], "buildbot")
+        self.assertIn("capabilities", res["result"])
+
+    @defer.inlineCallbacks
+    def test_initialize_unknown_version_falls_back(self) -> InlineCallbacksType[None]:
+        yield self._post({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "1999-01-01", "capabilities": {}},
+        })
+        res = self._written_json()
+        self.assertEqual(res["result"]["protocolVersion"], "2025-11-25")
+
+    @defer.inlineCallbacks
+    def test_ping(self) -> InlineCallbacksType[None]:
+        yield self._post({"jsonrpc": "2.0", "id": 2, "method": "ping"})
+        res = self._written_json()
+        self.assertEqual(res["id"], 2)
+        self.assertEqual(res["result"], {})
+
+    @defer.inlineCallbacks
+    def test_initialized_notification(self) -> InlineCallbacksType[None]:
+        yield self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        self.assertEqual(self.request.responseCode, 202)
+        self.assertEqual(self.request.written, b'')
+
+    @defer.inlineCallbacks
+    def test_method_not_found(self) -> InlineCallbacksType[None]:
+        yield self._post({"jsonrpc": "2.0", "id": 3, "method": "does/not/exist"})
+        res = self._written_json()
+        self.assertEqual(res["id"], 3)
+        self.assertEqual(res["error"]["code"], -32601)
+
+    @defer.inlineCallbacks
+    def test_parse_error(self) -> InlineCallbacksType[None]:
+        yield self.render_resource(
+            self.mcp,
+            b'/',
+            method=b'POST',
+            content=b'{ this is not json',
+            content_type=b'application/json',
+        )
+        res = self._written_json()
+        self.assertEqual(self.request.responseCode, 400)
+        self.assertEqual(res["error"]["code"], -32700)
+
+    @defer.inlineCallbacks
+    def test_invalid_jsonrpc_version(self) -> InlineCallbacksType[None]:
+        yield self._post({"jsonrpc": "1.0", "id": 4, "method": "ping"})
+        res = self._written_json()
+        self.assertEqual(res["error"]["code"], -32600)
+
+    @defer.inlineCallbacks
+    def test_get_not_allowed(self) -> InlineCallbacksType[None]:
+        yield self.render_resource(self.mcp, b'/', method=b'GET')
+        self.assertEqual(self.request.responseCode, 405)
+
+    @defer.inlineCallbacks
+    def test_invalid_origin_rejected(self) -> InlineCallbacksType[None]:
+        yield self._post(
+            {"jsonrpc": "2.0", "id": 5, "method": "ping"},
+            origin=b'http://evil.example.com',
+        )
+        self.assertEqual(self.request.responseCode, 403)
+
+    @defer.inlineCallbacks
+    def test_matching_origin_allowed(self) -> InlineCallbacksType[None]:
+        yield self._post(
+            {"jsonrpc": "2.0", "id": 6, "method": "ping"},
+            origin=b'http://localhost:8010',
+        )
+        res = self._written_json()
+        self.assertEqual(res["id"], 6)
+        self.assertEqual(res["result"], {})

--- a/master/buildbot/www/mcp/__init__.py
+++ b/master/buildbot/www/mcp/__init__.py
@@ -1,0 +1,3 @@
+from buildbot.www.mcp.server import McpResource
+
+__all__ = ["McpResource"]

--- a/master/buildbot/www/mcp/server.py
+++ b/master/buildbot/www/mcp/server.py
@@ -15,26 +15,212 @@
 
 from __future__ import annotations
 
+import fnmatch
+import json
+import re
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from urllib.parse import urlparse
 
+from twisted.internet import defer
+from twisted.python import log
+
+from buildbot.util import bytes2unicode
+from buildbot.util import unicode2bytes
 from buildbot.www import resource
 
 if TYPE_CHECKING:
     from twisted.web import server
 
+    from buildbot.master import BuildMaster
+
+# The MCP protocol revision this server implements.
+PROTOCOL_VERSION = "2025-11-25"
+SUPPORTED_PROTOCOL_VERSIONS = (PROTOCOL_VERSION,)
+
+JSONRPC_VERSION = "2.0"
+
+# JSON-RPC 2.0 error codes (https://www.jsonrpc.org/specification#error_object)
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+
+class JsonRpcError(Exception):
+    # Raised by a method handler to produce a JSON-RPC error response.
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
 
 class McpResource(resource.Resource):
     # Model Context Protocol (MCP) server endpoint, mounted at ``/mcp``.
     #
-    # This is the initial scaffold: the endpoint is registered and reachable so
-    # that the wiring (the ``c['www']['mcp']`` config key and the www
-    # registration) can be reviewed in isolation. The protocol implementation
-    # -- JSON-RPC 2.0 framing, the ``initialize`` handshake, tool dispatch and
-    # SSE streaming -- lands in subsequent commits. Until then every request
-    # gets a clean 501 Not Implemented.
+    # Implements the Streamable HTTP transport for MCP revision 2025-11-25: a
+    # single endpoint serving POST (client -> server JSON-RPC messages) and GET
+    # (an optional server -> client SSE stream). This layer provides the
+    # protocol mechanics -- JSON-RPC 2.0 framing, the initialize/initialized
+    # lifecycle, ping, method dispatch and Origin validation. Tools and live
+    # log streaming register handlers on top of it in later commits.
     isLeaf = True
+    needsReconfig = True
 
-    def render(self, request: server.Request) -> bytes:
-        request.setResponseCode(501)
+    def __init__(self, master: BuildMaster) -> None:
+        super().__init__(master)
+        self.origins: list[re.Pattern[str]] = []
+        # method name -> handler(params) -> result (may return a Deferred)
+        self._methods: dict[str, Callable[[dict[str, Any]], Any]] = {
+            'initialize': self._handle_initialize,
+            'ping': self._handle_ping,
+        }
+        # notification name -> handler(params) -> None (may return a Deferred)
+        self._notifications: dict[str, Callable[[dict[str, Any]], Any]] = {
+            'notifications/initialized': self._handle_initialized,
+        }
+
+    def reconfigResource(self, new_config: Any) -> None:
+        # Mirror RestRootResource: the default allowed origin is the buildbot
+        # URL's scheme://host[:port]; additional origins come from config.
+        buildbotURL = urlparse(unicode2bytes(new_config.buildbotURL))
+        origin_self = buildbotURL.scheme + b"://" + buildbotURL.netloc
+        self.origins = []
+        for o in new_config.www.get('allowed_origins', [origin_self]):
+            origin = bytes2unicode(o).lower()
+            self.origins.append(re.compile(fnmatch.translate(origin)))
+
+    # -- transport --------------------------------------------------------
+
+    def _is_origin_allowed(self, request: server.Request) -> bool:
+        # The MCP spec requires servers to validate the Origin header to guard
+        # against DNS-rebinding attacks. Non-browser MCP clients usually send
+        # no Origin (allowed); browsers send one, which must match the config.
+        req_origin = request.getHeader(b'origin')
+        if not req_origin:
+            return True
+        req_origin_str = bytes2unicode(req_origin).lower()
+        return any(o.match(req_origin_str) for o in self.origins)
+
+    def _json_response(self, request: server.Request, code: int, payload: dict[str, Any]) -> bytes:
+        request.setResponseCode(code)
+        request.setHeader(b'content-type', b'application/json; charset=utf-8')
+        return unicode2bytes(json.dumps(payload))
+
+    @staticmethod
+    def _error_obj(msg_id: Any, code: int, message: str, data: Any = None) -> dict[str, Any]:
+        error: dict[str, Any] = {"code": code, "message": message}
+        if data is not None:
+            error["data"] = data
+        return {"jsonrpc": JSONRPC_VERSION, "id": msg_id, "error": error}
+
+    def render_GET(self, request: server.Request) -> bytes:
+        # No unsolicited server -> client SSE stream is offered yet; the spec
+        # allows responding with 405 in that case.
+        if not self._is_origin_allowed(request):
+            return self._json_response(
+                request, 403, self._error_obj(None, INVALID_REQUEST, "invalid origin")
+            )
+        request.setResponseCode(405)
         request.setHeader(b'content-type', b'text/plain; charset=utf-8')
-        return b'MCP server not implemented yet\n'
+        return b'GET (server-initiated SSE stream) not supported\n'
+
+    def render_POST(self, request: server.Request) -> int:
+        return self.asyncRenderHelper(request, self.renderMcp)
+
+    @defer.inlineCallbacks
+    def renderMcp(self, request: server.Request) -> Any:
+        if not self._is_origin_allowed(request):
+            return self._json_response(
+                request, 403, self._error_obj(None, INVALID_REQUEST, "invalid origin")
+            )
+
+        raw = request.content.read() if request.content is not None else b''
+        try:
+            message = json.loads(bytes2unicode(raw))
+        except (ValueError, TypeError):
+            return self._json_response(
+                request, 400, self._error_obj(None, PARSE_ERROR, "parse error")
+            )
+
+        # MCP sends one JSON-RPC message per request; batches are not used.
+        if not isinstance(message, dict):
+            return self._json_response(
+                request, 400, self._error_obj(None, INVALID_REQUEST, "invalid request")
+            )
+
+        method = message.get('method')
+
+        # Notifications (method, no id) and client responses (no method) are
+        # acknowledged with a bare 202 Accepted per the Streamable HTTP spec.
+        if not isinstance(method, str) or 'id' not in message:
+            if isinstance(method, str) and method in self._notifications:
+                try:
+                    yield defer.maybeDeferred(
+                        self._notifications[method], message.get('params') or {}
+                    )
+                except Exception as e:
+                    log.err(e, 'while handling MCP notification')
+            request.setResponseCode(202)
+            return b''
+
+        msg_id = message.get('id')
+        if message.get('jsonrpc') != JSONRPC_VERSION:
+            return self._json_response(
+                request, 200, self._error_obj(msg_id, INVALID_REQUEST, "invalid request")
+            )
+
+        handler = self._methods.get(method)
+        if handler is None:
+            return self._json_response(
+                request,
+                200,
+                self._error_obj(msg_id, METHOD_NOT_FOUND, f"method not found: {method}"),
+            )
+
+        params = message.get('params') or {}
+        try:
+            result = yield defer.maybeDeferred(handler, params)
+        except JsonRpcError as e:
+            return self._json_response(
+                request, 200, self._error_obj(msg_id, e.code, e.message, e.data)
+            )
+        except Exception as e:
+            log.err(e, 'while handling MCP request')
+            return self._json_response(
+                request, 200, self._error_obj(msg_id, INTERNAL_ERROR, "internal error")
+            )
+
+        return self._json_response(
+            request, 200, {"jsonrpc": JSONRPC_VERSION, "id": msg_id, "result": result}
+        )
+
+    # -- method handlers --------------------------------------------------
+
+    def _handle_initialize(self, params: dict[str, Any]) -> dict[str, Any]:
+        from buildbot import version as bbversion  # noqa: PLC0415
+
+        # Version negotiation: echo the client's version if we support it,
+        # otherwise respond with our latest supported version.
+        requested = params.get('protocolVersion')
+        version = requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
+        return {
+            "protocolVersion": version,
+            # Server capabilities (tools, resources) are declared as they are
+            # implemented in later commits.
+            "capabilities": {},
+            "serverInfo": {
+                "name": "buildbot",
+                "version": bbversion,
+            },
+        }
+
+    def _handle_ping(self, params: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    def _handle_initialized(self, params: dict[str, Any]) -> None:
+        # The client signals it is ready for normal operation; nothing to do.
+        return None

--- a/master/buildbot/www/mcp/server.py
+++ b/master/buildbot/www/mcp/server.py
@@ -30,6 +30,7 @@ from buildbot.util import bytes2unicode
 from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 from buildbot.www import resource
+from buildbot.www.authz import Forbidden
 from buildbot.www.mcp.tools import McpTools
 from buildbot.www.mcp.tools import ToolError
 
@@ -77,15 +78,15 @@ class McpResource(resource.Resource):
         super().__init__(master)
         self.origins: list[re.Pattern[str]] = []
         self.tools = McpTools(master)
-        # method name -> handler(params) -> result (may return a Deferred)
-        self._methods: dict[str, Callable[[dict[str, Any]], Any]] = {
+        # method name -> handler(params, request) -> result (may return a Deferred)
+        self._methods: dict[str, Callable[..., Any]] = {
             'initialize': self._handle_initialize,
             'ping': self._handle_ping,
             'tools/list': self._handle_tools_list,
             'tools/call': self._handle_tools_call,
         }
-        # notification name -> handler(params) -> None (may return a Deferred)
-        self._notifications: dict[str, Callable[[dict[str, Any]], Any]] = {
+        # notification name -> handler(params, request) -> None (may return a Deferred)
+        self._notifications: dict[str, Callable[..., Any]] = {
             'notifications/initialized': self._handle_initialized,
         }
 
@@ -167,7 +168,7 @@ class McpResource(resource.Resource):
             if isinstance(method, str) and method in self._notifications:
                 try:
                     yield defer.maybeDeferred(
-                        self._notifications[method], message.get('params') or {}
+                        self._notifications[method], message.get('params') or {}, request
                     )
                 except Exception as e:
                     log.err(e, 'while handling MCP notification')
@@ -190,7 +191,7 @@ class McpResource(resource.Resource):
 
         params = message.get('params') or {}
         try:
-            result = yield defer.maybeDeferred(handler, params)
+            result = yield defer.maybeDeferred(handler, params, request)
         except JsonRpcError as e:
             return self._json_response(
                 request, 200, self._error_obj(msg_id, e.code, e.message, e.data)
@@ -207,7 +208,7 @@ class McpResource(resource.Resource):
 
     # -- method handlers --------------------------------------------------
 
-    def _handle_initialize(self, params: dict[str, Any]) -> dict[str, Any]:
+    def _handle_initialize(self, params: dict[str, Any], request: server.Request) -> dict[str, Any]:
         from buildbot import version as bbversion  # noqa: PLC0415
 
         # Version negotiation: echo the client's version if we support it,
@@ -225,24 +226,30 @@ class McpResource(resource.Resource):
             },
         }
 
-    def _handle_ping(self, params: dict[str, Any]) -> dict[str, Any]:
+    def _handle_ping(self, params: dict[str, Any], request: server.Request) -> dict[str, Any]:
         return {}
 
-    def _handle_initialized(self, params: dict[str, Any]) -> None:
+    def _handle_initialized(self, params: dict[str, Any], request: server.Request) -> None:
         # The client signals it is ready for normal operation; nothing to do.
         return None
 
-    def _handle_tools_list(self, params: dict[str, Any]) -> dict[str, Any]:
+    def _handle_tools_list(self, params: dict[str, Any], request: server.Request) -> dict[str, Any]:
         return {"tools": self.tools.list_tools()}
 
     @defer.inlineCallbacks
-    def _handle_tools_call(self, params: dict[str, Any]) -> Any:
+    def _handle_tools_call(self, params: dict[str, Any], request: server.Request) -> Any:
         name = params.get('name')
         if not isinstance(name, str) or not self.tools.has_tool(name):
             raise JsonRpcError(INVALID_PARAMS, f"unknown tool: {name}")
         arguments = params.get('arguments') or {}
         try:
-            data = yield self.tools.call_tool(name, arguments)
+            data = yield self.tools.call_tool(name, arguments, request)
+        except Forbidden:
+            # Authorization failure -> report as a tool error result.
+            return {
+                "content": [{"type": "text", "text": "permission denied"}],
+                "isError": True,
+            }
         except ToolError as e:
             # Tool-level errors are reported inside the result, not as a
             # protocol error, per the MCP tools specification.

--- a/master/buildbot/www/mcp/server.py
+++ b/master/buildbot/www/mcp/server.py
@@ -1,0 +1,40 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from buildbot.www import resource
+
+if TYPE_CHECKING:
+    from twisted.web import server
+
+
+class McpResource(resource.Resource):
+    # Model Context Protocol (MCP) server endpoint, mounted at ``/mcp``.
+    #
+    # This is the initial scaffold: the endpoint is registered and reachable so
+    # that the wiring (the ``c['www']['mcp']`` config key and the www
+    # registration) can be reviewed in isolation. The protocol implementation
+    # -- JSON-RPC 2.0 framing, the ``initialize`` handshake, tool dispatch and
+    # SSE streaming -- lands in subsequent commits. Until then every request
+    # gets a clean 501 Not Implemented.
+    isLeaf = True
+
+    def render(self, request: server.Request) -> bytes:
+        request.setResponseCode(501)
+        request.setHeader(b'content-type', b'text/plain; charset=utf-8')
+        return b'MCP server not implemented yet\n'

--- a/master/buildbot/www/mcp/server.py
+++ b/master/buildbot/www/mcp/server.py
@@ -27,8 +27,11 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot.util import bytes2unicode
+from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 from buildbot.www import resource
+from buildbot.www.mcp.tools import McpTools
+from buildbot.www.mcp.tools import ToolError
 
 if TYPE_CHECKING:
     from twisted.web import server
@@ -73,10 +76,13 @@ class McpResource(resource.Resource):
     def __init__(self, master: BuildMaster) -> None:
         super().__init__(master)
         self.origins: list[re.Pattern[str]] = []
+        self.tools = McpTools(master)
         # method name -> handler(params) -> result (may return a Deferred)
         self._methods: dict[str, Callable[[dict[str, Any]], Any]] = {
             'initialize': self._handle_initialize,
             'ping': self._handle_ping,
+            'tools/list': self._handle_tools_list,
+            'tools/call': self._handle_tools_call,
         }
         # notification name -> handler(params) -> None (may return a Deferred)
         self._notifications: dict[str, Callable[[dict[str, Any]], Any]] = {
@@ -92,6 +98,7 @@ class McpResource(resource.Resource):
         for o in new_config.www.get('allowed_origins', [origin_self]):
             origin = bytes2unicode(o).lower()
             self.origins.append(re.compile(fnmatch.translate(origin)))
+        self.tools.reset_caches()
 
     # -- transport --------------------------------------------------------
 
@@ -209,9 +216,9 @@ class McpResource(resource.Resource):
         version = requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
         return {
             "protocolVersion": version,
-            # Server capabilities (tools, resources) are declared as they are
-            # implemented in later commits.
-            "capabilities": {},
+            # Resource capabilities (live log streaming) are added in a later
+            # commit; tools are available now.
+            "capabilities": {"tools": {}},
             "serverInfo": {
                 "name": "buildbot",
                 "version": bbversion,
@@ -224,3 +231,23 @@ class McpResource(resource.Resource):
     def _handle_initialized(self, params: dict[str, Any]) -> None:
         # The client signals it is ready for normal operation; nothing to do.
         return None
+
+    def _handle_tools_list(self, params: dict[str, Any]) -> dict[str, Any]:
+        return {"tools": self.tools.list_tools()}
+
+    @defer.inlineCallbacks
+    def _handle_tools_call(self, params: dict[str, Any]) -> Any:
+        name = params.get('name')
+        if not isinstance(name, str) or not self.tools.has_tool(name):
+            raise JsonRpcError(INVALID_PARAMS, f"unknown tool: {name}")
+        arguments = params.get('arguments') or {}
+        try:
+            data = yield self.tools.call_tool(name, arguments)
+        except ToolError as e:
+            # Tool-level errors are reported inside the result, not as a
+            # protocol error, per the MCP tools specification.
+            return {"content": [{"type": "text", "text": str(e)}], "isError": True}
+        return {
+            "content": [{"type": "text", "text": json.dumps(data, default=toJson)}],
+            "isError": False,
+        }

--- a/master/buildbot/www/mcp/tools.py
+++ b/master/buildbot/www/mcp/tools.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -30,6 +31,13 @@ if TYPE_CHECKING:
 # tool call cannot overrun an LLM's context window.
 DEFAULT_LIMIT = 25
 MAX_LIMIT = 100
+
+# Log content bounds (in lines).
+DEFAULT_LOG_LINES = 200
+MAX_LOG_LINES = 1000
+# When searching, cap how many lines are scanned and how many matches returned.
+MAX_SEARCH_LINES = 5000
+MAX_MATCHES = 100
 
 
 class ToolError(Exception):
@@ -128,6 +136,47 @@ class McpTools:
                     "required": ["build_id"],
                 },
                 "handler": self.get_build,
+            },
+            "get_build_logs": {
+                "description": (
+                    "Inspect the logs of a build. Called with only build_id, it lists the "
+                    "available logs (per step). Pass step (number) and log (slug) to fetch "
+                    "that log's contents, paginated by line. Add query to return only the "
+                    "lines matching a regular expression (or substring)."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "build_id": {
+                            "type": "integer",
+                            "description": "The numeric build id (buildid).",
+                        },
+                        "step": {
+                            "type": "integer",
+                            "description": "Step number within the build (from the log listing).",
+                        },
+                        "log": {
+                            "type": "string",
+                            "description": "Log slug within the step (from the log listing).",
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Optional regex (or substring) to return only matching lines."
+                            ),
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "description": "First line to read (default 0).",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Max lines to return in content mode (default 200, cap 1000).",
+                        },
+                    },
+                    "required": ["build_id"],
+                },
+                "handler": self.get_build_logs,
             },
         }
 
@@ -301,4 +350,126 @@ class McpTools:
                 }
                 for s in steps
             ],
+        }
+
+    @defer.inlineCallbacks
+    def get_build_logs(self, args: dict[str, Any]) -> Any:
+        build_id = args.get('build_id')
+        if build_id is None:
+            raise ToolError("build_id is required")
+        build = yield self.master.data.get(('builds', build_id))
+        if build is None:
+            raise ToolError(f"no build with id {build_id}")
+
+        step = args.get('step')
+        log_slug = args.get('log')
+
+        # Without a specific step+log, list the logs available in the build.
+        if step is None or log_slug is None:
+            manifest = yield self._build_log_manifest(build_id)
+            return {"build_id": build_id, "logs": manifest}
+
+        log_path = ('builds', build_id, 'steps', step, 'logs', log_slug)
+        log_dict = yield self.master.data.get(log_path)
+        if log_dict is None:
+            raise ToolError(f"no log '{log_slug}' in step {step} of build {build_id}")
+        # stdio logs (type 's') store a per-line stream channel prefix (o/e/h);
+        # strip it so callers get clean text, mirroring Buildbot's raw-log
+        # endpoint (buildbot.data.logchunks.LogChunkEndpointBase.get_log_lines).
+        is_stdio = log_dict.get('type') == 's'
+
+        contents_path = (*log_path, 'contents')
+        query = args.get('query')
+        if query:
+            result = yield self._search_log(contents_path, query, args, is_stdio)
+        else:
+            result = yield self._fetch_log(contents_path, args, is_stdio)
+        return result
+
+    @staticmethod
+    def _split_log_lines(content: str, is_stdio: bool) -> list[str]:
+        lines = content.splitlines()
+        if is_stdio:
+            # drop the leading stream-channel character from each stdio line
+            lines = [line[1:] for line in lines]
+        return lines
+
+    @defer.inlineCallbacks
+    def _build_log_manifest(self, build_id: Any) -> Any:
+        steps = yield self.master.data.get(('builds', build_id, 'steps'))
+        manifest = []
+        for s in steps:
+            logs = yield self.master.data.get(('steps', s['stepid'], 'logs'))
+            for lg in logs:
+                manifest.append({
+                    "step": s["number"],
+                    "step_name": s["name"],
+                    "name": lg["name"],
+                    "slug": lg["slug"],
+                    "type": lg["type"],
+                    "num_lines": lg["num_lines"],
+                    "complete": lg["complete"],
+                })
+        return manifest
+
+    @defer.inlineCallbacks
+    def _fetch_log(self, path: tuple[Any, ...], args: dict[str, Any], is_stdio: bool) -> Any:
+        try:
+            offset = max(0, int(args.get('offset', 0)))
+        except (TypeError, ValueError):
+            offset = 0
+        try:
+            limit = int(args.get('limit', DEFAULT_LOG_LINES))
+        except (TypeError, ValueError):
+            limit = DEFAULT_LOG_LINES
+        limit = max(1, min(limit, MAX_LOG_LINES))
+
+        chunk = yield self.master.data.get(path, offset=offset, limit=limit)
+        if chunk is None:
+            return {"firstline": offset, "lines_returned": 0, "content": ""}
+        lines = self._split_log_lines(chunk.get('content', ''), is_stdio)
+        return {
+            "firstline": chunk.get('firstline', offset),
+            "lines_returned": len(lines),
+            "content": "\n".join(lines),
+        }
+
+    @defer.inlineCallbacks
+    def _search_log(
+        self, path: tuple[Any, ...], query: str, args: dict[str, Any], is_stdio: bool
+    ) -> Any:
+        try:
+            pattern = re.compile(query)
+        except re.error:
+            # Fall back to a literal substring search on an invalid regex.
+            pattern = re.compile(re.escape(query))
+        try:
+            offset = max(0, int(args.get('offset', 0)))
+        except (TypeError, ValueError):
+            offset = 0
+
+        chunk = yield self.master.data.get(path, offset=offset, limit=MAX_SEARCH_LINES)
+        if chunk is None:
+            return {
+                "query": query,
+                "scanned_lines": 0,
+                "match_count": 0,
+                "matches": [],
+                "truncated_matches": False,
+                "scan_capped": False,
+            }
+        firstline = chunk.get('firstline', offset)
+        lines = self._split_log_lines(chunk.get('content', ''), is_stdio)
+        matches = [
+            {"line": firstline + i, "text": line}
+            for i, line in enumerate(lines)
+            if pattern.search(line)
+        ]
+        return {
+            "query": query,
+            "scanned_lines": len(lines),
+            "match_count": len(matches),
+            "matches": matches[:MAX_MATCHES],
+            "truncated_matches": len(matches) > MAX_MATCHES,
+            "scan_capped": len(lines) >= MAX_SEARCH_LINES,
         }

--- a/master/buildbot/www/mcp/tools.py
+++ b/master/buildbot/www/mcp/tools.py
@@ -178,6 +178,55 @@ class McpTools:
                 },
                 "handler": self.get_build_logs,
             },
+            "force_build": {
+                "description": (
+                    "Trigger a build by invoking a force scheduler. Provide the force "
+                    "scheduler name; optionally a builder name and extra parameters "
+                    "(e.g. branch, revision). Requires force permission."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "scheduler": {
+                            "type": "string",
+                            "description": "Name of the force scheduler to invoke.",
+                        },
+                        "builder": {
+                            "type": "string",
+                            "description": "Builder name to build (optional; resolved to builderid).",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Reason recorded for the build (optional).",
+                        },
+                        "params": {
+                            "type": "object",
+                            "description": "Extra force-scheduler parameters (e.g. branch, revision).",
+                            "additionalProperties": True,
+                        },
+                    },
+                    "required": ["scheduler"],
+                },
+                "handler": self.force_build,
+            },
+            "cancel_build": {
+                "description": "Stop a running build by its build id. Requires stop permission.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "build_id": {
+                            "type": "integer",
+                            "description": "The numeric build id (buildid) to stop.",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Reason recorded for stopping (optional).",
+                        },
+                    },
+                    "required": ["build_id"],
+                },
+                "handler": self.cancel_build,
+            },
         }
 
     def list_tools(self) -> list[dict[str, Any]]:
@@ -193,11 +242,18 @@ class McpTools:
     def has_tool(self, name: str) -> bool:
         return name in self._tools
 
-    def call_tool(self, name: str, arguments: dict[str, Any]) -> defer.Deferred[Any]:
+    def call_tool(self, name: str, arguments: dict[str, Any], request: Any) -> defer.Deferred[Any]:
         spec = self._tools.get(name)
         if spec is None:
             raise ToolError(f"unknown tool: {name}")
-        return defer.maybeDeferred(spec["handler"], arguments or {})
+        return defer.maybeDeferred(spec["handler"], arguments or {}, request)
+
+    def _assert_allowed(
+        self, request: Any, ep: tuple[Any, ...], action: str, args: dict[str, Any]
+    ) -> defer.Deferred[Any]:
+        # Route through Buildbot's authorization exactly as the REST layer does
+        # (www/rest.py): never call data.control() without this check first.
+        return defer.maybeDeferred(self.master.www.assertUserAllowed, request, ep, action, args)
 
     # -- helpers ----------------------------------------------------------
 
@@ -250,7 +306,7 @@ class McpTools:
     # -- tool handlers ----------------------------------------------------
 
     @defer.inlineCallbacks
-    def get_status(self, args: dict[str, Any]) -> Any:
+    def get_status(self, args: dict[str, Any], request: Any) -> Any:
         builders = yield self.master.data.get(('builders',))
         workers = yield self.master.data.get(('workers',))
         running = yield self.master.data.get(
@@ -275,7 +331,7 @@ class McpTools:
         }
 
     @defer.inlineCallbacks
-    def get_builders(self, args: dict[str, Any]) -> Any:
+    def get_builders(self, args: dict[str, Any], request: Any) -> Any:
         limit, offset = self._paginate(args)
         builders = yield self.master.data.get(
             ('builders',), order=['name'], limit=limit, offset=offset
@@ -295,7 +351,7 @@ class McpTools:
         }
 
     @defer.inlineCallbacks
-    def get_workers(self, args: dict[str, Any]) -> Any:
+    def get_workers(self, args: dict[str, Any], request: Any) -> Any:
         limit, offset = self._paginate(args)
         workers = yield self.master.data.get(
             ('workers',), order=['name'], limit=limit, offset=offset
@@ -312,7 +368,7 @@ class McpTools:
         return {"workers": items, **self._page_meta(items, getattr(workers, 'total', None), offset)}
 
     @defer.inlineCallbacks
-    def get_recent_builds(self, args: dict[str, Any]) -> Any:
+    def get_recent_builds(self, args: dict[str, Any], request: Any) -> Any:
         limit, offset = self._paginate(args)
         filters = []
         if args.get('only_running'):
@@ -331,7 +387,7 @@ class McpTools:
         return {"builds": items, **self._page_meta(items, getattr(builds, 'total', None), offset)}
 
     @defer.inlineCallbacks
-    def get_build(self, args: dict[str, Any]) -> Any:
+    def get_build(self, args: dict[str, Any], request: Any) -> Any:
         build_id = args.get('build_id')
         if build_id is None:
             raise ToolError("build_id is required")
@@ -353,7 +409,7 @@ class McpTools:
         }
 
     @defer.inlineCallbacks
-    def get_build_logs(self, args: dict[str, Any]) -> Any:
+    def get_build_logs(self, args: dict[str, Any], request: Any) -> Any:
         build_id = args.get('build_id')
         if build_id is None:
             raise ToolError("build_id is required")
@@ -473,3 +529,44 @@ class McpTools:
             "truncated_matches": len(matches) > MAX_MATCHES,
             "scan_capped": len(lines) >= MAX_SEARCH_LINES,
         }
+
+    # -- write tool handlers ----------------------------------------------
+
+    @defer.inlineCallbacks
+    def force_build(self, args: dict[str, Any], request: Any) -> Any:
+        scheduler = args.get('scheduler')
+        if not scheduler:
+            raise ToolError("scheduler is required (the name of a force scheduler)")
+
+        force_args = dict(args.get('params') or {})
+        builder = args.get('builder')
+        if builder:
+            force_args['builderid'] = yield self._resolve_builder_id(builder)
+        if args.get('reason') and 'reason' not in force_args:
+            force_args['reason'] = args['reason']
+
+        ep = ('forceschedulers', scheduler)
+        yield self._assert_allowed(request, ep, 'force', force_args)
+        try:
+            res = yield self.master.data.control('force', force_args, ep)
+        except Exception as e:
+            raise ToolError(f"force failed: {e}") from e
+        return {"forced": True, "scheduler": scheduler, "result": res}
+
+    @defer.inlineCallbacks
+    def cancel_build(self, args: dict[str, Any], request: Any) -> Any:
+        build_id = args.get('build_id')
+        if build_id is None:
+            raise ToolError("build_id is required")
+        build = yield self.master.data.get(('builds', build_id))
+        if build is None:
+            raise ToolError(f"no build with id {build_id}")
+
+        control_args: dict[str, Any] = {}
+        if args.get('reason'):
+            control_args['reason'] = args['reason']
+
+        ep = ('builds', build_id)
+        yield self._assert_allowed(request, ep, 'stop', control_args)
+        yield self.master.data.control('stop', control_args, ep)
+        return {"stopped": True, "build_id": build_id}

--- a/master/buildbot/www/mcp/tools.py
+++ b/master/buildbot/www/mcp/tools.py
@@ -1,0 +1,304 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+
+from twisted.internet import defer
+
+from buildbot.data import resultspec
+from buildbot.process.results import Results
+
+if TYPE_CHECKING:
+    from buildbot.master import BuildMaster
+
+# Pagination defaults. Every list-returning tool is bounded so that a single
+# tool call cannot overrun an LLM's context window.
+DEFAULT_LIMIT = 25
+MAX_LIMIT = 100
+
+
+class ToolError(Exception):
+    # A user-facing tool error (e.g. unknown builder). Surfaced to the client
+    # as an MCP tool result with isError=true rather than a protocol error.
+    pass
+
+
+def result_label(results: int | None) -> str:
+    # Translate a numeric build/step result into a human-readable label.
+    if results is None:
+        return "running"
+    if 0 <= results < len(Results):
+        return Results[results]
+    return "unknown"
+
+
+class McpTools:
+    # The read-only MCP tool set, each backed by the Buildbot data API
+    # (``master.data``). Tools accept human-friendly arguments (e.g. a builder
+    # name) and return compact, JSON-serializable dicts.
+
+    def __init__(self, master: BuildMaster) -> None:
+        self.master = master
+        # builder name -> builderid cache (ids are stable within a master run;
+        # cleared on reconfig).
+        self._builder_id_cache: dict[str, int] = {}
+        self._tools = self._make_tools()
+
+    def reset_caches(self) -> None:
+        self._builder_id_cache = {}
+
+    # -- registry ---------------------------------------------------------
+
+    def _make_tools(self) -> dict[str, dict[str, Any]]:
+        pagination = {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of items to return (default 25, capped at 100).",
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Number of items to skip, for paging (default 0).",
+            },
+        }
+        return {
+            "get_status": {
+                "description": (
+                    "Overall snapshot of the Buildbot master: number of builders, "
+                    "worker connectivity, and the builds currently running."
+                ),
+                "inputSchema": {"type": "object", "properties": {}},
+                "handler": self.get_status,
+            },
+            "get_builders": {
+                "description": "List configured builders with their id, name, description and tags.",
+                "inputSchema": {"type": "object", "properties": dict(pagination)},
+                "handler": self.get_builders,
+            },
+            "get_workers": {
+                "description": "List workers, showing whether each is connected and/or paused.",
+                "inputSchema": {"type": "object", "properties": dict(pagination)},
+                "handler": self.get_workers,
+            },
+            "get_recent_builds": {
+                "description": (
+                    "List recent builds, most recent first. Optionally restrict to a "
+                    "single builder or to only the builds still running."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "builder": {
+                            "type": "string",
+                            "description": "Restrict results to this builder name.",
+                        },
+                        "only_running": {
+                            "type": "boolean",
+                            "description": "If true, return only builds still in progress.",
+                        },
+                        **pagination,
+                    },
+                },
+                "handler": self.get_recent_builds,
+            },
+            "get_build": {
+                "description": "Get a single build by its build id, including its steps and result.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "build_id": {
+                            "type": "integer",
+                            "description": "The numeric build id (buildid).",
+                        }
+                    },
+                    "required": ["build_id"],
+                },
+                "handler": self.get_build,
+            },
+        }
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": name,
+                "description": spec["description"],
+                "inputSchema": spec["inputSchema"],
+            }
+            for name, spec in self._tools.items()
+        ]
+
+    def has_tool(self, name: str) -> bool:
+        return name in self._tools
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> defer.Deferred[Any]:
+        spec = self._tools.get(name)
+        if spec is None:
+            raise ToolError(f"unknown tool: {name}")
+        return defer.maybeDeferred(spec["handler"], arguments or {})
+
+    # -- helpers ----------------------------------------------------------
+
+    def _paginate(self, args: dict[str, Any]) -> tuple[int, int]:
+        try:
+            limit = int(args.get("limit", DEFAULT_LIMIT))
+        except (TypeError, ValueError):
+            limit = DEFAULT_LIMIT
+        limit = max(1, min(limit, MAX_LIMIT))
+        try:
+            offset = int(args.get("offset", 0))
+        except (TypeError, ValueError):
+            offset = 0
+        offset = max(0, offset)
+        return limit, offset
+
+    @staticmethod
+    def _page_meta(items: list[Any], total: int | None, offset: int) -> dict[str, Any]:
+        returned = len(items)
+        has_more = (offset + returned) < total if total is not None else False
+        return {
+            "total_count": total,
+            "returned": returned,
+            "offset": offset,
+            "has_more": has_more,
+        }
+
+    @defer.inlineCallbacks
+    def _resolve_builder_id(self, name: str) -> Any:
+        if name in self._builder_id_cache:
+            return self._builder_id_cache[name]
+        builder = yield self.master.data.get(('builders', name))
+        if builder is None:
+            raise ToolError(f"unknown builder: {name}")
+        self._builder_id_cache[name] = builder['builderid']
+        return builder['builderid']
+
+    @staticmethod
+    def _build_summary(b: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "buildid": b["buildid"],
+            "number": b["number"],
+            "builderid": b["builderid"],
+            "workerid": b.get("workerid"),
+            "complete": b["complete"],
+            "result": result_label(b.get("results")),
+            "state": b["state_string"],
+        }
+
+    # -- tool handlers ----------------------------------------------------
+
+    @defer.inlineCallbacks
+    def get_status(self, args: dict[str, Any]) -> Any:
+        builders = yield self.master.data.get(('builders',))
+        workers = yield self.master.data.get(('workers',))
+        running = yield self.master.data.get(
+            ('builds',),
+            filters=[resultspec.Filter('complete', 'eq', [False])],
+            order=['-buildid'],
+            limit=MAX_LIMIT,
+        )
+        connected = sum(1 for w in workers if w.get('connected_to'))
+        return {
+            "builders": len(builders),
+            "workers": {"total": len(workers), "connected": connected},
+            "running_builds": [
+                {
+                    "buildid": b["buildid"],
+                    "builderid": b["builderid"],
+                    "number": b["number"],
+                    "state": b["state_string"],
+                }
+                for b in running
+            ],
+        }
+
+    @defer.inlineCallbacks
+    def get_builders(self, args: dict[str, Any]) -> Any:
+        limit, offset = self._paginate(args)
+        builders = yield self.master.data.get(
+            ('builders',), order=['name'], limit=limit, offset=offset
+        )
+        items = [
+            {
+                "builderid": b["builderid"],
+                "name": b["name"],
+                "description": b.get("description"),
+                "tags": b.get("tags", []),
+            }
+            for b in builders
+        ]
+        return {
+            "builders": items,
+            **self._page_meta(items, getattr(builders, 'total', None), offset),
+        }
+
+    @defer.inlineCallbacks
+    def get_workers(self, args: dict[str, Any]) -> Any:
+        limit, offset = self._paginate(args)
+        workers = yield self.master.data.get(
+            ('workers',), order=['name'], limit=limit, offset=offset
+        )
+        items = [
+            {
+                "workerid": w["workerid"],
+                "name": w["name"],
+                "connected": bool(w.get("connected_to")),
+                "paused": w.get("paused", False),
+            }
+            for w in workers
+        ]
+        return {"workers": items, **self._page_meta(items, getattr(workers, 'total', None), offset)}
+
+    @defer.inlineCallbacks
+    def get_recent_builds(self, args: dict[str, Any]) -> Any:
+        limit, offset = self._paginate(args)
+        filters = []
+        if args.get('only_running'):
+            filters.append(resultspec.Filter('complete', 'eq', [False]))
+
+        path: tuple[Any, ...] = ('builds',)
+        builder = args.get('builder')
+        if builder:
+            builderid = yield self._resolve_builder_id(builder)
+            path = ('builders', builderid, 'builds')
+
+        builds = yield self.master.data.get(
+            path, filters=filters, order=['-buildid'], limit=limit, offset=offset
+        )
+        items = [self._build_summary(b) for b in builds]
+        return {"builds": items, **self._page_meta(items, getattr(builds, 'total', None), offset)}
+
+    @defer.inlineCallbacks
+    def get_build(self, args: dict[str, Any]) -> Any:
+        build_id = args.get('build_id')
+        if build_id is None:
+            raise ToolError("build_id is required")
+        build = yield self.master.data.get(('builds', build_id))
+        if build is None:
+            raise ToolError(f"no build with id {build_id}")
+        steps = yield self.master.data.get(('builds', build_id, 'steps'))
+        return {
+            "build": self._build_summary(build),
+            "steps": [
+                {
+                    "number": s["number"],
+                    "name": s["name"],
+                    "state": s["state_string"],
+                    "result": result_label(s.get("results")),
+                }
+                for s in steps
+            ],
+        }

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -48,6 +48,7 @@ from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www import change_hook
 from buildbot.www import config as wwwconfig
+from buildbot.www import mcp
 from buildbot.www import resource as buildbot_resource
 from buildbot.www import rest
 from buildbot.www import sse
@@ -328,6 +329,10 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
         # /sse
         root.putChild(b'sse', sse.EventResource(self.master))
+
+        # /mcp
+        if new_config.www.get('mcp'):
+            root.putChild(b'mcp', mcp.McpResource(self.master))
 
         # /change_hook
         resource_obj: resource.IResource = change_hook.ChangeHookResource(master=self.master)

--- a/master/docs/manual/configuration/www/index.rst
+++ b/master/docs/manual/configuration/www/index.rst
@@ -8,6 +8,7 @@ Web server configuration
     :maxdepth: 2
 
     server
+    mcp
     ui/badges
     ui/console_view
     ui/grid_view
@@ -26,6 +27,7 @@ Web server configuration
 This section lists options to configure the web server.
 
 * :ref:`Config-WWW-Server` - describes the options that adjust how complete web server works.
+* :ref:`Config-WWW-MCP` - describes the built-in Model Context Protocol (MCP) server for AI assistants.
 
 .. _UI-Plugins:
 

--- a/master/docs/manual/configuration/www/mcp.rst
+++ b/master/docs/manual/configuration/www/mcp.rst
@@ -1,0 +1,119 @@
+.. _Config-WWW-MCP:
+
+MCP Server
+==========
+
+Buildbot can expose a built-in `Model Context Protocol <https://modelcontextprotocol.io/>`_
+(MCP) server. MCP is an open standard that lets AI assistants and LLM-powered
+agents discover and call capabilities offered by external systems. With the MCP
+server enabled, such a client can query build status, inspect and search build
+logs, and trigger or stop builds, using the same data and permissions as the
+rest of the web interface.
+
+Enabling
+--------
+
+The MCP server is part of the web server and is disabled by default. Enable it
+with the ``mcp`` key of the ``www`` configuration dictionary:
+
+.. code-block:: python
+
+    c['www'] = {
+        'port': 8010,
+        'mcp': True,
+    }
+
+When enabled, the server is reachable at the ``/mcp`` path of the web server
+(for example ``http://localhost:8010/mcp``). It speaks MCP over the Streamable
+HTTP transport: clients send JSON-RPC messages with HTTP ``POST`` requests.
+
+Connecting a client
+-------------------
+
+Any MCP-compatible client (for example an AI assistant integrated into an editor
+or IDE) connects by being pointed at the server's ``/mcp`` URL using the
+Streamable HTTP transport. Most clients are configured through a JSON block that
+registers named servers, of the form:
+
+.. code-block:: json
+
+    {
+      "mcpServers": {
+        "buildbot": {
+          "type": "http",
+          "url": "http://localhost:8010/mcp"
+        }
+      }
+    }
+
+Replace the URL with the address of your Buildbot web server. On startup the
+client performs the MCP ``initialize`` handshake, discovers the available tools,
+and makes them available to the model. The exact location of this configuration
+-- a project file, a user-level file, or a command-line registration -- depends
+on the client; consult its documentation for where to add an HTTP MCP server.
+
+If the web server requires authentication (see below), the client must be able
+to authenticate to it.
+
+Authentication and authorization
+--------------------------------
+
+The MCP endpoint lives inside the web server and therefore inherits whatever
+authentication is configured with the ``auth`` key (see :ref:`Web-Authentication`).
+It is exactly as secure as the rest of the web interface: with the default
+``NoAuth`` it is open, and with an authentication plugin configured it requires
+the same login.
+
+Authorization is enforced for the write tools (``force_build`` and
+``cancel_build``) using the same endpoint matchers as the REST API. A client
+may only force or stop a build if the authenticated user holds a role permitted
+by the configured ``ForceBuildEndpointMatcher`` / ``StopBuildEndpointMatcher``
+rules; otherwise the call returns an error result.
+
+As with the other streaming web APIs, the ``Origin`` header is validated against
+the configured ``allowed_origins`` to guard against DNS-rebinding.
+
+Tools
+-----
+
+The server exposes the following tools. Every tool that returns a list is
+bounded (default 25 items, capped at 100) and reports ``total_count`` and
+``has_more`` so that a single call cannot overrun a client's context window.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 15 65
+
+    * - Tool
+      - Access
+      - Description
+    * - ``get_status``
+      - read
+      - Overall snapshot: number of builders, worker connectivity and the builds currently running.
+    * - ``get_builders``
+      - read
+      - List configured builders (id, name, description, tags).
+    * - ``get_workers``
+      - read
+      - List workers, showing whether each is connected and/or paused.
+    * - ``get_recent_builds``
+      - read
+      - Recent builds, most recent first; optionally restricted to a builder or to running builds only.
+    * - ``get_build``
+      - read
+      - A single build by id, including its steps and result.
+    * - ``get_build_logs``
+      - read
+      - List a build's logs, fetch a log's contents (paginated by line), or search it with an optional regular expression.
+    * - ``force_build``
+      - write
+      - Trigger a build by invoking a force scheduler.
+    * - ``cancel_build``
+      - write
+      - Stop a running build by its build id.
+
+.. note::
+
+    Live streaming of in-progress build logs is not yet available; the
+    ``get_build_logs`` tool operates on stored log contents. Bearer-token
+    authentication for headless clients is also planned for a future release.

--- a/master/docs/manual/configuration/www/server.rst
+++ b/master/docs/manual/configuration/www/server.rst
@@ -34,6 +34,11 @@ This server is configured with the ``www`` configuration key, which specifies a 
             'plugins': {'waterfall_view': True}
         }
 
+``mcp``
+    If set to ``True``, enables the built-in Model Context Protocol (MCP) server
+    at the ``/mcp`` path, allowing AI assistants to query build status, search
+    logs and trigger builds. Disabled by default. See :ref:`Config-WWW-MCP`.
+
 ``default_page``
     Configure the default landing page of the web server, for example, to forward directly to another plugin. For example:
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -495,6 +495,7 @@ linenumber
 Linter
 linux
 listdir
+LLM
 localhost
 lodash
 Lodash
@@ -532,6 +533,7 @@ matchers
 MaxQ
 maxWarnCount
 mbcs
+MCP
 md
 mebibytes
 mergeability
@@ -840,6 +842,7 @@ stepid
 StepModel
 stopService
 storages
+Streamable
 strports
 subclassed
 subclasses

--- a/newsfragments/mcp-server.feature
+++ b/newsfragments/mcp-server.feature
@@ -1,0 +1,1 @@
+Buildbot now ships a built-in :ref:`Model Context Protocol (MCP) server <Config-WWW-MCP>`, enabled with ``c['www']['mcp'] = True``. It lets AI assistants query build and worker status, inspect and search build logs, and force or cancel builds through the web server, reusing Buildbot's existing authentication and authorization (:issue:`9000`).


### PR DESCRIPTION
This adds a built-in Model Context Protocol (MCP) server to the Buildbot web
service, addressing #9000. It lets MCP-compatible AI assistants query
build/worker status, inspect and search build logs, and trigger or cancel
builds — reusing Buildbot's existing data API and authentication.

### Design
- **In-tree, in the www layer** (`master/buildbot/www/mcp/`), served at `/mcp`
  on the existing web port. Enabled with `c['www']['mcp'] = True` (off by
  default). Living in the www layer means it inherits the configured
  authentication/authorization instead of introducing a separate auth model.
- **Transport:** Streamable HTTP (MCP revision 2025-11-25) — POST carries
  JSON-RPC; GET returns 405 (no server-initiated stream). No new runtime
  dependency: the JSON-RPC/MCP layer is implemented directly on Twisted (the
  official MCP SDK is asyncio-based and would require bridging the reactor).
- **Data access:** tools call through `master.data`, not the DB or REST HTTP.
- **Authorization:** write tools call `assertUserAllowed` before any
  `data.control()`, exactly as the REST layer does, so the existing
  `ForceBuild`/`StopBuild` endpoint matchers apply.

### Tools (8)
Read: `get_status`, `get_builders`, `get_workers`, `get_recent_builds`,
`get_build`, `get_build_logs` (list / fetch / regex-search; strips the stdio
channel prefix). Write: `force_build`, `cancel_build`. List-returning tools are
bounded (default 25, cap 100) and report `total_count`/`has_more` so a call
can't overrun a client's context window.

### Out of scope (planned follow-ups)
Live log streaming (`stream_logs` via SSE), bearer-token auth for headless
clients, an stdio transport shim, and `/.well-known/mcp` discovery. v1 read
authorization is coarse (reads expose the same data as the default-readable
data/REST API); per-endpoint read authz can follow.

### Testing
- Unit tests in `master/buildbot/test/unit/www/test_mcp.py` (protocol framing,
  lifecycle, every tool, pagination caps, authz-denied).
- Manually validated against a running master with an MCP client and an
  MCP-compatible editor assistant: the `initialize` handshake, tool discovery,
  and a real `force_build` → run → `get_build_logs` search round-trip.

Opening as a draft per the discussion in #9000 — happy to adjust scope or approach.