### PR TITLE
worker: fix data loss in LineBoundaryFinder when splitting long lines

### DIFF
--- a/newsfragments/7192.bugfix
+++ b/newsfragments/7192.bugfix
@@ -1,0 +1,10 @@
+Fix data loss in worker-side log line splitting. ``LineBoundaryFinder``
+in the worker had two slicing bugs that caused most of any log line
+longer than ``2 * max_line_length`` (4096 bytes by default) to be
+silently dropped before being sent to the master, surfacing as broken
+output for build steps that capture long single-line content such as
+JSON parsed via ``SetPropertyFromCommand`` (:issue:`7192`). After this
+fix, each split chunk contains ``max_line_length - 1`` contiguous source
+characters plus an appended newline and consumers that reassemble via
+``str.splitlines()`` followed by ``''.join()`` recover the original line
+intact.

--- a/worker/buildbot_worker/test/util/test_lineboundaries.py
+++ b/worker/buildbot_worker/test/util/test_lineboundaries.py
@@ -135,5 +135,51 @@ class LBF(unittest.TestCase):
         self.assertEqual(self.lbf.append('123456789012', 4.0), None)
         self.assertEqual(self.lbf.flush(), ('5123456789012\n', [13], [3.0]))
 
+    def test_long_line_split_no_data_loss(self) -> None:
+        """A long terminated line is split into chunks that reassemble bit-for-bit.
+
+        Regression test for https://github.com/buildbot/buildbot/issues/7192:
+        prior to the fix the splitting code's slice end was an absolute index,
+        so iterations after the first emitted empty content (just '\\n') and
+        most of the line was silently dropped. With max_line_length=20 a
+        50-char line splits into chunks of 19 + 19 + 12 source chars.
+        """
+        long_line = 'x' * 50
+        out = self.lbf.append(long_line + '\n', 1.0)
+        self.assertEqual(
+            out,
+            (
+                'x' * 19 + '\n' + 'x' * 19 + '\n' + 'x' * 12 + '\n',
+                [19, 39, 52],
+                [1.0, 1.0, 1.0],
+            ),
+        )
+        assert out is not None
+        self.assertEqual(''.join(out[0].splitlines()), long_line)
+
+    def test_long_partial_line_split_no_data_loss(self) -> None:
+        """A long unterminated line is split via the partial-line path without data loss."""
+        long_partial = 'p' * 50
+        out = self.lbf.append(long_partial, 1.0)
+        self.assertEqual(
+            out,
+            ('p' * 19 + '\n' + 'p' * 19 + '\n', [19, 39], [1.0, 1.0]),
+        )
+        flushed = self.lbf.flush()
+        self.assertEqual(flushed, ('p' * 12 + '\n', [12], [1.0]))
+        assert out is not None and flushed is not None
+        self.assertEqual(''.join((out[0] + flushed[0]).splitlines()), long_partial)
+
+    def test_long_json_line_round_trip(self) -> None:
+        """Reassembling worker-split chunks via splitlines + ''.join recovers the original.
+
+        Mirrors the consumer pattern used by SetPropertyFromCommand-style
+        callers in https://github.com/buildbot/buildbot/issues/7192.
+        """
+        payload = '{"data":"' + 'A' * 5000 + '"}'
+        out = self.lbf.append(payload + '\n', 1.0)
+        assert out is not None
+        self.assertEqual(''.join(out[0].splitlines()), payload)
+
     def test_empty_flush(self) -> None:
         self.assertEqual(self.lbf.flush(), None)

--- a/worker/buildbot_worker/util/lineboundaries.py
+++ b/worker/buildbot_worker/util/lineboundaries.py
@@ -68,12 +68,12 @@ class LineBoundaryFinder:
             # finds too long lines and splits them, each element in ret_lines will be a line of
             # appropriate length
             while position - first_position >= self.max_line_length:
-                line = text[first_position : self.max_line_length - 1] + '\n'
+                line = text[first_position : first_position + self.max_line_length - 1] + '\n'
                 ret_lines.append(line)
                 ret_line_count += 1
                 ret_text_length = ret_text_length + len(line)
                 ret_indexes.append(ret_text_length)
-                first_position = first_position + self.max_line_length
+                first_position = first_position + self.max_line_length - 1
 
             line = text[first_position : (position + 1)]
             ret_lines.append(line)
@@ -84,8 +84,9 @@ class LineBoundaryFinder:
 
         position = len(text)
         while position - first_position >= self.max_line_length:
-            line = text[first_position : self.max_line_length - 1] + '\n'
+            line = text[first_position : first_position + self.max_line_length - 1] + '\n'
             ret_lines.append(line)
+            ret_line_count += 1
             ret_text_length = ret_text_length + len(line)
             ret_indexes.append(ret_text_length)
             first_position = first_position + self.max_line_length - 1


### PR DESCRIPTION
LineBoundaryFinder splits log output longer than max_line_length into chunks before sending it to the master. The implementation had few bugs that silently dropped most of any line longer than 8192 (2 * max_line_length):

1. text[first_position : self.max_line_length - 1] in the splitting while loops used incorrect slice end. After the first iteration, subsequent slice produced an empty string. emitted.

2. The first while loop advanced first_position by max_line_length, but each chunk only consumes max_line_length - 1 source characters (the trailing '\n' is appended, not from the source). The corresponding loop in the partial-line code path already used the correct max_line_length - 1 increment, so this also caused 1 character of data loss per iteration on lines that contained an embedded newline.

3. The second while loop did not increment ret_line_count, so when it produced more than one chunk the line_times list returned to the caller had fewer entries than ret_indexes.

Each split chunk now contains max_line_length - 1 contiguous source characters plus an appended '\n', and consumers that reassemble via str.splitlines() + ''.join() recover the original line bit-for-bit (see issue #7192).