### PR TITLE
fix `BuildbotService` not passing keyword-argument `name` to subclasses

### DIFF
--- a/master/buildbot/test/unit/schedulers/test_canceller.py
+++ b/master/buildbot/test/unit/schedulers/test_canceller.py
@@ -522,6 +522,12 @@ class TestOldBuildCanceller(TestReactorMixin, unittest.TestCase):
 
         self.master.mq.assertProductions(expected_productions)
 
+
+    def test_canceller_with_keyword_arguments():
+        self.assertEqual(
+            OldBuildCanceller(name='canceller', filters=[]).name, 'canceller'
+        )
+
     @defer.inlineCallbacks
     def test_buildrequest_no_branch(self) -> InlineCallbacksType[None]:
         yield self.setup_canceller_with_filters()

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -16,6 +16,8 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
+import warnings
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
@@ -215,13 +217,41 @@ class BuildbotService(
     configured = False
     objectid: int | None = None
 
+    _legacy_check_config: ClassVar[bool] = False
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        spec = inspect.getfullargspec(cls.checkConfig)
+
+        if not (
+            'name' in spec.args
+            or 'name' in spec.kwonlyargs
+            or spec.varkw is not None
+        ):
+            warnings.warn(
+                f"{cls.__name__}.checkConfig does not accept a `name` argument",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            cls._legacy_check_config = True
+        else:
+            cls._legacy_check_config = any(
+                i._legacy_check_config for i in cls.mro() if issubclass(i, BuildbotService)
+            )
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        name = kwargs.pop("name", None)
-        if name is not None:
-            self.name = bytes2unicode(name)
+        if (name := kwargs.get('name', None)) is not None:
+            self.name = kwargs['name'] = bytes2unicode(name)
+
+        # gracefully handle some services not accepting the name argument
+        if 'name' in kwargs and self._legacy_check_config:
+            kwargs.pop('name')
+
         self.checkConfig(*args, **kwargs)
         if self.name is None:
             raise ValueError(f"{type(self)}: must pass a name to constructor")
+        elif not isinstance(self.name, str):
+            self.name = bytes2unicode(self.name)
         self._config_args = args
         self._config_kwargs = kwargs
         self.rendered = False


### PR DESCRIPTION
This fixes creating services such as `OldBuildCanceller`, which defines `checkConfig` with `name` as an argument, effectively requiring `name` to be a positional argument.

# Contributor Checklist:

* [x] I have updated the unit tests