### PR TITLE
docs: Fix outdated web frontend links in BaseParameter developer docs

### DIFF
--- a/master/docs/developer/cls-forcesched.rst
+++ b/master/docs/developer/cls-forcesched.rst
@@ -79,15 +79,13 @@ types.
 
     .. py:attribute:: type
 
-           A string identifying the type that the parameter conforms to. It is used by the angular
-           application to find which angular directive to use for showing the form widget. The
-           available values are visible in
-           :src:`www/base/src/app/common/directives/forcefields/forcefields.directive.js`.
+           A string identifying the type that the parameter conforms to. It is used by the web
+           frontend to find which form widget to use for showing the parameter. The available
+           values, and the React components that render them, are visible in
+           :src:`www/base/src/components/ForceBuildModal/Fields/FieldAny.tsx`.
 
-           Examples of how to create a custom parameter widgets are available in the Buildbot source code in directories:
-
-           * :src:`www/codeparameter`
-           * :src:`www/nestedexample`
+           The web frontend does not currently support custom parameter types: a parameter whose
+           ``type`` is not one of the known values is not rendered in the force build form.
 
     .. py:attribute:: default
 

--- a/newsfragments/8618.doc
+++ b/newsfragments/8618.doc
@@ -1,0 +1,1 @@
+Fix outdated links to the web frontend sources in the developer documentation of :py:class:`~buildbot.schedulers.forcesched.BaseParameter` (:issue:`8618`)


### PR DESCRIPTION
## Summary

Fixes #8618.

The developer documentation of `BaseParameter.type` in `developer/cls-forcesched.rst` still pointed at AngularJS-era sources that no longer exist:

- `www/base/src/app/common/directives/forcefields/forcefields.directive.js` — removed with the AngularJS frontend
- `www/codeparameter` — removed
- `www/nestedexample` — still in the tree, but a legacy AngularJS plugin (`.directive.js` + `.jade` + guanlecoja), so no longer a usable example for the React frontend

It also described the frontend as an "angular application" choosing an "angular directive".

## Changes

- Point at `www/base/src/components/ForceBuildModal/Fields/FieldAny.tsx`, where the React frontend maps `type` values to the components rendering them.
- Document that the frontend currently has no mechanism for custom parameter types — `FieldAny` renders nothing for unknown `type` values — instead of linking to obsolete examples of how to write custom widgets.
- Add an `8618.doc` newsfragment.

## Note

Several other developer pages (`www-server.rst`, `www-data-module.rst`, `config.rst`, and `manual/configuration/www/server.rst`) still describe the frontend as AngularJS-based. That is a larger rewrite and out of scope for this issue; happy to file a follow-up issue or PR for it.