### PR TITLE
worker(latent): re-attach to builder removed and re-added by reconfig

### DIFF
--- a/master/buildbot/test/integration/worker/test_latent.py
+++ b/master/buildbot/test/integration/worker/test_latent.py
@@ -632,6 +632,42 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertEqual(registered_workers, [('local', 'password_1'), ('local', 'password_1')])
 
     @defer.inlineCallbacks
+    def test_builder_removed_and_readded_by_reconfig_still_starts_worker(
+        self,
+    ) -> InlineCallbacksType[None]:
+        """
+        A builder removed by one reconfig and restored by a later one must still
+        be able to start its latent workers. The removal leaves the worker's
+        workerforbuilders entry behind, and that stale entry must not prevent
+        the re-added builder from getting its WorkerForBuilder back.
+        """
+        controller = LatentController(self, 'local')
+        builders = [
+            BuilderConfig(name="testy-1", workernames=["local"], factory=BuildFactory()),
+            BuilderConfig(name="testy-2", workernames=["local"], factory=BuildFactory()),
+        ]
+        config_dict = {
+            'builders': builders,
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+        yield self.setup_master(config_dict)
+
+        # testy-2 disappears in one reconfig and comes back in the next
+        yield self.reconfig_master({**config_dict, 'builders': builders[:1]})
+        yield self.reconfig_master(config_dict)
+
+        builder_id = yield self.master.data.updates.findBuilderId('testy-2')
+        yield self.create_build_request([builder_id])
+
+        self.assertEqual(controller.starting, True)
+
+        yield controller.start_instance(False)
+        yield controller.auto_stop(True)
+        self.flushLoggedErrors(LatentWorkerFailedToSubstantiate)
+
+    @defer.inlineCallbacks
     def test_substantiation_cancelled_by_insubstantiation_when_waiting_for_insubstantiation(
         self,
     ) -> InlineCallbacksType[None]:

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -649,7 +649,10 @@ class AbstractLatentWorker(AbstractWorker):
         @return: a Deferred that indicates when an attached worker has
         accepted the new builders and/or released the old ones."""
         for b in self.botmaster.getBuildersForWorker(self.name):  # type: ignore[union-attr]
-            if b.name not in self.workerforbuilders:
+            # Check the builder's pool rather than self.workerforbuilders: removing a
+            # builder in a reconfig leaves a stale entry in the latter, which must not
+            # prevent re-attaching when a later reconfig re-adds the builder.
+            if not any(wfb.worker is self for wfb in b.workers):
                 b.addLatentWorker(self)
         return super().updateWorker()
 

--- a/newsfragments/9135.bugfix
+++ b/newsfragments/9135.bugfix
@@ -1,0 +1,1 @@
+Latent workers are now re-attached to a builder that was removed and re-added by a reconfiguration. Previously such a builder could never start any of its latent workers (:issue:`9135`)


### PR DESCRIPTION
Fix for #9135 

# Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
