### PR TITLE
ci: replicate bbtravis to github action

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,0 +1,41 @@
+name: "Set up Python with dependencies"
+description: >
+  Set up a Python version with pip caching, then install requirements-pip.txt
+  and the given requirement files.
+
+inputs:
+  python-version:
+    description: "Python version passed to actions/setup-python"
+    required: false
+    default: "3.9"
+  requirements:
+    description: >
+      Whitespace/newline separated list of requirement files to install,
+      in addition to requirements-pip.txt.
+    required: false
+    default: "requirements-ci.txt"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: "actions/setup-python@v6"
+      with:
+        python-version: "${{ inputs.python-version }}"
+        cache: "pip"
+        cache-dependency-path: |
+          requirements-pip.txt
+          ${{ inputs.requirements }}
+          */setup.py
+          */pyproject.toml
+
+    - name: "Install Python dependencies"
+      shell: bash
+      env:
+        REQUIREMENTS: ${{ inputs.requirements }}
+      run: |
+        set -e
+        args="-r requirements-pip.txt"
+        for f in $REQUIREMENTS; do
+          args="$args -r $f"
+        done
+        python -m pip install $args

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,95 @@ on:
 permissions:
   contents: read
 
+env:
+  # Needed to ignore specific warns, otherwise, it'll warn a generic message
+  SQLALCHEMY_WARN_20: 1
+
+
 jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.9"
+            tests: ruff
+          - python-version: "3.9"
+            tests: docs
+          - python-version: "3.9"
+            tests: mypy
+          - python-version: "3.13"
+            tests: mypy
+          - python-version: "3.9"
+            tests: prettier
+
+    name: ${{ matrix.tests }} / python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: "actions/checkout@v6"
+
+      - uses: "actions/setup-node@v7"
+        if: ${{ matrix.tests == 'prettier' }}
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: "Install enchant (docs spell checker)"
+        if: ${{ matrix.tests == 'docs' }}
+        run: sudo apt-get update && sudo apt-get install -y libenchant-2-2
+
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            requirements-cidocs.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ci.txt
+          python -m pip install -e master -e worker
+
+      - name: "Install docs dependencies"
+        if: ${{ matrix.tests == 'docs' }}
+        run: python -m pip install -r requirements-cidocs.txt
+
+      - name: "ruff"
+        if: ${{ matrix.tests == 'ruff' }}
+        run: |
+          ruff check $(git ls-files | grep '.py$')
+          ruff format --check $(git ls-files | grep '.py$')
+
+      - name: "mypy"
+        if: ${{ matrix.tests == 'mypy' }}
+        run: |
+          [ "${{ matrix.python-version }}" = "3.9" ] && export MYPY_EXTRA_FLAGS=--no-warn-unused-ignores || true
+          make -j mypy
+
+      - name: "docs"
+        if: ${{ matrix.tests == 'docs' }}
+        run: make docs-release
+
+      - name: "docs spelling"
+        if: ${{ matrix.tests == 'docs' }}
+        run: make docs-release-spelling
+
+      - name: "prettier"
+        if: ${{ matrix.tests == 'prettier' }}
+        run: |
+          make frontend_npm_install
+          make prettier-check
+
   ci:
+    needs:
+      - lint
     strategy:
       fail-fast: false
       matrix:
@@ -26,10 +113,6 @@ jobs:
 
     name: ${{ matrix.os }} / python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-
-    env:
-      # Needed to ignore specific warns, otherwise, it'll warn a generic message
-      SQLALCHEMY_WARN_20: 1
 
     steps:
       - uses: "actions/checkout@v6"
@@ -64,6 +147,8 @@ jobs:
         timeout-minutes: 30
 
   sandboxed-worker:
+    needs:
+      - lint
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           - "3.14"
         os:
           - ubuntu-24.04-arm
+          - ubuntu-latest
           - windows-2022
 
     name: ${{ matrix.os }} / python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,22 +47,9 @@ jobs:
         if: ${{ matrix.tests == 'docs' }}
         run: sudo apt-get update && sudo apt-get install -y libenchant-2-2
 
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "${{ matrix.python-version }}"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
-            requirements-ci.txt
-            requirements-cidocs.txt
-            master/setup.py
-            worker/setup.py
-
-      - name: "Install dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci.txt
-          python -m pip install -e master -e worker
 
       - name: "Install docs dependencies"
         if: ${{ matrix.tests == 'docs' }}
@@ -116,20 +103,9 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "${{ matrix.python-version }}"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
-            requirements-ci.txt
-            master/setup.py
-            worker/setup.py
-
-      - name: "Install dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci.txt
 
       - name: "Install pinned dependency versions"
         if: ${{ matrix.twisted || matrix.treq || matrix.sqlalchemy }}
@@ -152,22 +128,13 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "3.9"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
+          requirements: |
             requirements-ci.txt
             requirements-ciworker.txt
             requirements-cidocs.txt
-            master/setup.py
-            worker/setup.py
-
-      - name: "Install dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci.txt -r requirements-ciworker.txt -r requirements-cidocs.txt
 
       - name: "Run tests"
         run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
@@ -210,20 +177,9 @@ jobs:
 
       # Set up the master Python last so it becomes the default "python".
       - name: "Set up master Python 3.9"
-        uses: "actions/setup-python@v6"
+        uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "3.9"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
-            requirements-ci.txt
-            master/setup.py
-            worker/setup.py
-
-      - name: "Install master dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci.txt
 
       - name: "Run interop tests"
         env:
@@ -247,20 +203,13 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "${{ matrix.python-version }}"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
-            requirements-ciworker.txt
-            worker/setup.py
+          requirements: "requirements-ciworker.txt"
 
-      - name: "Install dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ciworker.txt
-          python -m pip install treq==22.2.0 Twisted==21.2.0 "setuptools<82.0.0"
+      - name: "Install pinned dependency versions"
+        run: python -m pip install treq==22.2.0 Twisted==21.2.0 "setuptools<82.0.0"
 
       - name: "Run worker tests"
         run: "python -m twisted.trial --reporter=text --rterrors buildbot_worker.test"
@@ -278,20 +227,9 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "3.9"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
-            requirements-ci.txt
-            master/setup.py
-            worker/setup.py
-
-      - name: "Install dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci.txt
 
       - name: "Run tests"
         env:
@@ -322,25 +260,9 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "${{ matrix.python-version }}"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-ci.txt
-            requirements-cidb.txt
-            master/setup.py
-            worker/setup.py
-
-      - name: "Install dependencies"
-        run: |
-          python -c "import sys; print(sys.prefix)"
-          python -c "import sys; print(sys.exec_prefix)"
-          python -c "import sys; print(sys.executable)"
-          python -V -V
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci.txt
-          python -m pip list
 
       - name: "Check PyWin32"
         if: ${{ startsWith(matrix.os, 'windows-') }}
@@ -366,23 +288,14 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "actions/setup-python@v6"
+      - uses: "./.github/actions/setup-python-deps"
         with:
           python-version: "=3.10"
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-pip.txt
-            requirements-ci.txt
-            requirements-ci-pyinstaller.txt
-            master/setup.py
-            worker/setup.py
+          requirements: "requirements-ci-pyinstaller.txt"
 
-      - name: "Install dependencies"
-        run: |
-          python -m pip install -r requirements-pip.txt
-          python -m pip install -r requirements-ci-pyinstaller.txt
-          # do a true, non-editable install
-          python -m pip install ./worker
+      - name: "Install worker"
+        # do a true, non-editable install
+        run: python -m pip install ./worker
       - run: pyinstaller pyinstaller/buildbot-worker.spec
       - run: trial --reporter=text --rterrors buildbot.test.integration.interop
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,35 @@ jobs:
         run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
         timeout-minutes: 30
 
+  dev-virtualenv:
+    needs:
+      - lint
+    name: dev_virtualenv / python 3.9
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "3.9"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            requirements-ciworker.txt
+            requirements-cidocs.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ci.txt -r requirements-ciworker.txt -r requirements-cidocs.txt
+
+      - name: "Run tests"
+        run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
+        timeout-minutes: 30
+
   ci:
     needs:
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,41 @@ jobs:
         run: "python -m twisted.trial --reporter=text --rterrors buildbot.test.integration.interop"
         timeout-minutes: 30
 
+  worker-older-python:
+    needs:
+      - lint
+    strategy:
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+
+    name: trial_worker / python ${{ matrix.python-version }} / twisted 21.2.0
+    # Older Python versions (3.7, 3.8) are not available on the newest runners.
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ciworker.txt
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ciworker.txt
+          python -m pip install treq==22.2.0 Twisted==21.2.0 "setuptools<82.0.0"
+
+      - name: "Run worker tests"
+        run: "python -m twisted.trial --reporter=text --rterrors buildbot_worker.test"
+        timeout-minutes: 30
+
   ci:
     needs:
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,64 @@ jobs:
         run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
         timeout-minutes: 30
 
+  worker-interop:
+    needs:
+      - lint
+    strategy:
+      fail-fast: false
+      matrix:
+        worker-python:
+          - "3.9"
+          - "3.8"
+          - "3.7"
+
+    name: interop / master / worker py${{ matrix.worker-python }}
+    # Older Python versions (3.7, 3.8) are not available on the newest runners.
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: "actions/checkout@v6"
+
+      - name: "Set up worker Python ${{ matrix.worker-python }}"
+        uses: "actions/setup-python@v6"
+        id: worker-python
+        with:
+          python-version: "${{ matrix.worker-python }}"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ciworker.txt
+            worker/setup.py
+
+      - name: "Set up worker virtualenv"
+        run: |
+          "${{ steps.worker-python.outputs.python-path }}" -m venv /tmp/bbworkervenv
+          /tmp/bbworkervenv/bin/pip install -r requirements-pip.txt
+          /tmp/bbworkervenv/bin/pip install -r requirements-ciworker.txt
+
+      # Set up the master Python last so it becomes the default "python".
+      - name: "Set up master Python 3.9"
+        uses: "actions/setup-python@v6"
+        with:
+          python-version: "3.9"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install master dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ci.txt
+
+      - name: "Run interop tests"
+        env:
+          SANDBOXED_WORKER_PATH: /tmp/bbworkervenv/bin/buildbot-worker
+        run: "python -m twisted.trial --reporter=text --rterrors buildbot.test.integration.interop"
+        timeout-minutes: 30
+
   ci:
     needs:
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,39 @@ jobs:
         run: "python -m twisted.trial --reporter=text --rterrors buildbot_worker.test"
         timeout-minutes: 30
 
+  # Configuration when SQLite database is persistent between running tests
+  # (by default in other tests in-memory SQLite database is used which is
+  # recreated for each test).
+  # Helps to detect issues with incorrect database setup/cleanup in tests.
+  test-persisted-sqlite:
+    needs:
+      - lint
+    name: trial / sqlite persistent file
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "3.9"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ci.txt
+
+      - name: "Run tests"
+        env:
+          BUILDBOT_TEST_DB_URL: "sqlite:///${{ runner.temp }}/test_db{TEST_ID}.sqlite"
+        run: "python -m twisted.trial -j4 --reporter=text --rterrors buildbot.test buildbot_worker.test"
+        timeout-minutes: 30
+
   ci:
     needs:
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,56 @@ jobs:
           make frontend_npm_install
           make prettier-check
 
+  ci-backward-compat:
+    needs:
+      - lint
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # older twisted/treq, for backward compatibility
+          - name: "py3.9 / twisted 24.7.0 / treq 22.2.0"
+            python-version: "3.9"
+            twisted: "24.7.0"
+            treq: "22.2.0"
+          # older SQLAlchemy 1.4.x
+          - name: "py3.9 / sqlalchemy 1.4.52"
+            python-version: "3.9"
+            sqlalchemy: "1.4.52"
+
+    name: trial / ${{ matrix.name }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          python -m pip install -r requirements-ci.txt
+
+      - name: "Install pinned dependency versions"
+        if: ${{ matrix.twisted || matrix.treq || matrix.sqlalchemy }}
+        run: |
+          pkgs=""
+          if [ -n "${{ matrix.treq }}" ]; then pkgs="$pkgs treq==${{ matrix.treq }}"; fi
+          if [ -n "${{ matrix.twisted }}" ]; then pkgs="$pkgs Twisted==${{ matrix.twisted }}"; fi
+          if [ -n "${{ matrix.sqlalchemy }}" ]; then pkgs="$pkgs SQLAlchemy==${{ matrix.sqlalchemy }}"; fi
+          python -m pip install $pkgs
+
+      - name: "Run tests"
+        run: "python -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
+        timeout-minutes: 30
+
   ci:
     needs:
       - lint

--- a/.github/workflows/cidb.yml
+++ b/.github/workflows/cidb.yml
@@ -105,16 +105,11 @@ jobs:
       - run: sudo apt-get install aspell aspell-en iamerican ispell
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: "./.github/actions/setup-python-deps"
         with:
-          python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: |
+          python-version: "3.9"
+          requirements: |
             requirements-ci.txt
             requirements-cidb.txt
-            master/setup.py
-            worker/setup.py
 
-      - run: pip install -r requirements-pip.txt
-      - run: pip install -r requirements-ci.txt -r requirements-cidb.txt
       - run: $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,111 @@
+name: Frontend
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  js:
+    strategy:
+      matrix:
+        include:
+          - tests: js_build
+          - tests: js_unit
+
+    name: ${{ matrix.tests }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-node@v7"
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "3.9"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          # the Makefile frontend/tarball targets build their own virtualenv
+          python -m pip install virtualenv
+
+      - name: "js_build"
+        if: ${{ matrix.tests == 'js_build' }}
+        run: make frontend_build
+
+      - name: "js_unit"
+        if: ${{ matrix.tests == 'js_unit' }}
+        run: make frontend_tests
+
+  e2e:
+    needs:
+      - js
+    strategy:
+      matrix:
+        include:
+          - python-version: "3.9"
+            tests: e2e_react_whl
+          - python-version: "3.9"
+            tests: e2e_react_tgz
+          - python-version: "3.14"
+            tests: e2e_react_whl
+          - python-version: "3.14"
+            tests: e2e_react_tgz
+
+    name: ${{ matrix.tests }} / python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-node@v7"
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - uses: "actions/setup-python@v6"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-pip.txt
+            requirements-ci.txt
+            master/setup.py
+            worker/setup.py
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install -r requirements-pip.txt
+          # the Makefile frontend/tarball targets build their own virtualenv
+          python -m pip install virtualenv
+
+      - name: "Install Playwright browsers"
+        run: |
+          cd e2e
+          npm ci
+          npx playwright install --with-deps
+
+      - name: "maketarballs"
+        run: make tarballs
+
+      - name: "e2e (whl)"
+        if: ${{ matrix.tests == 'e2e_react_whl' }}
+        run: ./common/smokedist-react.sh whl
+
+      - name: "e2e (tar.gz)"
+        if: ${{ matrix.tests == 'e2e_react_tgz' }}
+        run: ./common/smokedist-react.sh tar.gz


### PR DESCRIPTION
While the Buildbot infra is unavailable, switch to Github action as full-on CI.