### PR TITLE
www: Fix UnicodeDecodeError when starting master under non-UTF-8 locale

### DIFF
--- a/master/buildbot/test/unit/www/test_config.py
+++ b/master/buildbot/test/unit/www/test_config.py
@@ -240,3 +240,29 @@ class IndexResourceTest(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             "plugins": {},
         }
         self.assertEqual(config_json, exp)
+
+    @defer.inlineCallbacks
+    def test_render_non_ascii_index(self) -> InlineCallbacksType[None]:
+        # index.html must be read and served as UTF-8 regardless of the system
+        # locale, which may be ASCII when LC_ALL/LANG are not set (issue #5502)
+        static_dir = self.mktemp()
+        os.mkdir(static_dir)
+        with open(os.path.join(static_dir, 'index.html'), 'w', encoding='utf-8') as f:
+            f.write(
+                '<!DOCTYPE html>\n'
+                '<html lang="en">\n'
+                '<head><meta charset="utf-8"><title>Büildböt ✓</title></head>\n'
+                '<body> <!-- BUILDBOT_CONFIG_PLACEHOLDER --></body>\n'
+                '</html>\n'
+            )
+
+        master = yield self.make_master(url='h:/a/b/', plugins={})
+        master.www.authz = mock.Mock(spec=Authz, unsafe=True)
+
+        rsrc = config.IndexResource(master, static_dir)
+        rsrc.reconfigResource(master.config)
+
+        res = yield self.render_resource(rsrc, b'/')
+        page = res.decode('utf-8')
+        self.assertIn('Büildböt ✓', page)
+        self.assertIn('window.buildbotFrontendConfig', page)

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -197,7 +197,7 @@ class IndexResource(resource.Resource):
     def __init__(self, master: BuildMaster, staticdir: str) -> None:
         super().__init__(master)
         self.static_dir = staticdir
-        with open(os.path.join(self.static_dir, 'index.html')) as index_f:
+        with open(os.path.join(self.static_dir, 'index.html'), encoding='utf-8') as index_f:
             self.index_template = index_f.read()
 
     def reconfigResource(self, new_config: Any) -> None:
@@ -249,4 +249,4 @@ class IndexResource(resource.Resource):
     </style>""",
         )
 
-        return unicode2bytes(rendered_index, encoding='ascii')
+        return unicode2bytes(rendered_index, encoding='utf-8')

--- a/newsfragments/5502.bugfix
+++ b/newsfragments/5502.bugfix
@@ -1,0 +1,1 @@
+Fixed ``UnicodeDecodeError`` when starting the master without ``LC_ALL``/``LANG`` set. The web UI ``index.html`` is now always read and served as UTF-8 instead of using the locale-dependent default encoding (:issue:`5502`).


### PR DESCRIPTION
## Summary

Fixes #5502.

`IndexResource` read `index.html` using the locale-dependent default encoding. When the master is started without `LC_ALL`/`LANG` set (e.g. from a system service), that default is ASCII, and startup crashes with `builtins.UnicodeDecodeError` if the file contains any non-ASCII characters — as reported in the issue. The issue dates back to 2020, but the unencoded `open()` is still present on master.

## Changes

- Read `index.html` with an explicit `encoding='utf-8'` in `IndexResource.__init__`, so startup no longer depends on the system locale.
- Encode the rendered page as UTF-8 instead of strict ASCII in `renderIndex`. The template declares `<meta charset="utf-8">`, and non-ASCII template content would previously have raised the same error at request time. (The `/config` JSON resource is unchanged: `json.dumps` emits pure ASCII, so `ascii` remains safe there.)
- Added `test_render_non_ascii_index`, which serves an `index.html` containing non-ASCII characters. When run under `LC_ALL=C` with the fix reverted, it reproduces exactly the reported error (`'ascii' codec can't decode byte 0xc3`); it passes with the fix.
- Added a `5502.bugfix` newsfragment.

## Testing

- `buildbot.test.unit.www.test_config` passes (7/7).
- Regression verified under `LC_ALL=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0`: fails before the fix, passes after.
- `ruff check` and `ruff format --check` clean with the CI-pinned version (0.15.7).