### PR TITLE
Add __init__.py for skipped tests

### DIFF
--- a/master/buildbot/test/integration/worker/__init__.py
+++ b/master/buildbot/test/integration/worker/__init__.py
@@ -1,0 +1,1 @@
+# silently skipped ?


### PR DESCRIPTION
Hello,

I ran into a pretty convoluted issue involving latent workers, builders changing across repeated config hot-reloads, and WorkerForBuilder state. 

I believe the tests that should protect against this are in `master/buildbot/test/integration/worker` and have not been running on CI since 105b30646.

Happy to help