### PR TITLE
Fix UnicodeDecodeError when LC_ALL/LANG is unset

### DIFF
--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -197,7 +197,7 @@ class IndexResource(resource.Resource):
     def __init__(self, master: BuildMaster, staticdir: str) -> None:
         super().__init__(master)
         self.static_dir = staticdir
-        with open(os.path.join(self.static_dir, 'index.html')) as index_f:
+        with open(os.path.join(self.static_dir, 'index.html'), encoding='utf-8') as index_f:
             self.index_template = index_f.read()
 
     def reconfigResource(self, new_config: Any) -> None:


### PR DESCRIPTION
Specify UTF-8 encoding when reading index.html template to fix UnicodeDecodeError on systems without LC_ALL/LANG set (e.g. systemd service).

Before: `open(...) as index_f` — defaults to ASCII, crashes on non-ASCII bytes.
After: `open(..., encoding='utf-8')`

Fixes #5502