### PR TITLE
www/rest: fix connection closure before JSON response finished writing

### DIFF
--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -31,6 +31,7 @@ from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
+from buildbot.util.twisted import async_to_deferred
 from buildbot.www import authz
 from buildbot.www import rest
 from buildbot.www.rest import JSONRPC_CODES
@@ -374,6 +375,25 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin, unittest.TestCase)
         head = yield self.render_resource(self.rsrc, b'/test', method=b'HEAD')
         self.assertEqual(head, b'')
         self.assertEqual(int(self.request.headers[b'content-length'][0]), len(get))
+
+    @async_to_deferred
+    async def test_api_response_finished_only_after_body_written(self) -> None:
+        request = self.make_request(b'/test')
+
+        written_at_finish: list[bytes] = []
+        original_finish = request.finish
+
+        def finish_spy() -> None:
+            written_at_finish.append(bytes(request.written))
+            original_finish()
+
+        request.finish = finish_spy  # type: ignore[method-assign]
+
+        content = await self.render_resource(self.rsrc, b'/test', request=request)
+
+        self.assertEqual(len(written_at_finish), 1)
+        self.assertEqual(written_at_finish[0], content)
+        self.assertEqual(int(request.headers[b'content-length'][0]), len(written_at_finish[0]))
 
     @defer.inlineCallbacks
     def test_api_collection(self) -> InlineCallbacksType[None]:

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -23,6 +23,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import cast
 from urllib.parse import urlparse
 
 from twisted.internet import defer
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Any
 
+    from twisted.internet.interfaces import IReactorThreads
     from twisted.web import server
 
     from buildbot.data.base import Endpoint
@@ -419,7 +421,15 @@ class V2RootResource(resource.Resource):
             else:
                 encoder.indent = 2
 
-            yield threads.deferToThread(V2RootResource._write_json_data, request, encoder, data)
+            _reactor = cast("IReactorThreads", self.master.reactor)
+            yield threads.deferToThreadPool(
+                _reactor,
+                _reactor.getThreadPool(),
+                self._write_json_data,
+                request,
+                encoder,
+                data,
+            )
 
     def reconfigResource(self, new_config: Any) -> None:
         # buildbotURL may contain reverse proxy path, Origin header is just
@@ -496,12 +506,14 @@ class V2RootResource(resource.Resource):
 
         return res
 
-    @staticmethod
     def _write_json_data(
+        self,
         request: server.Request,
         encoder: json.encoder.JSONEncoder,
         data: Any,
     ) -> None:
+        _reactor = cast("IReactorThreads", self.master.reactor)
+
         content_length = 0
         for chunk in encoder.iterencode(data):
             if _is_request_finished(request):
@@ -513,7 +525,7 @@ class V2RootResource(resource.Resource):
             for chunk in encoder.iterencode(data):
                 if _is_request_finished(request):
                     return
-                request.write(unicode2bytes(chunk))
+                threads.blockingCallFromThread(_reactor, request.write, unicode2bytes(chunk))
 
 
 RestRootResource.addApiVersion(2, V2RootResource)

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -82,6 +82,7 @@ def _is_request_finished(request: server.Request) -> bool:
 
 URL_ENCODED = b"application/x-www-form-urlencoded"
 JSON_ENCODED = b"application/json"
+_JSON_WRITE_BATCH_SIZE = 64 * 1024  # 64Kb
 
 
 class RestRootResource(resource.Resource):
@@ -522,10 +523,17 @@ class V2RootResource(resource.Resource):
         request.setHeader(b"content-length", unicode2bytes(str(content_length)))
 
         if request.method != b"HEAD":
+            buffer = bytearray()
             for chunk in encoder.iterencode(data):
                 if _is_request_finished(request):
                     return
-                threads.blockingCallFromThread(_reactor, request.write, unicode2bytes(chunk))
+                buffer += unicode2bytes(chunk)
+                if len(buffer) >= _JSON_WRITE_BATCH_SIZE:
+                    threads.blockingCallFromThread(_reactor, request.write, bytes(buffer))
+                    buffer.clear()
+
+            if buffer and not _is_request_finished(request):
+                threads.blockingCallFromThread(_reactor, request.write, bytes(buffer))
 
 
 RestRootResource.addApiVersion(2, V2RootResource)

--- a/newsfragments/rest-json-response-threaded-write.bugfix
+++ b/newsfragments/rest-json-response-threaded-write.bugfix
@@ -1,0 +1,1 @@
+Rest API JSON response no longer close before write finished (:issue:`9065`).


### PR DESCRIPTION
Fix #9065

# Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
