### PR TITLE
steps: Add Pytest step for running the Python test suite with pytest

### DIFF
--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -25,6 +25,7 @@ from twisted.internet import defer
 from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process import logobserver
+from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
@@ -462,3 +463,107 @@ class Sphinx(buildstep.ShellMixin, buildstep.BuildStep):
                 return SUCCESS
             return WARNINGS
         return FAILURE
+
+
+class Pytest(buildstep.ShellMixin, buildstep.BuildStep):
+    """A step that runs the Python test suite with pytest and extracts the
+    test counts from its output."""
+
+    name = "pytest"
+    command = ["python", "-m", "pytest"]
+    description = "running pytest"
+    descriptionDone = "pytest"
+
+    # categories reported by pytest in its final summary line, in the order
+    # they should appear in the step summary
+    _CATEGORIES = (
+        "passed",
+        "failed",
+        "errors",
+        "skipped",
+        "xfailed",
+        "xpassed",
+        "warnings",
+        "deselected",
+    )
+
+    # e.g. "===== 2 failed, 3 passed, 1 warning in 12.34s (0:00:12) ====="
+    _summary_line_re = re.compile(r'^=+ (?P<counts>.+) in [0-9.]+s(?: \([0-9:]+\))? =+$')
+    _count_re = re.compile(
+        r'(?P<count>\d+) (?P<category>passed|failed|errors?|skipped|xfailed|xpassed'
+        r'|warnings?|deselected)'
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        # pytest exit codes: 0 all tests passed, 1 some tests failed,
+        # 2 interrupted, 3 internal error, 4 usage error, 5 no tests collected
+        kwargs.setdefault(
+            'decodeRC',
+            {0: SUCCESS, 1: FAILURE, 2: EXCEPTION, 3: EXCEPTION, 4: EXCEPTION, 5: FAILURE},
+        )
+        kwargs = self.setupShellMixin(kwargs)
+        super().__init__(**kwargs)
+
+        self.counts: dict[str, int] = {}
+        self.addLogObserver('stdio', logobserver.LineConsumerLogObserver(self._log_consumer))
+
+    def _log_consumer(self) -> Generator[Any, Any, None]:
+        while True:
+            stream, line = yield
+            if stream == 'h':
+                continue
+            m = self._summary_line_re.match(line)
+            if m is None:
+                continue
+            counts = {}
+            for count_match in self._count_re.finditer(m.group('counts')):
+                category = count_match.group('category')
+                # normalize the categories that pytest emits in singular form
+                if category == 'error':
+                    category = 'errors'
+                elif category == 'warning':
+                    category = 'warnings'
+                counts[category] = int(count_match.group('count'))
+            if counts:
+                # in case multiple lines match, the last one wins: it is the
+                # final summary of the run
+                self.counts = counts
+
+    def _get_tests_total(self) -> int:
+        # warnings are not tests and deselected tests were not run
+        return sum(
+            self.counts.get(c, 0)
+            for c in ('passed', 'failed', 'errors', 'skipped', 'xfailed', 'xpassed')
+        )
+
+    def getResultSummary(self) -> dict[str, str]:
+        summary = ' '.join(self.descriptionDone)
+        if self.counts:
+            summary += f' {self._get_tests_total()} tests'
+            for category in self._CATEGORIES:
+                count = self.counts.get(category)
+                if count:
+                    label = category
+                    if count == 1 and category in ('errors', 'warnings'):
+                        label = category[:-1]
+                    summary += f' {count} {label}'
+
+        if self.results != SUCCESS:
+            summary += f' ({statusToString(self.results)})'
+
+        return {'step': summary}
+
+    @defer.inlineCallbacks
+    def run(self) -> InlineCallbacksType[int]:
+        cmd = yield self.makeRemoteShellCommand()
+        yield self.runCommand(cmd)
+
+        stdio_log = yield self.getLog('stdio')
+        yield stdio_log.finish()
+
+        if self.counts:
+            self.setStatistic('tests-total', self._get_tests_total())
+            for category in self._CATEGORIES:
+                self.setStatistic(f'tests-{category}', self.counts.get(category, 0))
+
+        return cmd.results()

--- a/master/buildbot/test/unit/steps/test_python.py
+++ b/master/buildbot/test/unit/steps/test_python.py
@@ -22,6 +22,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
+from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
@@ -630,4 +631,158 @@ class TestSphinx(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
             .exit(0)
         )
         self.expect_outcome(result=SUCCESS, state_string="sphinx 0 warnings")
+        return self.run_step()
+
+
+pytest_output_success = """\
+============================= test session starts ==============================
+platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0
+rootdir: /home/user/project
+collected 3 items
+
+test_foo.py ...                                                          [100%]
+
+============================== 3 passed in 0.12s ===============================
+"""
+
+pytest_output_failure = """\
+============================= test session starts ==============================
+platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0
+rootdir: /home/user/project
+collected 5 items
+
+test_foo.py ..F.F                                                        [100%]
+
+=================================== FAILURES ===================================
+_________________________________ test_bar _____________________________________
+
+    def test_bar():
+>       assert False
+E       assert False
+
+test_foo.py:6: AssertionError
+=========================== short test summary info ============================
+FAILED test_foo.py::test_bar - assert False
+FAILED test_foo.py::test_baz - assert False
+========================= 2 failed, 3 passed in 0.23s ==========================
+"""
+
+pytest_output_mixed = """\
+============================= test session starts ==============================
+collected 12 items / 2 deselected / 10 selected
+
+=========== 1 failed, 5 passed, 2 skipped, 1 xfailed, 1 xpassed, 3 warnings, \
+1 error, 2 deselected in 12.34s (0:00:12) ===========
+"""
+
+pytest_output_no_tests = """\
+============================= test session starts ==============================
+collected 0 items
+
+============================ no tests ran in 0.01s =============================
+"""
+
+
+class Pytest(TestBuildStepMixin, TestReactorMixin, unittest.TestCase):
+    def setUp(self) -> defer.Deferred[None]:  # type: ignore[override]
+        self.setup_test_reactor()
+        return self.setup_test_build_step()
+
+    @defer.inlineCallbacks
+    def test_success(self) -> InlineCallbacksType[None]:
+        step = self.setup_step(python.Pytest())
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['python', '-m', 'pytest'])
+            .stdout(pytest_output_success)
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS, state_string='pytest 3 tests 3 passed')
+        yield self.run_step()
+        self.assertEqual(step.statistics['tests-total'], 3)
+        self.assertEqual(step.statistics['tests-passed'], 3)
+        self.assertEqual(step.statistics['tests-failed'], 0)
+
+    @defer.inlineCallbacks
+    def test_failure(self) -> InlineCallbacksType[None]:
+        step = self.setup_step(python.Pytest())
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['python', '-m', 'pytest'])
+            .stdout(pytest_output_failure)
+            .exit(1)
+        )
+        self.expect_outcome(
+            result=FAILURE, state_string='pytest 5 tests 3 passed 2 failed (failure)'
+        )
+        yield self.run_step()
+        self.assertEqual(step.statistics['tests-total'], 5)
+        self.assertEqual(step.statistics['tests-passed'], 3)
+        self.assertEqual(step.statistics['tests-failed'], 2)
+
+    @defer.inlineCallbacks
+    def test_all_categories(self) -> InlineCallbacksType[None]:
+        step = self.setup_step(python.Pytest())
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['python', '-m', 'pytest'])
+            .stdout(pytest_output_mixed)
+            .exit(1)
+        )
+        self.expect_outcome(
+            result=FAILURE,
+            state_string='pytest 11 tests 5 passed 1 failed 1 error 2 skipped '
+            '1 xfailed 1 xpassed 3 warnings 2 deselected (failure)',
+        )
+        yield self.run_step()
+        self.assertEqual(
+            step.statistics,
+            {
+                'tests-total': 11,
+                'tests-passed': 5,
+                'tests-failed': 1,
+                'tests-errors': 1,
+                'tests-skipped': 2,
+                'tests-xfailed': 1,
+                'tests-xpassed': 1,
+                'tests-warnings': 3,
+                'tests-deselected': 2,
+            },
+        )
+
+    def test_no_tests_ran(self) -> defer.Deferred[None]:
+        self.setup_step(python.Pytest())
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['python', '-m', 'pytest'])
+            .stdout(pytest_output_no_tests)
+            .exit(5)
+        )
+        self.expect_outcome(result=FAILURE, state_string='pytest (failure)')
+        return self.run_step()
+
+    def test_usage_error(self) -> defer.Deferred[None]:
+        self.setup_step(python.Pytest())
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['python', '-m', 'pytest'])
+            .stderr('ERROR: usage: pytest [options]\n')
+            .exit(4)
+        )
+        self.expect_outcome(result=EXCEPTION, state_string='pytest (exception)')
+        return self.run_step()
+
+    def test_custom_command(self) -> defer.Deferred[None]:
+        self.setup_step(python.Pytest(command=['pytest', '-v', 'tests/']))
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['pytest', '-v', 'tests/'])
+            .stdout(pytest_output_success)
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS, state_string='pytest 3 tests 3 passed')
+        return self.run_step()
+
+    def test_summary_in_header_not_parsed(self) -> defer.Deferred[None]:
+        self.setup_step(python.Pytest())
+        self.expect_commands(
+            ExpectShell(workdir='wkdir', command=['python', '-m', 'pytest'])
+            .log('stdio', header='====== 1 failed in 0.1s ======\n')
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS, state_string='pytest')
         return self.run_step()

--- a/master/docs/manual/configuration/steps/index.rst
+++ b/master/docs/manual/configuration/steps/index.rst
@@ -44,6 +44,7 @@ Build Steps
     pyflakes
     sphinx
     pylint
+    pytest
     trial
     remove_pycs
     http_step

--- a/master/docs/manual/configuration/steps/pytest.rst
+++ b/master/docs/manual/configuration/steps/pytest.rst
@@ -1,0 +1,50 @@
+.. bb:step:: Pytest
+
+.. _Step-Pytest:
+
+Pytest
+++++++
+
+The :bb:step:`Pytest` step runs the Python test suite with `pytest <https://pytest.org>`_ and
+parses the test counts from its output.
+
+.. code-block:: python
+
+    from buildbot.plugins import steps
+
+    f.addStep(steps.Pytest())
+
+The default command is ``python -m pytest``; pass ``command`` to customize it, e.g. to select the
+tests to run or to run pytest from a virtualenv:
+
+.. code-block:: python
+
+    f.addStep(steps.Pytest(command=["venv/bin/python", "-m", "pytest", "tests/"]))
+
+The step parses the final summary line of the pytest output (e.g. ``2 failed, 3 passed, 1 warning
+in 12.34s``) and displays the counts in the step summary. The counts are also stored as the step
+statistics ``tests-total``, ``tests-passed``, ``tests-failed``, ``tests-errors``,
+``tests-skipped``, ``tests-xfailed``, ``tests-xpassed``, ``tests-warnings`` and
+``tests-deselected``. ``tests-total`` counts the tests that pytest collected and ran, so it does
+not include warnings and deselected tests.
+
+The result of the step follows the pytest exit code: success when all tests passed, failure when
+tests failed or no tests were collected, and exception when pytest was interrupted, hit an
+internal error or was invoked incorrectly. The mapping can be customized with the ``decodeRC``
+argument:
+
+.. code-block:: python
+
+    from buildbot.process import results
+
+    # treat "no tests collected" as success
+    f.addStep(steps.Pytest(decodeRC={0: results.SUCCESS, 5: results.SUCCESS}))
+
+In addition, the step accepts all arguments of the :bb:step:`ShellCommand` step.
+
+.. note::
+
+   The step parses the plain text output of pytest.
+   Options that change the output format, disable the summary line (e.g. ``-q`` keeps it, but
+   ``--no-summary`` style plugins may not) or enable colored output when not attached to a
+   terminal may prevent the counts from being detected.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -694,6 +694,8 @@ pylint
 pypi
 pypugjs
 pysqlite
+pytest
+Pytest
 pythonic
 Pythonic
 pywin

--- a/master/setup.py
+++ b/master/setup.py
@@ -201,7 +201,10 @@ setup_args = {
                     ('buildbot.steps.package.rpm.mock', ['Mock', 'MockBuildSRPM', 'MockRebuild']),
                     ('buildbot.steps.package.rpm.rpmbuild', ['RpmBuild']),
                     ('buildbot.steps.package.rpm.rpmlint', ['RpmLint']),
-                    ('buildbot.steps.python', ['BuildEPYDoc', 'PyFlakes', 'PyLint', 'Sphinx']),
+                    (
+                        'buildbot.steps.python',
+                        ['BuildEPYDoc', 'PyFlakes', 'PyLint', 'Pytest', 'Sphinx'],
+                    ),
                     ('buildbot.steps.python_twisted', ['HLint', 'Trial', 'RemovePYCs']),
                     (
                         'buildbot.steps.shell',

--- a/newsfragments/3914.feature
+++ b/newsfragments/3914.feature
@@ -1,0 +1,1 @@
+Added a new :bb:step:`Pytest` step that runs the Python test suite with pytest and parses the test counts from its output (:issue:`3914`).


### PR DESCRIPTION
## Summary

Fixes #3914.

Adds a new `Pytest` build step that runs the Python test suite with pytest and parses the test counts from its output, as requested in the issue. The previously suggested third-party `bb-pytest` step is unmaintained (and GPL3, so not importable), so this is a fresh implementation in `buildbot.steps.python`, following the conventions of the existing `PyFlakes`/`PyLint` steps.

## Behaviour

- Default command is `python -m pytest`; fully customizable via `command` (plus all `ShellMixin` arguments).
- Parses pytest's final summary line (e.g. `2 failed, 3 passed, 1 warning in 12.34s`), including the elapsed-time suffix for long runs and singular/plural category forms.
- Shows the counts in the step summary: `pytest 5 tests 3 passed 2 failed (failure)`.
- Stores counts as step statistics with the same `tests-*` naming used by the `Test` and `Trial` steps: `tests-total`, `tests-passed`, `tests-failed`, `tests-errors`, `tests-skipped`, `tests-xfailed`, `tests-xpassed`, `tests-warnings`, `tests-deselected`. `tests-total` counts only tests that were collected and ran.
- Step result follows pytest's exit code: 0 → success; 1 (tests failed) and 5 (no tests collected) → failure; 2/3/4 (interrupted / internal error / usage error) → exception. The mapping is overridable via `decodeRC`.

## Includes

- Plugin registration in `setup.py` (validated by `test_setup_entrypoints`).
- Documentation page `manual/configuration/steps/pytest.rst` plus index entry.
- 7 unit tests covering success, failure, all summary categories, no-tests-collected, usage errors, custom commands, and non-parsing of pytest-like content in log headers.
- `3914.feature` newsfragment.

## Testing

- `buildbot.test.unit.steps.test_python`: 42/42 pass.
- Full `buildbot.test.unit.steps` package: 1143 pass.
- `buildbot.test.unit.test_plugins` and `buildbot.test.integration.test_setup_entrypoints` pass.
- `ruff check` and `ruff format --check` clean.